### PR TITLE
Use requests for redirecting downloads

### DIFF
--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -347,7 +347,7 @@ def safe_download(
                         r = subprocess.run(["curl", "-#", f"-{s}L", url, "-o", f, "--retry", "3", "-C", "-"]).returncode
                         assert r == 0, f"Curl return value {r}"
                     else:  # requests download
-                        with requests.get(url, stream=True) as response:
+                        with requests.get(url, stream=True, headers={"Accept-Encoding": "identity"}) as response:
                             response.raise_for_status()
                             expected_size = int(response.headers.get("Content-Length", 0))
                             if i == 0 and expected_size > 1048576:

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -9,7 +9,7 @@ import tarfile
 from itertools import repeat
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
-from urllib import parse, request
+from urllib import parse
 
 from ultralytics.utils import ASSETS_URL, LOGGER, TQDM, checks, clean_url, emojis, is_online, url2file
 
@@ -65,8 +65,9 @@ def is_url(url: str | Path, check: bool = False) -> bool:
         if not (result.scheme and result.netloc):
             return False
         if check:
-            r = request.urlopen(request.Request(url, method="HEAD"), timeout=3)
-            return 200 <= r.getcode() < 400
+            import requests  # scoped as slow import
+
+            return requests.head(url, timeout=3, allow_redirects=True).ok
         return True
     except Exception:
         return False
@@ -325,10 +326,12 @@ def safe_download(
     if "://" not in url and Path(url).is_file():  # local file path ('://' check required in Windows Python<3.10)
         f = Path(url)
     else:
+        import requests  # scoped as slow import
+
         gdrive = url.startswith("https://drive.google.com/")  # check if the URL is a Google Drive link
         if gdrive:
             url, file = get_google_drive_file_info(url)
-        url = url.replace(" ", "%20")  # encode spaces for curl/urllib compatibility
+        url = url.replace(" ", "%20")  # encode spaces for curl compatibility
 
         f = Path(dir or ".") / (file or url2file(url))  # URL converted to filename
         if not f.is_file():  # URL and file do not exist
@@ -336,16 +339,17 @@ def safe_download(
             desc = f"Downloading {uri} to '{f}'"
             f.parent.mkdir(parents=True, exist_ok=True)  # make directory if missing
             curl_installed = shutil.which("curl")
-            expected_size = None  # set by urllib from Content-Length; reused to validate curl retries
+            expected_size = None  # set from Content-Length; reused to validate curl retries
             for i in range(retry + 1):
                 try:
                     if (curl or i > 0) and curl_installed:  # curl download with retry, continue
                         s = "sS" * (not progress)  # silent
                         r = subprocess.run(["curl", "-#", f"-{s}L", url, "-o", f, "--retry", "3", "-C", "-"]).returncode
                         assert r == 0, f"Curl return value {r}"
-                    else:  # urllib download
-                        with request.urlopen(url) as response:
-                            expected_size = int(response.getheader("Content-Length", 0))
+                    else:  # requests download
+                        with requests.get(url, stream=True) as response:
+                            response.raise_for_status()
+                            expected_size = int(response.headers.get("Content-Length", 0))
                             if i == 0 and expected_size > 1048576:
                                 check_disk_space(expected_size, path=f.parent)
                             buffer_size = max(8192, min(1048576, expected_size // 1000)) if expected_size else 8192
@@ -358,10 +362,7 @@ def safe_download(
                                 unit_divisor=1024,
                             ) as pbar:
                                 with open(f, "wb") as f_opened:
-                                    while True:
-                                        data = response.read(buffer_size)
-                                        if not data:
-                                            break
+                                    for data in response.iter_content(chunk_size=buffer_size):
                                         f_opened.write(data)
                                         pbar.update(len(data))
 


### PR DESCRIPTION
## Summary

Replace the two urllib HTTP call sites with the existing `requests` dependency so Python 3.8-3.10 follows HTTP 308 redirects without a compatibility shim.

Deleted: the urllib request import, both urllib HTTP calls, and the manual response read loop.

The one-line net addition is `raise_for_status()`, required because requests does not raise on HTTP errors automatically as urllib did.

## Validation

- `ruff format --check ultralytics/utils/downloads.py`
- `ruff check ultralytics/utils/downloads.py`
- `pytest -q tests/test_python.py` — 109 passed, 2 skipped
- Live 308 HEAD and streamed download on Python 3.8 — 137,419-byte `bus.jpg`
- Live 404 URL validation and download failure behavior

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Replaces Python’s built-in URL handling with `requests` for more reliable URL checks and file downloads.

### 📊 Key Changes

- Uses `requests.head()` in `is_url()` to validate URLs, including redirects.
- Uses streamed `requests.get()` downloads in `safe_download()`.
- Adds response error handling with `raise_for_status()`.
- Preserves download progress reporting, disk-space checks, retries, and curl support.
- Loads `requests` only when needed to avoid slowing startup.

### 🎯 Purpose & Impact

- ✅ Improves compatibility and reliability when accessing remote files.
- 🔁 Better handles HTTP redirects and server responses during downloads.
- 🛡️ Provides clearer failures for unsuccessful HTTP requests.
- ⚡ Keeps the lightweight import path fast through scoped imports.
- 📥 Existing download workflows should continue working while benefiting from more robust networking behavior.