### PR TITLE
Document Hailo INT8 accuracy expectations and deployment guidance

### DIFF
--- a/docs/en/integrations/hailo.md
+++ b/docs/en/integrations/hailo.md
@@ -181,7 +181,7 @@ Three practical rules follow from device measurements:
 
 1. **Calibrate in-domain, always.** Fine-tuning with out-of-domain images is equivalent to disabling fine-tuning entirely: a YOLO26n calibrated with 1,238 out-of-domain images retains the same accuracy (85.7%) as one compiled without fine-tuning. A small in-domain set beats a large out-of-domain one.
 2. **Lower `conf` by about 0.05 for YOLO26 deployments.** Quantization shifts YOLO26 scores down by roughly 0.05 on average, so a threshold tuned in PyTorch drops valid detections on the HEF. Using `conf=0.20` on device matches the detection count of PyTorch at `conf=0.25` and recovers about half of the accuracy gap; the remainder is ranking noise that no threshold recovers.
-3. **The attention penalty is structural on Hailo-8/8L.** The Dataflow Compiler only supports 8-bit inputs for `matmul` layers on this hardware generation, so attention products cannot run at higher precision. When accuracy is the top priority and the model choice is flexible, YOLO11 currently quantizes better than YOLO26 on Hailo-8/8L.
+3. **The attention penalty is structural on Hailo-8/8L (DFC 3.33).** The attention blocks compile to `matmul` operations that keep INT8 activation inputs in every mode the compiler offers for them; the 16-bit-output mode fails allocation for this graph, and raising the precision of the surrounding layers does not help because the matmul requantizes its inputs to INT8 anyway (protecting the depthwise and output convolutions at 16-bit left mAP unchanged in our tests). When accuracy is the priority and the model is interchangeable, YOLO11 currently quantizes better than YOLO26 here; newer Hailo generations (DFC 5.x) expose more mixed-precision options and may differ.
 
 ## Exported Artifacts
 

--- a/docs/en/integrations/hailo.md
+++ b/docs/en/integrations/hailo.md
@@ -165,6 +165,24 @@ model.export(format="hailo", name="hailo8l", data="my_dataset.yaml")
 
 `fraction` selects the portion of the dataset used for calibration. More images help only when they represent the deployment domain; out-of-domain images can reduce quantized accuracy and increase optimization time. If the INT8 HEF loses accuracy relative to the original PyTorch model, first improve the calibration data before changing model or runtime settings.
 
+### Accuracy Expectations by Model Family
+
+Measured on a Hailo-8L with in-domain calibration (COCO128, 128 images), INT8 HEF exports retain the following share of their PyTorch mAP50 under the same evaluation protocol:
+
+| Model   | mAP50 retention | Notes                                                    |
+| :------ | :-------------- | :------------------------------------------------------- |
+| YOLOv8n | ~100%           | DFL head with on-chip NMS                                |
+| YOLO11n | ~96%            | Attention blocks in the backbone are more INT8-sensitive |
+| YOLO26n | ~93%            | End-to-end head plus attention; see the confidence note  |
+
+Retention compares both models at the same confidence threshold. YOLOv8 and YOLO11 HEFs bake the export-time `conf` (default 0.25) into the on-chip NMS, so validating against a PyTorch baseline at its default low threshold integrates a larger part of the precision-recall curve and overstates the quantization gap.
+
+Three practical rules follow from device measurements:
+
+1. **Calibrate in-domain, always.** Fine-tuning with out-of-domain images is equivalent to disabling fine-tuning entirely: a YOLO26n calibrated with 1,238 out-of-domain images retains the same accuracy (85.7%) as one compiled without fine-tuning. A small in-domain set beats a large out-of-domain one.
+2. **Lower `conf` by about 0.05 for YOLO26 deployments.** Quantization shifts YOLO26 scores down by roughly 0.05 on average, so a threshold tuned in PyTorch drops valid detections on the HEF. Using `conf=0.20` on device matches the detection count of PyTorch at `conf=0.25` and recovers about half of the accuracy gap; the remainder is ranking noise that no threshold recovers.
+3. **The attention penalty is structural on Hailo-8/8L.** The Dataflow Compiler only supports 8-bit inputs for `matmul` layers on this hardware generation, so attention products cannot run at higher precision. When accuracy is the top priority and the model choice is flexible, YOLO11 currently quantizes better than YOLO26 on Hailo-8/8L.
+
 ## Exported Artifacts
 
 Export creates a directory containing the deployable HEF and Ultralytics metadata:
@@ -295,7 +313,7 @@ DFC optimization is the most expensive stage. Compilation time increases with mo
 
 ### Quantized Model Accuracy Drops
 
-Use calibration images that resemble production inputs and include the important objects, scales, lighting conditions, and backgrounds. Compare the original PyTorch model and exported HEF on the same validation set before deployment.
+Use calibration images that resemble production inputs and include the important objects, scales, lighting conditions, and backgrounds. Compare the original PyTorch model and exported HEF on the same validation set before deployment. A moderate family-dependent gap remains even with good calibration; see [Accuracy Expectations by Model Family](#accuracy-expectations-by-model-family) for the measured baselines.
 
 ### HEF Does Not Load on the Device
 


### PR DESCRIPTION
## Summary

Follow-up to the quantization findings from #25247, where @glenn-jocher suggested moving them into the docs. This adds a new "Accuracy Expectations by Model Family" subsection to the Hailo integration page, with the measured INT8 mAP50 retention per family and the three practical rules that come from the device measurements:

1. Calibration has to be in-domain — out-of-domain fine-tuning gave the same result as no fine-tuning at all.
2. YOLO26 confidence shifts on device, `conf` ends about 0.05 lower than in PyTorch.
3. Attention layers lose more accuracy on Hailo-8/8L, because the DFC only supports 8-bit matmul inputs on this generation.

The subsection also states the evaluation protocol explicitly: both models compared at the same `conf`. YOLOv8/YOLO11 HEFs run the on-chip NMS with the threshold fixed at export time, so comparing against a PyTorch `val` run at its default low threshold makes the quantization gap look bigger than it is. Without that note the table numbers are hard to reproduce.

Also, the "Quantized Model Accuracy Drops" troubleshooting entry now links to the table, so a user can check if their gap is normal for that family or a real calibration problem.

All numbers come from the Hailo-8L measurements reported in the #25247 discussion (HailoRT 4.23, DFC 3.33, COCO128 protocol).

Deleted: nothing — one docs subsection plus one troubleshooting cross-reference added, no code changes.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Documents Hailo INT8 accuracy expectations and deployment guidance across YOLO model families.

### 📊 Key Changes
- Adds measured mAP50 retention baselines for YOLOv8n, YOLO11n, and YOLO26n on Hailo-8L with in-domain calibration.
- Explains confidence-threshold alignment between PyTorch evaluation and on-chip NMS for exported HEFs.
- Provides practical guidance on in-domain calibration, YOLO26 confidence adjustment, and attention-related quantization limits on Hailo-8/8L.
- Updates the quantized accuracy troubleshooting section to reference the new model-family baselines.

### 🎯 Purpose & Impact
- Sets clearer expectations for INT8 accuracy before deployment.
- Helps users choose calibration data and confidence thresholds that better preserve device performance.
- Highlights model-family and hardware considerations that can affect Hailo deployment accuracy.
- Improves documentation for developers deploying Ultralytics models to Hailo edge devices.