### PR TITLE
Reduce semantic segmentation target memory in v8SegmentationLoss

### DIFF
--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -527,19 +527,19 @@ class v8SegmentationLoss(v8DetectionLoss):
                 imgsz,
             )
             if pred_semantic is not None:
-                sem_masks = batch["sem_masks"].to(self.device)  # NxHxW
-                sem_masks = F.one_hot(sem_masks.long(), num_classes=self.nc).permute(0, 3, 1, 2).float()  # NxCxHxW
-
+                sem_idx = batch["sem_masks"].to(self.device).long().unsqueeze(1)  # Nx1xHxW
                 if self.overlap:
-                    mask_zero = masks == 0  # NxHxW
-                    sem_masks[mask_zero.unsqueeze(1).expand_as(sem_masks)] = 0
+                    present = masks != 0  # NxHxW
                 else:
                     batch_idx = batch["batch_idx"].view(-1)  # [total_instances]
+                    present = torch.ones(batch_size, *masks.shape[-2:], dtype=torch.bool, device=self.device)
                     for i in range(batch_size):
                         instance_mask_i = masks[batch_idx == i]  # [num_instances_i, H, W]
-                        if len(instance_mask_i) == 0:
-                            continue
-                        sem_masks[i, :, instance_mask_i.sum(dim=0) == 0] = 0
+                        if len(instance_mask_i):
+                            present[i] = instance_mask_i.sum(dim=0) != 0
+                # One-hot targets zeroed at uncovered pixels, without F.one_hot's int64 NxHxWxC intermediate
+                sem_masks = torch.zeros(sem_idx.shape[0], self.nc, *sem_idx.shape[2:], device=self.device)
+                sem_masks.scatter_(1, sem_idx, present.unsqueeze(1).float())  # NxCxHxW
 
                 loss[4] = self.bcedice_loss(pred_semantic, sem_masks)
                 loss[4] *= self.hyp.box  # seg gain


### PR DESCRIPTION
The semantic loss branch in v8SegmentationLoss built its target in a wasteful way. `F.one_hot` created an int64 NxHxWxC tensor, then `.float()` copied it, and the background zeroing used boolean index assignment which materializes large int64 index tensors through `nonzero()`.

The target is now built directly with one float allocation and a single `scatter_` that writes the pixel presence value into the class channel. The non overlap branch computes the same presence map per image, and images with no instances keep a full one-hot target exactly like the old `continue` did.

Measured on one GPU with yolo26n-seg, coco.yaml, bs=16, imgsz=640:

| Metric | Before | After |
| --- | --- | --- |
| Semantic target build, transient peak | 525 MB | 136 MB |
| Semantic target build, time | 0.7 ms | 0.1 ms |
| Training peak after 100 batches | 4.54 GB | 4.41 GB |
| Steady training time per batch | 103.6 ms | 105.4 ms (within run noise) |

Outputs are bit exact. The one-hot microbenchmark result is exactly equal, and 100 batches of real COCO training give identical loss values to every digit for both `overlap_mask=True` and `overlap_mask=False`.

I also profiled the remaining segmentation loss memory with the CUDA allocator history. The instance mask loss retains about 440 MB of per-image BCE tensors until backward. Gradient checkpointing removes that but costs 10 to 15 percent training speed in both per-image and whole-loss variants, so I did not include it.

Deleted: the `F.one_hot` plus `permute` plus `.float()` chain, the `mask_zero.unsqueeze(1).expand_as` boolean index assignment, and the `sem_masks[i, :, ...] = 0` boolean index assignment in the non overlap loop.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Optimizes semantic segmentation target generation by reducing memory usage and improving efficiency.

### 📊 Key Changes

- Replaces `F.one_hot` with an in-place `scatter_` operation to create semantic mask targets.
- Avoids the large intermediate `int64` tensor previously produced during one-hot encoding.
- Simplifies handling of uncovered pixels for both overlapping and non-overlapping instance masks.
- Preserves the existing BCE-Dice loss calculation and segmentation weighting.

### 🎯 Purpose & Impact

- ⚡ Reduces memory consumption during semantic segmentation training, especially for large images or many classes.
- 🧠 Improves target preparation efficiency without changing the intended loss behavior.
- ✅ Maintains correct masking of pixels not covered by instances.
- 📈 May enable more stable training with larger batches or higher-resolution inputs.