### PR TITLE
Fix Python 3.13 pathlib checkpoint loading

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1661,12 +1661,14 @@ class _SafeLoad:
                 pathlib.WindowsPath,
                 (pathlib.WindowsPath, "pathlib.WindowsPath"),
                 (pathlib.WindowsPath, "pathlib.PosixPath"),
+                (pathlib.WindowsPath, f"{pathlib.PosixPath.__module__}.{pathlib.PosixPath.__qualname__}"),
             ]
         else:
             allow += [
                 pathlib.PosixPath,
                 (pathlib.PosixPath, "pathlib.PosixPath"),
                 (pathlib.PosixPath, "pathlib.WindowsPath"),
+                (pathlib.PosixPath, f"{pathlib.WindowsPath.__module__}.{pathlib.WindowsPath.__qualname__}"),
             ]
         return allow
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1657,9 +1657,9 @@ class _SafeLoad:
             (_getattr, "builtins.getattr"),  # non-det YOLOv8, YOLO11 ckpts (restrict to nn.Module attrs)
         ]
         if WINDOWS:
-            allow += [pathlib.WindowsPath, (pathlib.WindowsPath, "pathlib.PosixPath")]
+            allow += [(pathlib.WindowsPath, "pathlib.WindowsPath"), (pathlib.WindowsPath, "pathlib.PosixPath")]
         else:
-            allow += [pathlib.PosixPath, (pathlib.PosixPath, "pathlib.WindowsPath")]
+            allow += [(pathlib.PosixPath, "pathlib.PosixPath"), (pathlib.PosixPath, "pathlib.WindowsPath")]
         return allow
 
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1657,9 +1657,17 @@ class _SafeLoad:
             (_getattr, "builtins.getattr"),  # non-det YOLOv8, YOLO11 ckpts (restrict to nn.Module attrs)
         ]
         if WINDOWS:
-            allow += [(pathlib.WindowsPath, "pathlib.WindowsPath"), (pathlib.WindowsPath, "pathlib.PosixPath")]
+            allow += [
+                pathlib.WindowsPath,
+                (pathlib.WindowsPath, "pathlib.WindowsPath"),
+                (pathlib.WindowsPath, "pathlib.PosixPath"),
+            ]
         else:
-            allow += [(pathlib.PosixPath, "pathlib.PosixPath"), (pathlib.PosixPath, "pathlib.WindowsPath")]
+            allow += [
+                pathlib.PosixPath,
+                (pathlib.PosixPath, "pathlib.PosixPath"),
+                (pathlib.PosixPath, "pathlib.WindowsPath"),
+            ]
         return allow
 
 


### PR DESCRIPTION
## Summary

Python 3.13 moved concrete path classes to the internal `pathlib._local` module. Restricted checkpoint loading therefore registered native Python 3.13 paths but could not load Platform classification checkpoints serialized under the stable public `pathlib.PosixPath` name. Preserve native registration and add stable public aliases for both platform path classes so safe loading remains cross-version and cross-platform.

Deleted: nothing; the central allowlist needs two additional public-name aliases because replacing its native registrations would reject Python 3.13-generated checkpoints.

## Validation

- Reproduced the restricted-load failure with the exact Platform production classification checkpoint from community report 2122
- Loaded that public-name checkpoint successfully with `ULTRALYTICS_SAFE_LOAD=true` on Python 3.13
- Created and restricted-loaded a native Python 3.13 checkpoint containing `pathlib.Path`
- Exported the reported classification checkpoint successfully to ONNX at 224px, batch 1
- Loaded `yolo26n.pt` successfully with restricted loading
- `ruff format ultralytics/nn/tasks.py`
- `ruff check ultralytics/nn/tasks.py`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves YOLO model checkpoint loading across Windows and non-Windows systems by expanding safe `pathlib` compatibility. 🛠️

### 📊 Key Changes

- Added additional `pathlib.WindowsPath` and `pathlib.PosixPath` mappings to the checkpoint safe-loading allowlist.
- Supports both standard and fully qualified class names during deserialization.
- Handles checkpoints created on one operating system and loaded on another more reliably. 🌐

### 🎯 Purpose & Impact

- Reduces checkpoint loading errors caused by platform-specific path representations.
- Improves portability for users transferring models between Windows and Linux or other operating systems.
- Makes model loading more robust without changing training or inference behavior. ✅