### PR TITLE
Document On Premise training data boundaries

### DIFF
--- a/docs/en/platform/integrations/on-premise.md
+++ b/docs/en/platform/integrations/on-premise.md
@@ -1,13 +1,16 @@
 ---
 plans: [enterprise]
 title: On Premise - Ultralytics Platform
-description: Use local datasets and train YOLO models on your own computer without uploading images or model files to the cloud.
+description: Use local datasets and train YOLO models on your own computer while uploading completed models to Platform.
 keywords: Ultralytics Platform, On Premise, private datasets, local training, data residency, YOLO
 ---
 
 # On Premise
 
-[On Premise](https://platform.ultralytics.com) lets your Enterprise workspace use datasets and compute on a Linux, macOS, or Windows computer. You keep the familiar Platform experience for browsing, annotation, and training while your images, videos, and model files stay on your computer.
+[On Premise](https://platform.ultralytics.com) lets your Enterprise workspace use datasets and compute on a Linux,
+macOS, or Windows computer. Source images and videos remain on your computer. Training behaves like any other
+[remote training](../train/cloud-training.md#remote-training) location: metrics stream to Platform and completed model
+weights upload for download, prediction, export, and deployment.
 
 Setup takes one command. Platform detects your operating system, fills in sensible folder locations, installs Docker if needed, and shows live connection progress.
 
@@ -16,13 +19,23 @@ Setup takes one command. Platform detects your operating system, fills in sensib
 ```mermaid
 flowchart LR
     A[Your browser] <-->|Interface, labels, and progress| B[Ultralytics Platform]
-    A <-->|Previews and model downloads| C[Your On Premise computer]
-    B <-->|Jobs and status only| C
+    A <-->|Dataset previews| C[Your On Premise computer]
+    B <-->|Jobs, metrics, and model weights| C
     C --- D[(Dataset folder)]
     C --- E[(Models folder)]
 ```
 
-Images, videos, and model files travel directly between your browser and your computer. They never take the Platform path.
+### Data Boundaries
+
+| Data                              | Your On Premise computer                                                                 | Platform and cloud services                                                                                         |
+| --------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Source and derived dataset pixels | Stay local for ingest, preview, and training                                             | Never stored, logged, or processed                                                                                  |
+| Classes, labels, and annotations  | Source labels are read during ingest                                                     | Stored as the canonical dataset metadata so you can annotate in Platform                                            |
+| Training models                   | The run, best checkpoint, and other training artifacts are written to your models folder | The best checkpoint uploads for download, prediction, export, and deployment; other artifacts stay on your computer |
+
+Model weights, labels, annotations, and metrics can encode information learned from your images. Only the
+dataset pixels have the strict local-only boundary. Cloud prediction processes only images you separately submit to that
+cloud workflow; the worker never forwards an image from your mounted dataset.
 
 ## Before You Start
 
@@ -106,6 +119,18 @@ The defaults work without editing:
 
 The setup command creates these folders, installs and starts Docker when needed, and configures the connection to restart with your computer. Your operating system may ask you to approve installation or restart before setup can finish.
 
+### Docker Base Images
+
+The installer runs one container and selects the official Ultralytics base image for the host:
+
+| Host                                   | Base image                              |
+| -------------------------------------- | --------------------------------------- |
+| Apple Silicon or ARM64 Linux           | `ultralytics/ultralytics:8.4.100-arm64` |
+| x86-64 CPU                             | `ultralytics/ultralytics:8.4.100-cpu`   |
+| x86-64 with a supported NVIDIA runtime | `ultralytics/ultralytics:8.4.100`       |
+
+The installer pins the image matching Platform's Ultralytics version. The worker adds its connectivity dependencies without reinstalling Ultralytics. It detects CUDA at runtime, so an NVIDIA host still runs one container rather than separate CPU and GPU workers. These lightweight images support local ingest and training; Platform's existing cloud services handle model prediction and export after the best checkpoint uploads.
+
 !!! info "Optional GPU acceleration"
 
     CPU setup requires nothing beyond the guided installation. For NVIDIA GPU acceleration, install current NVIDIA drivers and enable Docker GPU support. Platform detects the GPU automatically.
@@ -148,13 +173,18 @@ Start training through the normal Platform training dialog:
 
 Platform runs the job on the connected computer. It uses an available NVIDIA GPU or falls back to CPU automatically, so a Mac can train a small model such as YOLO26n on COCO8 without dedicated GPU hardware.
 
-Checkpoints, final weights, and other training files are saved in the configured models folder. Progress and metrics appear in Platform as usual. On Premise training does not use Platform compute credits, and Platform never sends the job to cloud compute.
+Training files are written to the configured models folder while the run is active. The Ultralytics package uses the
+same remote-training callbacks as any customer-managed machine: progress and metrics stream to Platform, the best
+checkpoint uploads to Platform storage, and the completed model works with the existing download, prediction, export,
+and deployment paths. Other training artifacts remain in your models folder. On Premise training does not use Platform
+compute credits, and Platform never sends the training job to cloud compute.
 
 ## Manage the Connection
 
 Open `Settings > Integrations` to see whether the computer and its CPU or GPU are available. You can reconnect to refresh its access or disconnect it when it is no longer needed.
 
-Disconnecting prevents new jobs and previews but does not delete datasets, source files, or trained models from the computer.
+Disconnecting prevents new jobs and previews but does not delete datasets or source files from the computer. Uploaded
+models remain available in Platform.
 
 ## If Setup Does Not Finish
 
@@ -162,6 +192,7 @@ Disconnecting prevents new jobs and previews but does not delete datasets, sourc
 - **Windows asks for a restart:** Restart the computer, return to `Settings > Integrations`, and create a new install command.
 - **The setup command expired:** Create a new install command. Each command is temporary and works once.
 - **The connection stays offline:** Open Docker Desktop, rerun a newly generated command, and keep the terminal open until it reports that On Premise is running.
-- **Previews do not load:** Open Platform in a browser on the connected computer. Previews and model downloads come directly from that computer.
+- **Previews do not load:** Open Platform in a browser on the connected computer. Dataset previews come directly from
+  that computer.
 
 Also see [Datasets](../data/datasets.md), [Annotation](../data/annotation.md), and [Training](../train/index.md).


### PR DESCRIPTION
## Summary

- Document the exact 8.4.100 ARM64, CPU, and NVIDIA base images used by On Premise training.
- Clarify that one container uses the default Python environment without reinstalling Ultralytics.
- Define where dataset pixels, labels and annotations, the best checkpoint, and other training artifacts may go.
- Explain that the uploaded best checkpoint uses the existing cloud download, prediction, export, and deployment paths.

Reused/consolidated: the existing On Premise integration page and the Portal installer and remote-training callback contract.

Deleted: stale claims that model files never leave the host and ambiguous language about checkpoint, embedding, and prediction egress.

The added lines are required because the existing page did not document the exact base images or enterprise data-egress boundaries; there was no existing section to relocate.

## Validation

- Exact Docker manifests verified for ultralytics/ultralytics:8.4.100-arm64, ultralytics/ultralytics:8.4.100-cpu, and ultralytics/ultralytics:8.4.100
- Pinned Prettier check
- git diff --check
- Final cold Codex review: LGTM

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔒 Updates On Premise documentation to clarify local data handling, model uploads, Docker images, and remote-training behavior.

### 📊 Key Changes

- Clarifies that source images and videos remain on the local computer, while completed best-model weights upload to Platform.
- Adds a detailed **Data Boundaries** table covering dataset pixels, labels, annotations, metrics, checkpoints, and training artifacts.
- Updates the workflow diagram to show dataset previews staying local and jobs, metrics, and model weights being exchanged with Platform.
- Documents architecture-specific Docker base images for ARM64, CPU, and NVIDIA GPU hosts.
- Explains that one container detects CUDA at runtime and uses the matching pinned Ultralytics image.
- Updates training and disconnection guidance to reflect uploaded model availability and Platform integrations.
- Clarifies that cloud prediction only processes images explicitly submitted to that workflow.

### 🎯 Purpose & Impact

- 🔐 Gives Enterprise users a clearer understanding of what remains local and what is uploaded to Platform.
- ☁️ Enables completed On Premise models to use existing Platform workflows for download, prediction, export, and deployment.
- 🧩 Makes installation and hardware support easier to understand across Windows, macOS, Linux, CPU, and GPU systems.
- 📈 Confirms that training metrics stream to Platform without using Platform compute credits.
- 🛠️ Reduces setup confusion and improves troubleshooting for local previews, Docker, connectivity, and model management.