### PR TITLE
Persist Hailo network group activation and cache decoder anchors

### DIFF
--- a/ultralytics/nn/backends/hailo.py
+++ b/ultralytics/nn/backends/hailo.py
@@ -56,12 +56,12 @@ class HailoBackend(BaseBackend):
             target = stack.enter_context(VDevice())
             configure_params = ConfigureParams.create_from_hef(self.hef, interface=HailoStreamInterface.PCIe)
             network_group = target.configure(self.hef, configure_params)[0]
-            self._activation = network_group.create_params()
+            stack.enter_context(network_group.activate(network_group.create_params()))
             input_params = InputVStreamParams.make(network_group, format_type=FormatType.UINT8)
             output_params = OutputVStreamParams.make(network_group, format_type=FormatType.FLOAT32)
             self.model = stack.enter_context(InferVStreams(network_group, input_params, output_params))
             self._stack = stack.pop_all()
-        self._network_group = network_group
+        self._anchors = None
         self.end2end = True
 
     def __del__(self):
@@ -72,8 +72,7 @@ class HailoBackend(BaseBackend):
     def forward(self, im: torch.Tensor) -> np.ndarray:
         """Run Hailo inference and return detections in ``xyxy, confidence, class`` format."""
         im = np.ascontiguousarray(np.clip(im.permute(0, 2, 3, 1).cpu().numpy() * 255, 0, 255).astype(np.uint8))
-        with self._network_group.activate(self._activation):
-            results = self.model.infer({self.input_info.name: im})
+        results = self.model.infer({self.input_info.name: im})
         outputs = [results[x.name] for x in self.output_infos]
         return self._decode_raw(outputs) if not self.metadata.get("nms", False) else self._decode_nms(outputs[0])
 
@@ -105,8 +104,10 @@ class HailoBackend(BaseBackend):
         split = len(outputs) // 2
         box_maps = [torch.from_numpy(x).permute(0, 3, 1, 2) for x in outputs[:split]]
         cls_maps = [torch.from_numpy(x).permute(0, 3, 1, 2) for x in outputs[split:]]
-        strides = [self.input_info.shape[0] / x.shape[2] for x in box_maps]
-        anchors, stride_tensor = make_anchors(box_maps, strides)
+        if self._anchors is None:
+            strides = [self.input_info.shape[0] / x.shape[2] for x in box_maps]
+            self._anchors = make_anchors(box_maps, strides)
+        anchors, stride_tensor = self._anchors
         boxes = torch.cat([x.flatten(2) for x in box_maps], 2).transpose(1, 2)
         boxes = dist2bbox(boxes, anchors, xywh=False) * stride_tensor
         scores = torch.cat([x.flatten(2) for x in cls_maps], 2).transpose(1, 2).sigmoid()


### PR DESCRIPTION
Follow-up to the perf note in #25247, as requested there. Two per-frame costs in `HailoBackend` are constants of the loaded model: `forward` re-activated the network group on every frame, and `_decode_raw` rebuilt the anchor grid on every frame. The change enters the activation once in `load_model` (the group stays activated for the backend lifetime, and `__del__` deactivates it with the rest of the `ExitStack`), and caches the `make_anchors` result on first use. With the per-frame activation gone, `self._activation` and `self._network_group` had no consumers left, so both attributes are gone too; the `ExitStack` owns the activation context like the rest of the pipeline.

## measured

Hailo-8L over PCIe, HailoRT 4.23.0, bus.jpg at 640, 5 warmup + 100 timed `predict` calls per model, 5 rounds per variant in fresh processes, alternating baseline (1e9056f, the current branch head) and patched. Median [min-max] ms/frame:

| model | baseline | patched | median delta |
|---|---|---|---|
| yolo11n (on-chip NMS) | 31.7 [30.3-33.9] | 26.5 [25.5-28.7] | -16% |
| yolo26n (host decode) | 36.1 [33.0-36.3] | 29.6 [28.8-31.5] | -18% |

The absolute numbers move a few ms between rounds on my machine, but the patched side is faster in every one of the 5 rounds, for both models. These are end-to-end predict times, so preprocessing and decode are included.

## equivalence

`val` on COCO128 with the patched branch returns the numbers I posted in #25247 to the fourth decimal: yolo11n 0.5308/0.4146 and yolo26n 0.6050/0.4470 (mAP50/mAP50-95), covering both decode paths. yolov8n `predict` on bus.jpg returns detections identical to the baseline, box by box. Sequential loading of two models in one process keeps working: every benchmark round loads yolo11n and yolo26n back to back with an explicit release in between, so the cleanup from 4f0d044 was exercised ten times with the persistent activation .. no driver issues. The dead-attribute cleanup landed after the benchmark rounds; it only drops references the `ExitStack` already owns, and `_decode_raw` with the cached anchors returns bit-identical output to a per-frame rebuild on synthetic feature maps (batch 1 and 2).

Deleted: the per-frame `network_group.activate()` context in `forward`, the per-frame `make_anchors` rebuild in `_decode_raw`, and the now-unused `self._activation` and `self._network_group` attributes. The diff is +7/-6 because the anchor cache needs its first-use guard; the activation itself moves 1:1 into `load_model`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves Hailo backend inference by persisting network group activation and caching decoder anchors for more efficient detection.

### 📊 Key Changes
- Activates the Hailo network group during model loading and keeps it active for subsequent inference calls.
- Removes per-inference activation management from `forward`.
- Caches decoder anchors after their first computation in `_decode_raw`.

### 🎯 Purpose & Impact
- Reduces repeated setup overhead during Hailo inference.
- Avoids recomputing anchor data for every frame, improving inference efficiency.
- Preserves existing raw-output decoding behavior while simplifying resource management.