### PR TITLE
Avoid per-box and per-keypoint GPU syncs in `Results.plot()`

### DIFF
--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -519,7 +519,7 @@ class Results(SimpleClass, DataExportMixin):
         pred_boxes, show_boxes = self.obb if is_obb else self.boxes, boxes
         pred_masks, show_masks = self.masks, masks
         pred_probs, show_probs = self.probs, probs
-        if pred_boxes is not None:
+        if pred_boxes is not None and (show_boxes or (pred_masks and show_masks)):
             pred_boxes = pred_boxes.cpu()  # one host transfer avoids per-box GPU syncs in the color and label loops
         annotator = Annotator(
             deepcopy(self.orig_img if img is None else img),

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -519,6 +519,8 @@ class Results(SimpleClass, DataExportMixin):
         pred_boxes, show_boxes = self.obb if is_obb else self.boxes, boxes
         pred_masks, show_masks = self.masks, masks
         pred_probs, show_probs = self.probs, probs
+        if pred_boxes is not None:
+            pred_boxes = pred_boxes.cpu()  # one host transfer avoids per-box GPU syncs in the color and label loops
         annotator = Annotator(
             deepcopy(self.orig_img if img is None else img),
             line_width,
@@ -585,7 +587,7 @@ class Results(SimpleClass, DataExportMixin):
 
         # Plot Pose results
         if self.keypoints is not None:
-            for i, k in enumerate(reversed(self.keypoints.data)):
+            for i, k in enumerate(reversed(self.keypoints.cpu().numpy().data)):  # one host transfer, no per-kpt syncs
                 annotator.kpts(
                     k,
                     self.orig_shape,


### PR DESCRIPTION
## summary

`Results.plot()` annotates from tensors that are still on the GPU, and three places read them one scalar at a time. The detection loop does `int(d.cls)`, `float(d.conf)` and `int(d.id.item())` per box, so that is about 3-4 host syncs for every box drawn. The pose loop is worse: each `Annotator.kpts` call indexes 17 keypoints scalar by scalar (`x % shape`, `int(x)`, `conf < conf_thres`) plus the 19 skeleton limbs, so around 5 syncs per keypoint, per instance. And the segment block builds the mask colors from `pred_boxes.cls` (or `.id` when tracking) with one `int(x)` sync per box.

The change moves `pred_boxes` to the host once, right before the first block that reads it, so the detect loop and the mask-color loop index host data, and keypoints get the same single transfer. `semantic_mask` in this same method already does exactly this, and #24744 did it for the AI Gym loop, so this applies the same pattern to the loops that were left out. Behaviour is identical.

It is also numpy-safe: `BaseTensor.cpu()` and `.numpy()` return `self` when the data is already an ndarray, so a `Results` converted with `.cpu().numpy()` still plots.

## measured

RTX 4060 Laptop, torch 2.12.1+cu130, ultralytics 8.4.96. Ten rounds alternating baseline and patched in fresh processes, each round is the median of 60 `plot()` calls with `torch.cuda.synchronize()` around them. Median [min-max] across the 10 rounds:

| case | before | after | speedup |
|---|---|---|---|
| `yolo11n-pose` on bus.jpg (4 people), real pipeline | 7.53 ms [7.34-7.87] | 0.99 ms [0.97-1.11] | 7.55x |
| synthetic, 5 people (box + 17 kpts each) | 12.44 ms | 3.11 ms | 4.01x |
| synthetic, 10 people | 24.44 ms | 6.05 ms | 3.97x |
| synthetic, 30 people | 71.25 ms | 17.28 ms | 4.13x |

Only `plot()` is timed here, not inference. The saving applies to every frame when saving or showing video. On the segment path the mask-color loop also stops syncing, but the gain there is small in my machine (within run-to-run noise), because `Annotator.masks` already pays a full-image transfer. The reason to cover it anyway is simple: with this change `plot()` does zero per-box reads from the GPU, I am not claiming a separate speedup there.

## equivalence

I rendered with baseline and with the patch in separate processes and compared the output arrays byte by byte: 29 scenarios, 0 differences. That covers detect/pose/obb/segment from real inference against cuda, cpu tensor and numpy-backed results, with and without conf/labels, both `color_mode` values, tracking with ids, N=0, N=1, no keypoints, and edge coordinates (conf crossing the threshold, coords at exactly 0, exact multiples of the image dimension, negatives). All pixel-identical. `tests/test_python.py::test_results` and `test_results_plot_without_boxes` pass too.

Deleted: nothing — this is +3/-1. The fix is a single hoisted host transfer per tensor reusing the existing `BaseTensor.cpu()`/`.numpy()` API (the same thing this method already does for `semantic_mask`), and the per-object scalar reads themselves have to stay.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves `Results.plot()` performance by batching GPU-to-CPU transfers for boxes and keypoints, avoiding repeated synchronization overhead.

### 📊 Key Changes
- Moves prediction boxes to CPU once before color and label rendering loops.
- Converts keypoints to a CPU NumPy array once before plotting.
- Eliminates per-box and per-keypoint GPU synchronization during visualization.

### 🎯 Purpose & Impact
- Reduces plotting overhead and improves visualization performance for GPU-based inference.
- Preserves existing plotting behavior while minimizing host-device transfer operations.
- May be especially beneficial for results containing many detections or keypoints.