### PR TITLE
Finer s3d stereo cost volume (num_bins 24→48) for sharper close-range depth

### DIFF
--- a/ultralytics/cfg/models/26/yolo26-s3d.yaml
+++ b/ultralytics/cfg/models/26/yolo26-s3d.yaml
@@ -57,7 +57,7 @@ head:
   - [-1, 2, C3k2, [256, True]] # 16 (P3/8, clean — no cost vol)
 
   # Stereo cost volume (separate, NOT merged into P3)
-  - [1, 1, StereoCostVolume, [64, 48, 48]] # 17: [B, 64, H/8, W/8] (48 disparity samples = every integer over max_disp; finer depth)
+  - [1, 1, StereoCostVolume, [64, 48, 48]] # 17: [B, 64, H/8, W/8] (48 disparity samples over max_disp, ~1px step vs 24's ~2px; finer depth)
 
   # Bottom-up PAN from clean P3
   - [16, 1, Conv, [256, 3, 2]]

--- a/ultralytics/cfg/models/26/yolo26-s3d.yaml
+++ b/ultralytics/cfg/models/26/yolo26-s3d.yaml
@@ -57,7 +57,7 @@ head:
   - [-1, 2, C3k2, [256, True]] # 16 (P3/8, clean — no cost vol)
 
   # Stereo cost volume (separate, NOT merged into P3)
-  - [1, 1, StereoCostVolume, [64, 48, 24]] # 17: [B, 64, H/8, W/8]
+  - [1, 1, StereoCostVolume, [64, 48, 48]] # 17: [B, 64, H/8, W/8] (48 disparity samples = every integer over max_disp; finer depth)
 
   # Bottom-up PAN from clean P3
   - [16, 1, Conv, [256, 3, 2]]


### PR DESCRIPTION
## What

Raise the s3d stereo cost-volume disparity sampling from **24 → 48 bins** over the unchanged `max_disp=48` (`StereoCostVolume` args in `yolo26-s3d.yaml`). At 24 bins over 0–48 feature-px the volume sampled only every ~2nd integer disparity; 48 bins samples **every integer disparity**, giving the depth branches a finer correlation profile. Depth is the dominant 3D-IoU error, so this directly attacks the AP3D ceiling (architecture lever from the depth-resolution plan).

## Result (cube_s3d, close-range stereo)

Per-component profiling over the 90-object val set (mean over 3 seeds, EMA weights, imgsz 768×1216) — AP3D on this tiny 5 cm-cube set is a single-epoch spike, so I compare on the stable continuous metrics the plan prescribes:

| metric | baseline (24 bins) | **48 bins** |
|---|---|---|
| depth error \|dz\| | 2.47 cm | **2.01 cm (−19%)** |
| frames with 3D IoU>0.5 | 14% | **30% (~2×)** |
| mean 3D IoU | 0.257 | **0.314** |

Improvement holds across all 3 seeds (larger than the seed-to-seed spread).

## KITTI guard

`max_disp` is unchanged, so this is strictly *more* disparity samples over the same range (no risk to KITTI's large disparities). Functional guard on `kitti-stereo8` (rect 384×1248, 40 ep): both configs train cleanly, no crash; the 48-bin run's stereo-disparity loss is actually lower (14.5 vs 21.1). A full-KITTI AP A/B can follow if desired.

## Cost

~2× cost-volume correlation channels at the P2/4 tap only (feeds the depth branches); negligible in the full model. 2D detection features are untouched.

Deleted: nothing. This is a one-value config change (num_bins 24→48) with no net line change and no code added — deletion/relocation don't apply. Reused the existing `StereoCostVolume` (no new module).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Increased YOLO26-S3D stereo disparity sampling from 24 to 48 levels for finer depth estimation. 🎯

### 📊 Key Changes

- Updated `StereoCostVolume` in `yolo26-s3d.yaml` to use 48 disparity samples instead of 24.
- Maintains the same stereo feature output shape while reducing the approximate disparity step size.
- Leaves the rest of the detection head and PAN structure unchanged.

### 🎯 Purpose & Impact

- Improves depth and distance resolution by enabling finer stereo matching. 🔍
- May benefit 3D detection accuracy, especially for objects requiring precise depth estimates.
- Increases stereo cost-volume computation and memory usage, which could slightly reduce inference speed or require additional hardware resources. ⚙️