### PR TITLE
Keep `max-autotune` reproducible by disabling CUDA graph trees

### DIFF
--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -1069,17 +1069,18 @@ def attempt_compile(
         from torch import _dynamo, _inductor  # load lazy submodules (lazy in torch 2.0)
 
         _dynamo.reset()  # clear stale compilation cache so the options below actually take effect
-        if hasattr(_inductor, "list_mode_options"):  # torch>=2.1
+        if mode.startswith("max-autotune") and hasattr(_inductor, "list_mode_options"):  # torch>=2.1
             # max-autotune defaults enable CUDA graph trees and coordinate descent tuning, which give
             # nondeterministic results (see cudagraph skip warnings) and slow compiles. Keep the mode's
-            # other options but force these off so max-autotune stays reproducible.
+            # other options but force these off so max-autotune stays reproducible. Other modes are left
+            # untouched, e.g. reduce-overhead keeps its CUDA graphs.
             options = {
                 **_inductor.list_mode_options(mode),
                 "coordinate_descent_tuning": False,
                 "triton.cudagraph_trees": False,
             }
             model = torch.compile(model, backend="inductor", options=options)
-        else:  # torch 2.0 has no list_mode_options, fall back to plain mode
+        else:
             model = torch.compile(model, mode=mode, backend="inductor")
     except Exception as e:
         LOGGER.warning(f"{prefix} torch.compile failed, continuing uncompiled: {e}")

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -1066,9 +1066,8 @@ def attempt_compile(
     LOGGER.info(f"{prefix} starting torch.compile with '{mode}' mode...")
     t0 = time.perf_counter()
     try:
-        from torch import _dynamo, _inductor  # load lazy submodules (lazy in torch 2.0)
+        from torch import _inductor  # lazy submodule, force import before access on torch 2.0
 
-        _dynamo.reset()  # clear stale compilation cache so the options below actually take effect
         if mode.startswith("max-autotune") and hasattr(_inductor, "list_mode_options"):  # torch>=2.1
             # max-autotune defaults enable CUDA graph trees and coordinate descent tuning, which give
             # nondeterministic results (see cudagraph skip warnings) and slow compiles. Keep the mode's

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -1066,7 +1066,21 @@ def attempt_compile(
     LOGGER.info(f"{prefix} starting torch.compile with '{mode}' mode...")
     t0 = time.perf_counter()
     try:
-        model = torch.compile(model, mode=mode, backend="inductor")
+        from torch import _dynamo, _inductor  # load lazy submodules (lazy in torch 2.0)
+
+        _dynamo.reset()  # clear stale compilation cache so the options below actually take effect
+        if hasattr(_inductor, "list_mode_options"):  # torch>=2.1
+            # max-autotune defaults enable CUDA graph trees and coordinate descent tuning, which give
+            # nondeterministic results (see cudagraph skip warnings) and slow compiles. Keep the mode's
+            # other options but force these off so max-autotune stays reproducible.
+            options = {
+                **_inductor.list_mode_options(mode),
+                "coordinate_descent_tuning": False,
+                "triton.cudagraph_trees": False,
+            }
+            model = torch.compile(model, backend="inductor", options=options)
+        else:  # torch 2.0 has no list_mode_options, fall back to plain mode
+            model = torch.compile(model, mode=mode, backend="inductor")
     except Exception as e:
         LOGGER.warning(f"{prefix} torch.compile failed, continuing uncompiled: {e}")
         return model


### PR DESCRIPTION
Follow-up to #25229. That PR restored `max-autotune`, but the merge dropped the lines that keep it reproducible. This PR adds them back and makes the reason explicit in the code.

On current `main`, `max-autotune` runs with the default inductor options. Those defaults turn on `triton.cudagraph_trees` and `coordinate_descent_tuning`. CUDA graph trees give nondeterministic results and print cudagraph skip warnings during training, as shown in the #25229 benchmark logs. Coordinate descent tuning also makes compile slower.

Change:

`coordinate_descent_tuning` and `triton.cudagraph_trees` to `False`, so `max-autotune` stays reproducible.

The `torch>=2.1` check is because `list_mode_options` does not exist on torch 2.0. On 2.0 it falls back to plain `mode=mode`.

Tested on coco128 with `compile=max-autotune` on an RTX PRO 6000. It compiles and trains, with no cudagraph skip warnings.

`Deleted: nothing`. This re-adds reproducibility behavior that the #25229 merge removed. It is a net add because those overrides no longer exist on `main`, so there is nothing to relocate or delete in their place.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves `torch.compile` reliability by making `max-autotune` compilation more reproducible and efficient.

### 📊 Key Changes

- Detects PyTorch versions that support Inductor mode options.
- Disables coordinate descent tuning and CUDA graph trees for `max-autotune`.
- Preserves all other options associated with the selected compilation mode.
- Leaves other modes, such as `reduce-overhead`, unchanged.
- Retains graceful fallback to the uncompiled model if compilation fails.

### 🎯 Purpose & Impact

- 🎯 Produces more deterministic results when using `max-autotune`.
- ⚡ Reduces compilation overhead caused by CUDA graph and tuning behavior.
- 🛠️ Improves compatibility across supported PyTorch versions through lazy Inductor imports.
- ✅ Keeps existing behavior for other compilation modes while making optimized compilation more predictable.