### PR TITLE
Fix training from signed NDJSON URLs

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -584,6 +584,19 @@ def test_normalize_platform_uri():
     assert normalize_platform_uri("coco8.yaml") == "coco8.yaml"  # non-Platform inputs unchanged
 
 
+def test_convert_signed_ndjson(monkeypatch):
+    """Test signed NDJSON URLs are converted before dataset YAML validation."""
+    from ultralytics.data import converter, utils
+
+    async def convert(path):
+        return f"{path}.yaml"
+
+    monkeypatch.setattr(utils, "check_file", lambda _: "dataset.ndjson")
+    monkeypatch.setattr(converter, "convert_ndjson_to_yolo", convert)
+    url = "https://storage.googleapis.com/bucket/dataset-v1.ndjson?X-Goog-Signature=abc"
+    assert utils.convert_ndjson_to_yolo_if_needed(url) == "dataset.ndjson.yaml"
+
+
 def test_platform_job_transport(monkeypatch, tmp_path):
     """Test configurable Platform transport with an existing local checkpoint."""
     from types import SimpleNamespace

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.101"
+__version__ = "8.4.100"
 
 import importlib
 import os

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.100"
+__version__ = "8.4.101"
 
 import importlib
 import os

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -440,7 +440,7 @@ def convert_ndjson_to_yolo_if_needed(data: str | Path) -> str | Path:
     """Convert an NDJSON dataset or Platform dataset URI to YOLO format."""
     data = normalize_platform_uri(data)  # accept Platform web URLs (https://platform.ultralytics.com/.../datasets/...)
     data_str = str(data)
-    if data_str.endswith(".ndjson") or (data_str.startswith("ul://") and "/datasets/" in data_str):
+    if clean_url(data_str).endswith(".ndjson") or (data_str.startswith("ul://") and "/datasets/" in data_str):
         import asyncio
 
         from ultralytics.data.converter import convert_ndjson_to_yolo


### PR DESCRIPTION
## Summary
- recognize signed NDJSON dataset URLs after stripping authentication query parameters with the existing `clean_url()` owner
- add the exact GCS signed-URL regression test

Deleted: the raw full-URL `.endswith(".ndjson")` check that misclassified signed NDJSON URLs as YAML.

Net-positive justification: one focused regression test is required because the production failure only appears when a valid `.ndjson` pathname carries an authentication query string.

## Validation
- `pytest tests/test_python.py::test_convert_signed_ndjson -v`
- `ruff format --check ultralytics/data/utils.py tests/test_python.py ultralytics/__init__.py`
- `ruff check ultralytics/data/utils.py tests/test_python.py ultralytics/__init__.py`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🐛 Fixes NDJSON dataset conversion for signed download URLs with query parameters.

### 📊 Key Changes
- Updated `convert_ndjson_to_yolo_if_needed()` to clean URLs before checking for the `.ndjson` extension.
- Added a regression test covering signed Google Cloud Storage NDJSON URLs.
- Preserved existing handling for Ultralytics Platform dataset URIs.

### 🎯 Purpose & Impact
- ✅ Enables signed or parameterized NDJSON dataset URLs to be recognized and converted correctly.
- 🚀 Prevents dataset validation from failing when URLs include authentication query strings, such as `X-Goog-Signature`.
- 🧪 Improves reliability without changing behavior for local files or standard dataset inputs.