### PR TITLE
Fix Hailo post-export guidance

### DIFF
--- a/docs/en/integrations/hailo.md
+++ b/docs/en/integrations/hailo.md
@@ -163,7 +163,7 @@ When `data` is omitted, Ultralytics uses COCO128 as a convenient lightweight cal
 model.export(format="hailo", name="hailo8l", data="my_dataset.yaml")
 ```
 
-`fraction` selects the portion of the dataset used for calibration. More representative data can improve quantized accuracy but increases optimization time. If the INT8 HEF loses accuracy relative to the original PyTorch model, first improve the calibration data before changing model or runtime settings.
+`fraction` selects the portion of the dataset used for calibration. More images help only when they represent the deployment domain; out-of-domain images can reduce quantized accuracy and increase optimization time. If the INT8 HEF loses accuracy relative to the original PyTorch model, first improve the calibration data before changing model or runtime settings.
 
 ## Exported Artifacts
 
@@ -184,6 +184,10 @@ The intermediate ONNX graph is removed after compilation.
 
 ## Run Inference on Hailo Hardware
 
+!!! note "Inference support"
+
+    Ultralytics exports Hailo HEF files but does not currently run `predict` or `val` on them. Use HailoRT, TAPPAS, GStreamer, or the Raspberry Pi Hailo helper for inference.
+
 Install HailoRT on the target device. Raspberry Pi AI Kit and AI HAT+ users can follow the [Raspberry Pi AI software guide](https://www.raspberrypi.com/documentation/computers/ai.html):
 
 ```bash
@@ -193,7 +197,7 @@ hailortcli fw-control identify
 
 Copy the complete export directory to the device so `metadata.yaml` remains next to the HEF. Load the `*.hef` with HailoRT, TAPPAS, or the Raspberry Pi `picamera2.devices.Hailo` helper.
 
-YOLOv8 and YOLO11 exports include HailoRT NMS and return detections grouped by class. YOLO26 exports expose the six NMS-free detection-head tensors; use a runtime pipeline that supports YOLO26 post-processing.
+YOLOv8 and YOLO11 exports include HailoRT NMS and return detections grouped by class. YOLO26 exports expose six NMS-free one-to-one tensors ordered by branch: three regression tensors followed by three classification tensors. The classification outputs are logits, so apply sigmoid before decoding them with a YOLO26 end-to-end post-processing pipeline.
 
 For a GStreamer deployment, pass the HEF to `hailonet`:
 

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.99"
+__version__ = "8.4.98"
 
 import importlib
 import os

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.98"
+__version__ = "8.4.99"
 
 import importlib
 import os

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -58,7 +58,6 @@ Inference:
                          yolo26n_deepx_model        # DEEPX
                          yolo26n_qnn.onnx           # Qualcomm QNN
                          yolo26n.tflite             # LiteRT
-                         yolo26n_hailo_model        # Hailo HEF
 """
 
 from __future__ import annotations
@@ -80,7 +79,7 @@ from ultralytics.cfg import QUANTIZE_DOCS_URL, TASK2CALIBRATIONDATA, TASK2DATA, 
 from ultralytics.data import build_dataloader, build_yolo_dataset
 from ultralytics.data.dataset import ClassificationDataset
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
-from ultralytics.nn.autobackend import check_class_names, default_class_names
+from ultralytics.nn.autobackend import AutoBackend, check_class_names, default_class_names
 from ultralytics.nn.modules import C2f, Classify, Detect, RTDETRDecoder, Segment26, SemanticSegment
 from ultralytics.nn.tasks import ClassificationModel, DetectionModel, SegmentationModel, WorldModel
 from ultralytics.utils import (
@@ -876,11 +875,16 @@ class Exporter:
             )
             imgsz = self.imgsz[0] if square else str(self.imgsz)[1:-1].replace(" ", "")
             q = "quantize=16" if self.args.quantize == 16 else ""  # FP16 inference flag for the val/predict hint
+            inference_commands = (
+                f"\nPredict:         yolo predict task={model.task} model={f} imgsz={imgsz} {q}"
+                f"\nValidate:        yolo val task={model.task} model={f} imgsz={imgsz} data={data} {q} {s}"
+                if fmt in AutoBackend._BACKEND_MAP
+                else ""
+            )
             LOGGER.info(
                 f"\nExport complete ({time.time() - t:.1f}s)"
                 f"\nResults saved to {colorstr('bold', Path(f).resolve())}"
-                f"\nPredict:         yolo predict task={model.task} model={f} imgsz={imgsz} {q}"
-                f"\nValidate:        yolo val task={model.task} model={f} imgsz={imgsz} data={data} {q} {s}"
+                f"{inference_commands}"
                 f"\nVisualize:       https://netron.app"
             )
 


### PR DESCRIPTION
## Summary
- show prediction and validation commands only when the exported format has an AutoBackend inference implementation
- document the Hailo runtime boundary and YOLO26 tensor ordering, logits, and calibration sensitivity reported from Hailo-8L validation

## Validation
- verified Hailo is the only exported format absent from the AutoBackend registry
- `ruff check ultralytics/engine/exporter.py`
- `ruff format --check ultralytics/engine/exporter.py`
- `python -m compileall -q ultralytics/engine/exporter.py`
- `git diff --check`

Deleted: the false Hailo inference example and the unconditional post-export prediction/validation commands. The docs additions are required because Ultralytics currently exports HEFs but does not own their inference runtime.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves Hailo export documentation and prevents unsupported prediction and validation commands from being displayed for non-Ultralytics backends. 🛠️

### 📊 Key Changes
- Clarifies that representative, in-domain calibration data is more important than simply using more images for Hailo INT8 quantization.
- Documents that Ultralytics currently exports Hailo HEF files but does not support running `predict` or `val` directly on them.
- Expands YOLO26 Hailo guidance:
  - Outputs six NMS-free, one-to-one tensors.
  - Lists the tensor order as three regression outputs followed by three classification outputs.
  - Notes that classification logits require sigmoid processing in the deployment pipeline.
- Updates the exporter to show `Predict` and `Validate` commands only when the exported format is supported by `AutoBackend`.

### 🎯 Purpose & Impact
- Reduces confusion by avoiding unusable inference commands for formats such as Hailo HEF. ✅
- Helps users achieve better Hailo quantized accuracy by selecting calibration data that matches their deployment environment.
- Makes YOLO26 Hailo integration easier by documenting the required output ordering and post-processing steps.
- Preserves inference command guidance for supported export formats while providing cleaner and more accurate export logs.