### PR TITLE
Warn on TensorRT/CUDA version mismatch in Platform Models export docs

### DIFF
--- a/docs/en/platform/train/models.md
+++ b/docs/en/platform/train/models.md
@@ -247,7 +247,7 @@ The timings are single observed end-to-end production routing tests from July 20
 
 !!! warning "Match the TensorRT and CUDA versions on your device"
 
-    Before loading a downloaded engine, confirm your deployment device runs the same TensorRT and CUDA versions the engine was built with, whether that device is an x86 NVIDIA GPU or a Jetson. You can refer to the versions shown in the table above. On a version mismatch the engine fails to deserialize, so export locally on the target device instead.
+    Before loading a downloaded engine, confirm your deployment device runs the same TensorRT and CUDA versions the engine was built with, whether that device is an x86 NVIDIA GPU or a Jetson. For Jetson targets, those versions are shown in the table above. On a version mismatch the engine fails to deserialize, so export locally on the target device instead.
 
 ### RKNN Chip Support
 

--- a/docs/en/platform/train/models.md
+++ b/docs/en/platform/train/models.md
@@ -243,11 +243,11 @@ Ultralytics Platform offers the following Jetson target selections for TensorRT 
 | Jetson Orin Nano 8GB Super | `jetson-orin-nano-8gb` |   8 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       4m 59s | AGX Orin 64GB build/load; Nano SKU pending    |
 | Jetson Orin Nano 4GB       | `jetson-orin-nano-4gb` |   4 GB | Ampere, CC 8.7     | 3.12.3 | 13.2 | 10.16.1.11 |                       5m 01s | AGX Orin 64GB build/load; Nano SKU pending    |
 
-The timings are single observed end-to-end production routing tests from July 2026, rounded to the nearest second; they are reference measurements, not an SLA or per-SKU performance benchmark. Both Thor selections are built on a T5000 Developer Kit in NVIDIA's T4000 compatibility profile. The six Orin routes are built on an AGX Orin 64GB, where every resulting engine was loaded and run. Because TensorRT engines are tied to the build GPU and software stack, the smaller-Orin artifacts are candidates until they load and infer on their listed SKUs. Test memory fit on smaller Orin SKUs and perform INT8 calibration on the target device for best results. See the [NVIDIA Jetson guide](../../guides/nvidia-jetson.md) and [TensorRT integration guide](../../integrations/tensorrt.md) for local deployment details.
+The timings are single observed end-to-end production routing tests from July 2026, rounded to the nearest second; they are reference measurements, not an SLA or per-SKU performance benchmark. Both Thor selections are built on a T5000 Developer Kit in NVIDIA's T4000 compatibility profile. The six Orin routes are built on an AGX Orin 64GB, where every resulting engine was loaded and run.
 
 !!! warning "Match the TensorRT engine build environment"
 
-    Before loading a downloaded engine, confirm the deployment device matches the build platform and GPU family, uses the same TensorRT version, and provides a compatible CUDA runtime. For Jetson targets, the software versions are shown in the table above. If the environments do not match, export the engine locally on the deployment device instead.
+    Downloaded engines are tied to their build platform, GPU family, TensorRT version, and a compatible CUDA runtime. For Jetson targets, the software versions are shown in the table above. Validate each engine and its memory fit on the deployment device, and perform INT8 calibration there for best results. If the environments do not match, export the engine locally instead. See the [NVIDIA Jetson guide](../../guides/nvidia-jetson.md) and [TensorRT integration guide](../../integrations/tensorrt.md) for local deployment details.
 
 ### RKNN Chip Support
 

--- a/docs/en/platform/train/models.md
+++ b/docs/en/platform/train/models.md
@@ -245,9 +245,9 @@ Ultralytics Platform offers the following Jetson target selections for TensorRT 
 
 The timings are single observed end-to-end production routing tests from July 2026, rounded to the nearest second; they are reference measurements, not an SLA or per-SKU performance benchmark. Both Thor selections are built on a T5000 Developer Kit in NVIDIA's T4000 compatibility profile. The six Orin routes are built on an AGX Orin 64GB, where every resulting engine was loaded and run. Because TensorRT engines are tied to the build GPU and software stack, the smaller-Orin artifacts are candidates until they load and infer on their listed SKUs. Test memory fit on smaller Orin SKUs and perform INT8 calibration on the target device for best results. See the [NVIDIA Jetson guide](../../guides/nvidia-jetson.md) and [TensorRT integration guide](../../integrations/tensorrt.md) for local deployment details.
 
-!!! warning "Match the TensorRT and CUDA versions on your device"
+!!! warning "Match the TensorRT engine build environment"
 
-    Before loading a downloaded engine, confirm your deployment device runs the same TensorRT and CUDA versions the engine was built with, whether that device is an x86 NVIDIA GPU or a Jetson. For Jetson targets, those versions are shown in the table above. On a version mismatch the engine fails to deserialize, so export locally on the target device instead.
+    Before loading a downloaded engine, confirm the deployment device matches the build platform and GPU family, uses the same TensorRT version, and provides a compatible CUDA runtime. For Jetson targets, the software versions are shown in the table above. If the environments do not match, export the engine locally on the deployment device instead.
 
 ### RKNN Chip Support
 

--- a/docs/en/platform/train/models.md
+++ b/docs/en/platform/train/models.md
@@ -245,6 +245,10 @@ Ultralytics Platform offers the following Jetson target selections for TensorRT 
 
 The timings are single observed end-to-end production routing tests from July 2026, rounded to the nearest second; they are reference measurements, not an SLA or per-SKU performance benchmark. Both Thor selections are built on a T5000 Developer Kit in NVIDIA's T4000 compatibility profile. The six Orin routes are built on an AGX Orin 64GB, where every resulting engine was loaded and run. Because TensorRT engines are tied to the build GPU and software stack, the smaller-Orin artifacts are candidates until they load and infer on their listed SKUs. Test memory fit on smaller Orin SKUs and perform INT8 calibration on the target device for best results. See the [NVIDIA Jetson guide](../../guides/nvidia-jetson.md) and [TensorRT integration guide](../../integrations/tensorrt.md) for local deployment details.
 
+!!! warning "Match the TensorRT and CUDA versions on your device"
+
+    Before loading a downloaded engine, confirm your deployment device runs the same TensorRT and CUDA versions the engine was built with, whether that device is an x86 NVIDIA GPU or a Jetson. You can refer to the versions shown in the table above. On a version mismatch the engine fails to deserialize, so export locally on the target device instead.
+
 ### RKNN Chip Support
 
 When exporting to RKNN format, select your target Rockchip device:


### PR DESCRIPTION
## Summary

- Consolidate existing Platform guidance into a warning that downloaded TensorRT engines must match the build platform, GPU family, TensorRT version, and a compatible CUDA runtime.
- Direct users with a different deployment environment to export locally on the target device.

Deleted: duplicate compatibility, validation, calibration, and guide-link prose from the surrounding paragraph; consolidated it into the warning.

## Validation

- `npx prettier@3.6.2 --tab-width 4 --print-width 120 --write docs/en/platform/train/models.md`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

⚠️ Clarifies TensorRT engine compatibility requirements for Jetson deployments and adds a prominent validation warning.

### 📊 Key Changes

- Replaced the previous paragraph about Jetson engine testing and compatibility with a dedicated **“Match the TensorRT engine build environment”** warning.
- Explicitly states that downloaded engines depend on:
  - Build platform and GPU family
  - TensorRT version
  - Compatible CUDA runtime
- Directs users to validate engine loading and memory fit on the target Jetson device.
- Recommends performing INT8 calibration on the deployment device for best results.
- Advises users to export TensorRT engines locally when build and deployment environments do not match.
- Retains links to the [NVIDIA Jetson guide](https://docs.ultralytics.com/guides/nvidia-jetson/) and [TensorRT integration guide](https://docs.ultralytics.com/integrations/tensorrt/).

### 🎯 Purpose & Impact

- 🛠️ Helps users avoid deployment failures caused by incompatible prebuilt TensorRT engines.
- ✅ Makes platform, GPU, and software compatibility requirements easier to understand.
- 📦 Encourages safer validation of downloaded engines before production deployment.
- 🚀 Supports more reliable Jetson inference performance through device-specific testing and INT8 calibration.