### PR TITLE
Raise clean error for batch=1 training at minimum imgsz

### DIFF
--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -95,7 +95,7 @@ ALTERNATE_CORPUS = (
 
 # Controlled variations for cost-sensitive keys excluded from arbitrary mutation.
 SAFE_BOUNDARIES = {
-    "train": ["imgsz=48", "imgsz=64", "batch=2", "workers=0", "workers=1"],  # batch=1 starves BatchNorm at 1x1 maps
+    "train": ["imgsz=48", "imgsz=64", "batch=1", "batch=2", "workers=0", "workers=1"],
     "val": ["imgsz=48", "imgsz=64", "batch=1", "batch=2", "workers=0", "workers=1"],
     "predict": ["imgsz=48", "imgsz=64"],
     "track": ["imgsz=128", "imgsz=192", "vid_stride=2"],
@@ -172,6 +172,7 @@ EXPECTED_MODULES = (
     "ultralytics/data/utils.py",
     "ultralytics/data/augment.py:classify_augmentations",
     "ultralytics/data/loaders.py:__init__",  # source loaders ARE the source-validation layer; their raises are clean
+    "ultralytics/engine/trainer.py:_setup_train",  # trainer validation of batch/imgsz interplay before training
     "ultralytics/engine/exporter.py:validate_args",  # exporter's intentional per-format argument validation
     "ultralytics/engine/exporter.py:__call__",  # intentional compat asserts; per-format bugs raise in deeper frames
 )

--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -95,7 +95,7 @@ ALTERNATE_CORPUS = (
 
 # Controlled variations for cost-sensitive keys excluded from arbitrary mutation.
 SAFE_BOUNDARIES = {
-    "train": ["imgsz=48", "imgsz=64", "batch=1", "batch=2", "workers=0", "workers=1"],
+    "train": ["imgsz=48", "imgsz=64", "batch=2", "workers=0", "workers=1"],  # batch=1 starves BatchNorm at 1x1 maps
     "val": ["imgsz=48", "imgsz=64", "batch=1", "batch=2", "workers=0", "workers=1"],
     "predict": ["imgsz=48", "imgsz=64"],
     "track": ["imgsz=128", "imgsz=192", "vid_stride=2"],

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -365,6 +365,11 @@ class BaseTrainer:
         # Batch size
         if self.batch_size < 1 and RANK == -1:  # single-GPU only, estimate best batch size
             self.args.batch = self.batch_size = self.auto_batch()
+        if self.batch_size // max(self.world_size, 1) == 1 and self.args.imgsz < 2 * gs:
+            raise ValueError(
+                f"batch=1 training at imgsz={self.args.imgsz} gives BatchNorm a single value per channel; "
+                f"increase batch or use imgsz >= {2 * gs}"
+            )
 
         self._build_train_pipeline()
         self.validator = self.get_validator()


### PR DESCRIPTION
## Summary

The nightly fuzz smoke surfaced that `batch=1` training at the minimum image size dies deep inside the forward pass with a raw torch error — `ValueError: Expected more than 1 value per channel when training, got input size torch.Size([1, 256, 1, 1])` — because the deepest feature map collapses to 1x1 and train-mode BatchNorm sees a single value per channel. Reproduced identically for detect and classify at `main`; the failure needs `imgsz < 2 * max_stride` (i.e. the minimum stride multiple), so it covers every family including stride-64 P6 models.

This PR fixes the validation gap at the source instead of narrowing the fuzzer:

- `BaseTrainer._setup_train` now raises a clean, actionable `ValueError` (`batch=1 training at imgsz=32 gives BatchNorm a single value per channel; increase batch or use imgsz >= 64`) once the final batch size (including auto-batch and per-rank DDP splits) and max stride are known — covering CLI and Python API entry paths.
- `fuzz.py` keeps its `batch=1` train boundary probe (restored to `main`'s exact line), which now permanently verifies this contract, and adds the trainer validation frame to `EXPECTED_MODULES` (same precedent as the existing loader-validation entry) so the clean rejection classifies as `expected` and no nightly issue is filed.

Deleted: nothing — this closes a missing-range-check validation gap that no deletion can express; the deletion alternative (dropping the fuzz probe) would hide the defect while leaving it in the package.

## Validation

- `yolo train imgsz=32 batch=1` now raises the clean ValueError for detect and classify; `imgsz=64 batch=1` and `imgsz=32 batch=2` train to completion unchanged
- Fuzz harness replay of `train detect model=yolo26n.pt data=coco8.yaml imgsz=32 batch=1` classifies `expected` (2/2 runs) with this branch on `PYTHONPATH`
- 20k-trial sampler invariant check still passes; `ruff format`/`ruff check` clean on both files

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛡️ Added an early training validation to prevent unsupported `batch=1` configurations with small image sizes and BatchNorm.

### 📊 Key Changes

- Added a check in `trainer.py` during `_setup_train`.
- Raises a clear `ValueError` when the per-device batch size is 1 and the image size is smaller than twice the model stride.
- Provides actionable guidance to increase the batch size or use a larger image size.
- Updated fuzzing configuration to recognize this intentional validation error.

### 🎯 Purpose & Impact

- 🚫 Prevents training failures caused by BatchNorm receiving only a single value per channel.
- ⚡ Detects invalid batch/image-size combinations before the training pipeline starts.
- 💬 Gives users a more understandable error message and recommended fixes.
- ✅ Improves robustness for single-GPU and distributed training setups.