### PR TITLE
Support legacy checkpoints in Hailo export

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.97"
+__version__ = "8.4.98"
 
 import importlib
 import os

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -578,7 +578,10 @@ class Exporter:
             self.args.data = TASK2CALIBRATIONDATA.get(model.task)
         if fmt == "hailo":
             assert LINUX and not ARM64, "Hailo export is only supported on Linux x86_64."
-            family = Path(getattr(model, "yaml_file", None) or model.yaml.get("yaml_file", "")).stem.lower()
+            blocks = {str(x[2]) for x in model.yaml.get("backbone", []) + model.yaml.get("head", [])}
+            family = Path(getattr(model, "yaml_file", None) or model.yaml.get("yaml_file", "")).stem.lower() or (
+                "yolov8" if "C2f" in blocks else "yolo11" if {"C3k2", "C2PSA"} <= blocks else ""
+            )
             if (
                 model.task != "detect"
                 or type(model.model[-1]) is not Detect


### PR DESCRIPTION
## Summary
- derive the Hailo model family from its topology when legacy trained checkpoints omit `yaml_file`
- retain the existing detection head and supported-family validation
- bump the package patch version to 8.4.98

Deleted: nothing — the existing Hailo validation block is the correct owner, and its optional-metadata assumption required a topology fallback rather than relocation.

## Validation
- actual metadata-stripped YOLOv8, YOLO11, and YOLO26 checkpoints accepted
- YOLOv5, YOLOv10, and YOLO12 checkpoints rejected
- `uvx ruff check ultralytics/__init__.py ultralytics/engine/exporter.py`
- `uvx ruff format --check ultralytics/__init__.py ultralytics/engine/exporter.py`
- `python -m compileall -q ultralytics/engine/exporter.py`
- `git diff --check`

## Core Principles review
- Nothing can be deleted instead: family validation remains necessary to prevent unsupported architectures from reaching DFC.
- No condition suppresses a symptom: family identification is repaired at the existing validation owner.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves Hailo export compatibility by reliably identifying YOLO model families when YAML metadata is unavailable, and updates the package to version 8.4.98. 🚀

### 📊 Key Changes

- Updated the Ultralytics package version from `8.4.97` to `8.4.98`.
- Enhanced Hailo export logic to infer the model family from backbone and head blocks when no YAML filename is available.
- Added fallback detection for:
  - YOLOv8 models using `C2f` blocks.
  - YOLO11 models using both `C3k2` and `C2PSA` blocks.
- Preserved the existing Linux x86_64 restriction for Hailo exports.

### 🎯 Purpose & Impact

- Makes Hailo exports more robust for models created or loaded without complete YAML metadata. ✅
- Reduces export failures caused by missing or unavailable model configuration filenames.
- Improves compatibility for YOLOv8 and YOLO11 models targeting Hailo hardware.
- No expected impact on unrelated training, inference, or export formats.