### PR TITLE
Restore `max-autotune` option for `torch.compile()`

### DIFF
--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -1067,12 +1067,15 @@ def attempt_compile(
     t0 = time.perf_counter()
     try:
         torch._dynamo.reset()  # reset cache
-        options = {
-            **torch._inductor.list_mode_options()[mode],
-            "coordinate_descent_tuning": False,
-            "triton.cudagraph_trees": False,
-        }  # override non-reproducible/slow opts
-        model = torch.compile(model, backend="inductor", options=options)
+        if hasattr(torch._inductor, "list_mode_options"):  # torch>=2.1
+            options = {
+                **torch._inductor.list_mode_options(mode),
+                "coordinate_descent_tuning": False,
+                "triton.cudagraph_trees": False,
+            }  # override non-reproducible/slow opts
+            model = torch.compile(model, backend="inductor", options=options)
+        else:
+            model = torch.compile(model, mode=mode, backend="inductor")
     except Exception as e:
         LOGGER.warning(f"{prefix} torch.compile failed, continuing uncompiled: {e}")
         return model

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -1064,15 +1064,14 @@ def attempt_compile(
             LOGGER.warning(f"{prefix} no C++ compiler found for the inductor backend, continuing uncompiled: {e}")
             return model
     LOGGER.info(f"{prefix} starting torch.compile with '{mode}' mode...")
-    torch._dynamo.reset()  # reset cache
-    default_opts = torch._inductor.list_mode_options()[mode]
-    options = {
-        **default_opts,
-        "coordinate_descent_tuning": False,
-        "triton.cudagraph_trees": False,
-    }  # override non-reproducible/slow opts
     t0 = time.perf_counter()
     try:
+        torch._dynamo.reset()  # reset cache
+        options = {
+            **torch._inductor.list_mode_options()[mode],
+            "coordinate_descent_tuning": False,
+            "triton.cudagraph_trees": False,
+        }  # override non-reproducible/slow opts
         model = torch.compile(model, backend="inductor", options=options)
     except Exception as e:
         LOGGER.warning(f"{prefix} torch.compile failed, continuing uncompiled: {e}")

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -1066,12 +1066,12 @@ def attempt_compile(
     LOGGER.info(f"{prefix} starting torch.compile with '{mode}' mode...")
     t0 = time.perf_counter()
     try:
-        import torch._inductor  # ensure lazy submodule is loaded before access (lazy in torch 2.0)
+        from torch import _dynamo, _inductor  # load lazy submodules (lazy in torch 2.0)
 
-        torch._dynamo.reset()  # reset cache
-        if hasattr(torch._inductor, "list_mode_options"):  # torch>=2.1
+        _dynamo.reset()  # reset cache
+        if hasattr(_inductor, "list_mode_options"):  # torch>=2.1
             options = {
-                **torch._inductor.list_mode_options(mode),
+                **_inductor.list_mode_options(mode),
                 "coordinate_descent_tuning": False,
                 "triton.cudagraph_trees": False,
             }  # override non-reproducible/slow opts

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -1066,6 +1066,8 @@ def attempt_compile(
     LOGGER.info(f"{prefix} starting torch.compile with '{mode}' mode...")
     t0 = time.perf_counter()
     try:
+        import torch._inductor  # ensure lazy submodule is loaded before access (lazy in torch 2.0)
+
         torch._dynamo.reset()  # reset cache
         if hasattr(torch._inductor, "list_mode_options"):  # torch>=2.1
             options = {

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -1066,18 +1066,7 @@ def attempt_compile(
     LOGGER.info(f"{prefix} starting torch.compile with '{mode}' mode...")
     t0 = time.perf_counter()
     try:
-        from torch import _dynamo, _inductor  # load lazy submodules (lazy in torch 2.0)
-
-        _dynamo.reset()  # reset cache
-        if hasattr(_inductor, "list_mode_options"):  # torch>=2.1
-            options = {
-                **_inductor.list_mode_options(mode),
-                "coordinate_descent_tuning": False,
-                "triton.cudagraph_trees": False,
-            }  # override non-reproducible/slow opts
-            model = torch.compile(model, backend="inductor", options=options)
-        else:
-            model = torch.compile(model, mode=mode, backend="inductor")
+        model = torch.compile(model, mode=mode, backend="inductor")
     except Exception as e:
         LOGGER.warning(f"{prefix} torch.compile failed, continuing uncompiled: {e}")
         return model

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -1064,12 +1064,16 @@ def attempt_compile(
             LOGGER.warning(f"{prefix} no C++ compiler found for the inductor backend, continuing uncompiled: {e}")
             return model
     LOGGER.info(f"{prefix} starting torch.compile with '{mode}' mode...")
-    if mode == "max-autotune":
-        LOGGER.warning(f"{prefix} mode='{mode}' not recommended, using mode='max-autotune-no-cudagraphs' instead")
-        mode = "max-autotune-no-cudagraphs"
+    torch._dynamo.reset()  # reset cache
+    default_opts = torch._inductor.list_mode_options()[mode]
+    options = {
+        **default_opts,
+        "coordinate_descent_tuning": False,
+        "triton.cudagraph_trees": False,
+    }  # override non-reproducible/slow opts
     t0 = time.perf_counter()
     try:
-        model = torch.compile(model, mode=mode, backend="inductor")
+        model = torch.compile(model, backend="inductor", options=options)
     except Exception as e:
         LOGGER.warning(f"{prefix} torch.compile failed, continuing uncompiled: {e}")
         return model


### PR DESCRIPTION
## Summary

Restore the requested `compile=max-autotune` behavior by deleting the local rewrite to `max-autotune-no-cudagraphs` and passing the selected mode directly to `torch.compile()`.

This keeps mode ownership with PyTorch and avoids RKNN-specific options, global Dynamo cache resets, compatibility branches, and duplicated mode expansion.

Deleted: the forced `max-autotune` to `max-autotune-no-cudagraphs` rewrite.

## Validation

- Verified `attempt_compile(..., mode="max-autotune")` passes `mode="max-autotune"` and `backend="inductor"` directly to `torch.compile()`.
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Restores support for the user-selected `torch.compile` mode, including `max-autotune`, without automatically overriding it. ⚙️

### 📊 Key Changes

- Removed the automatic replacement of `mode="max-autotune"` with `mode="max-autotune-no-cudagraphs"`.
- `torch.compile` now receives the exact mode specified by the user.
- Removed the warning that discouraged `max-autotune`.

### 🎯 Purpose & Impact

- Gives users full control over PyTorch compilation settings. 🎛️
- Enables the performance benefits and behavior of the selected compilation mode, including CUDA graphs when supported.
- May improve optimization for suitable workloads, while users remain responsible for choosing a compatible mode for their hardware and model.