### PR TITLE
Use shared setup-uv action everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         if: matrix.os != 'cpu-latest'
         with:
           python-version: ${{ matrix.python }}
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
         with:
           python-version: ${{ matrix.python }}
           activate-environment: ${{ matrix.os == 'cpu-latest' }}
@@ -154,7 +154,7 @@ jobs:
         if: matrix.os != 'cpu-latest'
         with:
           python-version: ${{ matrix.python }}
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
         with:
           python-version: ${{ matrix.python }}
           activate-environment: true
@@ -308,7 +308,7 @@ jobs:
         if: matrix.os != 'cpu-latest'
         with:
           python-version: ${{ matrix.python }}
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
         with:
           python-version: ${{ matrix.python }}
           activate-environment: true
@@ -374,7 +374,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
         with:
           python-version: "3.13"
       - name: Install export system dependencies
@@ -429,7 +429,7 @@ jobs:
       YOLO_AUTOINSTALL: "false"
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
         with:
           activate-environment: true
       - name: Install requirements
@@ -473,7 +473,7 @@ jobs:
           python3.11 -m venv env-tests
           source env-tests/bin/activate
           echo PATH=$PATH >> $GITHUB_ENV
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
       - name: Install requirements
         uses: ultralytics/actions/retry@main
         with:
@@ -567,7 +567,7 @@ jobs:
       - name: Clean up runner
         uses: eviden-actions/clean-self-hosted-runner@v1
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
       - name: Activate virtual environment
         run: |
           python${{ matrix.python }} -m venv env --system-site-packages
@@ -608,7 +608,7 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
       - uses: conda-incubator/setup-miniconda@v4
         with:
           python-version: ${{ matrix.python }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,7 @@ jobs:
           token: ${{ secrets._GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           ref: ${{ env.BRANCH }}
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
         with:
           python-version: "3.14"
       - name: Install Dependencies

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
         with:
           python-version: "3.13"
           activate-environment: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
       - run: uv pip install --system --no-cache ultralytics-actions
       - id: check_pypi
         shell: python
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
       - run: uv pip install --system --no-cache build
       - name: Build ultralytics
         run: python -m build --outdir dist/
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
       - run: |
           uv venv sbom-env
           uv pip install -e .


### PR DESCRIPTION
## Summary

- replace all 13 Astral uv setup steps with the shared retried owner
- preserve existing Python-version and environment-activation inputs across hosted and self-hosted jobs

Reused: `ultralytics/actions/setup-uv@main` is the single cross-platform latest-uv installer owner.

Deleted: 13 direct `astral-sh/setup-uv` dependencies.

## Validation

- zero `uses: astral-sh/setup-uv` occurrences
- `actionlint` on all changed workflows; only pre-existing shell/custom-runner warnings remain
- `git diff --check`
- shared owner passed Windows, Ubuntu, and macOS CI in ultralytics/actions#819

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔧 Replaced the external `setup-uv` GitHub Action with Ultralytics’ internally maintained version across CI, documentation, fuzzing, and publishing workflows.

### 📊 Key Changes

- Updated all workflow references from `astral-sh/setup-uv@v7` to `ultralytics/actions/setup-uv@main`.
- Applied the change across:
  - Continuous integration and test jobs
  - Documentation builds
  - Fuzz testing
  - Package publishing and SBOM generation
- Preserved existing Python-version and virtual-environment configuration.

### 🎯 Purpose & Impact

- 🛠️ Centralizes UV setup and maintenance under Ultralytics’ own GitHub Actions.
- 🔄 Provides consistent dependency tooling across project workflows.
- 🚀 May simplify future updates and allow Ultralytics-specific improvements to the setup process.
- ✅ No direct changes to the Ultralytics Python package or user-facing model behavior.