### PR TITLE
Refresh depth8 with clean-label Kinect images

### DIFF
--- a/docs/en/datasets/depth/depth8.md
+++ b/docs/en/datasets/depth/depth8.md
@@ -8,7 +8,7 @@ keywords: Depth8, Ultralytics, dataset, depth estimation, monocular depth, YOLO2
 
 ## Introduction
 
-The [Ultralytics](https://www.ultralytics.com/) Depth8 dataset is a compact [monocular depth estimation](index.md) dataset with 8 images sampled from the [SUN RGB-D](sunrgbd.md) dataset: 4 for training and 4 for validation, drawn from its Kinect v1 and Kinect v2 captures (two per sensor in each split) for dense, artifact-free ground-truth depth maps. It is designed for rapid testing, debugging, and experimentation with [YOLO26](../../models/yolo26.md) depth estimation models and training pipelines — the 1.5 MB archive auto-downloads on first use, so `yolo depth train data=depth8.yaml` starts training within seconds.
+The [Ultralytics](https://www.ultralytics.com/) Depth8 dataset is a compact [monocular depth estimation](index.md) dataset with 8 images sampled from the [SUN RGB-D](sunrgbd.md) dataset: 4 for training and 4 for validation, drawn from its Kinect v1 and Kinect v2 captures (two per sensor in each split) for dense, artifact-free ground-truth depth maps. It is designed for rapid testing, debugging, and experimentation with [YOLO26](../../models/yolo26.md) depth estimation models and training pipelines — the 1.3 MB archive auto-downloads on first use, so `yolo depth train data=depth8.yaml` starts training within seconds.
 
 !!! note
 
@@ -88,7 +88,7 @@ If you use the SUN RGB-D dataset in your research or development work, please ci
 
 ### What is the Ultralytics Depth8 dataset used for?
 
-The Ultralytics Depth8 dataset is designed for rapid testing and debugging of [monocular depth estimation](../../tasks/depth.md) pipelines. With only 8 images (4 train, 4 val) in a 1.5 MB auto-downloading archive, it verifies the full train / val / predict cycle — paired depth-map loading, augmentation, loss computation, and metrics — in seconds, before scaling to a full dataset such as [SUN RGB-D](sunrgbd.md) or [NYU Depth V2](nyu-depth-v2.md).
+The Ultralytics Depth8 dataset is designed for rapid testing and debugging of [monocular depth estimation](../../tasks/depth.md) pipelines. With only 8 images (4 train, 4 val) in a 1.3 MB auto-downloading archive, it verifies the full train / val / predict cycle — paired depth-map loading, augmentation, loss computation, and metrics — in seconds, before scaling to a full dataset such as [SUN RGB-D](sunrgbd.md) or [NYU Depth V2](nyu-depth-v2.md).
 
 ### How does Depth8 differ from the full SUN RGB-D dataset?
 

--- a/docs/en/datasets/depth/depth8.md
+++ b/docs/en/datasets/depth/depth8.md
@@ -8,7 +8,7 @@ keywords: Depth8, Ultralytics, dataset, depth estimation, monocular depth, YOLO2
 
 ## Introduction
 
-The [Ultralytics](https://www.ultralytics.com/) Depth8 dataset is a compact [monocular depth estimation](index.md) dataset with 8 images sampled from the [SUN RGB-D](sunrgbd.md) dataset: 4 for training and 4 for validation, one per RGB-D sensor (Kinect v1, Kinect v2, Intel RealSense, Asus Xtion) in each split. It is designed for rapid testing, debugging, and experimentation with [YOLO26](../../models/yolo26.md) depth estimation models and training pipelines — the 1.5 MB archive auto-downloads on first use, so `yolo depth train data=depth8.yaml` starts training within seconds.
+The [Ultralytics](https://www.ultralytics.com/) Depth8 dataset is a compact [monocular depth estimation](index.md) dataset with 8 images sampled from the [SUN RGB-D](sunrgbd.md) dataset: 4 for training and 4 for validation, drawn from its Kinect v1 and Kinect v2 captures (two per sensor in each split) for dense, artifact-free ground-truth depth maps. It is designed for rapid testing, debugging, and experimentation with [YOLO26](../../models/yolo26.md) depth estimation models and training pipelines — the 1.5 MB archive auto-downloads on first use, so `yolo depth train data=depth8.yaml` starts training within seconds.
 
 !!! note
 
@@ -28,7 +28,7 @@ depth8/
     └── val/    # 4 float32 .npy depth maps
 ```
 
-Depth values are real indoor sensor captures ranging from roughly 0.6 m to 9 m, matching the ≤10 m range of the full SUN RGB-D dataset.
+Depth values are real indoor sensor captures ranging from roughly 0.5 m to 4 m, well within the ≤10 m range of the full SUN RGB-D dataset.
 
 ## Dataset YAML
 
@@ -92,7 +92,7 @@ The Ultralytics Depth8 dataset is designed for rapid testing and debugging of [m
 
 ### How does Depth8 differ from the full SUN RGB-D dataset?
 
-Depth8 samples 8 images from SUN RGB-D's 9,245-train/1,090-val split, keeping one image per RGB-D sensor per split. It uses the identical directory layout and `.npy` depth format, so a pipeline that runs on Depth8 runs unmodified on the full dataset — just point `data=` at `depth-sunrgbd.yaml` instead of `depth8.yaml`. Unlike the full dataset, Depth8 downloads in seconds and needs no conversion step.
+Depth8 samples 8 images from SUN RGB-D's 9,245-train/1,090-val split, favoring Kinect v1/v2 captures with clean, dense depth maps. It uses the identical directory layout and `.npy` depth format, so a pipeline that runs on Depth8 runs unmodified on the full dataset — just point `data=` at `depth-sunrgbd.yaml` instead of `depth8.yaml`. Unlike the full dataset, Depth8 downloads in seconds and needs no conversion step.
 
 ### Should I use Depth8 for benchmarking?
 

--- a/docs/en/datasets/depth/index.md
+++ b/docs/en/datasets/depth/index.md
@@ -84,7 +84,7 @@ The YOLO26 depth models are pretrained on a broad multi-dataset mix (~2.19M imag
 
 **Debugging**
 
-- [Depth8](depth8.md) — 8 SUN RGB-D images in a 1.5 MB auto-downloading archive, for rapid pipeline testing
+- [Depth8](depth8.md) — 8 SUN RGB-D images in a 1.3 MB auto-downloading archive, for rapid pipeline testing
 
 **Pretraining sources**
 

--- a/ultralytics/cfg/datasets/depth8.yaml
+++ b/ultralytics/cfg/datasets/depth8.yaml
@@ -6,7 +6,7 @@
 # parent
 # ├── ultralytics
 # └── datasets
-#     └── depth8 ← downloads here (1.5 MB)
+#     └── depth8 ← downloads here (1.3 MB)
 #         ├── images/{train,val}  # RGB images
 #         └── depth/{train,val}   # paired *.npy, float32 meters (images/ -> depth/)
 

--- a/ultralytics/cfg/datasets/depth8.yaml
+++ b/ultralytics/cfg/datasets/depth8.yaml
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-# Depth8 dataset (8 images from SUN RGB-D, one per RGB-D sensor per split) by Ultralytics
+# Depth8 dataset (8 clean-label indoor images from SUN RGB-D Kinect v1/v2, 4 train / 4 val) by Ultralytics
 # Documentation: https://docs.ultralytics.com/datasets/depth/depth8
 # Example usage: yolo depth train data=depth8.yaml model=yolo26n-depth.pt
 # parent


### PR DESCRIPTION
## Summary

Replaces the 8 Depth8 debug images with 8 whose ground-truth depth labels are clean, dense, and artifact-free.

The old set kept **one image per RGB-D sensor per split**, which forced in the Intel RealSense and Asus Xtion captures — their depth maps show heavy blocky quantization, hole-filling squares, and speckle, so the *label* renders unclearly. The new set draws only from SUN RGB-D's **Kinect v1 / Kinect v2** captures (2 per sensor per split, 4 kv1 + 4 kv2 total), which provide smooth dense depth. Scene variety is preserved (bedroom, kitchen, bathroom, kids-room, office).

The packaged `depth8.zip` on the `ultralytics/assets` `v0.0.0` release was replaced in place — **same download URL**, so all existing references keep working (1.46 MB → 1.33 MB). This PR updates only the stale prose that described the old sensor-diversity rationale and depth range.

- `depth8.yaml`: header comment now describes the Kinect v1/v2 clean-label selection.
- `docs/.../depth8.md`: intro, "how does it differ" FAQ, and depth-range note (0.6–9 m → 0.5–4 m) updated to match the new set.

## Verification

Full `yolo depth train data=depth8.yaml model=yolo26n-depth.pt` cycle runs end-to-end on the new set: labels scan 4/4 train + 4/4 val with 0 corrupt, training + validation complete (δ1=0.646), and auto-calibration succeeds. Live download from the release confirmed serving the new images.

Deleted: the RealSense/Xtion image+depth pairs from the shipped depth8 archive (4 of 8), and the "one image per RGB-D sensor per split" rationale from the yaml comment and docs. No code paths, functions, or tests reference the image filenames (`test_engine.py` keys only on `depth8.yaml`), so no code changes were needed.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the Depth8 dataset documentation and configuration to reflect a smaller, cleaner SUN RGB-D sample focused on Kinect v1/v2 images. 📚

### 📊 Key Changes
- Updated Depth8 to use clean, dense depth maps from Kinect v1 and Kinect v2 captures.
- Clarified the split as 4 training and 4 validation images, with two images per sensor in each split.
- Revised the reported depth range from approximately 0.6–9 m to 0.5–4 m.
- Updated the archive size from 1.5 MB to 1.3 MB across the documentation and dataset YAML configuration.
- Improved descriptions of the dataset’s relationship to the full SUN RGB-D dataset.

### 🎯 Purpose & Impact
- Makes the Depth8 dataset documentation more accurate and transparent. ✅
- Provides a more reliable, artifact-free sample for quickly testing YOLO26 depth estimation training and validation pipelines.
- Reduces the download size slightly, enabling faster setup for debugging and experimentation.
- Maintains compatibility with the full SUN RGB-D directory structure and `.npy` depth-map format, allowing users to transition to larger datasets without pipeline changes.