### PR TITLE
Record successful Platform checkpoint uploads

### DIFF
--- a/docs/en/reference/utils/callbacks/platform.md
+++ b/docs/en/reference/utils/callbacks/platform.md
@@ -44,10 +44,6 @@ keywords: platform callbacks, training callbacks, console logging, YOLO11 traini
 
 <br><br><hr><br>
 
-## ::: ultralytics.utils.callbacks.platform._upload_model_async
-
-<br><br><hr><br>
-
 ## ::: ultralytics.utils.callbacks.platform._get_environment_info
 
 <br><br><hr><br>

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -270,20 +270,25 @@ def _upload_model(model_path, project, name, progress=False, retry=1, model_id=N
     if safe_upload(file=model_path, url=data["uploadUrl"], retry=retry, progress=progress):
         gcs_path = data.get("gcsPath")
         if gcs_path and run_id:
-            _send(
+            saved = _send(
                 "checkpoint_saved",
-                {"modelPath": gcs_path, "modelSize": model_path.stat().st_size, "runId": run_id},
+                {
+                    "modelPath": gcs_path,
+                    "runId": run_id,
+                    "uploadPath": data.get("uploadPath"),
+                },
                 project,
                 name,
                 model_id,
             )
+            return gcs_path if saved else None
         return gcs_path
     return None
 
 
 def _upload_model_async(model_path, project, name, model_id=None, run_id=None):
     """Upload model asynchronously using bounded thread pool."""
-    _executor.submit(_upload_model, model_path, project, name, model_id=model_id, run_id=run_id)
+    return _executor.submit(_upload_model, model_path, project, name, model_id=model_id, run_id=run_id)
 
 
 def _get_environment_info():
@@ -359,7 +364,8 @@ def on_pretrain_routine_start(trainer):
     ctx = {
         "model_id": None,
         "run_id": None,
-        "last_upload": 0,
+        "last_upload": time(),
+        "checkpoint_upload": None,
         "cancelled": False,
         "console_logger": None,
         "system_logger": None,
@@ -485,13 +491,17 @@ def on_model_save(trainer):
     # Rate limit to every 15 minutes (900 seconds)
     if time() - ctx["last_upload"] < 900:
         return
+    if ctx["checkpoint_upload"] and not ctx["checkpoint_upload"].done():
+        return
 
     model_path = trainer.best if trainer.best and Path(trainer.best).exists() else trainer.last
     if not model_path:
         return
 
     project, name = _get_project_name(trainer)
-    _upload_model_async(model_path, project, name, model_id=ctx["model_id"], run_id=ctx["run_id"])
+    ctx["checkpoint_upload"] = _upload_model_async(
+        model_path, project, name, model_id=ctx["model_id"], run_id=ctx["run_id"]
+    )
     ctx["last_upload"] = time()
 
 
@@ -515,6 +525,8 @@ def on_train_end(trainer):
     gcs_path = None
     model_size = None
     if trainer.best and Path(trainer.best).exists():
+        if ctx["checkpoint_upload"]:
+            ctx["checkpoint_upload"].result()
         model_size = Path(trainer.best).stat().st_size
         gcs_path = _upload_model(
             trainer.best,
@@ -557,6 +569,7 @@ def on_train_end(trainer):
             },
             "classNames": class_names,
             "plots": plots,
+            "runId": ctx["run_id"],
         },
         project,
         name,

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -271,8 +271,20 @@ def _upload_model(model_path, project, name, progress=False, retry=1, model_id=N
 
 
 def _upload_model_async(model_path, project, name, model_id=None):
-    """Upload model asynchronously using bounded thread pool."""
-    _executor.submit(_upload_model, model_path, project, name, model_id=model_id)
+    """Upload model asynchronously and record the successful checkpoint on Platform."""
+
+    def upload_and_record():
+        model_size = Path(model_path).stat().st_size
+        if gcs_path := _upload_model(model_path, project, name, model_id=model_id):
+            _send(
+                "checkpoint_saved",
+                {"modelPath": gcs_path, "modelSize": model_size},
+                project,
+                name,
+                model_id,
+            )
+
+    _executor.submit(upload_and_record)
 
 
 def _get_environment_info():

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -184,7 +184,7 @@ def _sanitize_json_value(value):
     return value
 
 
-def _send(event, data, project, name, model_id=None, retry=2):
+def _send(event, data, project, name, model_id=None, retry=2, timeout=30):
     """Send event to Platform endpoint with retry logic."""
     payload = {"event": event, "project": project, "name": name, "data": _sanitize_json_value(data)}
     if model_id:
@@ -196,7 +196,7 @@ def _send(event, data, project, name, model_id=None, retry=2):
             f"{PLATFORM_API_URL}/training/metrics",
             json=payload,
             headers={"Authorization": f"Bearer {_api_key}"},
-            timeout=30,
+            timeout=timeout,
         )
         if 400 <= r.status_code < 500 and r.status_code not in {408, 429}:
             try:
@@ -280,6 +280,7 @@ def _upload_model(model_path, project, name, progress=False, retry=1, model_id=N
                 project,
                 name,
                 model_id,
+                timeout=90,
             )
             return gcs_path if saved else None
         return gcs_path

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -287,11 +287,6 @@ def _upload_model(model_path, project, name, progress=False, retry=1, model_id=N
     return None
 
 
-def _upload_model_async(model_path, project, name, model_id=None, run_id=None):
-    """Upload model asynchronously using bounded thread pool."""
-    return _executor.submit(_upload_model, model_path, project, name, model_id=model_id, run_id=run_id)
-
-
 def _get_environment_info():
     """Collect comprehensive environment info using existing ultralytics utilities."""
     import shutil
@@ -500,8 +495,8 @@ def on_model_save(trainer):
         return
 
     project, name = _get_project_name(trainer)
-    ctx["checkpoint_upload"] = _upload_model_async(
-        model_path, project, name, model_id=ctx["model_id"], run_id=ctx["run_id"]
+    ctx["checkpoint_upload"] = _executor.submit(
+        _upload_model, model_path, project, name, model_id=ctx["model_id"], run_id=ctx["run_id"]
     )
     ctx["last_upload"] = time()
 

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -234,7 +234,7 @@ def _handle_control_response(trainer, ctx, response):
         LOGGER.info(f"{PREFIX}Training cancelled from Platform ⚠️")
 
 
-def _upload_model(model_path, project, name, progress=False, retry=1, model_id=None):
+def _upload_model(model_path, project, name, progress=False, retry=1, model_id=None, run_id=None):
     """Upload model checkpoint to Platform via signed URL."""
     from ultralytics.utils.uploads import safe_upload
 
@@ -249,6 +249,8 @@ def _upload_model(model_path, project, name, progress=False, retry=1, model_id=N
         payload = {"project": project, "name": name, "filename": model_path.name}
         if model_id:
             payload["modelId"] = model_id  # Direct lookup avoids slug mismatch from auto-increment
+        if run_id:
+            payload["runId"] = run_id
         r = requests.post(
             f"{PLATFORM_API_URL}/models/upload",
             json=payload,
@@ -266,25 +268,22 @@ def _upload_model(model_path, project, name, progress=False, retry=1, model_id=N
 
     # Upload to GCS using safe_upload with retry logic and optional progress bar
     if safe_upload(file=model_path, url=data["uploadUrl"], retry=retry, progress=progress):
-        return data.get("gcsPath")
-    return None
-
-
-def _upload_model_async(model_path, project, name, model_id=None):
-    """Upload model asynchronously and record the successful checkpoint on Platform."""
-
-    def upload_and_record():
-        model_size = Path(model_path).stat().st_size
-        if gcs_path := _upload_model(model_path, project, name, model_id=model_id):
+        gcs_path = data.get("gcsPath")
+        if gcs_path and run_id:
             _send(
                 "checkpoint_saved",
-                {"modelPath": gcs_path, "modelSize": model_size},
+                {"modelPath": gcs_path, "modelSize": model_path.stat().st_size, "runId": run_id},
                 project,
                 name,
                 model_id,
             )
+        return gcs_path
+    return None
 
-    _executor.submit(upload_and_record)
+
+def _upload_model_async(model_path, project, name, model_id=None, run_id=None):
+    """Upload model asynchronously using bounded thread pool."""
+    _executor.submit(_upload_model, model_path, project, name, model_id=model_id, run_id=run_id)
 
 
 def _get_environment_info():
@@ -357,7 +356,14 @@ def on_pretrain_routine_start(trainer):
     LOGGER.info(f"{PREFIX}Streaming training metrics to Platform")
 
     # Single dict for all platform callback state (like trainer.hub_session for HUB callbacks)
-    ctx = {"model_id": None, "last_upload": time(), "cancelled": False, "console_logger": None, "system_logger": None}
+    ctx = {
+        "model_id": None,
+        "run_id": None,
+        "last_upload": 0,
+        "cancelled": False,
+        "console_logger": None,
+        "system_logger": None,
+    }
     trainer.platform = ctx
 
     # Create callback to send console output to Platform
@@ -397,6 +403,7 @@ def on_pretrain_routine_start(trainer):
     )
     if response and response.get("modelId"):
         ctx["model_id"] = response["modelId"]
+        ctx["run_id"] = response.get("runId")
         # Server returns actual slug (may differ from requested name due to auto-increment, e.g. "train" → "train-2")
         if response.get("modelSlug"):
             ctx["model_slug"] = response["modelSlug"]
@@ -484,7 +491,7 @@ def on_model_save(trainer):
         return
 
     project, name = _get_project_name(trainer)
-    _upload_model_async(model_path, project, name, model_id=ctx["model_id"])
+    _upload_model_async(model_path, project, name, model_id=ctx["model_id"], run_id=ctx["run_id"])
     ctx["last_upload"] = time()
 
 
@@ -509,7 +516,15 @@ def on_train_end(trainer):
     model_size = None
     if trainer.best and Path(trainer.best).exists():
         model_size = Path(trainer.best).stat().st_size
-        gcs_path = _upload_model(trainer.best, project, name, progress=True, retry=3, model_id=ctx["model_id"])
+        gcs_path = _upload_model(
+            trainer.best,
+            project,
+            name,
+            progress=True,
+            retry=3,
+            model_id=ctx["model_id"],
+            run_id=ctx["run_id"],
+        )
         if not gcs_path:
             LOGGER.warning(f"{PREFIX}Model will not be available for download on Platform (upload failed)")
 


### PR DESCRIPTION
## Summary

- keep the existing 15-minute asynchronous checkpoint cadence, including the first periodic upload after 15 minutes
- acknowledge successful uploads through the existing `_upload_model` owner so Platform can promote them to the model
- serialize periodic uploads and wait for any earlier background upload only on the already-blocking final upload path
- bind checkpoint and completion callbacks to the server-issued training run ID

Platform keeps one canonical `best.pt`; each newer valid checkpoint overwrites it. Periodic network uploads remain non-blocking, while the final upload remains blocking as before.

Deleted: the duplicate nested upload wrapper, the discarded async upload result, and the proposed immediate-first-upload behavior. Reused `_upload_model`, `_upload_model_async`, the existing executor, and the existing 15-minute timer.

Net-positive justification: the returned Future and run ID are the minimum coordination needed to prevent an older background or stale-run upload from overwriting the latest canonical checkpoint.

## Validation

- `ruff format ultralytics/utils/callbacks/platform.py`
- `ruff check ultralytics/utils/callbacks/platform.py`
- `python -m compileall -q ultralytics/utils/callbacks/platform.py`

Platform counterpart: https://github.com/ultralytics/portal/pull/2899

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Improves Platform checkpoint uploads by linking them to training runs, preventing duplicate uploads, and ensuring final uploads complete reliably.

### 📊 Key Changes

- Adds `run_id` tracking throughout the Platform training callback workflow.
- Includes `runId` when requesting signed model-upload URLs and when reporting saved checkpoints.
- Replaces the standalone asynchronous upload helper with tracked executor futures.
- Prevents overlapping checkpoint uploads during training.
- Waits for any active checkpoint upload to finish before completing the training-end upload.
- Adds configurable request timeouts to `_send()`, including a longer timeout for checkpoint confirmation.
- Updates Platform callback documentation to remove the private `_upload_model_async` reference.

### 🎯 Purpose & Impact

- ✅ Ensures uploaded checkpoints are correctly associated with the corresponding training run.
- ⚡ Reduces redundant or concurrent uploads, improving resource usage and reliability.
- 📦 Makes final model availability on the Platform more dependable by waiting for in-progress uploads.
- 🔗 Enables Platform users to track intermediate checkpoints and final training outputs more accurately.
- 🛠️ Keeps generated API documentation aligned with the updated internal implementation.