### PR TITLE
Fix HTTP 308 redirect handling in safe_download on Python <=3.10

### DIFF
--- a/docs/en/reference/utils/downloads.md
+++ b/docs/en/reference/utils/downloads.md
@@ -12,6 +12,14 @@ keywords: Ultralytics, download utilities, URL validation, zip directory, unzip 
 
 <br>
 
+## ::: ultralytics.utils.downloads._Http308RedirectHandler
+
+<br><br><hr><br>
+
+## ::: ultralytics.utils.downloads._urlopen
+
+<br><br><hr><br>
+
 ## ::: ultralytics.utils.downloads.is_url
 
 <br><br><hr><br>

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -42,9 +42,9 @@ def _urlopen(*args, **kwargs):
     """Open a URL like `urllib.request.urlopen`, backporting HTTP 308 Permanent Redirect support.
 
     Extends whichever opener is in effect (the one installed via `urllib.request.install_opener`, or urllib's default)
-    instead of replacing it, so any custom proxy, auth, or TLS handlers the caller configured keep working.
-    Re-checks the installed opener on every call, matching `urlopen()`'s own behavior, so a later
-    `install_opener()` call is picked up rather than left stale.
+    instead of replacing it, so any custom proxy, auth, or TLS handlers the caller configured keep working. Re-checks
+    the installed opener on every call, matching `urlopen()`'s own behavior, so a later `install_opener()` call is
+    picked up rather than left stale.
     """
     global _fallback_opener
     opener = request._opener

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -41,9 +41,8 @@ _opener = None  # lazily built on first use, matching urllib.request.urlopen()'s
 def _urlopen(*args, **kwargs):
     """Open a URL like `urllib.request.urlopen`, backporting HTTP 308 Permanent Redirect support.
 
-    Extends whichever opener is in effect (the one installed via `urllib.request.install_opener`, or
-    urllib's default) instead of replacing it, so any custom proxy, auth, or TLS handlers the caller
-    configured keep working.
+    Extends whichever opener is in effect (the one installed via `urllib.request.install_opener`, or urllib's default)
+    instead of replacing it, so any custom proxy, auth, or TLS handlers the caller configured keep working.
     """
     global _opener
     if _opener is None:

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -35,24 +35,21 @@ class _Http308RedirectHandler(request.HTTPRedirectHandler):
         return super().redirect_request(req, fp, code, msg, headers, newurl)
 
 
-_fallback_opener = None  # lazily built default opener, reused only while nothing has been installed
-
-
 def _urlopen(*args, **kwargs):
     """Open a URL like `urllib.request.urlopen`, backporting HTTP 308 Permanent Redirect support.
 
     Extends whichever opener is in effect (the one installed via `urllib.request.install_opener`, or urllib's default)
-    instead of replacing it, so any custom proxy, auth, or TLS handlers the caller configured keep working. Re-checks
-    the installed opener on every call, matching `urlopen()`'s own behavior, so a later `install_opener()` call is
-    picked up rather than left stale.
+    instead of replacing it, so any custom proxy, auth, or TLS handlers the caller configured keep working. Reads
+    and, if newly built, installs into urllib's own global opener slot, so a lazily built default is reused/reset
+    exactly like `urlopen()`'s and a later `install_opener()`/`urlcleanup()` call is picked up rather than left
+    stale. Openers that don't expose handler management (anything with just an `open()` method is a valid
+    installed opener) are left untouched; their owner is responsible for redirect behavior.
     """
-    global _fallback_opener
     opener = request._opener
     if opener is None:
-        if _fallback_opener is None:
-            _fallback_opener = request.build_opener()
-        opener = _fallback_opener
-    if not any(isinstance(h, _Http308RedirectHandler) for h in opener.handlers):
+        opener = request.build_opener()
+        request.install_opener(opener)
+    if hasattr(opener, "handlers") and not any(isinstance(h, _Http308RedirectHandler) for h in opener.handlers):
         opener.add_handler(_Http308RedirectHandler())
     return opener.open(*args, **kwargs)
 

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -41,8 +41,9 @@ def _urlopen(*args, **kwargs):
     if opener is None:
         opener = request.build_opener()
         request.install_opener(opener)
-    if any(type(h) is request.HTTPRedirectHandler for h in opener.handlers) and not any(
-        hasattr(h, "http_error_308") for h in opener.handlers
+    handlers = getattr(opener, "handlers", ())
+    if any(type(h) is request.HTTPRedirectHandler for h in handlers) and not any(
+        hasattr(h, "http_error_308") for h in handlers
     ):
         opener.add_handler(_Http308RedirectHandler())
     return opener.open(*args, **kwargs)

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -35,7 +35,7 @@ class _Http308RedirectHandler(request.HTTPRedirectHandler):
         return super().redirect_request(req, fp, code, msg, headers, newurl)
 
 
-_opener = None  # lazily built on first use, matching urllib.request.urlopen()'s own opener timing
+_fallback_opener = None  # lazily built default opener, reused only while nothing has been installed
 
 
 def _urlopen(*args, **kwargs):
@@ -43,13 +43,18 @@ def _urlopen(*args, **kwargs):
 
     Extends whichever opener is in effect (the one installed via `urllib.request.install_opener`, or urllib's default)
     instead of replacing it, so any custom proxy, auth, or TLS handlers the caller configured keep working.
+    Re-checks the installed opener on every call, matching `urlopen()`'s own behavior, so a later
+    `install_opener()` call is picked up rather than left stale.
     """
-    global _opener
-    if _opener is None:
-        _opener = request._opener or request.build_opener()
-        if not any(isinstance(h, _Http308RedirectHandler) for h in _opener.handlers):
-            _opener.add_handler(_Http308RedirectHandler())
-    return _opener.open(*args, **kwargs)
+    global _fallback_opener
+    opener = request._opener
+    if opener is None:
+        if _fallback_opener is None:
+            _fallback_opener = request.build_opener()
+        opener = _fallback_opener
+    if not any(isinstance(h, _Http308RedirectHandler) for h in opener.handlers):
+        opener.add_handler(_Http308RedirectHandler())
+    return opener.open(*args, **kwargs)
 
 
 # Define Ultralytics GitHub assets maintained at https://github.com/ultralytics/assets

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -36,20 +36,14 @@ class _Http308RedirectHandler(request.HTTPRedirectHandler):
 
 
 def _urlopen(*args, **kwargs):
-    """Open a URL like `urllib.request.urlopen`, backporting HTTP 308 Permanent Redirect support.
-
-    Extends whichever opener is in effect (the one installed via `urllib.request.install_opener`, or urllib's default)
-    instead of replacing it, so any custom proxy, auth, or TLS handlers the caller configured keep working. Reads and,
-    if newly built, installs into urllib's own global opener slot, so a lazily built default is reused/reset exactly
-    like `urlopen()`'s and a later `install_opener()`/`urlcleanup()` call is picked up rather than left
-    stale. Openers that don't expose handler management (anything with just an `open()` method is a valid
-    installed opener) are left untouched; their owner is responsible for redirect behavior.
-    """
+    """Open a URL like `urllib.request.urlopen`, backporting HTTP 308 support when no handler provides it."""
     opener = request._opener
     if opener is None:
         opener = request.build_opener()
         request.install_opener(opener)
-    if hasattr(opener, "handlers") and not any(isinstance(h, _Http308RedirectHandler) for h in opener.handlers):
+    if any(type(h) is request.HTTPRedirectHandler for h in opener.handlers) and not any(
+        hasattr(h, "http_error_308") for h in opener.handlers
+    ):
         opener.add_handler(_Http308RedirectHandler())
     return opener.open(*args, **kwargs)
 

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -13,6 +13,39 @@ from urllib import parse, request
 
 from ultralytics.utils import ASSETS_URL, LOGGER, TQDM, checks, clean_url, emojis, is_online, url2file
 
+
+class _Http308RedirectHandler(request.HTTPRedirectHandler):
+    """Follow HTTP 308 Permanent Redirect responses, unsupported by urllib's opener before Python 3.11."""
+
+    http_error_308 = request.HTTPRedirectHandler.http_error_301
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        """Allow 308 alongside the redirect codes urllib recognizes natively on this Python version."""
+        m = req.get_method()
+        if code == 308 and m in ("GET", "HEAD"):
+            content_headers = ("content-length", "content-type")
+            newheaders = {k: v for k, v in req.headers.items() if k.lower() not in content_headers}
+            return request.Request(
+                newurl.replace(" ", "%20"),
+                method=m,
+                headers=newheaders,
+                origin_req_host=req.origin_req_host,
+                unverifiable=True,
+            )
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+_opener = None  # lazily built on first use, matching urllib.request.urlopen()'s own opener timing
+
+
+def _urlopen(*args, **kwargs):
+    """Open a URL like `urllib.request.urlopen`, backporting HTTP 308 Permanent Redirect support."""
+    global _opener
+    if _opener is None:
+        _opener = request.build_opener(_Http308RedirectHandler)
+    return _opener.open(*args, **kwargs)
+
+
 # Define Ultralytics GitHub assets maintained at https://github.com/ultralytics/assets
 GITHUB_ASSETS_REPO = "ultralytics/assets"
 GITHUB_ASSETS_NAMES = frozenset(
@@ -65,7 +98,7 @@ def is_url(url: str | Path, check: bool = False) -> bool:
         if not (result.scheme and result.netloc):
             return False
         if check:
-            r = request.urlopen(request.Request(url, method="HEAD"), timeout=3)
+            r = _urlopen(request.Request(url, method="HEAD"), timeout=3)
             return 200 <= r.getcode() < 400
         return True
     except Exception:
@@ -344,7 +377,7 @@ def safe_download(
                         r = subprocess.run(["curl", "-#", f"-{s}L", url, "-o", f, "--retry", "3", "-C", "-"]).returncode
                         assert r == 0, f"Curl return value {r}"
                     else:  # urllib download
-                        with request.urlopen(url) as response:
+                        with _urlopen(url) as response:
                             expected_size = int(response.getheader("Content-Length", 0))
                             if i == 0 and expected_size > 1048576:
                                 check_disk_space(expected_size, path=f.parent)

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -39,10 +39,17 @@ _opener = None  # lazily built on first use, matching urllib.request.urlopen()'s
 
 
 def _urlopen(*args, **kwargs):
-    """Open a URL like `urllib.request.urlopen`, backporting HTTP 308 Permanent Redirect support."""
+    """Open a URL like `urllib.request.urlopen`, backporting HTTP 308 Permanent Redirect support.
+
+    Extends whichever opener is in effect (the one installed via `urllib.request.install_opener`, or
+    urllib's default) instead of replacing it, so any custom proxy, auth, or TLS handlers the caller
+    configured keep working.
+    """
     global _opener
     if _opener is None:
-        _opener = request.build_opener(_Http308RedirectHandler)
+        _opener = request._opener or request.build_opener()
+        if not any(isinstance(h, _Http308RedirectHandler) for h in _opener.handlers):
+            _opener.add_handler(_Http308RedirectHandler())
     return _opener.open(*args, **kwargs)
 
 

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -39,9 +39,9 @@ def _urlopen(*args, **kwargs):
     """Open a URL like `urllib.request.urlopen`, backporting HTTP 308 Permanent Redirect support.
 
     Extends whichever opener is in effect (the one installed via `urllib.request.install_opener`, or urllib's default)
-    instead of replacing it, so any custom proxy, auth, or TLS handlers the caller configured keep working. Reads
-    and, if newly built, installs into urllib's own global opener slot, so a lazily built default is reused/reset
-    exactly like `urlopen()`'s and a later `install_opener()`/`urlcleanup()` call is picked up rather than left
+    instead of replacing it, so any custom proxy, auth, or TLS handlers the caller configured keep working. Reads and,
+    if newly built, installs into urllib's own global opener slot, so a lazily built default is reused/reset exactly
+    like `urlopen()`'s and a later `install_opener()`/`urlcleanup()` call is picked up rather than left
     stale. Openers that don't expose handler management (anything with just an `open()` method is a valid
     installed opener) are left untouched; their owner is responsible for redirect behavior.
     """


### PR DESCRIPTION
## summary

Python's `urllib.request.HTTPRedirectHandler` only added support for HTTP 308 Permanent Redirect in Python 3.11. On Python 3.8-3.10, a 308 response causes `safe_download()`'s first (urllib) attempt to raise, logging a "Download failure, retrying" warning before curl's retry succeeds — visible on the very first command copy-pasted from most docs pages, since `https://ultralytics.com/images/bus.jpg` now serves a 308 redirect chain. Adds a small opener that backports Python 3.11's 308 handling, reused by both `is_url()` and `safe_download()`; the opener is built lazily on first use to match `urllib.request.urlopen()`'s own timing for reading proxy environment variables.

Deleted: redundant backport injection on native and custom 308-handler paths, plus redundant opener-lifecycle commentary. The remaining net-positive diff is the minimal Python 3.11 HTTP 308 redirect backport shared by `is_url()` and `safe_download()`; existing custom redirect handlers retain ownership of their policy.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Adds backward-compatible HTTP 308 redirect support to Ultralytics URL checks and downloads.

### 📊 Key Changes

- Introduced a custom `_Http308RedirectHandler` for Python versions where `urllib` does not natively follow HTTP 308 redirects.
- Added `_urlopen`, a wrapper around `urllib.request.urlopen` that automatically installs the redirect handler when needed.
- Updated URL validation and file download workflows to use `_urlopen`.
- Added documentation entries for the new internal download utilities.

### 🎯 Purpose & Impact

- ✅ Prevents download and URL-check failures when servers respond with HTTP 308 Permanent Redirects.
- 📦 Improves compatibility across supported Python versions without changing existing download APIs.
- 🔗 Enables more reliable access to redirected model weights, datasets, and other assets.
- 🛠️ Keeps native redirect behavior intact when custom handlers or newer Python versions already provide HTTP 308 support.