### PR TITLE
Add Hailo inference backend

### DIFF
--- a/docs/en/integrations/hailo.md
+++ b/docs/en/integrations/hailo.md
@@ -184,10 +184,6 @@ The intermediate ONNX graph is removed after compilation.
 
 ## Run Inference on Hailo Hardware
 
-!!! note "Inference support"
-
-    Ultralytics exports Hailo HEF files but does not currently run `predict` or `val` on them. Use HailoRT, TAPPAS, GStreamer, or the Raspberry Pi Hailo helper for inference.
-
 Install HailoRT on the target device. Raspberry Pi AI Kit and AI HAT+ users can follow the [Raspberry Pi AI software guide](https://www.raspberrypi.com/documentation/computers/ai.html):
 
 ```bash
@@ -195,9 +191,16 @@ sudo apt install hailo-all
 hailortcli fw-control identify
 ```
 
-Copy the complete export directory to the device so `metadata.yaml` remains next to the HEF. Load the `*.hef` with HailoRT, TAPPAS, or the Raspberry Pi `picamera2.devices.Hailo` helper.
+Copy the complete export directory to the device so `metadata.yaml` remains next to the HEF. Ultralytics uses HailoRT to run `predict` and `val` directly on the exported directory:
 
-YOLOv8 and YOLO11 exports include HailoRT NMS and return detections grouped by class. YOLO26 exports expose six NMS-free one-to-one tensors ordered by branch: three regression tensors followed by three classification tensors. The classification outputs are logits, so apply sigmoid before decoding them with a YOLO26 end-to-end post-processing pipeline.
+```python
+from ultralytics import YOLO
+
+model = YOLO("yolo11n_hailo_model")
+results = model.predict("path/to/image.jpg")
+```
+
+The backend converts YOLOv8 and YOLO11 HailoRT NMS output and decodes YOLO26 one-to-one outputs automatically. TAPPAS, GStreamer, and the Raspberry Pi `picamera2.devices.Hailo` helper remain available for application-specific pipelines.
 
 For a GStreamer deployment, pass the HEF to `hailonet`:
 
@@ -300,7 +303,7 @@ Confirm that `name` matched the physical Hailo architecture and that the device 
 
 ### Output Parsing Looks Incorrect
 
-YOLOv8 and YOLO11 HEFs include HailoRT NMS and return detections grouped by class. YOLO26 exports raw one-to-one detection-head outputs for an NMS-free runtime path. Use post-processing that matches the exported model family.
+Keep `metadata.yaml` beside the HEF so Ultralytics can select the matching YOLOv8, YOLO11, or YOLO26 post-processing path. Custom HailoRT applications must likewise match post-processing to the exported model family.
 
 ## FAQ
 

--- a/docs/en/reference/nn/backends/hailo.md
+++ b/docs/en/reference/nn/backends/hailo.md
@@ -1,0 +1,17 @@
+---
+title: nn.backends.hailo API Reference
+description: Reference for `ultralytics.nn.backends.hailo` in the Ultralytics package.
+keywords: Ultralytics, ultralytics.nn.backends.hailo, API reference, YOLO, Python
+---
+
+# Reference for `ultralytics/nn/backends/hailo.py`
+
+!!! success "Improvements"
+
+    This page is sourced from [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/backends/hailo.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/backends/hailo.py). Have an improvement or example to add? Open a [Pull Request](https://docs.ultralytics.com/help/contributing) — thank you! 🙏
+
+<br>
+
+## ::: ultralytics.nn.backends.hailo.HailoBackend
+
+<br><br>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -794,6 +794,7 @@ nav:
               - coreml: reference/nn/backends/coreml.md
               - deepx: reference/nn/backends/deepx.md
               - executorch: reference/nn/backends/executorch.md
+              - hailo: reference/nn/backends/hailo.md
               - litert: reference/nn/backends/litert.md
               - mnn: reference/nn/backends/mnn.md
               - ncnn: reference/nn/backends/ncnn.md

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.98"
+__version__ = "8.4.99"
 
 import importlib
 import os

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -17,6 +17,7 @@ from .backends import (
     CoreMLBackend,
     DeepXBackend,
     ExecuTorchBackend,
+    HailoBackend,
     LiteRTBackend,
     MNNBackend,
     NCNNBackend,
@@ -115,6 +116,7 @@ class AutoBackend(nn.Module):
             | DEEPX                 | *_deepx_model/    |
             | Qualcomm QNN          | *_qnn.onnx        |
             | LiteRT                | *.tflite          |
+            | Hailo                 | *_hailo_model/    |
 
     Attributes:
         backend (BaseBackend): The loaded inference backend instance.
@@ -160,6 +162,7 @@ class AutoBackend(nn.Module):
         "deepx": DeepXBackend,
         "qnn": QNNBackend,
         "litert": LiteRTBackend,
+        "hailo": HailoBackend,
     }
 
     @torch.no_grad()

--- a/ultralytics/nn/backends/__init__.py
+++ b/ultralytics/nn/backends/__init__.py
@@ -11,6 +11,7 @@ from .base import BaseBackend
 from .coreml import CoreMLBackend
 from .deepx import DeepXBackend
 from .executorch import ExecuTorchBackend
+from .hailo import HailoBackend
 from .litert import LiteRTBackend
 from .mnn import MNNBackend
 from .ncnn import NCNNBackend
@@ -30,6 +31,7 @@ __all__ = [
     "CoreMLBackend",
     "DeepXBackend",
     "ExecuTorchBackend",
+    "HailoBackend",
     "LiteRTBackend",
     "MNNBackend",
     "NCNNBackend",

--- a/ultralytics/nn/backends/hailo.py
+++ b/ultralytics/nn/backends/hailo.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from contextlib import ExitStack
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from ultralytics.utils import LOGGER
+
+from .base import BaseBackend
+
+
+class HailoBackend(BaseBackend):
+    """HailoRT inference backend for Ultralytics Hailo HEF models."""
+
+    def load_model(self, weight: str | Path) -> None:
+        """Load a Hailo HEF model and its Ultralytics metadata."""
+        try:
+            from hailo_platform import (
+                HEF,
+                ConfigureParams,
+                FormatType,
+                HailoStreamInterface,
+                InferVStreams,
+                InputVStreamParams,
+                OutputVStreamParams,
+                VDevice,
+            )
+        except ImportError as e:
+            raise ImportError(
+                "Hailo inference requires HailoRT. "
+                "See https://docs.ultralytics.com/integrations/hailo/#run-hailo-inference"
+            ) from e
+
+        w = Path(weight)
+        hef_file = w if w.suffix == ".hef" else next(w.rglob("*.hef"), None)
+        if hef_file is None or not hef_file.is_file():
+            raise FileNotFoundError(f"No .hef file found in: {w}")
+
+        LOGGER.info(f"Loading {hef_file} for Hailo inference...")
+        metadata_file = hef_file.parent / "metadata.yaml"
+        if metadata_file.exists():
+            from ultralytics.utils import YAML
+
+            self.apply_metadata(YAML.load(metadata_file))
+        if self.task and self.task != "detect":
+            raise ValueError(f"Hailo inference only supports detection models, not task='{self.task}'.")
+
+        self._stack = ExitStack()
+        self.hef = HEF(str(hef_file))
+        self.input_info = self.hef.get_input_vstream_infos()[0]
+        self.output_infos = self.hef.get_output_vstream_infos()
+        target = self._stack.enter_context(VDevice())
+        configure_params = ConfigureParams.create_from_hef(self.hef, interface=HailoStreamInterface.PCIe)
+        network_group = target.configure(self.hef, configure_params)[0]
+        self._activation = network_group.create_params()
+        input_params = InputVStreamParams.make(network_group, format_type=FormatType.UINT8)
+        output_params = OutputVStreamParams.make(network_group, format_type=FormatType.FLOAT32)
+        self.model = self._stack.enter_context(InferVStreams(network_group, input_params, output_params))
+        self._network_group = network_group
+        self.end2end = True
+
+    def forward(self, im: torch.Tensor) -> np.ndarray:
+        """Run Hailo inference and return detections in ``xyxy, confidence, class`` format."""
+        im = np.ascontiguousarray(np.clip(im.permute(0, 2, 3, 1).cpu().numpy() * 255, 0, 255).astype(np.uint8))
+        with self._network_group.activate(self._activation):
+            results = self.model.infer({self.input_info.name: im})
+        outputs = [results[x.name] for x in self.output_infos]
+        return self._decode_raw(outputs) if not self.metadata.get("nms", False) else self._decode_nms(outputs[0])
+
+    def _decode_nms(self, output: list) -> np.ndarray:
+        """Convert Hailo per-class NMS output from normalized ``yxyx`` to pixel ``xyxy`` coordinates."""
+        height, width = self.input_info.shape[:2]
+        scale = np.array([width, height, width, height], dtype=np.float32)
+        frames = []
+        for detections in output:
+            rows = []
+            for class_id, class_detections in enumerate(detections):
+                if len(class_detections):
+                    class_detections = np.asarray(class_detections)
+                    boxes = class_detections[:, [1, 0, 3, 2]] * scale
+                    classes = np.full((len(boxes), 1), class_id, dtype=np.float32)
+                    rows.append(np.concatenate((boxes, class_detections[:, 4:5], classes), axis=1))
+            frame = np.concatenate(rows) if rows else np.empty((0, 6), dtype=np.float32)
+            frames.append(frame[np.argsort(-frame[:, 4])[:300]])
+        count = max(map(len, frames), default=0)
+        predictions = np.zeros((len(frames), count, 6), dtype=np.float32)
+        for i, frame in enumerate(frames):
+            predictions[i, : len(frame)] = frame
+        return predictions
+
+    def _decode_raw(self, outputs: list[np.ndarray]) -> np.ndarray:
+        """Decode branch-first YOLO26 regression and class outputs."""
+        from ultralytics.utils.tal import dist2bbox, make_anchors
+
+        split = len(outputs) // 2
+        box_maps = [torch.from_numpy(x).permute(0, 3, 1, 2) for x in outputs[:split]]
+        cls_maps = [torch.from_numpy(x).permute(0, 3, 1, 2) for x in outputs[split:]]
+        strides = [self.input_info.shape[0] / x.shape[2] for x in box_maps]
+        anchors, stride_tensor = make_anchors(box_maps, strides)
+        boxes = torch.cat([x.flatten(2) for x in box_maps], 2).transpose(1, 2)
+        boxes = dist2bbox(boxes, anchors, xywh=False) * stride_tensor
+        scores = torch.cat([x.flatten(2) for x in cls_maps], 2).transpose(1, 2).sigmoid()
+        classes = scores.shape[2]
+        anchor_index = scores.amax(-1).topk(min(300, scores.shape[1]), dim=1).indices[..., None]
+        boxes = boxes.gather(1, anchor_index.repeat(1, 1, 4))
+        scores = scores.gather(1, anchor_index.repeat(1, 1, classes))
+        scores, index = scores.flatten(1).topk(min(300, scores.shape[1] * classes), dim=1)
+        boxes = boxes.gather(1, (index // classes)[..., None].repeat(1, 1, 4))
+        return torch.cat((boxes, scores[..., None], (index % classes)[..., None].float()), 2).numpy()

--- a/ultralytics/nn/backends/hailo.py
+++ b/ultralytics/nn/backends/hailo.py
@@ -17,7 +17,7 @@ class HailoBackend(BaseBackend):
     """HailoRT inference backend for Ultralytics Hailo HEF models."""
 
     def load_model(self, weight: str | Path) -> None:
-        """Load a Hailo HEF model and its Ultralytics metadata."""
+        """Load a Hailo export directory and its Ultralytics metadata."""
         try:
             from hailo_platform import (
                 HEF,
@@ -36,7 +36,7 @@ class HailoBackend(BaseBackend):
             ) from e
 
         w = Path(weight)
-        hef_file = w if w.suffix == ".hef" else next(w.rglob("*.hef"), None)
+        hef_file = next(w.rglob("*.hef"), None)
         if hef_file is None or not hef_file.is_file():
             raise FileNotFoundError(f"No .hef file found in: {w}")
 

--- a/ultralytics/nn/backends/hailo.py
+++ b/ultralytics/nn/backends/hailo.py
@@ -56,12 +56,12 @@ class HailoBackend(BaseBackend):
             target = stack.enter_context(VDevice())
             configure_params = ConfigureParams.create_from_hef(self.hef, interface=HailoStreamInterface.PCIe)
             network_group = target.configure(self.hef, configure_params)[0]
-            self._activation = network_group.create_params()
+            stack.enter_context(network_group.activate(network_group.create_params()))
             input_params = InputVStreamParams.make(network_group, format_type=FormatType.UINT8)
             output_params = OutputVStreamParams.make(network_group, format_type=FormatType.FLOAT32)
             self.model = stack.enter_context(InferVStreams(network_group, input_params, output_params))
             self._stack = stack.pop_all()
-        self._network_group = network_group
+        self._anchors = None
         self.end2end = True
 
     def __del__(self):
@@ -72,8 +72,7 @@ class HailoBackend(BaseBackend):
     def forward(self, im: torch.Tensor) -> np.ndarray:
         """Run Hailo inference and return detections in ``xyxy, confidence, class`` format."""
         im = np.ascontiguousarray(np.clip(im.permute(0, 2, 3, 1).cpu().numpy() * 255, 0, 255).astype(np.uint8))
-        with self._network_group.activate(self._activation):
-            results = self.model.infer({self.input_info.name: im})
+        results = self.model.infer({self.input_info.name: im})
         outputs = [results[x.name] for x in self.output_infos]
         return self._decode_raw(outputs) if not self.metadata.get("nms", False) else self._decode_nms(outputs[0])
 
@@ -105,8 +104,10 @@ class HailoBackend(BaseBackend):
         split = len(outputs) // 2
         box_maps = [torch.from_numpy(x).permute(0, 3, 1, 2) for x in outputs[:split]]
         cls_maps = [torch.from_numpy(x).permute(0, 3, 1, 2) for x in outputs[split:]]
-        strides = [self.input_info.shape[0] / x.shape[2] for x in box_maps]
-        anchors, stride_tensor = make_anchors(box_maps, strides)
+        if self._anchors is None:
+            strides = [self.input_info.shape[0] / x.shape[2] for x in box_maps]
+            self._anchors = make_anchors(box_maps, strides)
+        anchors, stride_tensor = self._anchors
         boxes = torch.cat([x.flatten(2) for x in box_maps], 2).transpose(1, 2)
         boxes = dist2bbox(boxes, anchors, xywh=False) * stride_tensor
         scores = torch.cat([x.flatten(2) for x in cls_maps], 2).transpose(1, 2).sigmoid()

--- a/ultralytics/nn/backends/hailo.py
+++ b/ultralytics/nn/backends/hailo.py
@@ -49,19 +49,25 @@ class HailoBackend(BaseBackend):
         if self.task and self.task != "detect":
             raise ValueError(f"Hailo inference only supports detection models, not task='{self.task}'.")
 
-        self._stack = ExitStack()
         self.hef = HEF(str(hef_file))
         self.input_info = self.hef.get_input_vstream_infos()[0]
         self.output_infos = self.hef.get_output_vstream_infos()
-        target = self._stack.enter_context(VDevice())
-        configure_params = ConfigureParams.create_from_hef(self.hef, interface=HailoStreamInterface.PCIe)
-        network_group = target.configure(self.hef, configure_params)[0]
-        self._activation = network_group.create_params()
-        input_params = InputVStreamParams.make(network_group, format_type=FormatType.UINT8)
-        output_params = OutputVStreamParams.make(network_group, format_type=FormatType.FLOAT32)
-        self.model = self._stack.enter_context(InferVStreams(network_group, input_params, output_params))
+        with ExitStack() as stack:
+            target = stack.enter_context(VDevice())
+            configure_params = ConfigureParams.create_from_hef(self.hef, interface=HailoStreamInterface.PCIe)
+            network_group = target.configure(self.hef, configure_params)[0]
+            self._activation = network_group.create_params()
+            input_params = InputVStreamParams.make(network_group, format_type=FormatType.UINT8)
+            output_params = OutputVStreamParams.make(network_group, format_type=FormatType.FLOAT32)
+            self.model = stack.enter_context(InferVStreams(network_group, input_params, output_params))
+            self._stack = stack.pop_all()
         self._network_group = network_group
         self.end2end = True
+
+    def __del__(self):
+        """Release the Hailo pipeline and device."""
+        if stack := getattr(self, "_stack", None):
+            stack.close()
 
     def forward(self, im: torch.Tensor) -> np.ndarray:
         """Run Hailo inference and return detections in ``xyxy, confidence, class`` format."""

--- a/ultralytics/nn/backends/hailo.py
+++ b/ultralytics/nn/backends/hailo.py
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 from __future__ import annotations
 
 from contextlib import ExitStack


### PR DESCRIPTION
## Summary

- add lazy HailoRT AutoBackend inference for Ultralytics-exported HEF directories
- convert YOLOv8/YOLO11 on-device NMS output and decode YOLO26 branch-first one-to-one outputs
- reuse the existing BaseBackend, metadata, anchor, box-decoding, and end-to-end prediction contracts
- replace the Hailo docs limitation with direct `predict` and `val` guidance

## Validation

- `pytest -q tests/test_python.py --disable-warnings --maxfail=1` — 109 passed, 2 skipped
- Ruff, Prettier, reference generation, dispatch checks, and synthetic NMS/YOLO26 decoder checks
- HailoRT 4.23 and 5.3 expose the same blocking VStreams API used here
- Hailo-8L hardware validation requested from @JESUSROYETH

Deleted: the obsolete no-inference warning and manual YOLO26 decoder instructions; no existing runtime backend could be reused because Hailo was the sole export format without one.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Adds native HailoRT inference support for Ultralytics Hailo exports, including automatic YOLOv8, YOLO11, and YOLO26 output decoding.

### 📊 Key Changes

- Added a new `HailoBackend` for loading Hailo `.hef` files and running inference through HailoRT.
- Integrated Hailo support into `AutoBackend` for models in `*_hailo_model/` export directories.
- Added automatic post-processing for:
  - YOLOv8 and YOLO11 HailoRT NMS outputs.
  - YOLO26 raw, NMS-free outputs.
- Added validation to ensure Hailo inference is used only with detection models.
- Added documentation and API reference pages for the Hailo backend.
- Updated the Hailo integration guide with direct `predict` usage and metadata requirements.
- Bumped the Ultralytics version to `8.4.99`.

### 🎯 Purpose & Impact

- ✅ Enables direct `predict` and `val` workflows on Hailo hardware through Ultralytics and HailoRT.
- ⚡ Simplifies deployment by automatically locating the HEF file and decoding model-specific outputs.
- 🧩 Preserves compatibility with TAPPAS, GStreamer, and Raspberry Pi Hailo helper pipelines for custom applications.
- 📦 Requires HailoRT on the target device and the exported `metadata.yaml` to remain alongside the HEF file.
- 📚 Improves developer experience with dedicated backend documentation and clearer troubleshooting guidance.