### PR TITLE
Fix flaky Axelera export environment

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -320,7 +320,13 @@ EXPORT_ENVS = {
         "extras": ["export-base"],
         # Axelera export requires 2.8.0 <= torch < 2.12.0.
         "torch": ">=2.8,<2.12",
-        "requirements": ["axelera-devkit==1.7.0", "numpy<=2.3.5", "onnx>=1.12.0,<2.0.0", "onnxslim>=0.1.71"],
+        "requirements": [
+            "axelera-devkit==1.7.0",
+            "omnimalloc==0.5.0",
+            "numpy<=2.3.5",
+            "onnx>=1.12.0,<2.0.0",
+            "onnxslim>=0.1.71",
+        ],
         "indexes": [
             ("--extra-index-url", "https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple"),
         ],

--- a/ultralytics/utils/export/axelera.py
+++ b/ultralytics/utils/export/axelera.py
@@ -51,14 +51,11 @@ def torch2axelera(
         prev_protobuf = os.environ.get("PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION")
         os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
         try:
-            try:
-                from axelera import compiler
-            except ImportError:
-                check_requirements(
-                    ["axelera-devkit==1.7.0", "numpy<=2.3.5"],
-                    cmds="--extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple",
-                )
-                from axelera import compiler
+            check_requirements(
+                ["axelera-devkit==1.7.0", "omnimalloc==0.5.0", "numpy<=2.3.5"],
+                cmds="--extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple",
+            )
+            from axelera import compiler
 
             from axelera.compiler import CompilerConfig
             from axelera.compiler.config.model_specific import extract_ultralytics_metadata

--- a/ultralytics/utils/export/axelera.py
+++ b/ultralytics/utils/export/axelera.py
@@ -56,7 +56,6 @@ def torch2axelera(
                 cmds="--extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple",
             )
             from axelera import compiler
-
             from axelera.compiler import CompilerConfig
             from axelera.compiler.config.model_specific import extract_ultralytics_metadata
 

--- a/ultralytics/utils/export/axelera.py
+++ b/ultralytics/utils/export/axelera.py
@@ -51,11 +51,16 @@ def torch2axelera(
         prev_protobuf = os.environ.get("PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION")
         os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
         try:
-            check_requirements(
-                ["axelera-devkit==1.7.0", "omnimalloc==0.5.0", "numpy<=2.3.5"],
-                cmds="--extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple",
-            )
-            from axelera import compiler
+            try:
+                from axelera import compiler
+            except ImportError:
+                check_requirements(
+                    ["axelera-devkit==1.7.0", "numpy<=2.3.5"],
+                    cmds="--extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple",
+                )
+                from axelera import compiler
+
+            check_requirements("omnimalloc==0.5.0")
             from axelera.compiler import CompilerConfig
             from axelera.compiler.config.model_specific import extract_ultralytics_metadata
 


### PR DESCRIPTION
## Summary

- pin `omnimalloc==0.5.0` in the isolated Axelera export environment
- validate the same allocator compatibility before runtime exports
- preserve the existing missing-Axelera install path so NumPy is not newly modified after import

Axelera devkit 1.7.0 declares `omnimalloc>=0.3.0,<1.0.0`, but its compiler still uses the `BufferKind` API removed in omnimalloc 0.6.0. CI was green with 0.5.0 and began failing as soon as fresh resolution selected 0.6.0.

The small net line increase is unavoidable because the CI resolver and runtime dependency checker execute independently; Ruff also expands the CI requirements list once the compatibility pin is added.

Deleted: nothing — the external package metadata is too broad, so both independent dependency owners require the explicit compatibility pin.

## Tests

- `ruff check ultralytics/engine/exporter.py ultralytics/utils/export/axelera.py`
- `ruff format --check ultralytics/engine/exporter.py ultralytics/utils/export/axelera.py`
- `pytest -q tests/test_exports.py::test_export_env_has_smoke tests/test_exports.py::test_every_format_env_is_registered`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Adds the required `omnimalloc` dependency to improve reliability for Axelera model exports. 🚀

### 📊 Key Changes

- Adds `omnimalloc==0.5.0` to the Axelera export requirements.
- Adds a runtime dependency check before importing Axelera compiler components.
- Keeps existing Axelera, PyTorch, NumPy, ONNX, and ONNX slimming version constraints unchanged.

### 🎯 Purpose & Impact

- Ensures Axelera exports have all required memory-management dependencies installed.
- Provides a clearer setup path by checking for `omnimalloc` during export.
- Reduces the risk of export failures caused by missing or incompatible dependencies. ✅