### PR TITLE
Expand fuzz exploration envelope

### DIFF
--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -86,10 +86,11 @@ CLAMPS = {
 EXPORT_POOL = ["torchscript", "onnx", "openvino"]  # CPU-friendly formats installed on every shard
 
 # Additional pretrained families with ordinary CLI contracts. Keep modes narrow to avoid prompt-only training paths.
+# The last field overrides CLAMPS: RT-DETR's 300-query decoder needs >=160px of anchors (below that is a T2 gap).
 ALTERNATE_CORPUS = (
-    ("detect", "rtdetr-l.pt", "coco8.yaml", {"val", "predict", "export"}),
-    ("detect", "yolov8s-worldv2.pt", "coco8.yaml", {"predict", "export"}),
-    ("segment", "yoloe-11s-seg-pf.pt", "coco8-seg.yaml", {"predict", "export"}),
+    ("detect", "rtdetr-l.pt", "coco8.yaml", {"val", "predict", "export"}, "imgsz=160"),
+    ("detect", "yolov8s-worldv2.pt", "coco8.yaml", {"predict", "export"}, ""),
+    ("segment", "yoloe-11s-seg-pf.pt", "coco8-seg.yaml", {"predict", "export"}, ""),
 )
 
 # Controlled variations for cost-sensitive keys excluded from arbitrary mutation.
@@ -225,7 +226,7 @@ def precache_assets(uni):
         attempt_download_asset(WEIGHTS_DIR / uni["task2model"][task])
         data = uni["task2data"][task]
         check_cls_dataset(data) if str(data).startswith("imagenet") else check_det_dataset(data, autodownload=True)
-    for _task, model, _data, _modes in ALTERNATE_CORPUS:
+    for _task, model, *_ in ALTERNATE_CORPUS:
         attempt_download_asset(WEIGHTS_DIR / model)
 
     prepare_sources(uni)
@@ -290,9 +291,9 @@ def build_corpus(uni):
             elif mode == "track":
                 argv.append(f"source={uni['video']}")
             corpus.append({"mode": mode, "task": task, "argv": argv})  # export: default torchscript stays implicit
-    for task, model, data, modes in ALTERNATE_CORPUS:
+    for task, model, data, modes, clamp in ALTERNATE_CORPUS:
         for mode in modes:
-            argv = [mode, task, f"model={model}", *strip_defaults(CLAMPS[mode].split(), uni["defaults"])]
+            argv = [mode, task, f"model={model}", *strip_defaults((clamp or CLAMPS[mode]).split(), uni["defaults"])]
             if mode == "val":
                 argv.append(f"data={data}")
             elif mode == "predict":
@@ -316,12 +317,13 @@ def sample_trial(rng, uni, corpus, personality):
         """Append the non-default k=v pairs to argv and record their keys as mutated."""
         for a in pairs:
             key, _, value = a.partition("=")
-            argv[:] = [x for x in argv if x.partition("=")[0] != key]  # canonical last-value-wins CLI semantics
-            if value.lower() != str(uni["defaults"].get(key)).lower():
+            argv[2:] = [x for x in argv[2:] if x.partition("=")[0] != key]  # last-value-wins; argv[:2] is mode/task
+            changed = value.lower() != str(uni["defaults"].get(key)).lower()
+            if changed:
                 argv.append(a)
             if key not in mutated:
                 mutated.append(key)
-            validity[key] = valid
+            validity[key] = valid or not changed  # a stripped default-valued arg leaves a supported effective value
 
     def mutate_combos(max_groups=4):
         """Combine compatible mode-specific argument groups without repeating keys."""
@@ -621,7 +623,6 @@ def cmd_repro(args):
     argv = shlex.split(args.command)
     if argv and argv[0] == "yolo":  # issue bodies quote full `yolo ...` commands; accept them verbatim
         argv = argv[1:]
-    mode = next((a for a in argv if a in MODES), "predict")
 
     def portable(arg):
         """Remap runner-local absolute model/source paths from issue commands to this machine's copies."""
@@ -635,12 +636,13 @@ def cmd_repro(args):
             else:
                 prepare_sources(uni)
                 candidates = [ASSETS / PureWindowsPath(v).name]
-                candidates.extend(Path(p) for p, _valid in uni["sources"][mode])
+                candidates.extend(Path(p) for pool in uni["sources"].values() for p, _valid in pool)
             if local := next((p for p in candidates if p.name == PureWindowsPath(v).name and p.exists()), None):
                 return f"{k}={local}"
         return arg
 
     argv = [portable(a) for a in argv]
+    mode = next((a for a in argv if a in MODES), "predict")
     task = next((a for a in argv if a in uni["tasks"]), "detect")
     trial = {"mode": mode, "task": task, "argv": argv, "mutated": ["repro"]}  # replayed commands were fuzz-mutated
     outcomes = []

--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -171,6 +171,7 @@ EXPECTED_MODULES = (
     "ultralytics/utils/checks.py",
     "ultralytics/data/utils.py",
     "ultralytics/data/augment.py:classify_augmentations",
+    "ultralytics/data/loaders.py:__init__",  # source loaders ARE the source-validation layer; their raises are clean
     "ultralytics/engine/exporter.py:validate_args",  # exporter's intentional per-format argument validation
     "ultralytics/engine/exporter.py:__call__",  # intentional compat asserts; per-format bugs raise in deeper frames
 )
@@ -371,6 +372,15 @@ def sample_trial(rng, uni, corpus, personality):
     }
 
 
+def probe_supported(key, value):
+    """Range floors where an otherwise-valid probe value is degenerate on the clamped fuzz corpora."""
+    if key == "fraction":  # below 0.25 the 4-image coco8 train splits select zero images
+        return float(value) >= 0.25
+    if key == "mask_ratio":  # the mask downsample ratio must stay within the clamped train imgsz
+        return 1 <= float(value) <= 16
+    return True
+
+
 def sample_mutation(rng, uni, chaos=False):
     """Pick one fuzzable key, a probe value, and whether that value is documented-valid for the key."""
     family = rng.choices(["enum", "fraction", "int", "bool", "float"], weights=[4, 2, 2, 1, 1])[0]
@@ -388,10 +398,9 @@ def sample_mutation(rng, uni, chaos=False):
             value = str(rng.randint(1, 4096)) if valid else f"{rng.randint(0, 4096)}.5"
         else:
             value = f"{rng.uniform(0, 180):.8g}" if valid else rng.choice(["nan", "1e309"])
-        return key, value, valid and not (key == "fraction" and float(value) < 0.25)
+        return key, value, valid and probe_supported(key, value)
     value = rng.choice(pool["valid"] + pool["invalid"] + (CHAOS_PROBES if chaos else []))
-    # dataset fraction below 0.25 selects zero images of the 4-image coco8 train splits: degenerate, not supported
-    return key, value, value in pool["valid"] and not (key == "fraction" and float(value) < 0.25)
+    return key, value, value in pool["valid"] and probe_supported(key, value)
 
 
 def run_trial(trial, timeout=None):

--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -298,7 +298,8 @@ def build_corpus(uni):
                 argv.append(f"data={data}")
             elif mode == "predict":
                 argv.append(f"source={uni['source']}")
-            corpus.append({"mode": mode, "task": task, "argv": argv})
+            pinned = {a.partition("=")[0] for a in clamp.split()}  # overridden keys are family floors: never varied
+            corpus.append({"mode": mode, "task": task, "argv": argv, "pinned": pinned})
     return corpus
 
 
@@ -325,6 +326,12 @@ def sample_trial(rng, uni, corpus, personality):
                 mutated.append(key)
             validity[key] = valid or not changed  # a stripped default-valued arg leaves a supported effective value
 
+    def mutate_boundary():
+        """Vary one cost-sensitive key within its safe envelope, honoring the base entry's pinned family floors."""
+        pool = [b for b in SAFE_BOUNDARIES[mode] if b.partition("=")[0] not in base.get("pinned", ())]
+        if pool:
+            mutate([rng.choice(pool)])
+
     def mutate_combos(max_groups=4):
         """Combine compatible mode-specific argument groups without repeating keys."""
         options = [c.split() for m, c in COMBO_POOL if m == mode]
@@ -343,7 +350,7 @@ def sample_trial(rng, uni, corpus, personality):
         mutate([f"format={rng.choice(uni['export_pool'])}"])
     if strategy == "combo":
         mutate_combos()
-        mutate([rng.choice(SAFE_BOUNDARIES[mode])])
+        mutate_boundary()
     elif strategy == "invalid":
         n_keys = rng.randint(1, 4 if personality == "chaos" else 3)
         for _ in range(n_keys):
@@ -353,7 +360,7 @@ def sample_trial(rng, uni, corpus, personality):
         source, valid = rng.choice(uni["sources"][mode])
         mutate([f"source={source}"], valid=valid)
         mutate_combos(max_groups=2)
-        mutate([rng.choice(SAFE_BOUNDARIES[mode])])
+        mutate_boundary()
     return {
         "mode": mode,
         "task": base["task"],
@@ -381,9 +388,10 @@ def sample_mutation(rng, uni, chaos=False):
             value = str(rng.randint(1, 4096)) if valid else f"{rng.randint(0, 4096)}.5"
         else:
             value = f"{rng.uniform(0, 180):.8g}" if valid else rng.choice(["nan", "1e309"])
-        return key, value, valid
+        return key, value, valid and not (key == "fraction" and float(value) < 0.25)
     value = rng.choice(pool["valid"] + pool["invalid"] + (CHAOS_PROBES if chaos else []))
-    return key, value, value in pool["valid"] and not (family == "fraction" and value == "0.0")
+    # dataset fraction below 0.25 selects zero images of the 4-image coco8 train splits: degenerate, not supported
+    return key, value, value in pool["valid"] and not (key == "fraction" and float(value) < 0.25)
 
 
 def run_trial(trial, timeout=None):
@@ -635,7 +643,7 @@ def cmd_repro(args):
                 candidates = [WEIGHTS_DIR / PureWindowsPath(v).name]
             else:
                 prepare_sources(uni)
-                candidates = [ASSETS / PureWindowsPath(v).name]
+                candidates = [ASSETS, ASSETS / PureWindowsPath(v).name]
                 candidates.extend(Path(p) for pool in uni["sources"].values() for p, _valid in pool)
             if local := next((p for p in candidates if p.name == PureWindowsPath(v).name and p.exists()), None):
                 return f"{k}={local}"

--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -209,7 +209,6 @@ def load_universe():
         "bool_keys": sorted(CFG_BOOL_KEYS - NEVER_MUTATE),
         "float_keys": sorted(CFG_FLOAT_KEYS - NEVER_MUTATE - CFG_FRACTION_KEYS),
         "enum_keys": sorted(set(ENUM_POOLS) - NEVER_MUTATE),
-        "assets": ASSETS,
         "source": str(ASSETS / "bus.jpg"),
         "export_pool": [*EXPORT_POOL, *(["coreml"] if importlib.util.find_spec("coremltools") else [])],
         "logger": LOGGER,
@@ -234,18 +233,13 @@ def precache_assets(uni):
 
 def prepare_sources(uni):
     """Create cached valid and malformed media sources used by predict and track trials."""
-    from ultralytics.utils import ASSETS_URL, WEIGHTS_DIR
+    from ultralytics.utils import ASSETS, ASSETS_URL, WEIGHTS_DIR
     from ultralytics.utils.downloads import safe_download
 
     source_dir = WEIGHTS_DIR.parent / "fuzz-sources"
-    image_dir = source_dir / "image directory"
-    unicode_dir = source_dir / "path with spaces"
-    image_dir.mkdir(parents=True, exist_ok=True)
-    unicode_dir.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(uni["assets"] / "bus.jpg", image_dir / "bus.jpg")
-    shutil.copy2(uni["assets"] / "zidane.jpg", image_dir / "zidane.jpg")
-    unicode_image = unicode_dir / "fuzz-🚀.jpg"
-    shutil.copy2(uni["assets"] / "bus.jpg", unicode_image)
+    source_dir.mkdir(parents=True, exist_ok=True)
+    unicode_image = source_dir / "path with spaces 🚀.jpg"
+    shutil.copy2(ASSETS / "bus.jpg", unicode_image)
     empty_image, corrupt_image, empty_dir = source_dir / "empty.jpg", source_dir / "corrupt.jpg", source_dir / "empty"
     empty_image.touch()
     corrupt_image.write_bytes(b"not an image")
@@ -254,9 +248,9 @@ def prepare_sources(uni):
     safe_download(f"{ASSETS_URL}/{video.name}", file=video)
     uni["sources"] = {
         "predict": [
-            (str(uni["assets"] / "bus.jpg"), True),
-            (str(uni["assets"] / "zidane.jpg"), True),
-            (str(image_dir), True),
+            (str(ASSETS / "bus.jpg"), True),
+            (str(ASSETS / "zidane.jpg"), True),
+            (str(ASSETS), True),
             (str(unicode_image), True),
             (str(video), True),
             (str(empty_image), False),
@@ -499,11 +493,6 @@ def stderr_tail(stderr, lines=30):
     return "\n".join(stderr.strip().splitlines()[-lines:])
 
 
-def format_command(argv):
-    """Return a shell-safe, round-trippable yolo command for logs and issue reproduction."""
-    return "yolo " + shlex.join(argv)
-
-
 def cmd_fuzz(args):
     """Run the budgeted fuzzing loop and write trials JSONL + findings JSON for the report job."""
     uni = load_universe()
@@ -543,7 +532,7 @@ def cmd_fuzz(args):
                 "mode": trial["mode"],
                 "task": trial["task"],
                 "strategy": trial.get("strategy", "corpus"),
-                "command": format_command(trial["argv"]),
+                "command": "yolo " + shlex.join(trial["argv"]),
                 "stderr_tail": stderr_tail(stderr),
                 "duration_s": duration,
             }
@@ -632,6 +621,7 @@ def cmd_repro(args):
     argv = shlex.split(args.command)
     if argv and argv[0] == "yolo":  # issue bodies quote full `yolo ...` commands; accept them verbatim
         argv = argv[1:]
+    mode = next((a for a in argv if a in MODES), "predict")
 
     def portable(arg):
         """Remap runner-local absolute model/source paths from issue commands to this machine's copies."""
@@ -651,7 +641,6 @@ def cmd_repro(args):
         return arg
 
     argv = [portable(a) for a in argv]
-    mode = next((a for a in argv if a in MODES), "predict")
     task = next((a for a in argv if a in uni["tasks"]), "detect")
     trial = {"mode": mode, "task": task, "argv": argv, "mutated": ["repro"]}  # replayed commands were fuzz-mutated
     outcomes = []

--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -13,7 +13,7 @@ Subcommands:
     report  Aggregate shard findings and file GitHub issues via `gh` (stdlib only, no ultralytics import).
 
 Usage:
-    python .github/scripts/fuzz.py fuzz --budget-minutes 285 --seed 123 --personality chaos --out fuzz-out
+    python .github/scripts/fuzz.py fuzz --budget-minutes 300 --seed 123 --personality chaos --out fuzz-out
     python .github/scripts/fuzz.py repro "train detect model=yolo26n.pt data=coco8.yaml epochs=abc imgsz=32"
     python .github/scripts/fuzz.py report --in fuzz-out --max-issues 3 --dry-run
 """
@@ -26,6 +26,7 @@ import json
 import os
 import random
 import re
+import shlex
 import shutil
 import signal
 import subprocess
@@ -37,20 +38,20 @@ from pathlib import Path, PureWindowsPath
 # Per-mode subprocess timeouts (seconds) on Linux CPU runners, ~6-10x headroom over observed norms
 # Windows runners are ~2x slower (interpreter startup, filesystem), so all timeouts scale there
 TIMEOUT_SCALE = 2 if os.name == "nt" else 1
-MODE_TIMEOUTS = {"train": 360, "val": 180, "predict": 180, "export": 480}
+MODE_TIMEOUTS = {"train": 360, "val": 180, "predict": 180, "track": 240, "export": 480}
 CONFIRM_TIMEOUT = 180  # shorter secondary timeout when confirming hangs (never re-pay the full timeout)
 MAX_HANG_CONFIRMS = 5  # cap hang confirmations per shard so one pathological class can't eat the budget
 MIN_FREE_GB = 5  # stop fuzzing gracefully below this much free disk
 CANARY_FAIL_FRACTION = 0.2  # >20% unmutated known-good corpus failures marks the shard infra_failed
 
-MODES = ["train", "val", "predict", "export"]  # benchmark swallows exceptions; track/solutions deferred
+MODES = ["train", "val", "predict", "track", "export"]  # benchmark swallows exceptions; solutions deferred
 PERSONALITIES = {  # mode-selection weights only; mutation kernel and classifier are identical across shards
-    "train": {"train": 0.7, "val": 0.1, "predict": 0.1, "export": 0.1},
-    "export": {"train": 0.1, "val": 0.1, "predict": 0.1, "export": 0.7},
-    "predict-val": {"train": 0.1, "val": 0.4, "predict": 0.4, "export": 0.1},
-    "chaos": {"train": 0.25, "val": 0.25, "predict": 0.25, "export": 0.25},
+    "train": {"train": 0.7, "val": 0.075, "predict": 0.075, "track": 0.075, "export": 0.075},
+    "export": {"train": 0.075, "val": 0.075, "predict": 0.075, "track": 0.075, "export": 0.7},
+    "predict-val": {"train": 0.05, "val": 0.35, "predict": 0.35, "track": 0.2, "export": 0.05},
+    "chaos": {m: 0.2 for m in MODES},
 }
-STRATEGY_WEIGHTS = [("invalid", 0.4), ("combo", 0.4), ("corpus", 0.2)]
+STRATEGY_WEIGHTS = [("invalid", 0.4), ("combo", 0.4), ("source", 0.2)]
 
 # Cost/hazard keys pinned to clamped known-good values, never mutated (`time` is training duration in HOURS)
 NEVER_MUTATE = frozenset(
@@ -79,9 +80,26 @@ CLAMPS = {
     "train": "imgsz=32 epochs=1 batch=4 workers=2 cache=disk",
     "val": "imgsz=32",
     "predict": "imgsz=32",
+    "track": "imgsz=160",
     "export": "imgsz=32",
 }
-EXPORT_POOL = ["torchscript", "onnx", "openvino"]  # CPU-friendly with deps installed by the export-base extra
+EXPORT_POOL = ["torchscript", "onnx", "openvino"]  # CPU-friendly formats installed on every shard
+
+# Additional pretrained families with ordinary CLI contracts. Keep modes narrow to avoid prompt-only training paths.
+ALTERNATE_CORPUS = (
+    ("detect", "rtdetr-l.pt", "coco8.yaml", {"val", "predict", "export"}),
+    ("detect", "yolov8s-worldv2.pt", "coco8.yaml", {"predict", "export"}),
+    ("segment", "yoloe-11s-seg-pf.pt", "coco8-seg.yaml", {"predict", "export"}),
+)
+
+# Controlled variations for cost-sensitive keys excluded from arbitrary mutation.
+SAFE_BOUNDARIES = {
+    "train": ["imgsz=48", "imgsz=64", "batch=1", "batch=2", "workers=0", "workers=1"],
+    "val": ["imgsz=48", "imgsz=64", "batch=1", "batch=2", "workers=0", "workers=1"],
+    "predict": ["imgsz=48", "imgsz=64"],
+    "track": ["imgsz=128", "imgsz=192", "vid_stride=2"],
+    "export": ["imgsz=48", "imgsz=64", "batch=2"],
+}
 
 # Probe pools: "valid" values are supported inputs (deep failures are T1 bugs); "invalid" values are ones the
 # cfg layer SHOULD reject — by current checks or by missing range checks — so deep failures are T2 validation
@@ -132,6 +150,11 @@ COMBO_POOL = [
     ("predict", "retina_masks=True"),
     ("predict", "line_width=1 show_labels=False show_conf=False"),
     ("predict", "vid_stride=2 stream_buffer=True"),
+    ("track", "tracker=bytetrack.yaml"),
+    ("track", "tracker=botsort.yaml"),
+    ("track", "tracker=fasttrack.yaml"),
+    ("track", "save_txt=True save_conf=True"),
+    ("track", "vid_stride=2 stream_buffer=True"),
     ("export", "dynamic=True"),
     ("export", "nms=True"),
     ("export", "simplify=False"),
@@ -186,7 +209,9 @@ def load_universe():
         "bool_keys": sorted(CFG_BOOL_KEYS - NEVER_MUTATE),
         "float_keys": sorted(CFG_FLOAT_KEYS - NEVER_MUTATE - CFG_FRACTION_KEYS),
         "enum_keys": sorted(set(ENUM_POOLS) - NEVER_MUTATE),
+        "assets": ASSETS,
         "source": str(ASSETS / "bus.jpg"),
+        "export_pool": [*EXPORT_POOL, *(["coreml"] if importlib.util.find_spec("coremltools") else [])],
         "logger": LOGGER,
     }
 
@@ -201,6 +226,52 @@ def precache_assets(uni):
         attempt_download_asset(WEIGHTS_DIR / uni["task2model"][task])
         data = uni["task2data"][task]
         check_cls_dataset(data) if str(data).startswith("imagenet") else check_det_dataset(data, autodownload=True)
+    for _task, model, _data, _modes in ALTERNATE_CORPUS:
+        attempt_download_asset(WEIGHTS_DIR / model)
+
+    prepare_sources(uni)
+
+
+def prepare_sources(uni):
+    """Create cached valid and malformed media sources used by predict and track trials."""
+    from ultralytics.utils import ASSETS_URL, WEIGHTS_DIR
+    from ultralytics.utils.downloads import safe_download
+
+    source_dir = WEIGHTS_DIR.parent / "fuzz-sources"
+    image_dir = source_dir / "image directory"
+    unicode_dir = source_dir / "path with spaces"
+    image_dir.mkdir(parents=True, exist_ok=True)
+    unicode_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(uni["assets"] / "bus.jpg", image_dir / "bus.jpg")
+    shutil.copy2(uni["assets"] / "zidane.jpg", image_dir / "zidane.jpg")
+    unicode_image = unicode_dir / "fuzz-🚀.jpg"
+    shutil.copy2(uni["assets"] / "bus.jpg", unicode_image)
+    empty_image, corrupt_image, empty_dir = source_dir / "empty.jpg", source_dir / "corrupt.jpg", source_dir / "empty"
+    empty_image.touch()
+    corrupt_image.write_bytes(b"not an image")
+    empty_dir.mkdir(exist_ok=True)
+    video = source_dir / "decelera_portrait_min.mov"
+    safe_download(f"{ASSETS_URL}/{video.name}", file=video)
+    uni["sources"] = {
+        "predict": [
+            (str(uni["assets"] / "bus.jpg"), True),
+            (str(uni["assets"] / "zidane.jpg"), True),
+            (str(image_dir), True),
+            (str(unicode_image), True),
+            (str(video), True),
+            (str(empty_image), False),
+            (str(corrupt_image), False),
+            (str(empty_dir), False),
+        ],
+        "track": [
+            (str(video), True),
+            (str(unicode_image), True),
+            (str(empty_image), False),
+            (str(corrupt_image), False),
+            (str(empty_dir), False),
+        ],
+    }
+    uni["video"] = str(video)
 
 
 def strip_defaults(pairs, defaults):
@@ -215,41 +286,78 @@ def build_corpus(uni):
         # Bare weight names keep issue repro commands portable; they resolve against the precached weights_dir
         model, data = uni["task2model"][task], uni["task2data"][task]
         for mode in MODES:
+            if mode == "track" and task in {"classify", "semantic"}:
+                continue
             argv = [mode, task, f"model={model}", *strip_defaults(CLAMPS[mode].split(), uni["defaults"])]
             if mode in {"train", "val"}:
                 argv.append(f"data={data}")
             elif mode == "predict":
                 argv.append(f"source={uni['source']}")
+            elif mode == "track":
+                argv.append(f"source={uni['video']}")
             corpus.append({"mode": mode, "task": task, "argv": argv})  # export: default torchscript stays implicit
+    for task, model, data, modes in ALTERNATE_CORPUS:
+        for mode in modes:
+            argv = [mode, task, f"model={model}", *strip_defaults(CLAMPS[mode].split(), uni["defaults"])]
+            if mode == "val":
+                argv.append(f"data={data}")
+            elif mode == "predict":
+                argv.append(f"source={uni['source']}")
+            corpus.append({"mode": mode, "task": task, "argv": argv})
     return corpus
 
 
 def sample_trial(rng, uni, corpus, personality):
-    """Sample one trial: pick a mode by personality weight, then a strategy (invalid/combo/corpus mutation)."""
+    """Sample one trial with canonical arguments from invalid, valid-combination, or source strategies."""
     weights = PERSONALITIES[personality]
     mode = rng.choices(MODES, weights=[weights[m] for m in MODES])[0]
     base = rng.choice([c for c in corpus if c["mode"] == mode])
     argv, mutated = list(base["argv"]), []
-    strategy = rng.choices([s for s, _ in STRATEGY_WEIGHTS], weights=[w for _, w in STRATEGY_WEIGHTS])[0]
+    strategies = STRATEGY_WEIGHTS if mode in {"predict", "track"} else STRATEGY_WEIGHTS[:2]
+    strategy = rng.choices([s for s, _ in strategies], weights=[w for _, w in strategies])[0]
 
     validity = {}  # key -> is its EFFECTIVE value supported: stripped args contribute nothing, duplicates last-win
 
     def mutate(pairs, valid=True):
         """Append the non-default k=v pairs to argv and record their keys as mutated."""
-        for a in strip_defaults(pairs, uni["defaults"]):
-            argv.append(a)
-            mutated.append(a.partition("=")[0])
-            validity[a.partition("=")[0]] = valid
+        for a in pairs:
+            key, _, value = a.partition("=")
+            argv[:] = [x for x in argv if x.partition("=")[0] != key]  # canonical last-value-wins CLI semantics
+            if value.lower() != str(uni["defaults"].get(key)).lower():
+                argv.append(a)
+            if key not in mutated:
+                mutated.append(key)
+            validity[key] = valid
+
+    def mutate_combos(max_groups=4):
+        """Combine compatible mode-specific argument groups without repeating keys."""
+        options = [c.split() for m, c in COMBO_POOL if m == mode]
+        rng.shuffle(options)
+        used, target = set(), rng.randint(1, max_groups)
+        for combo in options:
+            keys = {a.partition("=")[0] for a in combo}
+            if keys.isdisjoint(used):
+                mutate(combo)
+                used.update(keys)
+                target -= 1
+            if not target:
+                break
 
     if mode == "export":  # fuzz the format from the installable pool; the default torchscript stays implicit
-        mutate([f"format={rng.choice(EXPORT_POOL)}"])
+        mutate([f"format={rng.choice(uni['export_pool'])}"])
     if strategy == "combo":
-        mutate(rng.choice([c for m, c in COMBO_POOL if m == mode]).split())
+        mutate_combos()
+        mutate([rng.choice(SAFE_BOUNDARIES[mode])])
     elif strategy == "invalid":
         n_keys = rng.randint(1, 4 if personality == "chaos" else 3)
         for _ in range(n_keys):
             key, value, valid = sample_mutation(rng, uni, chaos=personality == "chaos")
             mutate([f"{key}={value}"], valid=valid)
+    else:
+        source, valid = rng.choice(uni["sources"][mode])
+        mutate([f"source={source}"], valid=valid)
+        mutate_combos(max_groups=2)
+        mutate([rng.choice(SAFE_BOUNDARIES[mode])])
     return {
         "mode": mode,
         "task": base["task"],
@@ -269,8 +377,17 @@ def sample_mutation(rng, uni, chaos=False):
     else:
         key = rng.choice(uni[f"{family}_keys"])
         pool = PROBES[family]
+    if family in {"fraction", "int", "float"} and rng.random() < 0.5:
+        valid = rng.random() < 0.5
+        if family == "fraction":
+            value = f"{rng.uniform(0.000001, 0.999999):.8g}" if valid else f"{rng.uniform(1.000001, 4):.8g}"
+        elif family == "int":
+            value = str(rng.randint(1, 4096)) if valid else f"{rng.randint(0, 4096)}.5"
+        else:
+            value = f"{rng.uniform(0, 180):.8g}" if valid else rng.choice(["nan", "1e309"])
+        return key, value, valid
     value = rng.choice(pool["valid"] + pool["invalid"] + (CHAOS_PROBES if chaos else []))
-    return key, value, value in pool["valid"] and not (key == "fraction" and value == "0.0")
+    return key, value, value in pool["valid"] and not (family == "fraction" and value == "0.0")
 
 
 def run_trial(trial, timeout=None):
@@ -382,6 +499,11 @@ def stderr_tail(stderr, lines=30):
     return "\n".join(stderr.strip().splitlines()[-lines:])
 
 
+def format_command(argv):
+    """Return a shell-safe, round-trippable yolo command for logs and issue reproduction."""
+    return "yolo " + shlex.join(argv)
+
+
 def cmd_fuzz(args):
     """Run the budgeted fuzzing loop and write trials JSONL + findings JSON for the report job."""
     uni = load_universe()
@@ -421,7 +543,7 @@ def cmd_fuzz(args):
                 "mode": trial["mode"],
                 "task": trial["task"],
                 "strategy": trial.get("strategy", "corpus"),
-                "command": "yolo " + " ".join(trial["argv"]),
+                "command": format_command(trial["argv"]),
                 "stderr_tail": stderr_tail(stderr),
                 "duration_s": duration,
             }
@@ -467,21 +589,31 @@ def cmd_fuzz(args):
         changed = " ".join(a for a in trial["argv"] if a.partition("=")[0] in set(trial.get("mutated", [])))
         log.info(f"[fuzz] #{n} {outcome:>13} {duration:6.1f}s  yolo {trial['mode']} {trial['task']} {changed}".rstrip())
 
+    executed, duplicate_samples = set(), 0
     for base in corpus:  # canaries first: unmutated corpus must pass or the environment itself is broken
         if time.time() > deadline or (args.max_trials and n >= args.max_trials):
             break
+        executed.add(tuple(base["argv"]))
         execute(dict(base), canary=True)
     while time.time() < deadline and (not args.max_trials or n < args.max_trials):
         if shutil.disk_usage(tempfile.gettempdir()).free < MIN_FREE_GB * 1024**3:
             log.warning(f"[fuzz] stopping early: <{MIN_FREE_GB}GB free disk")
             break
-        execute(sample_trial(rng, uni, corpus, args.personality))
+        trial = sample_trial(rng, uni, corpus, args.personality)
+        command = tuple(trial["argv"])
+        if command in executed:
+            duplicate_samples += 1
+            continue
+        executed.add(command)
+        execute(trial)
 
     infra_failed = bool(canary_results) and (canary_results.count(False) / len(canary_results)) > CANARY_FAIL_FRACTION
     summary = {
         "personality": args.personality,
         "seed": args.seed,
         "trials": n,
+        "unique_commands": len(executed),
+        "duplicate_samples": duplicate_samples,
         "counters": counters,
         "infra_failed": infra_failed,
         "findings": sorted(findings.values(), key=lambda x: (x["tier"], x["signature"])),
@@ -497,7 +629,7 @@ def cmd_repro(args):
     """Replay one exact command several times through the classifier and print the verdict."""
     uni = load_universe()
     log = uni["logger"]
-    argv = args.command.split()
+    argv = shlex.split(args.command)
     if argv and argv[0] == "yolo":  # issue bodies quote full `yolo ...` commands; accept them verbatim
         argv = argv[1:]
 
@@ -507,9 +639,14 @@ def cmd_repro(args):
         if k in {"model", "source"} and ("/" in v or "\\" in v) and not Path(v).exists():
             from ultralytics.utils import ASSETS, WEIGHTS_DIR
 
-            # PureWindowsPath splits on both separators, so Windows-origin issue commands remap on any OS
-            local = (WEIGHTS_DIR if k == "model" else ASSETS) / PureWindowsPath(v).name
-            if local.exists():
+            # PureWindowsPath splits on both separators, so Windows-origin issue commands remap on any OS.
+            if k == "model":
+                candidates = [WEIGHTS_DIR / PureWindowsPath(v).name]
+            else:
+                prepare_sources(uni)
+                candidates = [ASSETS / PureWindowsPath(v).name]
+                candidates.extend(Path(p) for p, _valid in uni["sources"][mode])
+            if local := next((p for p in candidates if p.name == PureWindowsPath(v).name and p.exists()), None):
                 return f"{k}={local}"
         return arg
 
@@ -546,12 +683,14 @@ def cmd_report(args):
         print("[report] no findings files found")
         return
     run_url = f"https://github.com/{args.repo}/actions/runs/{os.environ.get('GITHUB_RUN_ID', '')}"
-    findings, counters, flagged = {}, {}, []
+    findings, counters, flagged, unique_commands, duplicate_samples = {}, {}, [], 0, 0
     for shard in shards:
         for k, v in shard["counters"].items():
             counters[k] = counters.get(k, 0) + v
         if shard["infra_failed"]:  # warn only: a regression tripping the canaries IS the finding, never discard it
             flagged.append(shard["personality"])
+        unique_commands += shard.get("unique_commands", shard["trials"])
+        duplicate_samples += shard.get("duplicate_samples", 0)
         for f in shard["findings"]:
             prev = findings.get(f["signature"])
             if not prev or (prev["tier"] == "T2" and f["tier"] == "T1"):  # prefer the T1 view of a shared signature
@@ -696,6 +835,7 @@ def cmd_report(args):
     summary = (
         f"## Fuzz — {total} trials\n\n"
         + "\n".join(table)
+        + f"\n\nExploration: {unique_commands} unique commands · {duplicate_samples} duplicate samples skipped"
         + f"\n\nNew issue threads created: {created} (cap {args.max_issues})"
         + (f" · ⚠️ shards with >20% canary failures: {', '.join(flagged)}" if flagged else "")
     )
@@ -745,7 +885,7 @@ def main():
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     p = sub.add_parser("fuzz", help="run a budgeted fuzzing loop")
-    p.add_argument("--budget-minutes", type=float, default=285)
+    p.add_argument("--budget-minutes", type=float, default=300)
     p.add_argument("--seed", type=int, default=0)
     p.add_argument("--personality", choices=sorted(PERSONALITIES), default="chaos")
     p.add_argument("--out", default="fuzz-out")

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -15,7 +15,7 @@ on:
     inputs:
       minutes:
         description: "Fuzzing budget per runner in minutes"
-        default: "285"
+        default: "300"
         type: string
       repro_command:
         description: "Reproduce one exact command from a fuzz issue instead of fuzzing, e.g. 'train detect model=yolo26n.pt data=coco8.yaml epochs=abc'"
@@ -34,19 +34,23 @@ jobs:
   Fuzz:
     if: github.repository == 'ultralytics/ultralytics' || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 330
+    timeout-minutes: 345
     strategy:
       fail-fast: false
       matrix:
         include: # one OS per personality: exports are the most platform-sensitive, predict/val exercise macOS spawn multiprocessing
           - personality: train
             os: ubuntu-latest
+            extras: export-base,solutions
           - personality: export
             os: windows-latest
+            extras: export-base,solutions
           - personality: predict-val
             os: macos-26
+            extras: export-base,export-coreml,solutions
           - personality: chaos
             os: ubuntu-latest
+            extras: export-base,solutions
     defaults:
       run:
         shell: bash # multi-line run blocks and ${GITHUB_WORKSPACE} expansion on all three OSes
@@ -64,7 +68,7 @@ jobs:
         with:
           retries: 3
           retry_delay_seconds: 30
-          run: uv pip install -e ".[export-base,solutions]" --torch-backend cpu
+          run: uv pip install -e ".[${{ matrix.extras }}]" --torch-backend cpu
       - name: Check environment
         run: yolo checks
       - name: Configure Ultralytics cache paths
@@ -87,7 +91,7 @@ jobs:
       - name: Fuzz
         if: github.event.inputs.repro_command == ''
         env:
-          MINUTES: ${{ github.event.inputs.minutes || '285' }} # via env, never interpolated into shell
+          MINUTES: ${{ github.event.inputs.minutes || '300' }} # via env, never interpolated into shell
         run: |
           python .github/scripts/fuzz.py fuzz \
             --budget-minutes "$MINUTES" \


### PR DESCRIPTION
## Summary

- replace duplicate-heavy steady-state corpus replay with unique invalid, compatible-combination, and media-source exploration
- add track coverage, cached video and malformed/path edge-case sources, plus RT-DETR, YOLO-Worldv2, and prompt-free YOLOE corpus entries (RT-DETR clamped to `imgsz=160`, the repo test convention — its 300-query decoder needs ≥160px of anchors)
- exercise CoreML on the macOS shard and increase each fuzz budget from 285 to 300 minutes
- report unique commands and skipped duplicate samples, with shell-safe reproducer commands
- keep argument canonicalization from ever touching the positional mode/task tokens (`val` is both a mode and a bool cfg key), and mark probes whose value equals the package default as effectively valid

Deleted: the steady-state `corpus` sampling strategy, duplicate effective CLI arguments, and the mode-keyed source-pool lookup in `repro` (candidates are filtered by filename, so one union of all pools replaces it).

## Validation

- `ruff format`, `ruff check`, `py_compile`, `git diff --check` on `.github/scripts/fuzz.py`
- 45-trial local smoke (`--max-trials 45`, chaos): all 35 canaries pass — including 4 track canaries and the RT-DETR/YOLO-Worldv2/YOLOE alternates — 0 timeouts/crashes/flakes, `infra_failed=False`; mutated trials exercised multi-group track combos, cached-video sources, and randomized numeric probes
- 20k-trial sampler invariant check: positional mode/task tokens always survive mutation and canonical argv never carries duplicate keys (the pre-fix head loses the `val` token at seed 221)
- `repro` replays a runner-origin `source=.../fuzz-sources/path with spaces 🚀.jpg` command by remapping to the local cached copy; `report --dry-run` confirmed stdlib-only (no `ultralytics` module imported)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧪 Expands Ultralytics fuzz testing to cover tracking, additional model families, realistic media sources, and more diverse command combinations.

### 📊 Key Changes
- Added `track` mode fuzzing with tracker configurations, video inputs, and tracking-specific timeouts.
- Added alternate pretrained models, including RT-DETR, YOLO-World, and YOLOE segmentation models.
- Introduced valid and malformed image, video, directory, Unicode, and space-containing file paths for source validation.
- Added safe boundary testing for resource-sensitive settings such as image size, batch size, workers, and video stride.
- Improved mutation handling to respect last-value-wins behavior, model-specific parameter floors, and supported value ranges.
- Added optional Core ML export testing when `coremltools` is available.
- Improved command quoting and reproduction support with `shlex`, including portable path remapping across operating systems.
- Prevented duplicate fuzz commands and reported unique-command and skipped-duplicate statistics.
- Increased the default fuzzing budget from 285 to 300 minutes and workflow timeouts accordingly.
- Updated CI dependencies so each runner can use the extras required for its assigned fuzzing personality.

### 🎯 Purpose & Impact
- 🛡️ Broadens automated coverage across tracking, exports, source loading, and multiple model families.
- 🐞 Improves detection of both input-validation issues and deeper runtime bugs with more realistic and malformed inputs.
- 🌍 Makes fuzz findings easier to reproduce across Linux, Windows, and macOS, including commands containing quoted or platform-specific paths.
- ⚡ Reduces wasted CI time by skipping duplicate trials and exploring more unique command combinations.
- 📈 Provides longer and more comprehensive fuzzing runs, increasing the likelihood of catching rare regressions before release.