### PR TITLE
Repair broken forward links in the newcomer training path

### DIFF
--- a/docs/en/datasets/detect/index.md
+++ b/docs/en/datasets/detect/index.md
@@ -280,7 +280,7 @@ Here is a list of the supported datasets and a brief description for each:
 
 ### Adding your own dataset
 
-If you have your own dataset and would like to use it for training detection models with Ultralytics YOLO format, ensure that it follows the format specified above under "Ultralytics YOLO format". Convert your annotations to the required format and specify the paths, number of classes, and class names in the YAML configuration file.
+If you have your own dataset and would like to use it for training detection models with Ultralytics YOLO format, ensure that it follows the format specified above under "Ultralytics YOLO format". Convert your annotations to the required format and specify the paths, number of classes, and class names in the YAML configuration file. Once that YAML file is ready, you're set to [train on your own data](../../modes/train.md).
 
 ## Port or Convert Label Formats
 
@@ -301,6 +301,10 @@ You can easily convert labels from the popular [COCO dataset](coco.md) format to
 This conversion tool can be used to convert the COCO dataset or any dataset in the COCO format to the Ultralytics YOLO format. The process transforms the JSON-based COCO annotations into the simpler text-based YOLO format, making it compatible with [Ultralytics YOLO models](../../models/yolo26.md).
 
 Remember to double-check if the dataset you want to use is compatible with your model and follows the necessary format conventions. Properly formatted datasets are crucial for training successful object detection models.
+
+## What's Next
+
+With your dataset formatted, [start training your model](../../modes/train.md). Not sure which pretrained model to start from? Compare options in the [YOLO26 model family](../../models/yolo26.md).
 
 ## FAQ
 

--- a/docs/en/datasets/detect/index.md
+++ b/docs/en/datasets/detect/index.md
@@ -280,7 +280,7 @@ Here is a list of the supported datasets and a brief description for each:
 
 ### Adding your own dataset
 
-If you have your own dataset and would like to use it for training detection models with Ultralytics YOLO format, ensure that it follows the format specified above under "Ultralytics YOLO format". Convert your annotations to the required format and specify the paths, number of classes, and class names in the YAML configuration file. Once that YAML file is ready, you're set to [train on your own data](../../modes/train.md).
+If you have your own dataset and would like to use it for training detection models with Ultralytics YOLO format, ensure that it follows the format specified above under "Ultralytics YOLO format". Convert your annotations to the required format and specify the paths, number of classes, and class names in the YAML configuration file.
 
 ## Port or Convert Label Formats
 

--- a/docs/en/modes/export.md
+++ b/docs/en/modes/export.md
@@ -124,6 +124,10 @@ Not every export format supports every precision. Explicit `quantize` requests e
 
 For INT8 and W8A16 exports, provide representative calibration data with `data`, such as `data="coco8.yaml"`, unless the target integration documents a default or auto-enabled behavior. The LiteRT `"w8a32"` (dynamic INT8) scheme needs no calibration data.
 
+## What's Next
+
+Find your deployment target's integration guide — [ONNX](../integrations/onnx.md), [TensorRT](../integrations/tensorrt.md), [CoreML](../integrations/coreml.md), and more are on the [full integrations list](../integrations/index.md) — for how to run the exported model.
+
 ## FAQ
 
 ### How do I export a YOLO26 model to ONNX format?

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -529,7 +529,7 @@ All Ultralytics `predict()` calls will return a list of `Results` objects:
 
 ### Results by Task
 
-Each prediction returns one `Results` object per image or frame. The common fields above are always available, while the
+Which fields below populate depends on your model's task — [compare detection, segmentation, classification, pose, OBB, and semantic segmentation](../tasks/index.md) if you haven't picked one yet. Each prediction returns one `Results` object per image or frame. The common fields above are always available, while the
 task-specific prediction data is stored in the fields below. Coordinate, confidence, and probability tensors are
 `torch.float32` unless half precision is used, then `torch.float16`. After `result.numpy()`, tensors become NumPy arrays with matching NumPy dtypes.
 Instance masks are `torch.uint8` binary tensors, while semantic masks use the smallest practical integer dtype for class
@@ -960,6 +960,10 @@ This script will run predictions on each frame of the video, visualize the resul
 [car spare parts]: https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/car-parts-detection-for-predict.avif
 [football player detect]: https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/football-players-detection.avif
 [human fall detect]: https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/person-fall-detection.avif
+
+## What's Next
+
+Ready to move past a pretrained model? [Confirm your task fits your problem](../tasks/index.md), format your own data with the [Datasets guide](../datasets/index.md), then [train on it](train.md).
 
 ## FAQ
 

--- a/docs/en/modes/train.md
+++ b/docs/en/modes/train.md
@@ -10,7 +10,7 @@ keywords: Ultralytics, YOLO26, model training, deep learning, object detection, 
 
 ## Introduction
 
-Training a [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) model involves feeding it data and adjusting its parameters so that it can make accurate predictions. Train mode in Ultralytics YOLO26 is engineered for effective and efficient training of object detection models, fully utilizing modern hardware capabilities. This guide aims to cover all the details you need to get started with training your own models using YOLO26's robust set of features.
+Training a [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) model involves feeding it data and adjusting its parameters so that it can make accurate predictions. Train mode in Ultralytics YOLO26 is engineered for effective and efficient training of object detection models, fully utilizing modern hardware capabilities. This guide aims to cover all the details you need to get started with training your own models using YOLO26's robust set of features. If you haven't installed Ultralytics yet, start with the [Quickstart guide](../quickstart.md).
 
 <p align="center">
   <br>
@@ -346,6 +346,10 @@ To use TensorBoard locally run the below command and view results at `localhost:
 This will load TensorBoard and direct it to the directory where your training logs are saved.
 
 After setting up your logger, you can then proceed with your model training. All training metrics will be automatically logged in your chosen platform, and you can access these logs to monitor your model's performance over time, compare different models, and identify areas for improvement.
+
+## What's Next
+
+[Validate](val.md) your trained model against held-out data to check its real-world accuracy, then [export](export.md) it to ONNX, TensorRT, or another deployment format. Training on your own data instead of COCO8? Format it first with the [Datasets guide](../datasets/index.md).
 
 ## FAQ
 

--- a/docs/en/modes/val.md
+++ b/docs/en/modes/val.md
@@ -183,6 +183,10 @@ The below examples showcase YOLO model validation with custom arguments in Pytho
 
 For more details see the [`DataExportMixin` class documentation](../reference/utils/__init__.md#ultralytics.utils.__init__.DataExportMixin).
 
+## What's Next
+
+Happy with the metrics? [Export the model](export.md) to a deployment format. If accuracy is off, [go back and retrain](train.md) with different [hyperparameters](../guides/hyperparameter-tuning.md) or more training data.
+
 ## FAQ
 
 ### How do I validate my YOLO26 model with Ultralytics?

--- a/docs/en/tasks/index.md
+++ b/docs/en/tasks/index.md
@@ -62,6 +62,10 @@ Oriented Bounding Box (OBB) detection enhances traditional object detection by a
 
 Ultralytics YOLO26 supports multiple computer vision tasks, including detection, instance segmentation, semantic segmentation, classification, oriented object detection, and keypoint detection. Each task addresses specific needs in the computer vision landscape, from basic object identification to detailed pose analysis. By understanding the capabilities and applications of each task, you can select the most appropriate approach for your specific computer vision challenges and leverage YOLO26's powerful features to build effective solutions.
 
+## What's Next
+
+Picked a task? Format your data for it with the [Datasets guide](../datasets/index.md), then [train on your own images](../modes/train.md).
+
 ## FAQ
 
 ### What computer vision tasks can Ultralytics YOLO26 perform?


### PR DESCRIPTION
## Summary

Adds goal-phrased `## What's Next` sections before the FAQ on predict, tasks, dataset, train, val, and export pages, plus inline forward links at the specific points where the newcomer path (predict → pick a task → prepare a dataset → train → validate → export) previously had none. `train.md` also gains a backward link to the quickstart guide, and `quickstart.md` itself is untouched since it's already being rewritten in a separate open PR.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improved documentation navigation with contextual “What’s Next” guidance across key YOLO26 workflows. 🧭

### 📊 Key Changes

- Added next-step links to dataset, task, training, validation, prediction, and export documentation.
- Connected related workflow stages, including:
  - Dataset formatting → model training
  - Training → validation and export
  - Validation → deployment or retraining
  - Export → platform-specific integration guides
  - Prediction → task selection, dataset preparation, and training
- Added a Quickstart guide link to the training introduction.
- Clarified that prediction result fields depend on the selected task and linked to the task comparison guide.
- Highlighted the YOLO26 model family when helping users choose a pretrained model.

### 🎯 Purpose & Impact

- Makes the documentation easier to follow for new and existing users. 🚀
- Helps users move smoothly through the complete computer vision workflow, from selecting a task and preparing data to training and deployment.
- Reduces navigation friction by surfacing relevant guides at the point users need them.
- Improves clarity around task-specific prediction outputs and available deployment integrations.