### PR TITLE
Add Hailo segmentation export and inference for YOLOv8 and YOLO11

### DIFF
--- a/docs/en/integrations/hailo.md
+++ b/docs/en/integrations/hailo.md
@@ -1,12 +1,12 @@
 ---
 comments: true
-description: Export Ultralytics YOLO object detection models directly to Hailo HEF for computer vision and edge AI on Hailo-8, Hailo-8L, Hailo-10, and Hailo-15 accelerators.
-keywords: Hailo export, Hailo HEF, export YOLO to Hailo, YOLO Hailo, Hailo-8, Hailo-8L, Hailo-10, Hailo-15, Raspberry Pi AI Kit, Raspberry Pi AI HAT+, Hailo Dataflow Compiler, Hailo DFC, HailoRT, Hailo AI accelerator, edge AI, embedded AI, computer vision, object detection, model quantization, INT8 quantization, Ultralytics YOLO, YOLO26, YOLO11, YOLOv8
+description: Export Ultralytics YOLO detection and segmentation models directly to Hailo HEF for computer vision and edge AI on Hailo-8, Hailo-8L, Hailo-10, and Hailo-15 accelerators.
+keywords: Hailo export, Hailo HEF, export YOLO to Hailo, YOLO Hailo, Hailo-8, Hailo-8L, Hailo-10, Hailo-15, Raspberry Pi AI Kit, Raspberry Pi AI HAT+, Hailo Dataflow Compiler, Hailo DFC, HailoRT, Hailo AI accelerator, edge AI, embedded AI, computer vision, object detection, instance segmentation, model quantization, INT8 quantization, Ultralytics YOLO, YOLO26, YOLO11, YOLOv8
 ---
 
 # Hailo Export for Ultralytics YOLO Models
 
-Hailo AI accelerators run compiled Hailo Executable Format (HEF) models on edge devices such as the [Raspberry Pi AI Kit](https://www.raspberrypi.com/products/ai-kit/) and [AI HAT+](https://www.raspberrypi.com/documentation/accessories/ai-hat-plus.html). Ultralytics exports YOLO detection models directly to HEF with the Hailo Dataflow Compiler (DFC).
+Hailo AI accelerators run compiled Hailo Executable Format (HEF) models on edge devices such as the [Raspberry Pi AI Kit](https://www.raspberrypi.com/products/ai-kit/) and [AI HAT+](https://www.raspberrypi.com/documentation/accessories/ai-hat-plus.html). Ultralytics exports YOLO detection and segmentation models directly to HEF with the Hailo Dataflow Compiler (DFC).
 
 Hailo deployment is designed for computer vision at the edge: cameras, robots, industrial systems, gateways, and other devices that need local object detection without sending every frame to the cloud. A compiled HEF contains the quantized network, hardware allocation, scheduling, and optional HailoRT post-processing needed by the selected accelerator.
 
@@ -37,13 +37,13 @@ YOLO (.pt) -> ONNX -> Hailo parse -> INT8 optimization -> HEF compile
 The exporter performs these stages automatically:
 
 1. Exports a static ONNX graph with compiler-compatible settings.
-2. Selects the detection-head outputs for the model architecture.
+2. Selects the head outputs for the model architecture.
 3. Generates normalization, activation, and post-processing directives.
 4. Builds a representative calibration stream and quantizes the model to INT8.
 5. Compiles the optimized graph for the selected Hailo accelerator.
 6. Saves the HEF with Ultralytics metadata and removes the intermediate ONNX file.
 
-YOLOv8 and YOLO11 use HailoRT YOLO NMS in the compiled pipeline. YOLO26 uses its NMS-free one-to-one detection outputs, so the exporter selects a different output and quantization path automatically. Users do not need to find ONNX end nodes, write a Hailo model script (`.alls`), or create an NMS JSON manually.
+YOLOv8 and YOLO11 use HailoRT YOLO NMS in the compiled pipeline. YOLO26 uses its NMS-free one-to-one detection outputs, so the exporter selects a different output and quantization path automatically. YOLOv8-seg and YOLO11-seg compile the raw segmentation head tensors, which Ultralytics decodes at inference. Users do not need to find ONNX end nodes, write a Hailo model script (`.alls`), or create an NMS JSON manually.
 
 ## Installation
 
@@ -100,23 +100,24 @@ model.export(format="hailo", name="hailo8l", imgsz=640)
 
 ## Supported Models and Hardware
 
-The Hailo ecosystem covers a broad range of computer vision workloads, but the Ultralytics `format="hailo"` exporter currently validates only standard YOLO object detection heads. The table below describes this direct integration, not every workload the Hailo ecosystem can run.
+The Hailo ecosystem covers a broad range of computer vision workloads, but the Ultralytics `format="hailo"` exporter currently validates only standard YOLO detection and segmentation heads. The table below describes this direct integration, not every workload the Hailo ecosystem can run.
 
-| Ultralytics task          | Direct Hailo export | Supported model families | Notes                                                        |
-| :------------------------ | :-----------------: | :----------------------- | :----------------------------------------------------------- |
-| Object detection          |         ✅          | YOLOv8, YOLO11, YOLO26   | Standard Ultralytics `Detect` heads, including custom models |
-| Instance segmentation     |         ❌          | —                        | Not yet supported by the direct exporter                     |
-| Image classification      |         ❌          | —                        | Not yet supported by the direct exporter                     |
-| Pose estimation           |         ❌          | —                        | Not yet supported by the direct exporter                     |
-| Oriented object detection |         ❌          | —                        | OBB heads are not yet supported                              |
-| Semantic segmentation     |         ❌          | —                        | Not yet supported by the direct exporter                     |
+| Ultralytics task          | Direct Hailo export | Supported model families | Notes                                                                                       |
+| :------------------------ | :-----------------: | :----------------------- | :------------------------------------------------------------------------------------------ |
+| Object detection          |         ✅          | YOLOv8, YOLO11, YOLO26   | Standard Ultralytics `Detect` heads, including custom models                                |
+| Instance segmentation     |         ✅          | YOLOv8, YOLO11           | Raw head tensors decoded by Ultralytics at inference; YOLO26-seg is not currently supported |
+| Image classification      |         ❌          | —                        | Not yet supported by the direct exporter                                                    |
+| Pose estimation           |         ❌          | —                        | Not yet supported by the direct exporter                                                    |
+| Oriented object detection |         ❌          | —                        | OBB heads are not yet supported                                                             |
+| Semantic segmentation     |         ❌          | —                        | Not yet supported by the direct exporter                                                    |
 
 Specialized detection families such as YOLOv10, YOLO-World, YOLOE, and RT-DETR are also ❌ unsupported. Ultralytics rejects these tasks and model families before compilation instead of producing an unvalidated HEF.
 
-| Model family    | Hailo-8 / Hailo-8L | Hailo-10 / Hailo-15 | Output                                                 |
-| :-------------- | :----------------: | :-----------------: | :----------------------------------------------------- |
-| YOLOv8 / YOLO11 |         ✅         |         ✅          | HEF with HailoRT YOLO NMS                              |
-| YOLO26          |         ✅         |         ✅          | NMS-free detection-head outputs for supported runtimes |
+| Model family            | Hailo-8 / Hailo-8L | Hailo-10 / Hailo-15 | Output                                                        |
+| :---------------------- | :----------------: | :-----------------: | :------------------------------------------------------------ |
+| YOLOv8 / YOLO11         |         ✅         |         ✅          | HEF with HailoRT YOLO NMS                                     |
+| YOLO26                  |         ✅         |         ✅          | NMS-free detection-head outputs for supported runtimes        |
+| YOLOv8-seg / YOLO11-seg |         ✅         |         ✅          | Raw segmentation tensors, decoded by Ultralytics at inference |
 
 Select one of these `name` values:
 
@@ -150,7 +151,7 @@ Hailo compilation is hardware-specific and uses a fixed input shape. Keep these 
 - Calibration images should represent the lighting, viewpoints, objects, and backgrounds expected in production.
 - A HEF compiled with one `imgsz` does not become dynamically resizable at runtime.
 - Custom class counts are supported because Ultralytics generates post-processing configuration from the model metadata.
-- Detection models with standard Ultralytics `Detect` heads are supported; segmentation, pose, oriented bounding box, classification, YOLO-World, YOLOE, YOLOv10, and RT-DETR exports are not currently supported.
+- Detection models with standard Ultralytics `Detect` heads and YOLOv8/YOLO11 segmentation models are supported; YOLO26 segmentation, pose, oriented bounding box, classification, YOLO-World, YOLOE, YOLOv10, and RT-DETR exports are not currently supported.
 - Hailo-8/8L and Hailo-10/15 artifacts are compiled by different DFC generations and are not interchangeable.
 
 ## Calibration and INT8 Quantization
@@ -178,7 +179,7 @@ yolo11n_hailo_model/
 
 - `*.hef` is the compiled model loaded by HailoRT.
 - `metadata.yaml` preserves model names, task, input size, stride, and Hailo target information.
-- `nms_config.json` records the generated HailoRT NMS configuration for YOLOv8 and YOLO11 detection models. YOLO26 does not use this file.
+- `nms_config.json` records the generated HailoRT NMS configuration for YOLOv8 and YOLO11 detection models. YOLO26 and segmentation models do not use this file.
 
 The intermediate ONNX graph is removed after compilation.
 
@@ -317,7 +318,7 @@ A supported GPU greatly reduces DFC optimization time. CPU compilation is possib
 
 ### Which YOLO models support Hailo export?
 
-Direct export supports object detection models with the standard YOLOv8, YOLO11, or YOLO26 detection head. This includes custom-trained models built from those standard detection architectures. Classification, segmentation, pose, OBB, YOLOv10, YOLO-World, YOLOE, and RT-DETR are rejected rather than producing an unvalidated HEF.
+Direct export supports detection models with the standard YOLOv8, YOLO11, or YOLO26 detection head, and YOLOv8/YOLO11 segmentation models. This includes custom-trained models built from those standard architectures. Classification, YOLO26 segmentation, pose, OBB, YOLOv10, YOLO-World, YOLOE, and RT-DETR are rejected rather than producing an unvalidated HEF.
 
 ### Can I export a custom-trained YOLO model?
 
@@ -345,12 +346,12 @@ Download the compiler wheel for your hardware generation from the Hailo Develope
 
 ## Summary
 
-Ultralytics Hailo export provides a direct path from a trained YOLO detection model to a deployable HEF:
+Ultralytics Hailo export provides a direct path from a trained YOLO model to a deployable HEF:
 
-1. Load a YOLOv8, YOLO11, or YOLO26 detection model.
+1. Load a YOLOv8, YOLO11, or YOLO26 detection model, or a YOLOv8/YOLO11 segmentation model.
 2. Export with `format="hailo"` and select the target architecture.
 3. Calibrate and compile locally with the matching DFC, or use managed export in Ultralytics Platform.
 4. Copy the HEF and `metadata.yaml` to the Hailo-powered edge device.
-5. Run object detection with HailoRT, Raspberry Pi Picamera2, or a GStreamer video pipeline.
+5. Run inference with HailoRT, Raspberry Pi Picamera2, or a GStreamer video pipeline.
 
 For other computer vision deployment targets, see [Export mode](../modes/export.md), [Benchmark mode](../modes/benchmark.md), and the [integrations guide](index.md). Related hardware guides include [ONNX](onnx.md), [OpenVINO](openvino.md), [TensorRT](tensorrt.md), [NCNN](ncnn.md), [RKNN](rockchip-rknn.md), [Sony IMX500](sony-imx500.md), and [Qualcomm QNN](qnn.md).

--- a/docs/en/integrations/index.md
+++ b/docs/en/integrations/index.md
@@ -75,7 +75,7 @@ Welcome to the Ultralytics Integrations page! This page provides an overview of 
 
 - [Gradio](gradio.md): Deploy Ultralytics models with Gradio for real-time, interactive object detection demos.
 
-- [Hailo](hailo.md): Export Ultralytics YOLO detection models directly to Hailo HEF for Hailo-8, Hailo-8L, Hailo-10, and Hailo-15 accelerators.
+- [Hailo](hailo.md): Export Ultralytics YOLO detection and segmentation models directly to Hailo HEF for Hailo-8, Hailo-8L, Hailo-10, and Hailo-15 accelerators.
 
 - [MNN](mnn.md): Developed by [Alibaba](https://www.alibabagroup.com/), MNN is a highly efficient and lightweight deep learning framework. It supports inference and training of deep learning models and has industry-leading performance for inference and training on-device.
 

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.99"
+__version__ = "8.4.100"
 
 import importlib
 import os

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -80,7 +80,7 @@ from ultralytics.data import build_dataloader, build_yolo_dataset
 from ultralytics.data.dataset import ClassificationDataset
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.nn.autobackend import AutoBackend, check_class_names, default_class_names
-from ultralytics.nn.modules import C2f, Classify, Detect, RTDETRDecoder, Segment26, SemanticSegment
+from ultralytics.nn.modules import C2f, Classify, Detect, RTDETRDecoder, Segment, Segment26, SemanticSegment
 from ultralytics.nn.tasks import ClassificationModel, DetectionModel, SegmentationModel, WorldModel
 from ultralytics.utils import (
     ARM64,
@@ -581,12 +581,17 @@ class Exporter:
             family = Path(getattr(model, "yaml_file", None) or model.yaml.get("yaml_file", "")).stem.lower() or (
                 "yolov8" if "C2f" in blocks else "yolo11" if {"C3k2", "C2PSA"} <= blocks else ""
             )
+            if model.task == "segment" and any(isinstance(m, Segment26) for m in model.modules()):
+                raise ValueError("Hailo export does not currently support YOLO26 segmentation models.")
             if (
-                model.task != "detect"
-                or type(model.model[-1]) is not Detect
+                model.task not in {"detect", "segment"}
+                or type(model.model[-1]) not in {Detect, Segment}
                 or not family.startswith(("yolov8", "yolo11", "yolo26"))
             ):
-                raise ValueError("Hailo export currently supports YOLOv8, YOLO11, and YOLO26 detection models only.")
+                raise ValueError(
+                    "Hailo export currently supports YOLOv8, YOLO11, and YOLO26 detection models "
+                    "and YOLOv8/YOLO11 segmentation models."
+                )
             if self.args.end2end is not None:
                 raise ValueError(
                     "Hailo export selects the model output path automatically; remove the end2end argument."
@@ -1464,7 +1469,7 @@ class Exporter:
 
     @try_export
     def export_hailo(self, prefix=colorstr("Hailo:")):
-        """Export a YOLO detection model to Hailo Executable Format (HEF)."""
+        """Export a YOLO model to Hailo Executable Format (HEF)."""
         try:
             import tensorflow as tf
             from hailo_sdk_client import ClientRunner
@@ -1482,6 +1487,7 @@ class Exporter:
         head_index = len(self.model.model) - 1
         head = self.model.model[head_index]
         one2one = getattr(self.model, "end2end", False)
+        segment = self.model.task == "segment"
         scales = range(len(head.one2one_cv2 if one2one else head.cv2))
         if one2one:
             end_nodes = [
@@ -1489,6 +1495,10 @@ class Exporter:
                 for branch in (2, 3)
                 for i in scales
             ]
+        elif segment:
+            end_nodes = [
+                f"/model.{head_index}/cv{branch}.{i}/cv{branch}.{i}.2/Conv" for i in scales for branch in (2, 3, 4)
+            ] + [f"/model.{head_index}/proto/cv3/act/Mul"]
         else:
             end_nodes = [
                 f"/model.{head_index}/cv{branch}.{i}/cv{branch}.{i}.2/Conv" for i in scales for branch in (2, 3)
@@ -1510,6 +1520,11 @@ class Exporter:
             if one2one:
                 outputs = ", ".join(f"output_layer{i + 1}" for i in range(len(end_nodes)))
                 model_script.append(f"quantization_param([{outputs}], precision_mode=a16_w16)")
+            elif segment:
+                outputs = [layer.inputs[0].rsplit("/", 1)[-1] for layer in runner.get_hn_model().get_output_layers()]
+                model_script.extend(
+                    f"change_output_activation({outputs[i]}, sigmoid)" for i in range(1, len(outputs) - 1, 3)
+                )
             else:
                 outputs = [layer.inputs[0].rsplit("/", 1)[-1] for layer in runner.get_hn_model().get_output_layers()]
                 nms_config = output_dir / "nms_config.json"
@@ -1556,7 +1571,10 @@ class Exporter:
                 )
             )
             (output_dir / f"{self.file.stem}.hef").write_bytes(runner.compile())
-            YAML.save(output_dir / "metadata.yaml", {**self.metadata, "hailo_arch": self.args.name, "nms": not one2one})
+            YAML.save(
+                output_dir / "metadata.yaml",
+                {**self.metadata, "hailo_arch": self.args.name, "nms": not (one2one or segment)},
+            )
             return str(output_dir)
         finally:
             f_onnx.unlink(missing_ok=True)

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1520,43 +1520,43 @@ class Exporter:
             if one2one:
                 outputs = ", ".join(f"output_layer{i + 1}" for i in range(len(end_nodes)))
                 model_script.append(f"quantization_param([{outputs}], precision_mode=a16_w16)")
-            elif segment:
-                outputs = [layer.inputs[0].rsplit("/", 1)[-1] for layer in runner.get_hn_model().get_output_layers()]
-                model_script.extend(
-                    f"change_output_activation({outputs[i]}, sigmoid)" for i in range(1, len(outputs) - 1, 3)
-                )
             else:
                 outputs = [layer.inputs[0].rsplit("/", 1)[-1] for layer in runner.get_hn_model().get_output_layers()]
-                nms_config = output_dir / "nms_config.json"
-                nms_config.write_text(
-                    json.dumps(
-                        {
-                            "nms_scores_th": self.args.conf if self.args.conf is not None else 0.25,
-                            "nms_iou_th": self.args.iou,
-                            "image_dims": self.imgsz,
-                            "max_proposals_per_class": 100,
-                            "classes": len(self.model.names),
-                            "regression_length": 16,
-                            "background_removal": False,
-                            "background_removal_index": 0,
-                            "bbox_decoders": [
-                                {
-                                    "name": f"bbox_decoder_{stride}",
-                                    "stride": stride,
-                                    "reg_layer": outputs[i * 2],
-                                    "cls_layer": outputs[i * 2 + 1],
-                                }
-                                for i, stride in enumerate(int(x) for x in head.stride)
-                            ],
-                        },
-                        indent=2,
+                if segment:
+                    model_script.extend(
+                        f"change_output_activation({outputs[i]}, sigmoid)" for i in range(1, len(outputs) - 1, 3)
                     )
-                )
-                model_script.extend(
-                    f"change_output_activation({outputs[i]}, sigmoid)" for i in range(1, len(outputs), 2)
-                )
-                model_script.append(f'nms_postprocess("{nms_config}", meta_arch=yolov8, engine=cpu)')
-                model_script.append("allocator_param(width_splitter_defuse=disabled)")
+                else:
+                    nms_config = output_dir / "nms_config.json"
+                    nms_config.write_text(
+                        json.dumps(
+                            {
+                                "nms_scores_th": self.args.conf if self.args.conf is not None else 0.25,
+                                "nms_iou_th": self.args.iou,
+                                "image_dims": self.imgsz,
+                                "max_proposals_per_class": 100,
+                                "classes": len(self.model.names),
+                                "regression_length": 16,
+                                "background_removal": False,
+                                "background_removal_index": 0,
+                                "bbox_decoders": [
+                                    {
+                                        "name": f"bbox_decoder_{stride}",
+                                        "stride": stride,
+                                        "reg_layer": outputs[i * 2],
+                                        "cls_layer": outputs[i * 2 + 1],
+                                    }
+                                    for i, stride in enumerate(int(x) for x in head.stride)
+                                ],
+                            },
+                            indent=2,
+                        )
+                    )
+                    model_script.extend(
+                        f"change_output_activation({outputs[i]}, sigmoid)" for i in range(1, len(outputs), 2)
+                    )
+                    model_script.append(f'nms_postprocess("{nms_config}", meta_arch=yolov8, engine=cpu)')
+                    model_script.append("allocator_param(width_splitter_defuse=disabled)")
             runner.load_model_script("\n".join(model_script))
 
             def calibration_dataset():

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -581,7 +581,7 @@ class Exporter:
             family = Path(getattr(model, "yaml_file", None) or model.yaml.get("yaml_file", "")).stem.lower() or (
                 "yolov8" if "C2f" in blocks else "yolo11" if {"C3k2", "C2PSA"} <= blocks else ""
             )
-            if model.task == "segment" and any(isinstance(m, Segment26) for m in model.modules()):
+            if isinstance(model.model[-1], Segment26):
                 raise ValueError("Hailo export does not currently support YOLO26 segmentation models.")
             if (
                 model.task not in {"detect", "segment"}

--- a/ultralytics/nn/backends/hailo.py
+++ b/ultralytics/nn/backends/hailo.py
@@ -64,6 +64,10 @@ class HailoBackend(BaseBackend):
             self.model = stack.enter_context(InferVStreams(network_group, input_params, output_params))
             self._stack = stack.pop_all()
         self._anchors = None
+        if self.task == "segment":
+            from ultralytics.nn.modules import DFL
+
+            self._dfl = DFL()
         self.end2end = self.task != "segment"  # segmentation returns dense output for the predictor's NMS
 
     def __del__(self):
@@ -114,10 +118,7 @@ class HailoBackend(BaseBackend):
             strides = [self.input_info.shape[0] / x.shape[2] for x in reg_maps]
             self._anchors = make_anchors(reg_maps, strides)
         anchors, stride_tensor = self._anchors
-        dist = torch.cat([x.flatten(2) for x in reg_maps], 2)
-        b, _, a = dist.shape
-        proj = torch.arange(16, dtype=torch.float32)
-        dist = (dist.view(b, 4, 16, a).permute(0, 3, 1, 2).softmax(3) * proj).sum(3)  # DFL
+        dist = self._dfl(torch.cat([x.flatten(2) for x in reg_maps], 2)).transpose(1, 2)
         boxes = dist2bbox(dist, anchors, xywh=True) * stride_tensor
         cls = torch.cat([x.flatten(2) for x in cls_maps], 2).transpose(1, 2)  # sigmoid baked in at export
         cof = torch.cat([x.flatten(2) for x in cof_maps], 2).transpose(1, 2)

--- a/ultralytics/nn/backends/hailo.py
+++ b/ultralytics/nn/backends/hailo.py
@@ -46,8 +46,10 @@ class HailoBackend(BaseBackend):
             from ultralytics.utils import YAML
 
             self.apply_metadata(YAML.load(metadata_file))
-        if self.task and self.task != "detect":
-            raise ValueError(f"Hailo inference only supports detection models, not task='{self.task}'.")
+        if self.task and self.task not in {"detect", "segment"}:
+            raise ValueError(
+                f"Hailo inference only supports detection and segmentation models, not task='{self.task}'."
+            )
 
         self.hef = HEF(str(hef_file))
         self.input_info = self.hef.get_input_vstream_infos()[0]
@@ -62,18 +64,20 @@ class HailoBackend(BaseBackend):
             self.model = stack.enter_context(InferVStreams(network_group, input_params, output_params))
             self._stack = stack.pop_all()
         self._anchors = None
-        self.end2end = True
+        self.end2end = self.task != "segment"  # segmentation returns dense output for the predictor's NMS
 
     def __del__(self):
         """Release the Hailo pipeline and device."""
         if stack := getattr(self, "_stack", None):
             stack.close()
 
-    def forward(self, im: torch.Tensor) -> np.ndarray:
-        """Run Hailo inference and return detections in ``xyxy, confidence, class`` format."""
+    def forward(self, im: torch.Tensor) -> np.ndarray | list[torch.Tensor]:
+        """Run Hailo inference and return decoded detections, or dense outputs and prototypes for segmentation."""
         im = np.ascontiguousarray(np.clip(im.permute(0, 2, 3, 1).cpu().numpy() * 255, 0, 255).astype(np.uint8))
         results = self.model.infer({self.input_info.name: im})
         outputs = [results[x.name] for x in self.output_infos]
+        if self.task == "segment":
+            return self._decode_segment(outputs)
         return self._decode_raw(outputs) if not self.metadata.get("nms", False) else self._decode_nms(outputs[0])
 
     def _decode_nms(self, output: list) -> np.ndarray:
@@ -96,6 +100,28 @@ class HailoBackend(BaseBackend):
         for i, frame in enumerate(frames):
             predictions[i, : len(frame)] = frame
         return predictions
+
+    def _decode_segment(self, outputs: list[np.ndarray]) -> list[torch.Tensor]:
+        """Decode raw segmentation tensors (reg, cls, coeff per scale + prototypes) for the predictor's NMS."""
+        from ultralytics.utils.tal import dist2bbox, make_anchors
+
+        proto = torch.from_numpy(outputs[-1]).permute(0, 3, 1, 2)
+        k = len(outputs) - 1
+        reg_maps = [torch.from_numpy(x).permute(0, 3, 1, 2) for x in outputs[0:k:3]]
+        cls_maps = [torch.from_numpy(x).permute(0, 3, 1, 2) for x in outputs[1:k:3]]
+        cof_maps = [torch.from_numpy(x).permute(0, 3, 1, 2) for x in outputs[2:k:3]]
+        if self._anchors is None:
+            strides = [self.input_info.shape[0] / x.shape[2] for x in reg_maps]
+            self._anchors = make_anchors(reg_maps, strides)
+        anchors, stride_tensor = self._anchors
+        dist = torch.cat([x.flatten(2) for x in reg_maps], 2)
+        b, _, a = dist.shape
+        proj = torch.arange(16, dtype=torch.float32)
+        dist = (dist.view(b, 4, 16, a).permute(0, 3, 1, 2).softmax(3) * proj).sum(3)  # DFL
+        boxes = dist2bbox(dist, anchors, xywh=True) * stride_tensor
+        cls = torch.cat([x.flatten(2) for x in cls_maps], 2).transpose(1, 2)  # sigmoid baked in at export
+        cof = torch.cat([x.flatten(2) for x in cof_maps], 2).transpose(1, 2)
+        return [torch.cat((boxes, cls, cof), 2).transpose(1, 2), proto]
 
     def _decode_raw(self, outputs: list[np.ndarray]) -> np.ndarray:
         """Decode branch-first YOLO26 regression and class outputs."""


### PR DESCRIPTION
## Summary

Follow-up to #25247, extending the Hailo integration to instance segmentation for YOLOv8 and YOLO11. Axelera already covers this task, and users keep asking for it on the Hailo forum.

- `export_hailo` adds a segmentation branch: the ten raw head tensors (reg/cls/coeff per scale plus the prototypes, cut at `proto/cv3/act/Mul`), with the sigmoid for the class outputs applied on chip. There is no on-chip NMS, the DFC has no segmentation meta-architecture, so the HEF gets `nms: false` like the YOLO26 detect path.
- `HailoBackend` gets a new `_decode_segment`: DFL and `dist2bbox` on the cached anchors plus the mask coefficients, returning the standard dense output and prototypes, so the predictor's NMS and `process_mask` run unchanged. `nc`/`nm` come from the tensors; DFL uses the standard `reg_max=16`, same as the detect path's NMS config.
- YOLO26 segmentation is rejected with a clear error: the Hailo-8/8L allocator does not support the attention matmul fan-out of `Segment26` (verified on device with both the model-zoo ONNX and the native export).
- Docs: segmentation rows in the task and model tables, and the detection-only wording that was still in the rest of the page (supported-models intro, limitations, artifacts note, FAQ, summary), plus the Hailo entry in the integrations index, so every statement matches what the exporter now accepts.

Deleted: nothing — both changes extend the existing per-path branches in `export_hailo` and `HailoBackend` without touching the detect paths.

## Validation (Hailo-8L PCIe, HailoRT 4.23, DFC 3.33, this branch)

Both `yolov8n-seg` and `yolo11n-seg` exported end to end with this exporter (609 s / 798 s), then run through the full official pipeline on the device:

| `val` on coco128-seg | box mAP50 / mAP50-95 | mask mAP50 / mAP50-95 |
| --- | --- | --- |
| PyTorch `yolov8n-seg.pt` | 0.593 / 0.440 | 0.550 / 0.363 |
| HEF yolov8n-seg | 0.579 / 0.426 | 0.538 / 0.350 |
| PyTorch `yolo11n-seg.pt` | 0.652 / 0.484 | 0.604 / 0.394 |
| HEF yolo11n-seg | 0.618 / 0.456 | 0.566 / 0.366 |

Mask retention is 98.0% (YOLOv8) and 93.6% (YOLO11) of the PyTorch mAP50. `predict` returns boxes and masks through the standard pipeline (5/5 on bus.jpg). In a separate matched-pair check with `ops.process_mask`, the HEF masks reach mean mask-IoU 0.936 against PyTorch (n=610 pairs over COCO128), and the full pipeline (inference + decode + NMS + `process_mask` with upsample) runs at 14.6 ms/frame (68 FPS) for yolov8n-seg and 21.6 ms/frame (46 FPS) for yolo11n-seg on the 8L.

`uvx ruff check` and `uvx ruff format --check` pass on the changed files.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds Hailo export and inference support for YOLOv8 and YOLO11 instance segmentation models, alongside updated documentation and backend decoding.

### 📊 Key Changes
- Extends Hailo export validation to support YOLOv8 and YOLO11 `Segment` heads while rejecting YOLO26 segmentation.
- Exports segmentation head tensors and prototypes, applies the required Hailo activation configuration, and records segmentation metadata.
- Adds Hailo backend decoding for regression, classification, mask coefficients, and prototype outputs before Ultralytics post-processing.
- Updates Hailo integration documentation, supported-model tables, limitations, and integration listings.

### 🎯 Purpose & Impact
- Enables deployment of YOLOv8 and YOLO11 instance segmentation models on Hailo accelerators.
- Allows segmentation inference through existing Ultralytics prediction workflows instead of requiring custom runtime decoding.
- Preserves existing detection and YOLO26 support while clearly documenting unsupported segmentation and other task families.
- Expands edge AI deployment options for Hailo-powered devices such as Raspberry Pi platforms.