### PR TITLE
Reuse Platform callbacks for managed workers

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -612,6 +612,10 @@ def test_platform_job_transport(monkeypatch, tmp_path):
         captured["headers"]["X-Alpha-Signature"]
         == hmac.new(b"secret", captured["data"].encode(), hashlib.sha256).hexdigest()
     )
+    monkeypatch.delenv("ALPHA_JOB_ID")
+    monkeypatch.setattr(platform, "_api_key", "api-key")
+    platform._send("epoch_end", {"epoch": 1}, "user/project", "model")
+    assert captured["headers"] == {"Authorization": "Bearer api-key"}
 
     model = tmp_path / "models" / "best.pt"
     model.parent.mkdir()

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -585,10 +585,8 @@ def test_normalize_platform_uri():
 
 
 def test_platform_job_transport(monkeypatch, tmp_path):
-    """Test signed Platform callbacks with an existing local checkpoint."""
+    """Test configurable Platform transport with an existing local checkpoint."""
     import hashlib
-    import hmac
-    import json
     from types import SimpleNamespace
 
     from ultralytics.utils.callbacks import platform
@@ -600,21 +598,11 @@ def test_platform_job_transport(monkeypatch, tmp_path):
         return SimpleNamespace(status_code=200, json=lambda: {"received": True}, raise_for_status=lambda: None)
 
     monkeypatch.setattr(platform, "requests", SimpleNamespace(post=post), raising=False)
-    monkeypatch.setenv("ALPHA_JOB_ID", "model-id")
-    monkeypatch.setenv("PLATFORM_INSTANCE_ID", "instance-id")
-    monkeypatch.setenv("PLATFORM_WEBHOOK_SECRET", "secret")
+    monkeypatch.setattr(platform, "_api_key", "api-key")
     monkeypatch.setenv("PLATFORM_WEBHOOK_URL", "https://example.test/metrics")
     assert platform._send("epoch_end", {"epoch": 0}, "user/project", "model") == {"received": True}
     assert captured["url"] == "https://example.test/metrics"
-    assert json.loads(captured["data"])["data"] == {"epoch": 0, "instanceId": "instance-id"}
-    assert captured["headers"]["X-Alpha-Job-Id"] == "model-id"
-    assert (
-        captured["headers"]["X-Alpha-Signature"]
-        == hmac.new(b"secret", captured["data"].encode(), hashlib.sha256).hexdigest()
-    )
-    monkeypatch.delenv("ALPHA_JOB_ID")
-    monkeypatch.setattr(platform, "_api_key", "api-key")
-    platform._send("epoch_end", {"epoch": 1}, "user/project", "model")
+    assert captured["json"]["data"] == {"epoch": 0}
     assert captured["headers"] == {"Authorization": "Bearer api-key"}
 
     model = tmp_path / "models" / "best.pt"

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -584,6 +584,46 @@ def test_normalize_platform_uri():
     assert normalize_platform_uri("coco8.yaml") == "coco8.yaml"  # non-Platform inputs unchanged
 
 
+def test_platform_job_transport(monkeypatch, tmp_path):
+    """Test signed Platform callbacks with an existing local checkpoint."""
+    import hashlib
+    import hmac
+    import json
+    from types import SimpleNamespace
+
+    from ultralytics.utils.callbacks import platform
+
+    captured = {}
+
+    def post(url, **kwargs):
+        captured.update(url=url, **kwargs)
+        return SimpleNamespace(status_code=200, json=lambda: {"received": True}, raise_for_status=lambda: None)
+
+    monkeypatch.setattr(platform, "requests", SimpleNamespace(post=post), raising=False)
+    monkeypatch.setenv("ALPHA_JOB_ID", "model-id")
+    monkeypatch.setenv("PLATFORM_INSTANCE_ID", "instance-id")
+    monkeypatch.setenv("PLATFORM_WEBHOOK_SECRET", "secret")
+    monkeypatch.setenv("PLATFORM_WEBHOOK_URL", "https://example.test/metrics")
+    assert platform._send("epoch_end", {"epoch": 0}, "user/project", "model") == {"received": True}
+    assert captured["url"] == "https://example.test/metrics"
+    assert json.loads(captured["data"])["data"] == {"epoch": 0, "instanceId": "instance-id"}
+    assert captured["headers"]["X-Alpha-Job-Id"] == "model-id"
+    assert (
+        captured["headers"]["X-Alpha-Signature"]
+        == hmac.new(b"secret", captured["data"].encode(), hashlib.sha256).hexdigest()
+    )
+
+    model = tmp_path / "models" / "best.pt"
+    model.parent.mkdir()
+    model.write_bytes(b"weights")
+    monkeypatch.setenv("PLATFORM_ARTIFACT_ROOT", str(tmp_path))
+    assert platform._upload_model(model, "user/project", "model") == {
+        "modelPath": "models/best.pt",
+        "modelSize": 7,
+        "modelChecksum": hashlib.sha256(b"weights").hexdigest(),
+    }
+
+
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")
 @pytest.mark.skipif(IS_JETSON or IS_RASPBERRYPI, reason="Edge devices not intended for training")
 def test_train_scratch():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -586,10 +586,17 @@ def test_normalize_platform_uri():
 
 def test_platform_job_transport(monkeypatch, tmp_path):
     """Test configurable Platform transport with an existing local checkpoint."""
-    import hashlib
     from types import SimpleNamespace
 
+    from ultralytics import SETTINGS, cfg
     from ultralytics.utils.callbacks import platform
+
+    monkeypatch.setattr(cfg, "TESTS_RUNNING", False)
+    monkeypatch.setitem(SETTINGS, "runs_dir", str(tmp_path))
+    args = SimpleNamespace(
+        save_dir=None, project="user/project", task="detect", name="model", mode="train", exist_ok=True
+    )
+    assert cfg.get_save_dir(args) == tmp_path / "detect/user/project/model"
 
     captured = {}
 
@@ -599,20 +606,19 @@ def test_platform_job_transport(monkeypatch, tmp_path):
 
     monkeypatch.setattr(platform, "requests", SimpleNamespace(post=post), raising=False)
     monkeypatch.setattr(platform, "_api_key", "api-key")
-    monkeypatch.setenv("PLATFORM_WEBHOOK_URL", "https://example.test/metrics")
+    monkeypatch.setattr(platform, "PLATFORM_API_URL", "https://example.test/api/webhooks")
     assert platform._send("epoch_end", {"epoch": 0}, "user/project", "model") == {"received": True}
-    assert captured["url"] == "https://example.test/metrics"
+    assert captured["url"] == "https://example.test/api/webhooks/training/metrics"
     assert captured["json"]["data"] == {"epoch": 0}
     assert captured["headers"] == {"Authorization": "Bearer api-key"}
 
     model = tmp_path / "models" / "best.pt"
     model.parent.mkdir()
     model.write_bytes(b"weights")
-    monkeypatch.setenv("PLATFORM_ARTIFACT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PLATFORM_API_URL", "http://127.0.0.1:8765")
     assert platform._upload_model(model, "user/project", "model") == {
-        "modelPath": "models/best.pt",
+        "modelPath": str(model),
         "modelSize": 7,
-        "modelChecksum": hashlib.sha256(b"weights").hexdigest(),
     }
 
 

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -22,7 +22,6 @@ from ultralytics.utils import (
     LOGGER,
     RANK,
     ROOT,
-    RUNS_DIR,
     SETTINGS,
     SETTINGS_FILE,
     STR_OR_PATH,
@@ -510,7 +509,7 @@ def get_save_dir(args: SimpleNamespace, name: str | None = None) -> Path:
 
         project = args.project or ""
         if not Path(project).is_absolute():
-            base = ROOT.parent / "tests/tmp/runs" if TESTS_RUNNING else RUNS_DIR
+            base = ROOT.parent / "tests/tmp/runs" if TESTS_RUNNING else Path(SETTINGS["runs_dir"])
             worker = os.environ.get("PYTEST_XDIST_WORKER")
             if worker and TESTS_RUNNING:  # isolate parallel pytest-xdist workers
                 base = base / worker

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -7,8 +7,6 @@ import socket
 import sys
 from concurrent.futures import ThreadPoolExecutor
 from hashlib import sha256
-from hmac import new as hmac_new
-from json import dumps
 from math import isfinite
 from pathlib import Path
 from time import sleep, time
@@ -39,8 +37,9 @@ def slugify(text):
 
 try:
     assert not TESTS_RUNNING  # do not log pytest
+    assert SETTINGS.get("platform", False) is True or os.getenv("ULTRALYTICS_API_KEY") or SETTINGS.get("api_key")
     _api_key = os.getenv("ULTRALYTICS_API_KEY") or SETTINGS.get("api_key")
-    assert _api_key or (os.getenv("PLATFORM_WEBHOOK_SECRET") and os.getenv("ALPHA_JOB_ID"))
+    assert _api_key  # verify API key is present
 
     import requests
 
@@ -188,30 +187,16 @@ def _sanitize_json_value(value):
 
 def _send(event, data, project, name, model_id=None, retry=2, timeout=30):
     """Send event to Platform endpoint with retry logic."""
-    if instance_id := os.getenv("PLATFORM_INSTANCE_ID"):
-        data = {**data, "instanceId": instance_id}
     payload = {"event": event, "project": project, "name": name, "data": _sanitize_json_value(data)}
     if model_id:
         payload["modelId"] = model_id
 
     @Retry(times=retry, delay=1)
     def post():
-        secret = os.getenv("PLATFORM_WEBHOOK_SECRET")
-        job_id = os.getenv("ALPHA_JOB_ID")
-        headers = {"Authorization": f"Bearer {_api_key}"}
-        request_body = {"json": payload}
-        if secret and job_id:
-            body = dumps(payload, separators=(",", ":"))
-            headers = {
-                "Content-Type": "application/json",
-                "X-Alpha-Job-Id": job_id,
-                "X-Alpha-Signature": hmac_new(secret.encode(), body.encode(), sha256).hexdigest(),
-            }
-            request_body = {"data": body}
         r = requests.post(
             os.getenv("PLATFORM_WEBHOOK_URL", f"{PLATFORM_API_URL}/training/metrics"),
-            **request_body,
-            headers=headers,
+            json=payload,
+            headers={"Authorization": f"Bearer {_api_key}"},
             timeout=timeout,
         )
         if 400 <= r.status_code < 500 and r.status_code not in {408, 429}:
@@ -611,6 +596,6 @@ callbacks = (
         "on_model_save": on_model_save,
         "on_train_end": on_train_end,
     }
-    if _api_key or (os.getenv("PLATFORM_WEBHOOK_SECRET") and os.getenv("ALPHA_JOB_ID"))
+    if _api_key
     else {}
 )

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -6,7 +6,6 @@ import re
 import socket
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from hashlib import sha256
 from math import isfinite
 from pathlib import Path
 from time import sleep, time
@@ -25,7 +24,7 @@ from ultralytics.utils import (
 )
 
 PREFIX = colorstr("Platform: ")
-PLATFORM_API_URL = f"{PLATFORM_URL}/api/webhooks"
+PLATFORM_API_URL = os.getenv("PLATFORM_API_URL", f"{PLATFORM_URL}/api/webhooks")
 
 
 def slugify(text):
@@ -194,7 +193,7 @@ def _send(event, data, project, name, model_id=None, retry=2, timeout=30):
     @Retry(times=retry, delay=1)
     def post():
         r = requests.post(
-            os.getenv("PLATFORM_WEBHOOK_URL", f"{PLATFORM_API_URL}/training/metrics"),
+            f"{PLATFORM_API_URL}/training/metrics",
             json=payload,
             headers={"Authorization": f"Bearer {_api_key}"},
             timeout=timeout,
@@ -244,17 +243,8 @@ def _upload_model(model_path, project, name, progress=False, retry=1, model_id=N
         LOGGER.warning(f"{PREFIX}Model file not found: {model_path}")
         return None
     model_size = model_path.stat().st_size
-    if root := os.getenv("PLATFORM_ARTIFACT_ROOT"):
-        try:
-            relative_path = model_path.resolve().relative_to(Path(root).resolve()).as_posix()
-        except ValueError:
-            LOGGER.warning(f"{PREFIX}Model file is outside PLATFORM_ARTIFACT_ROOT: {model_path}")
-            return None
-        digest = sha256()
-        with model_path.open("rb") as file:
-            while chunk := file.read(1024 * 1024):
-                digest.update(chunk)
-        return {"modelPath": relative_path, "modelSize": model_size, "modelChecksum": digest.hexdigest()}
+    if os.getenv("PLATFORM_API_URL"):
+        return {"modelPath": str(model_path.resolve()), "modelSize": model_size}
 
     # Get signed upload URL from Platform (server sanitizes filename for storage safety)
     @Retry(times=3, delay=2)
@@ -496,9 +486,6 @@ def on_model_save(trainer):
     ctx = getattr(trainer, "platform", None)
     if not ctx or RANK not in {-1, 0} or not trainer.args.project:
         return
-    if os.getenv("PLATFORM_ARTIFACT_ROOT"):
-        return  # Local checkpoints are already saved at their destination.
-
     # Rate limit to every 15 minutes (900 seconds)
     if time() - ctx["last_upload"] < 900:
         return

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -40,7 +40,7 @@ def slugify(text):
 try:
     assert not TESTS_RUNNING  # do not log pytest
     _api_key = os.getenv("ULTRALYTICS_API_KEY") or SETTINGS.get("api_key")
-    assert _api_key or os.getenv("PLATFORM_WEBHOOK_SECRET")
+    assert _api_key or (os.getenv("PLATFORM_WEBHOOK_SECRET") and os.getenv("ALPHA_JOB_ID"))
 
     import requests
 
@@ -197,13 +197,14 @@ def _send(event, data, project, name, model_id=None, retry=2, timeout=30):
     @Retry(times=retry, delay=1)
     def post():
         secret = os.getenv("PLATFORM_WEBHOOK_SECRET")
+        job_id = os.getenv("ALPHA_JOB_ID")
         headers = {"Authorization": f"Bearer {_api_key}"}
         request_body = {"json": payload}
-        if secret:
+        if secret and job_id:
             body = dumps(payload, separators=(",", ":"))
             headers = {
                 "Content-Type": "application/json",
-                "X-Alpha-Job-Id": os.environ["ALPHA_JOB_ID"],
+                "X-Alpha-Job-Id": job_id,
                 "X-Alpha-Signature": hmac_new(secret.encode(), body.encode(), sha256).hexdigest(),
             }
             request_body = {"data": body}
@@ -610,6 +611,6 @@ callbacks = (
         "on_model_save": on_model_save,
         "on_train_end": on_train_end,
     }
-    if _api_key or os.getenv("PLATFORM_WEBHOOK_SECRET")
+    if _api_key or (os.getenv("PLATFORM_WEBHOOK_SECRET") and os.getenv("ALPHA_JOB_ID"))
     else {}
 )

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -6,6 +6,9 @@ import re
 import socket
 import sys
 from concurrent.futures import ThreadPoolExecutor
+from hashlib import sha256
+from hmac import new as hmac_new
+from json import dumps
 from math import isfinite
 from pathlib import Path
 from time import sleep, time
@@ -36,9 +39,8 @@ def slugify(text):
 
 try:
     assert not TESTS_RUNNING  # do not log pytest
-    assert SETTINGS.get("platform", False) is True or os.getenv("ULTRALYTICS_API_KEY") or SETTINGS.get("api_key")
     _api_key = os.getenv("ULTRALYTICS_API_KEY") or SETTINGS.get("api_key")
-    assert _api_key  # verify API key is present
+    assert _api_key or os.getenv("PLATFORM_WEBHOOK_SECRET")
 
     import requests
 
@@ -186,16 +188,29 @@ def _sanitize_json_value(value):
 
 def _send(event, data, project, name, model_id=None, retry=2, timeout=30):
     """Send event to Platform endpoint with retry logic."""
+    if instance_id := os.getenv("PLATFORM_INSTANCE_ID"):
+        data = {**data, "instanceId": instance_id}
     payload = {"event": event, "project": project, "name": name, "data": _sanitize_json_value(data)}
     if model_id:
         payload["modelId"] = model_id
 
     @Retry(times=retry, delay=1)
     def post():
+        secret = os.getenv("PLATFORM_WEBHOOK_SECRET")
+        headers = {"Authorization": f"Bearer {_api_key}"}
+        request_body = {"json": payload}
+        if secret:
+            body = dumps(payload, separators=(",", ":"))
+            headers = {
+                "Content-Type": "application/json",
+                "X-Alpha-Job-Id": os.environ["ALPHA_JOB_ID"],
+                "X-Alpha-Signature": hmac_new(secret.encode(), body.encode(), sha256).hexdigest(),
+            }
+            request_body = {"data": body}
         r = requests.post(
-            f"{PLATFORM_API_URL}/training/metrics",
-            json=payload,
-            headers={"Authorization": f"Bearer {_api_key}"},
+            os.getenv("PLATFORM_WEBHOOK_URL", f"{PLATFORM_API_URL}/training/metrics"),
+            **request_body,
+            headers=headers,
             timeout=timeout,
         )
         if 400 <= r.status_code < 500 and r.status_code not in {408, 429}:
@@ -235,13 +250,25 @@ def _handle_control_response(trainer, ctx, response):
 
 
 def _upload_model(model_path, project, name, progress=False, retry=1, model_id=None, run_id=None):
-    """Upload model checkpoint to Platform via signed URL."""
+    """Publish a model checkpoint to its configured Platform storage location."""
     from ultralytics.utils.uploads import safe_upload
 
     model_path = Path(model_path)
     if not model_path.exists():
         LOGGER.warning(f"{PREFIX}Model file not found: {model_path}")
         return None
+    model_size = model_path.stat().st_size
+    if root := os.getenv("PLATFORM_ARTIFACT_ROOT"):
+        try:
+            relative_path = model_path.resolve().relative_to(Path(root).resolve()).as_posix()
+        except ValueError:
+            LOGGER.warning(f"{PREFIX}Model file is outside PLATFORM_ARTIFACT_ROOT: {model_path}")
+            return None
+        digest = sha256()
+        with model_path.open("rb") as file:
+            while chunk := file.read(1024 * 1024):
+                digest.update(chunk)
+        return {"modelPath": relative_path, "modelSize": model_size, "modelChecksum": digest.hexdigest()}
 
     # Get signed upload URL from Platform (server sanitizes filename for storage safety)
     @Retry(times=3, delay=2)
@@ -282,8 +309,8 @@ def _upload_model(model_path, project, name, progress=False, retry=1, model_id=N
                 model_id,
                 timeout=90,
             )
-            return gcs_path if saved else None
-        return gcs_path
+            return {"modelPath": gcs_path, "modelSize": model_size} if saved else None
+        return {"modelPath": gcs_path, "modelSize": model_size}
     return None
 
 
@@ -483,6 +510,8 @@ def on_model_save(trainer):
     ctx = getattr(trainer, "platform", None)
     if not ctx or RANK not in {-1, 0} or not trainer.args.project:
         return
+    if os.getenv("PLATFORM_ARTIFACT_ROOT"):
+        return  # Local checkpoints are already saved at their destination.
 
     # Rate limit to every 15 minutes (900 seconds)
     if time() - ctx["last_upload"] < 900:
@@ -518,13 +547,11 @@ def on_train_end(trainer):
         ctx["console_logger"] = None
 
     # Upload best model (blocking with progress bar to ensure it completes)
-    gcs_path = None
-    model_size = None
+    artifact = None
     if trainer.best and Path(trainer.best).exists():
         if ctx["checkpoint_upload"]:
             ctx["checkpoint_upload"].result()
-        model_size = Path(trainer.best).stat().st_size
-        gcs_path = _upload_model(
+        artifact = _upload_model(
             trainer.best,
             project,
             name,
@@ -533,7 +560,7 @@ def on_train_end(trainer):
             model_id=ctx["model_id"],
             run_id=ctx["run_id"],
         )
-        if not gcs_path:
+        if not artifact:
             LOGGER.warning(f"{PREFIX}Model will not be available for download on Platform (upload failed)")
 
     # Collect plots from trainer and validator, deduplicating by type
@@ -560,8 +587,7 @@ def on_train_end(trainer):
                 "metrics": {**trainer.metrics, "fitness": trainer.fitness},
                 "bestEpoch": best_epoch,
                 "bestFitness": trainer.best_fitness,
-                "modelPath": gcs_path,  # Only send GCS path, not local path
-                "modelSize": model_size,
+                **(artifact or {}),
             },
             "classNames": class_names,
             "plots": plots,
@@ -584,6 +610,6 @@ callbacks = (
         "on_model_save": on_model_save,
         "on_train_end": on_train_end,
     }
-    if _api_key
+    if _api_key or os.getenv("PLATFORM_WEBHOOK_SECRET")
     else {}
 )


### PR DESCRIPTION
## Summary

Reuse the existing Platform training callbacks for managed workers. `PLATFORM_API_URL` now selects the Platform API base, and the existing callback lifecycle reports an already-local checkpoint when that base is configured. Hosted callbacks and hosted model uploads keep their existing behavior.

`get_save_dir()` now reads the existing `SETTINGS["runs_dir"]` value at training time instead of a stale import-time copy, so a worker can direct the normal trainer output into its mounted model directory before training starts.

Portal #2909 points the same callbacks at its authenticated loopback Platform API. The worker performs the single HMAC-signed outward request, normalizes the local path, computes its existing file revision, and durably persists completion before acknowledging it. The package gains no on-premise callback system, artifact-root setting, signer, or training argument.

Deleted: `PLATFORM_WEBHOOK_URL`; `PLATFORM_ARTIFACT_ROOT`; package-owned model hashing and path confinement; the local-checkpoint `on_model_save` branch; the stale imported `RUNS_DIR` value. Portal #2909 deletes its duplicate start, epoch, and completion callbacks plus its separate CPU/GPU worker services.

Net-positive justification: the implementation replaces existing owners and is net-negative; the remaining net additions are focused regression tests for configurable API routing, live `runs_dir`, and local checkpoint publication.

## Validation

- `python -m pytest tests/test_python.py -q -k platform_job_transport`
- `python -m ruff check ultralytics/cfg/__init__.py ultralytics/utils/callbacks/platform.py tests/test_python.py`
- `python -m ruff format --check ultralytics/cfg/__init__.py ultralytics/utils/callbacks/platform.py tests/test_python.py`
- `git diff --check`
- Apple arm64 Docker with `ultralytics/ultralytics:latest-arm64`, CPU, COCO8, one epoch
- verified the mounted PR source, live `runs_dir`, and checkpoint under `/workspace/models`
- verified start, console, epoch, and completion through the Portal worker endpoint
- verified completion persisted before outward delivery and removed after successful replay
- verified `best.pt` path, 5,482,458-byte size, and worker-computed SHA-256 revision

## Core Principles review

- What could have been deleted instead of added? The new webhook and artifact-root concepts, package hashing, duplicate save guard, and stale settings snapshot were deleted. The existing Platform API, settings, callback, trainer, and worker revision owners are reused.
- Does any condition suppress a symptom rather than relocate a trigger? No. The existing callbacks fire at the same lifecycle points; `PLATFORM_API_URL` selects their API and `_upload_model` owns whether the resulting checkpoint is local or hosted.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 Improved Platform integration with configurable API endpoints, local model artifact support, and more flexible run-directory handling.

### 📊 Key Changes
- Added support for overriding the Platform API URL through the `PLATFORM_API_URL` environment variable.
- Updated model publishing to return both the model path and file size.
- Added local artifact handling when using a custom Platform API endpoint, avoiding unnecessary signed-upload requests.
- Included model metadata in training completion payloads using the new artifact structure.
- Changed run-directory resolution to use the configurable `SETTINGS["runs_dir"]` value.
- Added tests covering Platform webhook transport, API headers, local checkpoint handling, and custom run directories.

### 🎯 Purpose & Impact
- 🧩 Makes Platform communication easier to configure for local, testing, and self-hosted environments.
- 📦 Ensures training results consistently report model location and size.
- ⚡ Simplifies development and integration testing by supporting local model checkpoints without remote storage.
- 🗂️ Allows users to control where training outputs are saved through the existing `runs_dir` setting.
- ✅ Improves reliability and test coverage for Platform training workflows.