### PR TITLE
Document Platform Jetson export targets

### DIFF
--- a/docs/en/guides/nvidia-jetson.md
+++ b/docs/en/guides/nvidia-jetson.md
@@ -107,7 +107,7 @@ The fastest way to get started with Ultralytics YOLO26 on NVIDIA Jetson is to ru
     sudo docker pull $t && sudo docker run -it --ipc=host --runtime=nvidia $t
     ```
 
-=== "JetPack 7 (Thor/DGX Spark)"
+=== "JetPack 7.0 (Thor/DGX Spark)"
 
     ```bash
     t=ultralytics/ultralytics:latest-nvidia-arm64
@@ -116,7 +116,7 @@ The fastest way to get started with Ultralytics YOLO26 on NVIDIA Jetson is to ru
 
 !!! note "JetPack 7 Docker scope"
 
-    The public `latest-nvidia-arm64` image currently owns the JetPack 7.0 Thor/DGX Spark path. For JetPack 7.2 on Orin, use the native installation below until the public image is explicitly validated and updated for that combination.
+    The public `latest-nvidia-arm64` image currently owns only the JetPack 7.0 Thor/DGX Spark path. For JetPack 7.2 on Thor or Orin, use the native installation below until the public image is explicitly validated and updated for those combinations.
 
 After this is done, skip to [Use TensorRT on NVIDIA Jetson section](#use-tensorrt-on-nvidia-jetson).
 

--- a/docs/en/guides/nvidia-jetson.md
+++ b/docs/en/guides/nvidia-jetson.md
@@ -28,7 +28,7 @@ This comprehensive guide provides a detailed walkthrough for deploying Ultralyti
 
 !!! note
 
-    This guide has been tested with [NVIDIA Jetson AGX Thor Developer Kit (Jetson T5000)](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-thor) running the latest stable JetPack release of [JP7.0](https://developer.nvidia.com/embedded/jetpack/downloads), [NVIDIA Jetson AGX Orin Developer Kit (64GB)](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin) running JetPack release of [JP6.2](https://developer.nvidia.com/embedded/jetpack-sdk-62), [NVIDIA Jetson Orin Nano Super Developer Kit](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/nano-super-developer-kit) running JetPack release of [JP6.1](https://developer.nvidia.com/embedded/jetpack-sdk-61), [Seeed Studio reComputer J4012](https://www.seeedstudio.com/reComputer-J4012-p-5586.html) which is based on NVIDIA Jetson Orin NX 16GB running JetPack release of [JP6.0](https://developer.nvidia.com/embedded/jetpack-sdk-60)/ JetPack release of [JP5.1.3](https://developer.nvidia.com/embedded/jetpack-sdk-513) and [Seeed Studio reComputer J1020 v2](https://www.seeedstudio.com/reComputer-J1020-v2-p-5498.html) which is based on NVIDIA Jetson Nano 4GB running JetPack release of [JP4.6.1](https://developer.nvidia.com/embedded/jetpack-sdk-461). It is expected to work across all the NVIDIA Jetson hardware lineup, including the latest and legacy devices.
+    This guide has been tested with [NVIDIA Jetson AGX Thor Developer Kit (Jetson T5000)](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-thor) and [NVIDIA Jetson AGX Orin Developer Kit (64GB)](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin) running the latest stable [JetPack 7.2](https://developer.nvidia.com/embedded/jetpack/downloads), [NVIDIA Jetson Orin Nano Super Developer Kit](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/nano-super-developer-kit) running JetPack release of [JP6.1](https://developer.nvidia.com/embedded/jetpack-sdk-61), [Seeed Studio reComputer J4012](https://www.seeedstudio.com/reComputer-J4012-p-5586.html) which is based on NVIDIA Jetson Orin NX 16GB running JetPack release of [JP6.0](https://developer.nvidia.com/embedded/jetpack-sdk-60)/ JetPack release of [JP5.1.3](https://developer.nvidia.com/embedded/jetpack-sdk-513) and [Seeed Studio reComputer J1020 v2](https://www.seeedstudio.com/reComputer-J1020-v2-p-5498.html) which is based on NVIDIA Jetson Nano 4GB running JetPack release of [JP4.6.1](https://developer.nvidia.com/embedded/jetpack-sdk-461). It is expected to work across all the NVIDIA Jetson hardware lineup, including the latest and legacy devices.
 
 ## What is NVIDIA Jetson?
 
@@ -77,9 +77,9 @@ The below table highlights NVIDIA JetPack versions supported by different NVIDIA
 | Jetson TX2        | ✅        | ❌        | ❌        | ❌        |
 | Jetson Xavier NX  | ✅        | ✅        | ❌        | ❌        |
 | Jetson AGX Xavier | ✅        | ✅        | ❌        | ❌        |
-| Jetson AGX Orin   | ❌        | ✅        | ✅        | ❌        |
-| Jetson Orin NX    | ❌        | ✅        | ✅        | ❌        |
-| Jetson Orin Nano  | ❌        | ✅        | ✅        | ❌        |
+| Jetson AGX Orin   | ❌        | ✅        | ✅        | ✅        |
+| Jetson Orin NX    | ❌        | ✅        | ✅        | ✅        |
+| Jetson Orin Nano  | ❌        | ✅        | ✅        | ✅        |
 | Jetson AGX Thor   | ❌        | ❌        | ❌        | ✅        |
 
 ## Quick Start with Docker
@@ -120,7 +120,7 @@ After this is done, skip to [Use TensorRT on NVIDIA Jetson section](#use-tensorr
 
 For a native installation without Docker, please refer to the steps below.
 
-### Run on JetPack 7.0
+### Run on JetPack 7.2
 
 #### Install Ultralytics Package
 
@@ -148,9 +148,9 @@ Here we will install Ultralytics package on the Jetson with optional dependencie
 
 #### Install PyTorch and Torchvision
 
-The above ultralytics installation will install Torch and Torchvision. However, these 2 packages installed via pip are not compatible to run on Jetson AGX Thor which comes with JetPack 7.0 and CUDA 13. Therefore, we need to manually install them.
+The above ultralytics installation will install Torch and Torchvision. However, these 2 packages installed via pip are not compatible to run on JetPack 7.2 devices with CUDA 13. Therefore, we need to manually install them.
 
-Install `torch` and `torchvision` according to JP7.0
+Install `torch` and `torchvision` according to JP7.2
 
 ```bash
 pip install torch torchvision --index-url https://download.pytorch.org/whl/cu130
@@ -302,6 +302,12 @@ pip install onnxruntime_gpu-1.17.0-cp38-cp38-linux_aarch64.whl
 ## Use TensorRT on NVIDIA Jetson
 
 Among all the model export formats supported by Ultralytics, TensorRT offers the highest inference performance on NVIDIA Jetson devices, making it our top recommendation for Jetson deployments. For setup instructions and advanced usage, see our [dedicated TensorRT integration guide](../integrations/tensorrt.md).
+
+You can also export from the browser without configuring the build environment locally. In the [Ultralytics Platform model Export tab](../platform/train/models.md#nvidia-jetson-tensorrt-targets), select TensorRT and the exact Jetson target to build and download a device-targeted `.engine` file.
+
+!!! warning "TensorRT engines are device-specific"
+
+    TensorRT profiles and tunes an engine on its build GPU. Match the target's GPU architecture and TensorRT/CUDA runtime, and validate the downloaded engine on the deployment device. INT8 calibration should use the target device for best results.
 
 ### Convert Model to TensorRT and Run Inference
 

--- a/docs/en/guides/nvidia-jetson.md
+++ b/docs/en/guides/nvidia-jetson.md
@@ -57,8 +57,8 @@ For a more detailed comparison table, please visit the **Compare Specifications*
 
 The first step after getting your hands on an NVIDIA Jetson device is to flash NVIDIA JetPack to the device. There are several different ways of flashing NVIDIA Jetson devices.
 
-1. If you own an official NVIDIA Development Kit such as the Jetson AGX Thor Developer Kit, you can [download an image and prepare a bootable USB stick to flash JetPack to the included SSD](https://docs.nvidia.com/jetson/agx-thor-devkit/user-guide/latest/quick_start.html).
-2. If you own an official NVIDIA Development Kit such as the Jetson Orin Nano Developer Kit, you can [download an image and prepare an SD card with JetPack for booting the device](https://developer.nvidia.com/embedded/learn/get-started-jetson-orin-nano-devkit).
+1. For JetPack 7.2 on an official Jetson AGX Thor, AGX Orin, or Orin Nano Developer Kit, download the unified Jetson ISO, write it to a USB flash drive, and follow the device-specific quick start for [AGX Thor](https://docs.nvidia.com/jetson/agx-thor-devkit/user-guide/latest/quick_start.html), [AGX Orin](https://docs.nvidia.com/jetson/agx-orin-devkit/user-guide/latest/quick_start.html), or [Orin Nano](https://docs.nvidia.com/jetson/orin-nano-devkit/user-guide/latest/quick_start.html). Starting with JetPack 7.2, Orin Nano no longer uses a downloadable SD-card image; the ISO USB installs Jetson Linux onto the device's microSD card or NVMe SSD.
+2. If you intentionally use JetPack 6 on a Jetson Orin Nano Developer Kit, follow NVIDIA's [JetPack 6.x update and SD-card instructions](https://docs.nvidia.com/jetson/orin-nano-devkit/user-guide/latest/update_firmware.html).
 3. If you own any other NVIDIA Development Kit, you can [flash JetPack to the device using SDK Manager](https://docs.nvidia.com/sdk-manager/install-with-sdkm-jetson/index.html).
 4. If you own a Seeed Studio reComputer J4012 device, you can [flash JetPack to the included SSD](https://wiki.seeedstudio.com/reComputer_J4012_Flash_Jetpack/) and if you own a Seeed Studio reComputer J1020 v2 device, you can [flash JetPack to the eMMC/ SSD](https://wiki.seeedstudio.com/reComputer_J2021_J202_Flash_Jetpack/).
 5. If you own any other third-party device powered by the NVIDIA Jetson module, it is recommended to follow [command-line flashing](https://docs.nvidia.com/jetson/archives/r35.5.0/DeveloperGuide/IN/QuickStart.html).
@@ -107,12 +107,16 @@ The fastest way to get started with Ultralytics YOLO26 on NVIDIA Jetson is to ru
     sudo docker pull $t && sudo docker run -it --ipc=host --runtime=nvidia $t
     ```
 
-=== "JetPack 7"
+=== "JetPack 7 (Thor/DGX Spark)"
 
     ```bash
     t=ultralytics/ultralytics:latest-nvidia-arm64
     sudo docker pull $t && sudo docker run -it --ipc=host --runtime=nvidia $t
     ```
+
+!!! note "JetPack 7 Docker scope"
+
+    The public `latest-nvidia-arm64` image currently owns the JetPack 7.0 Thor/DGX Spark path. For JetPack 7.2 on Orin, use the native installation below until the public image is explicitly validated and updated for that combination.
 
 After this is done, skip to [Use TensorRT on NVIDIA Jetson section](#use-tensorrt-on-nvidia-jetson).
 
@@ -303,11 +307,11 @@ pip install onnxruntime_gpu-1.17.0-cp38-cp38-linux_aarch64.whl
 
 Among all the model export formats supported by Ultralytics, TensorRT offers the highest inference performance on NVIDIA Jetson devices, making it our top recommendation for Jetson deployments. For setup instructions and advanced usage, see our [dedicated TensorRT integration guide](../integrations/tensorrt.md).
 
-You can also export from the browser without configuring the build environment locally. In the [Ultralytics Platform model Export tab](../platform/train/models.md#nvidia-jetson-tensorrt-targets), select TensorRT and the exact Jetson target to build and download a device-targeted `.engine` file.
+You can also export from the browser without configuring the build environment locally. In the [Ultralytics Platform model Export tab](../platform/train/models.md#nvidia-jetson-tensorrt-targets), select TensorRT and the intended Jetson target. Thor selections are validated on physical Thor hardware. The six Orin selections currently produce AGX-Orin-built candidate engines; validate them on the intended Orin SKU before deployment.
 
 !!! warning "TensorRT engines are device-specific"
 
-    TensorRT profiles and tunes an engine on its build GPU. Match the target's GPU architecture and TensorRT/CUDA runtime, and validate the downloaded engine on the deployment device. INT8 calibration should use the target device for best results.
+    TensorRT profiles and tunes an engine on its build GPU. Match the target's GPU architecture and TensorRT/CUDA runtime, and validate every downloaded engine on the deployment device. Same-architecture Orin SKUs are not an automatic portability guarantee, and INT8 calibration should use the target device for best results.
 
 ### Convert Model to TensorRT and Run Inference
 

--- a/docs/en/integrations/tensorrt.md
+++ b/docs/en/integrations/tensorrt.md
@@ -22,6 +22,10 @@ This toolkit optimizes deep learning models for NVIDIA GPUs and results in faste
 
 TensorRT is known for its compatibility with various model formats, including TensorFlow, [PyTorch](https://www.ultralytics.com/glossary/pytorch), and ONNX, providing developers with a flexible solution for integrating and optimizing models from different frameworks. This versatility enables efficient [model deployment](https://www.ultralytics.com/glossary/model-deployment) across diverse hardware and software environments.
 
+!!! warning "TensorRT engines are hardware- and runtime-specific"
+
+    TensorRT profiles and tunes an engine on its build GPU. Build for the deployment GPU architecture and match the TensorRT/CUDA runtime; do not treat an `.engine` file as a portable model format. For edge deployment, [Ultralytics Platform](../platform/train/models.md#nvidia-jetson-tensorrt-targets) can build directly for eight Jetson targets, or you can export locally on the destination device.
+
 ## Key Features of TensorRT Models
 
 TensorRT models offer a range of key features that contribute to their efficiency and effectiveness in high-speed deep learning inference:

--- a/docs/en/integrations/tensorrt.md
+++ b/docs/en/integrations/tensorrt.md
@@ -24,7 +24,7 @@ TensorRT is known for its compatibility with various model formats, including Te
 
 !!! warning "TensorRT engines are hardware- and runtime-specific"
 
-    TensorRT profiles and tunes an engine on its build GPU. Build for the deployment GPU architecture and match the TensorRT/CUDA runtime; do not treat an `.engine` file as a portable model format. For edge deployment, [Ultralytics Platform](../platform/train/models.md#nvidia-jetson-tensorrt-targets) can build directly for eight Jetson targets, or you can export locally on the destination device.
+    TensorRT profiles and tunes an engine on its build GPU. Build for the deployment GPU architecture and match the TensorRT/CUDA runtime; do not treat an `.engine` file as a portable model format. For edge deployment, [Ultralytics Platform](../platform/train/models.md#nvidia-jetson-tensorrt-targets) offers eight Jetson target selections, with physical build and validation status documented for each, or you can export locally on the destination device.
 
 ## Key Features of TensorRT Models
 

--- a/docs/en/platform/api/index.md
+++ b/docs/en/platform/api/index.md
@@ -1314,7 +1314,7 @@ POST /api/exports
 | --------- | ------ | ----------- | ------------------------------------------------------- |
 | `modelId` | string | Yes         | Source model ID                                         |
 | `format`  | string | Yes         | Export format (see table below)                         |
-| `gpuType` | string | Conditional | Required when `format` is `engine` (TensorRT)           |
+| `gpuType` | string | Conditional | Required when `format` is `engine`; use a supported [GPU or Jetson target](../train/models.md#nvidia-jetson-tensorrt-targets) |
 | `args`    | object | No          | Export arguments (`imgsz`, `quantize`, `dynamic`, etc.) |
 
 === "cURL"

--- a/docs/en/platform/api/index.md
+++ b/docs/en/platform/api/index.md
@@ -1310,12 +1310,12 @@ POST /api/exports
 
 **Body:**
 
-| Field     | Type   | Required    | Description                                             |
-| --------- | ------ | ----------- | ------------------------------------------------------- |
-| `modelId` | string | Yes         | Source model ID                                         |
-| `format`  | string | Yes         | Export format (see table below)                         |
+| Field     | Type   | Required    | Description                                                                                                                   |
+| --------- | ------ | ----------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `modelId` | string | Yes         | Source model ID                                                                                                               |
+| `format`  | string | Yes         | Export format (see table below)                                                                                               |
 | `gpuType` | string | Conditional | Required when `format` is `engine`; use a supported [GPU or Jetson target](../train/models.md#nvidia-jetson-tensorrt-targets) |
-| `args`    | object | No          | Export arguments (`imgsz`, `quantize`, `dynamic`, etc.) |
+| `args`    | object | No          | Export arguments (`imgsz`, `quantize`, `dynamic`, etc.)                                                                       |
 
 === "cURL"
 

--- a/docs/en/platform/train/models.md
+++ b/docs/en/platform/train/models.md
@@ -278,7 +278,7 @@ Export jobs progress through the following statuses:
 
 !!! tip "Export Time"
 
-    Export time varies by format and target. TensorRT exports run on the selected NVIDIA GPU or Jetson target and may take several minutes because TensorRT profiles and tunes the engine for that hardware.
+    Export time varies by format and build host. TensorRT exports may take several minutes because TensorRT profiles and tunes the engine on the physical GPU shown in the [Jetson validation table](#nvidia-jetson-tensorrt-targets) or the selected cloud GPU.
 
 ### Bulk Export Actions
 

--- a/docs/en/platform/train/models.md
+++ b/docs/en/platform/train/models.md
@@ -218,7 +218,7 @@ The Platform supports export to [19+ deployment formats](../../modes/export.md#e
 | Target             | Recommended Format  | Notes                                                          |
 | ------------------ | ------------------- | -------------------------------------------------------------- |
 | **NVIDIA GPUs**    | TensorRT            | Select the same GPU family as the deployment device            |
-| **NVIDIA Jetson**  | TensorRT            | Select the intended target and check its validation status      |
+| **NVIDIA Jetson**  | TensorRT            | Select the intended target and check its validation status     |
 | **Intel Hardware** | OpenVINO            | CPUs, GPUs, and VPUs                                           |
 | **Apple Devices**  | CoreML or LiteRT    | iOS, macOS, Apple Silicon                                      |
 | **Android**        | LiteRT or NCNN      | LiteRT (Google's on-device runtime) or NCNN for ARM            |
@@ -232,16 +232,16 @@ The Platform supports export to [19+ deployment formats](../../modes/export.md#e
 
 Ultralytics Platform offers the following Jetson target selections for TensorRT `.engine` exports. As of July 2026, the Jetson export workers use JetPack 7.2 / L4T r39.2, Python 3.12.3, NVIDIA PyTorch 2.12.0a0 (26.04 build), CUDA 13.2, and TensorRT 10.16.1.11 inside the export container.
 
-| Target selection           | API `gpuType`          | Memory | GPU architecture   | Python | CUDA | TensorRT   | Measured YOLO26n FP16 export | Physical build/load validation              |
-| -------------------------- | ---------------------- | -----: | ------------------ | ------ | ---- | ---------- | ---------------------------: | ------------------------------------------- |
+| Target selection           | API `gpuType`          | Memory | GPU architecture   | Python | CUDA | TensorRT   | Measured YOLO26n FP16 export | Physical build/load validation                |
+| -------------------------- | ---------------------- | -----: | ------------------ | ------ | ---- | ---------- | ---------------------------: | --------------------------------------------- |
 | Jetson Thor T5000          | `jetson-thor-t5000`    | 128 GB | Blackwell, CC 11.0 | 3.12.3 | 13.2 | 10.16.1.11 |                      ~1m 46s | Thor in NVIDIA T4000 profile; T5000 candidate |
-| Jetson Thor T4000          | `jetson-thor-t4000`    |  64 GB | Blackwell, CC 11.0 | 3.12.3 | 13.2 | 10.16.1.11 |                      ~1m 46s | Thor in NVIDIA T4000 profile                |
-| Jetson AGX Orin 64GB       | `jetson-agx-orin-64gb` |  64 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       7m 15s | Built, loaded, and inferred on AGX Orin 64GB |
-| Jetson AGX Orin 32GB       | `jetson-agx-orin-32gb` |  32 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       5m 34s | AGX Orin 64GB build/load; 32GB SKU pending  |
-| Jetson Orin NX 16GB        | `jetson-orin-nx-16gb`  |  16 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       5m 09s | AGX Orin 64GB build/load; NX SKU pending    |
-| Jetson Orin NX 8GB         | `jetson-orin-nx-8gb`   |   8 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       5m 01s | AGX Orin 64GB build/load; NX SKU pending    |
-| Jetson Orin Nano 8GB Super | `jetson-orin-nano-8gb` |   8 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       4m 59s | AGX Orin 64GB build/load; Nano SKU pending  |
-| Jetson Orin Nano 4GB       | `jetson-orin-nano-4gb` |   4 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       5m 01s | AGX Orin 64GB build/load; Nano SKU pending  |
+| Jetson Thor T4000          | `jetson-thor-t4000`    |  64 GB | Blackwell, CC 11.0 | 3.12.3 | 13.2 | 10.16.1.11 |                      ~1m 46s | Thor in NVIDIA T4000 profile                  |
+| Jetson AGX Orin 64GB       | `jetson-agx-orin-64gb` |  64 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       7m 15s | Built, loaded, and inferred on AGX Orin 64GB  |
+| Jetson AGX Orin 32GB       | `jetson-agx-orin-32gb` |  32 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       5m 34s | AGX Orin 64GB build/load; 32GB SKU pending    |
+| Jetson Orin NX 16GB        | `jetson-orin-nx-16gb`  |  16 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       5m 09s | AGX Orin 64GB build/load; NX SKU pending      |
+| Jetson Orin NX 8GB         | `jetson-orin-nx-8gb`   |   8 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       5m 01s | AGX Orin 64GB build/load; NX SKU pending      |
+| Jetson Orin Nano 8GB Super | `jetson-orin-nano-8gb` |   8 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       4m 59s | AGX Orin 64GB build/load; Nano SKU pending    |
+| Jetson Orin Nano 4GB       | `jetson-orin-nano-4gb` |   4 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       5m 01s | AGX Orin 64GB build/load; Nano SKU pending    |
 
 The timings are single observed end-to-end production routing tests from July 2026, rounded to the nearest second; they are reference measurements, not an SLA or per-SKU performance benchmark. Both Thor selections are built on a T5000 Developer Kit in NVIDIA's T4000 compatibility profile. The six Orin routes are built on an AGX Orin 64GB, where every resulting engine was loaded and run. Because TensorRT engines are tied to the build GPU and software stack, the smaller-Orin artifacts are candidates until they load and infer on their listed SKUs. Test memory fit on smaller Orin SKUs and perform INT8 calibration on the target device for best results. See the [NVIDIA Jetson guide](../../guides/nvidia-jetson.md) and [TensorRT integration guide](../../integrations/tensorrt.md) for local deployment details.
 

--- a/docs/en/platform/train/models.md
+++ b/docs/en/platform/train/models.md
@@ -217,7 +217,8 @@ The Platform supports export to [19+ deployment formats](../../modes/export.md#e
 
 | Target             | Recommended Format  | Notes                                                          |
 | ------------------ | ------------------- | -------------------------------------------------------------- |
-| **NVIDIA GPUs**    | TensorRT            | Maximum inference speed                                        |
+| **NVIDIA GPUs**    | TensorRT            | Select the same GPU family as the deployment device            |
+| **NVIDIA Jetson**  | TensorRT            | Select the exact Jetson target from the table below            |
 | **Intel Hardware** | OpenVINO            | CPUs, GPUs, and VPUs                                           |
 | **Apple Devices**  | CoreML or LiteRT    | iOS, macOS, Apple Silicon                                      |
 | **Android**        | LiteRT or NCNN      | LiteRT (Google's on-device runtime) or NCNN for ARM            |
@@ -226,6 +227,23 @@ The Platform supports export to [19+ deployment formats](../../modes/export.md#e
 | **General**        | ONNX                | Works with most runtimes                                       |
 
 ![Ultralytics Platform Model Export Progress](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-model-export-progress.avif)
+
+### NVIDIA Jetson TensorRT Targets
+
+Ultralytics Platform can build TensorRT `.engine` files directly for the following Jetson targets. As of July 2026, the Jetson export workers use JetPack 7.2 / L4T r39.2, Python 3.12.3, NVIDIA PyTorch 2.12.0a0 (26.04 build), CUDA 13.2, and TensorRT 10.16.1.11 inside the export container.
+
+| Target device              | API `gpuType`          | Memory | GPU architecture   | Python | CUDA | TensorRT   | Measured YOLO26n FP16 export |
+| -------------------------- | ---------------------- | -----: | ------------------ | ------ | ---- | ---------- | ---------------------------: |
+| Jetson Thor T5000          | `jetson-thor-t5000`    | 128 GB | Blackwell, CC 11.0 | 3.12.3 | 13.2 | 10.16.1.11 |                      ~1m 46s |
+| Jetson Thor T4000          | `jetson-thor-t4000`    |  64 GB | Blackwell, CC 11.0 | 3.12.3 | 13.2 | 10.16.1.11 |                      ~1m 46s |
+| Jetson AGX Orin 64GB       | `jetson-agx-orin-64gb` |  64 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       7m 15s |
+| Jetson AGX Orin 32GB       | `jetson-agx-orin-32gb` |  32 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       5m 34s |
+| Jetson Orin NX 16GB        | `jetson-orin-nx-16gb`  |  16 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       5m 09s |
+| Jetson Orin NX 8GB         | `jetson-orin-nx-8gb`   |   8 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       5m 01s |
+| Jetson Orin Nano 8GB Super | `jetson-orin-nano-8gb` |   8 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       4m 59s |
+| Jetson Orin Nano 4GB       | `jetson-orin-nano-4gb` |   4 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       5m 01s |
+
+The timings are single observed end-to-end production exports from July 2026, rounded to the nearest second; they are reference measurements, not an SLA. Both Thor targets are built on a T5000 Developer Kit in NVIDIA's T4000 compatibility profile. The six Orin routes are built on an AGX Orin 64GB, where every resulting engine was loaded and run. Because TensorRT engines are tied to the build GPU and software stack, validate an engine on its intended device before deployment. In particular, test memory fit on smaller Orin SKUs and perform INT8 calibration on the target device for best results. See the [NVIDIA Jetson guide](../../guides/nvidia-jetson.md) and [TensorRT integration guide](../../integrations/tensorrt.md) for local deployment details.
 
 ### RKNN Chip Support
 
@@ -260,7 +278,7 @@ Export jobs progress through the following statuses:
 
 !!! tip "Export Time"
 
-    Export time varies by format. TensorRT exports may take several minutes due to engine optimization. GPU-required formats (TensorRT) run on Ultralytics Cloud GPUs — the default export GPU is RTX 4090.
+    Export time varies by format and target. TensorRT exports run on the selected NVIDIA GPU or Jetson target and may take several minutes because TensorRT profiles and tunes the engine for that hardware.
 
 ### Bulk Export Actions
 

--- a/docs/en/platform/train/models.md
+++ b/docs/en/platform/train/models.md
@@ -218,7 +218,7 @@ The Platform supports export to [19+ deployment formats](../../modes/export.md#e
 | Target             | Recommended Format  | Notes                                                          |
 | ------------------ | ------------------- | -------------------------------------------------------------- |
 | **NVIDIA GPUs**    | TensorRT            | Select the same GPU family as the deployment device            |
-| **NVIDIA Jetson**  | TensorRT            | Select the exact Jetson target from the table below            |
+| **NVIDIA Jetson**  | TensorRT            | Select the intended target and check its validation status      |
 | **Intel Hardware** | OpenVINO            | CPUs, GPUs, and VPUs                                           |
 | **Apple Devices**  | CoreML or LiteRT    | iOS, macOS, Apple Silicon                                      |
 | **Android**        | LiteRT or NCNN      | LiteRT (Google's on-device runtime) or NCNN for ARM            |
@@ -230,20 +230,20 @@ The Platform supports export to [19+ deployment formats](../../modes/export.md#e
 
 ### NVIDIA Jetson TensorRT Targets
 
-Ultralytics Platform can build TensorRT `.engine` files directly for the following Jetson targets. As of July 2026, the Jetson export workers use JetPack 7.2 / L4T r39.2, Python 3.12.3, NVIDIA PyTorch 2.12.0a0 (26.04 build), CUDA 13.2, and TensorRT 10.16.1.11 inside the export container.
+Ultralytics Platform offers the following Jetson target selections for TensorRT `.engine` exports. As of July 2026, the Jetson export workers use JetPack 7.2 / L4T r39.2, Python 3.12.3, NVIDIA PyTorch 2.12.0a0 (26.04 build), CUDA 13.2, and TensorRT 10.16.1.11 inside the export container.
 
-| Target device              | API `gpuType`          | Memory | GPU architecture   | Python | CUDA | TensorRT   | Measured YOLO26n FP16 export |
-| -------------------------- | ---------------------- | -----: | ------------------ | ------ | ---- | ---------- | ---------------------------: |
-| Jetson Thor T5000          | `jetson-thor-t5000`    | 128 GB | Blackwell, CC 11.0 | 3.12.3 | 13.2 | 10.16.1.11 |                      ~1m 46s |
-| Jetson Thor T4000          | `jetson-thor-t4000`    |  64 GB | Blackwell, CC 11.0 | 3.12.3 | 13.2 | 10.16.1.11 |                      ~1m 46s |
-| Jetson AGX Orin 64GB       | `jetson-agx-orin-64gb` |  64 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       7m 15s |
-| Jetson AGX Orin 32GB       | `jetson-agx-orin-32gb` |  32 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       5m 34s |
-| Jetson Orin NX 16GB        | `jetson-orin-nx-16gb`  |  16 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       5m 09s |
-| Jetson Orin NX 8GB         | `jetson-orin-nx-8gb`   |   8 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       5m 01s |
-| Jetson Orin Nano 8GB Super | `jetson-orin-nano-8gb` |   8 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       4m 59s |
-| Jetson Orin Nano 4GB       | `jetson-orin-nano-4gb` |   4 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       5m 01s |
+| Target selection           | API `gpuType`          | Memory | GPU architecture   | Python | CUDA | TensorRT   | Measured YOLO26n FP16 export | Physical build/load validation              |
+| -------------------------- | ---------------------- | -----: | ------------------ | ------ | ---- | ---------- | ---------------------------: | ------------------------------------------- |
+| Jetson Thor T5000          | `jetson-thor-t5000`    | 128 GB | Blackwell, CC 11.0 | 3.12.3 | 13.2 | 10.16.1.11 |                      ~1m 46s | Thor in NVIDIA T4000 profile; T5000 candidate |
+| Jetson Thor T4000          | `jetson-thor-t4000`    |  64 GB | Blackwell, CC 11.0 | 3.12.3 | 13.2 | 10.16.1.11 |                      ~1m 46s | Thor in NVIDIA T4000 profile                |
+| Jetson AGX Orin 64GB       | `jetson-agx-orin-64gb` |  64 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       7m 15s | Built, loaded, and inferred on AGX Orin 64GB |
+| Jetson AGX Orin 32GB       | `jetson-agx-orin-32gb` |  32 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       5m 34s | AGX Orin 64GB build/load; 32GB SKU pending  |
+| Jetson Orin NX 16GB        | `jetson-orin-nx-16gb`  |  16 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       5m 09s | AGX Orin 64GB build/load; NX SKU pending    |
+| Jetson Orin NX 8GB         | `jetson-orin-nx-8gb`   |   8 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       5m 01s | AGX Orin 64GB build/load; NX SKU pending    |
+| Jetson Orin Nano 8GB Super | `jetson-orin-nano-8gb` |   8 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       4m 59s | AGX Orin 64GB build/load; Nano SKU pending  |
+| Jetson Orin Nano 4GB       | `jetson-orin-nano-4gb` |   4 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       5m 01s | AGX Orin 64GB build/load; Nano SKU pending  |
 
-The timings are single observed end-to-end production exports from July 2026, rounded to the nearest second; they are reference measurements, not an SLA. Both Thor targets are built on a T5000 Developer Kit in NVIDIA's T4000 compatibility profile. The six Orin routes are built on an AGX Orin 64GB, where every resulting engine was loaded and run. Because TensorRT engines are tied to the build GPU and software stack, validate an engine on its intended device before deployment. In particular, test memory fit on smaller Orin SKUs and perform INT8 calibration on the target device for best results. See the [NVIDIA Jetson guide](../../guides/nvidia-jetson.md) and [TensorRT integration guide](../../integrations/tensorrt.md) for local deployment details.
+The timings are single observed end-to-end production routing tests from July 2026, rounded to the nearest second; they are reference measurements, not an SLA or per-SKU performance benchmark. Both Thor selections are built on a T5000 Developer Kit in NVIDIA's T4000 compatibility profile. The six Orin routes are built on an AGX Orin 64GB, where every resulting engine was loaded and run. Because TensorRT engines are tied to the build GPU and software stack, the smaller-Orin artifacts are candidates until they load and infer on their listed SKUs. Test memory fit on smaller Orin SKUs and perform INT8 calibration on the target device for best results. See the [NVIDIA Jetson guide](../../guides/nvidia-jetson.md) and [TensorRT integration guide](../../integrations/tensorrt.md) for local deployment details.
 
 ### RKNN Chip Support
 


### PR DESCRIPTION
## Summary

- add a canonical Platform table for all eight live Jetson TensorRT export targets
- document target IDs, memory, GPU architecture/compute capability, Python/CUDA/TensorRT versions, and measured YOLO26n FP16 export times
- link the Jetson and TensorRT guides to browser-based device-targeted exports and clarify engine portability
- update the JetPack matrix and JetPack 7 instructions for NVIDIA's current 7.2 Orin support

Deleted: stale JetPack 7.0/Orin-unsupported guidance and the outdated statement that TensorRT Platform exports run only on a default RTX 4090.

## Validation

- `git diff --check`
- `codespell docs/en/guides/nvidia-jetson.md docs/en/integrations/tensorrt.md docs/en/platform/api/index.md docs/en/platform/train/models.md`
- verified all target IDs against the live Platform GPU registry
- verified Python/CUDA/TensorRT from the live Jetson worker and the shared pinned worker image
- kept docs prose unwrapped

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Updated NVIDIA Jetson and TensorRT documentation for JetPack 7.2, hardware-specific engines, and Ultralytics Platform Jetson export targets.

### 📊 Key Changes

- Updated Jetson testing details and native installation instructions to use **JetPack 7.2** for supported Thor and Orin devices.
- Clarified JetPack 7.2 flashing workflows, including the unified ISO process and the removal of downloadable SD-card images for Orin Nano.
- Expanded JetPack compatibility tables to include AGX Orin, Orin NX, and Orin Nano support with JetPack 7.
- Documented the current scope of the public JetPack 7 Docker image, which is limited to the JetPack 7.0 Thor/DGX Spark path.
- Added warnings that TensorRT `.engine` files are hardware- and runtime-specific and should be built or validated on the deployment device.
- Added eight NVIDIA Jetson TensorRT export targets to the [Ultralytics Platform](https://platform.ultralytics.com), including Thor, AGX Orin, Orin NX, and Orin Nano variants.
- Documented each Jetson target’s GPU architecture, software stack, export timing, and physical validation status.
- Updated the Platform export API documentation so `gpuType` supports Jetson targets as well as standard GPUs.

### 🎯 Purpose & Impact

- ✅ Helps users install and run Ultralytics models more reliably on current NVIDIA Jetson hardware.
- ⚡ Enables browser-based TensorRT exports through the Ultralytics Platform without requiring a local build environment.
- 🛡️ Reduces deployment failures by clearly explaining that TensorRT engines are not universally portable across Jetson SKUs or software stacks.
- 🔍 Gives users visibility into which Jetson targets have been physically validated and which exports still require on-device testing.
- 📈 Encourages target-device validation and calibration, especially for INT8 deployments and lower-memory Orin models.