### PR TITLE
Add Hailo pose, OBB, and classification export and inference for YOLOv8 and YOLO11

### DIFF
--- a/docs/en/guides/model-deployment-options.md
+++ b/docs/en/guides/model-deployment-options.md
@@ -56,7 +56,7 @@ Here is a short description of each format and when to reach for it. For the ful
 - **[DEEPX](../integrations/deepx.md)** (`deepx`): Targets DEEPX NPU hardware with INT8 quantization for embedded edge inference.
 - **[Qualcomm QNN](../integrations/qnn.md)** (`qnn`): On-device inference on Snapdragon Hexagon NPU, Adreno GPU, and CPU through the Qualcomm AI stack.
 
-The [Hailo integration](../integrations/hailo.md) exports YOLO detection, segmentation, pose, OBB, and classification models directly to Hailo HEF for Hailo-8, Hailo-8L, Hailo-10, and Hailo-15 accelerators. The [Ambarella integration](../integrations/ambarella.md) follows an ONNX-first workflow and compiles ONNX exports to the AmbaPB format with Ambarella's CVflow toolchain for CVflow® SoCs such as the CV72, optionally using SpongeTorch compression-aware training.
+The [Hailo integration](../integrations/hailo.md) exports YOLO detection, segmentation, pose, OBB, and classification models directly to Hailo HEF; see its compatibility table for validated models and targets. The [Ambarella integration](../integrations/ambarella.md) follows an ONNX-first workflow and compiles ONNX exports to the AmbaPB format with Ambarella's CVflow toolchain for CVflow® SoCs such as the CV72, optionally using SpongeTorch compression-aware training.
 
 ## Deployment Options Compared
 

--- a/docs/en/guides/model-deployment-options.md
+++ b/docs/en/guides/model-deployment-options.md
@@ -56,7 +56,7 @@ Here is a short description of each format and when to reach for it. For the ful
 - **[DEEPX](../integrations/deepx.md)** (`deepx`): Targets DEEPX NPU hardware with INT8 quantization for embedded edge inference.
 - **[Qualcomm QNN](../integrations/qnn.md)** (`qnn`): On-device inference on Snapdragon Hexagon NPU, Adreno GPU, and CPU through the Qualcomm AI stack.
 
-The [Hailo integration](../integrations/hailo.md) exports YOLO detection models directly to Hailo HEF for Hailo-8, Hailo-8L, Hailo-10, and Hailo-15 accelerators. The [Ambarella integration](../integrations/ambarella.md) follows an ONNX-first workflow and compiles ONNX exports to the AmbaPB format with Ambarella's CVflow toolchain for CVflow® SoCs such as the CV72, optionally using SpongeTorch compression-aware training.
+The [Hailo integration](../integrations/hailo.md) exports YOLO detection, segmentation, pose, OBB, and classification models directly to Hailo HEF for Hailo-8, Hailo-8L, Hailo-10, and Hailo-15 accelerators. The [Ambarella integration](../integrations/ambarella.md) follows an ONNX-first workflow and compiles ONNX exports to the AmbaPB format with Ambarella's CVflow toolchain for CVflow® SoCs such as the CV72, optionally using SpongeTorch compression-aware training.
 
 ## Deployment Options Compared
 

--- a/docs/en/integrations/hailo.md
+++ b/docs/en/integrations/hailo.md
@@ -1,12 +1,12 @@
 ---
 comments: true
-description: Export Ultralytics YOLO detection and segmentation models directly to Hailo HEF for computer vision and edge AI on Hailo-8, Hailo-8L, Hailo-10, and Hailo-15 accelerators.
-keywords: Hailo export, Hailo HEF, export YOLO to Hailo, YOLO Hailo, Hailo-8, Hailo-8L, Hailo-10, Hailo-15, Raspberry Pi AI Kit, Raspberry Pi AI HAT+, Hailo Dataflow Compiler, Hailo DFC, HailoRT, Hailo AI accelerator, edge AI, embedded AI, computer vision, object detection, instance segmentation, model quantization, INT8 quantization, Ultralytics YOLO, YOLO26, YOLO11, YOLOv8
+description: Export Ultralytics YOLO detection, segmentation, pose, OBB, and classification models directly to Hailo HEF for computer vision and edge AI on Hailo-8, Hailo-8L, Hailo-10, and Hailo-15 accelerators.
+keywords: Hailo export, Hailo HEF, export YOLO to Hailo, YOLO Hailo, Hailo-8, Hailo-8L, Hailo-10, Hailo-15, Raspberry Pi AI Kit, Raspberry Pi AI HAT+, Hailo Dataflow Compiler, Hailo DFC, HailoRT, Hailo AI accelerator, edge AI, embedded AI, computer vision, object detection, instance segmentation, pose estimation, oriented bounding box, image classification, model quantization, INT8 quantization, Ultralytics YOLO, YOLO26, YOLO11, YOLOv8
 ---
 
 # Hailo Export for Ultralytics YOLO Models
 
-Hailo AI accelerators run compiled Hailo Executable Format (HEF) models on edge devices such as the [Raspberry Pi AI Kit](https://www.raspberrypi.com/products/ai-kit/) and [AI HAT+](https://www.raspberrypi.com/documentation/accessories/ai-hat-plus.html). Ultralytics exports YOLO detection and segmentation models directly to HEF with the Hailo Dataflow Compiler (DFC).
+Hailo AI accelerators run compiled Hailo Executable Format (HEF) models on edge devices such as the [Raspberry Pi AI Kit](https://www.raspberrypi.com/products/ai-kit/) and [AI HAT+](https://www.raspberrypi.com/documentation/accessories/ai-hat-plus.html). Ultralytics exports YOLO detection, segmentation, pose, OBB, and classification models directly to HEF with the Hailo Dataflow Compiler (DFC).
 
 Hailo deployment is designed for computer vision at the edge: cameras, robots, industrial systems, gateways, and other devices that need local object detection without sending every frame to the cloud. A compiled HEF contains the quantized network, hardware allocation, scheduling, and optional HailoRT post-processing needed by the selected accelerator.
 
@@ -43,7 +43,7 @@ The exporter performs these stages automatically:
 5. Compiles the optimized graph for the selected Hailo accelerator.
 6. Saves the HEF with Ultralytics metadata and removes the intermediate ONNX file.
 
-YOLOv8 and YOLO11 use HailoRT YOLO NMS in the compiled pipeline. YOLO26 uses its NMS-free one-to-one detection outputs, so the exporter selects a different output and quantization path automatically. YOLOv8-seg and YOLO11-seg compile the raw segmentation head tensors, which Ultralytics decodes at inference. Users do not need to find ONNX end nodes, write a Hailo model script (`.alls`), or create an NMS JSON manually.
+YOLOv8 and YOLO11 use HailoRT YOLO NMS in the compiled pipeline. YOLO26 uses its NMS-free one-to-one detection outputs, so the exporter selects a different output and quantization path automatically. YOLOv8/YOLO11 segmentation, pose, and OBB compile the raw head tensors, which Ultralytics decodes at inference, and YOLOv8/YOLO11/YOLO26 classification runs softmax on chip so the HEF returns class probabilities directly. Users do not need to find ONNX end nodes, write a Hailo model script (`.alls`), or create an NMS JSON manually.
 
 ## Installation
 
@@ -100,24 +100,27 @@ model.export(format="hailo", name="hailo8l", imgsz=640)
 
 ## Supported Models and Hardware
 
-The Hailo ecosystem covers a broad range of computer vision workloads, but the Ultralytics `format="hailo"` exporter currently validates only standard YOLO detection and segmentation heads. The table below describes this direct integration, not every workload the Hailo ecosystem can run.
+The Hailo ecosystem covers a broad range of computer vision workloads, but the Ultralytics `format="hailo"` exporter currently validates standard YOLO detection, segmentation, pose, OBB, and classification heads. The table below describes this direct integration, not every workload the Hailo ecosystem can run.
 
-| Ultralytics task          | Direct Hailo export | Supported model families | Notes                                                                                       |
-| :------------------------ | :-----------------: | :----------------------- | :------------------------------------------------------------------------------------------ |
-| Object detection          |         ✅          | YOLOv8, YOLO11, YOLO26   | Standard Ultralytics `Detect` heads, including custom models                                |
-| Instance segmentation     |         ✅          | YOLOv8, YOLO11           | Raw head tensors decoded by Ultralytics at inference; YOLO26-seg is not currently supported |
-| Image classification      |         ❌          | —                        | Not yet supported by the direct exporter                                                    |
-| Pose estimation           |         ❌          | —                        | Not yet supported by the direct exporter                                                    |
-| Oriented object detection |         ❌          | —                        | OBB heads are not yet supported                                                             |
-| Semantic segmentation     |         ❌          | —                        | Not yet supported by the direct exporter                                                    |
+| Ultralytics task          | Direct Hailo export | Supported model families | Notes                                                                                        |
+| :------------------------ | :-----------------: | :----------------------- | :------------------------------------------------------------------------------------------- |
+| Object detection          |         ✅          | YOLOv8, YOLO11, YOLO26   | Standard Ultralytics `Detect` heads, including custom models                                 |
+| Instance segmentation     |         ✅          | YOLOv8, YOLO11           | Raw head tensors decoded by Ultralytics at inference; YOLO26-seg is not currently supported  |
+| Image classification      |         ✅          | YOLOv8, YOLO11, YOLO26   | Softmax runs on chip; the HEF returns class probabilities directly                           |
+| Pose estimation           |         ✅          | YOLOv8, YOLO11           | Raw head tensors decoded by Ultralytics at inference; YOLO26-pose is not currently supported |
+| Oriented object detection |         ✅          | YOLOv8, YOLO11           | Raw head tensors decoded by Ultralytics at inference; YOLO26-OBB is not currently supported  |
+| Semantic segmentation     |         ❌          | —                        | Not yet supported by the direct exporter                                                     |
 
 Specialized detection families such as YOLOv10, YOLO-World, YOLOE, and RT-DETR are also ❌ unsupported. Ultralytics rejects these tasks and model families before compilation instead of producing an unvalidated HEF.
 
-| Model family            | Hailo-8 / Hailo-8L | Hailo-10 / Hailo-15 | Output                                                        |
-| :---------------------- | :----------------: | :-----------------: | :------------------------------------------------------------ |
-| YOLOv8 / YOLO11         |         ✅         |         ✅          | HEF with HailoRT YOLO NMS                                     |
-| YOLO26                  |         ✅         |         ✅          | NMS-free detection-head outputs for supported runtimes        |
-| YOLOv8-seg / YOLO11-seg |         ✅         |         ✅          | Raw segmentation tensors, decoded by Ultralytics at inference |
+| Model family                         | Hailo-8 / Hailo-8L | Hailo-10 / Hailo-15 | Output                                                        |
+| :----------------------------------- | :----------------: | :-----------------: | :------------------------------------------------------------ |
+| YOLOv8 / YOLO11                      |         ✅         |         ✅          | HEF with HailoRT YOLO NMS                                     |
+| YOLO26                               |         ✅         |         ✅          | NMS-free detection-head outputs for supported runtimes        |
+| YOLOv8-seg / YOLO11-seg              |         ✅         |         ✅          | Raw segmentation tensors, decoded by Ultralytics at inference |
+| YOLOv8-pose / YOLO11-pose            |         ✅         |         ✅          | Raw pose tensors, decoded by Ultralytics at inference         |
+| YOLOv8-obb / YOLO11-obb              |         ✅         |         ✅          | Raw OBB tensors, decoded by Ultralytics at inference          |
+| YOLOv8-cls / YOLO11-cls / YOLO26-cls |         ✅         |         ✅          | On-chip softmax; HEF returns class probabilities              |
 
 Select one of these `name` values:
 
@@ -151,7 +154,7 @@ Hailo compilation is hardware-specific and uses a fixed input shape. Keep these 
 - Calibration images should represent the lighting, viewpoints, objects, and backgrounds expected in production.
 - A HEF compiled with one `imgsz` does not become dynamically resizable at runtime.
 - Custom class counts are supported because Ultralytics generates post-processing configuration from the model metadata.
-- Detection models with standard Ultralytics `Detect` heads and YOLOv8/YOLO11 segmentation models are supported; YOLO26 segmentation, pose, oriented bounding box, classification, YOLO-World, YOLOE, YOLOv10, and RT-DETR exports are not currently supported.
+- Detection models with standard Ultralytics `Detect` heads, YOLOv8/YOLO11 segmentation, pose, and OBB models, and YOLOv8/YOLO11/YOLO26 classification models are supported; YOLO26 segmentation, pose, and oriented bounding box, along with YOLO-World, YOLOE, YOLOv10, and RT-DETR exports, are not currently supported.
 - Hailo-8/8L and Hailo-10/15 artifacts are compiled by different DFC generations and are not interchangeable.
 
 ## Calibration and INT8 Quantization
@@ -197,7 +200,7 @@ yolo11n_hailo_model/
 
 - `*.hef` is the compiled model loaded by HailoRT.
 - `metadata.yaml` preserves model names, task, input size, stride, and Hailo target information.
-- `nms_config.json` records the generated HailoRT NMS configuration for YOLOv8 and YOLO11 detection models. YOLO26 and segmentation models do not use this file.
+- `nms_config.json` records the generated HailoRT NMS configuration for YOLOv8 and YOLO11 detection models. YOLO26 detection and all non-detection tasks (segmentation, pose, OBB, classification) do not use this file.
 
 The intermediate ONNX graph is removed after compilation.
 
@@ -336,7 +339,7 @@ A supported GPU greatly reduces DFC optimization time. CPU compilation is possib
 
 ### Which YOLO models support Hailo export?
 
-Direct export supports detection models with the standard YOLOv8, YOLO11, or YOLO26 detection head, and YOLOv8/YOLO11 segmentation models. This includes custom-trained models built from those standard architectures. Classification, YOLO26 segmentation, pose, OBB, YOLOv10, YOLO-World, YOLOE, and RT-DETR are rejected rather than producing an unvalidated HEF.
+Direct export supports detection models with the standard YOLOv8, YOLO11, or YOLO26 detection head, YOLOv8/YOLO11 segmentation, pose, and OBB models, and YOLOv8/YOLO11/YOLO26 classification models. This includes custom-trained models built from those standard architectures. YOLO26 segmentation, pose, and OBB, along with YOLOv10, YOLO-World, YOLOE, and RT-DETR, are rejected rather than producing an unvalidated HEF.
 
 ### Can I export a custom-trained YOLO model?
 
@@ -366,7 +369,7 @@ Download the compiler wheel for your hardware generation from the Hailo Develope
 
 Ultralytics Hailo export provides a direct path from a trained YOLO model to a deployable HEF:
 
-1. Load a YOLOv8, YOLO11, or YOLO26 detection model, or a YOLOv8/YOLO11 segmentation model.
+1. Load a YOLOv8, YOLO11, or YOLO26 detection or classification model, or a YOLOv8/YOLO11 segmentation, pose, or OBB model.
 2. Export with `format="hailo"` and select the target architecture.
 3. Calibrate and compile locally with the matching DFC, or use managed export in Ultralytics Platform.
 4. Copy the HEF and `metadata.yaml` to the Hailo-powered edge device.

--- a/docs/en/integrations/hailo.md
+++ b/docs/en/integrations/hailo.md
@@ -1,6 +1,6 @@
 ---
 comments: true
-description: Export Ultralytics YOLO detection, segmentation, pose, OBB, and classification models directly to Hailo HEF for computer vision and edge AI on Hailo-8, Hailo-8L, Hailo-10, and Hailo-15 accelerators.
+description: Export Ultralytics YOLO detection, segmentation, pose, OBB, and classification models directly to Hailo HEF for computer vision and edge AI.
 keywords: Hailo export, Hailo HEF, export YOLO to Hailo, YOLO Hailo, Hailo-8, Hailo-8L, Hailo-10, Hailo-15, Raspberry Pi AI Kit, Raspberry Pi AI HAT+, Hailo Dataflow Compiler, Hailo DFC, HailoRT, Hailo AI accelerator, edge AI, embedded AI, computer vision, object detection, instance segmentation, pose estimation, oriented bounding box, image classification, model quantization, INT8 quantization, Ultralytics YOLO, YOLO26, YOLO11, YOLOv8
 ---
 
@@ -43,7 +43,7 @@ The exporter performs these stages automatically:
 5. Compiles the optimized graph for the selected Hailo accelerator.
 6. Saves the HEF with Ultralytics metadata and removes the intermediate ONNX file.
 
-YOLOv8 and YOLO11 use HailoRT YOLO NMS in the compiled pipeline. YOLO26 uses its NMS-free one-to-one detection outputs, so the exporter selects a different output and quantization path automatically. YOLOv8/YOLO11 segmentation, pose, and OBB compile the raw head tensors, which Ultralytics decodes at inference, and YOLOv8/YOLO11/YOLO26 classification runs softmax on chip so the HEF returns class probabilities directly. Users do not need to find ONNX end nodes, write a Hailo model script (`.alls`), or create an NMS JSON manually.
+YOLOv8 and YOLO11 detection models use HailoRT YOLO NMS in the compiled pipeline. YOLO26 detection models use their NMS-free one-to-one outputs, so the exporter selects a different output and quantization path automatically. YOLOv8/YOLO11 segmentation, pose, and OBB compile the raw head tensors, which Ultralytics decodes at inference, and YOLOv8/YOLO11/YOLO26 classification runs softmax on chip so the HEF returns class probabilities directly. Users do not need to find ONNX end nodes, write a Hailo model script (`.alls`), or create an NMS JSON manually.
 
 ## Installation
 
@@ -100,7 +100,7 @@ model.export(format="hailo", name="hailo8l", imgsz=640)
 
 ## Supported Models and Hardware
 
-The Hailo ecosystem covers a broad range of computer vision workloads, but the Ultralytics `format="hailo"` exporter currently validates standard YOLO detection, segmentation, pose, OBB, and classification heads. The table below describes this direct integration, not every workload the Hailo ecosystem can run.
+The Hailo ecosystem covers a broad range of computer vision workloads, but the Ultralytics `format="hailo"` exporter currently validates standard YOLO detection, segmentation, pose, OBB, and classification heads. The task table describes the available exporter paths; hardware validation is listed separately below.
 
 | Ultralytics task          | Direct Hailo export | Supported model families | Notes                                                                                        |
 | :------------------------ | :-----------------: | :----------------------- | :------------------------------------------------------------------------------------------- |
@@ -115,12 +115,14 @@ Specialized detection families such as YOLOv10, YOLO-World, YOLOE, and RT-DETR a
 
 | Model family                         | Hailo-8 / Hailo-8L | Hailo-10 / Hailo-15 | Output                                                        |
 | :----------------------------------- | :----------------: | :-----------------: | :------------------------------------------------------------ |
-| YOLOv8 / YOLO11                      |         ✅         |         ✅          | HEF with HailoRT YOLO NMS                                     |
-| YOLO26                               |         ✅         |         ✅          | NMS-free detection-head outputs for supported runtimes        |
+| YOLOv8 / YOLO11 detection            |         ✅         |         ✅          | HEF with HailoRT YOLO NMS                                     |
+| YOLO26 detection                     |         ✅         |         ✅          | NMS-free detection-head outputs for supported runtimes        |
 | YOLOv8-seg / YOLO11-seg              |         ✅         |         ✅          | Raw segmentation tensors, decoded by Ultralytics at inference |
-| YOLOv8-pose / YOLO11-pose            |         ✅         |         ✅          | Raw pose tensors, decoded by Ultralytics at inference         |
-| YOLOv8-obb / YOLO11-obb              |         ✅         |         ✅          | Raw OBB tensors, decoded by Ultralytics at inference          |
-| YOLOv8-cls / YOLO11-cls / YOLO26-cls |         ✅         |         ✅          | On-chip softmax; HEF returns class probabilities              |
+| YOLOv8-pose / YOLO11-pose            | Hailo-8L validated |    Not validated    | Raw pose tensors, decoded by Ultralytics at inference         |
+| YOLOv8-obb / YOLO11-obb              | Hailo-8L validated |    Not validated    | Raw OBB tensors, decoded by Ultralytics at inference          |
+| YOLOv8-cls / YOLO11-cls / YOLO26-cls | Hailo-8L validated |    Not validated    | On-chip softmax; HEF returns class probabilities              |
+
+Pose, OBB, and classification were validated on Hailo-8L with HailoRT 4.23 and DFC 3.33. The exporter accepts the other listed targets, but those new task paths require validation with the matching compiler and device before production use.
 
 Select one of these `name` values:
 
@@ -222,7 +224,7 @@ model = YOLO("yolo11n_hailo_model")
 results = model.predict("path/to/image.jpg")
 ```
 
-The backend converts YOLOv8 and YOLO11 HailoRT NMS output and decodes YOLO26 one-to-one outputs automatically. TAPPAS, GStreamer, and the Raspberry Pi `picamera2.devices.Hailo` helper remain available for application-specific pipelines.
+For detection models, the backend converts YOLOv8 and YOLO11 HailoRT NMS output and decodes YOLO26 one-to-one outputs automatically. It decodes raw segmentation, pose, and OBB tensors and returns on-chip classification probabilities through the standard Ultralytics results pipeline. TAPPAS, GStreamer, and the Raspberry Pi `picamera2.devices.Hailo` helper remain available for application-specific pipelines.
 
 For a GStreamer deployment, pass the HEF to `hailonet`:
 
@@ -299,7 +301,7 @@ Model and pipeline choices often matter more than compiler flags:
 | `conf`     | `float`       | `0.25`    | YOLOv8/YOLO11 HailoRT NMS confidence threshold     |
 | `iou`      | `float`       | `0.7`     | YOLOv8/YOLO11 HailoRT NMS IoU threshold            |
 
-The exporter selects the correct output path from the model family: YOLOv8 and YOLO11 receive HailoRT NMS, while YOLO26 keeps its NMS-free one-to-one outputs. Do not pass `end2end`; explicit overrides are rejected. Dynamic shapes, batches larger than one, embedded Ultralytics NMS, FP16, and FP32 are also unsupported.
+For detection export, YOLOv8 and YOLO11 receive HailoRT NMS, while YOLO26 keeps its NMS-free one-to-one outputs. Segmentation, pose, and OBB use raw head tensors, and classification returns on-chip probabilities. Do not pass `end2end`; explicit overrides are rejected. Dynamic shapes, batches larger than one, embedded Ultralytics NMS, FP16, and FP32 are also unsupported.
 
 ## Troubleshooting Hailo Export
 

--- a/docs/en/integrations/index.md
+++ b/docs/en/integrations/index.md
@@ -75,7 +75,7 @@ Welcome to the Ultralytics Integrations page! This page provides an overview of 
 
 - [Gradio](gradio.md): Deploy Ultralytics models with Gradio for real-time, interactive object detection demos.
 
-- [Hailo](hailo.md): Export Ultralytics YOLO detection, segmentation, pose, OBB, and classification models directly to Hailo HEF for Hailo-8, Hailo-8L, Hailo-10, and Hailo-15 accelerators.
+- [Hailo](hailo.md): Export Ultralytics YOLO detection, segmentation, pose, OBB, and classification models directly to Hailo HEF; see the integration guide for validated models and targets.
 
 - [MNN](mnn.md): Developed by [Alibaba](https://www.alibabagroup.com/), MNN is a highly efficient and lightweight deep learning framework. It supports inference and training of deep learning models and has industry-leading performance for inference and training on-device.
 

--- a/docs/en/integrations/index.md
+++ b/docs/en/integrations/index.md
@@ -75,7 +75,7 @@ Welcome to the Ultralytics Integrations page! This page provides an overview of 
 
 - [Gradio](gradio.md): Deploy Ultralytics models with Gradio for real-time, interactive object detection demos.
 
-- [Hailo](hailo.md): Export Ultralytics YOLO detection and segmentation models directly to Hailo HEF for Hailo-8, Hailo-8L, Hailo-10, and Hailo-15 accelerators.
+- [Hailo](hailo.md): Export Ultralytics YOLO detection, segmentation, pose, OBB, and classification models directly to Hailo HEF for Hailo-8, Hailo-8L, Hailo-10, and Hailo-15 accelerators.
 
 - [MNN](mnn.md): Developed by [Alibaba](https://www.alibabagroup.com/), MNN is a highly efficient and lightweight deep learning framework. It supports inference and training of deep learning models and has industry-leading performance for inference and training on-device.
 

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.100"
+__version__ = "8.4.101"
 
 import importlib
 import os

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -80,7 +80,19 @@ from ultralytics.data import build_dataloader, build_yolo_dataset
 from ultralytics.data.dataset import ClassificationDataset
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.nn.autobackend import AutoBackend, check_class_names, default_class_names
-from ultralytics.nn.modules import C2f, Classify, Detect, RTDETRDecoder, Segment, Segment26, SemanticSegment
+from ultralytics.nn.modules import (
+    OBB,
+    OBB26,
+    C2f,
+    Classify,
+    Detect,
+    Pose,
+    Pose26,
+    RTDETRDecoder,
+    Segment,
+    Segment26,
+    SemanticSegment,
+)
 from ultralytics.nn.tasks import ClassificationModel, DetectionModel, SegmentationModel, WorldModel
 from ultralytics.utils import (
     ARM64,
@@ -587,16 +599,17 @@ class Exporter:
             family = Path(getattr(model, "yaml_file", None) or model.yaml.get("yaml_file", "")).stem.lower() or (
                 "yolov8" if "C2f" in blocks else "yolo11" if {"C3k2", "C2PSA"} <= blocks else ""
             )
-            if isinstance(model.model[-1], Segment26):
-                raise ValueError("Hailo export does not currently support YOLO26 segmentation models.")
+            task26 = {Segment26: "segmentation", Pose26: "pose", OBB26: "OBB"}.get(type(model.model[-1]))
+            if task26:
+                raise ValueError(f"Hailo export does not currently support YOLO26 {task26} models.")
             if (
-                model.task not in {"detect", "segment"}
-                or type(model.model[-1]) not in {Detect, Segment}
+                model.task not in {"detect", "segment", "pose", "obb", "classify"}
+                or type(model.model[-1]) not in {Detect, Segment, Pose, OBB, Classify}
                 or not family.startswith(("yolov8", "yolo11", "yolo26"))
             ):
                 raise ValueError(
-                    "Hailo export currently supports YOLOv8, YOLO11, and YOLO26 detection models "
-                    "and YOLOv8/YOLO11 segmentation models."
+                    "Hailo export currently supports YOLOv8/YOLO11/YOLO26 detection and classification models "
+                    "and YOLOv8/YOLO11 segmentation, pose, and OBB models."
                 )
             if self.args.end2end is not None:
                 raise ValueError(
@@ -1493,22 +1506,30 @@ class Exporter:
         head_index = len(self.model.model) - 1
         head = self.model.model[head_index]
         one2one = getattr(self.model, "end2end", False)
-        segment = self.model.task == "segment"
-        scales = range(len(head.one2one_cv2 if one2one else head.cv2))
-        if one2one:
-            end_nodes = [
-                f"/model.{head_index}/one2one_cv{branch}.{i}/one2one_cv{branch}.{i}.2/Conv"
-                for branch in (2, 3)
-                for i in scales
-            ]
-        elif segment:
-            end_nodes = [
-                f"/model.{head_index}/cv{branch}.{i}/cv{branch}.{i}.2/Conv" for i in scales for branch in (2, 3, 4)
-            ] + [f"/model.{head_index}/proto/cv3/act/Mul"]
+        task = self.model.task
+        if task == "classify":
+            # The Classify head ends in Gemm -> Softmax; cut at the Softmax so the HEF returns the same
+            # (1, nc) probabilities as the PyTorch model. The DFC translates the softmax to a native layer.
+            end_nodes = [f"/model.{head_index}/Softmax"]
         else:
-            end_nodes = [
-                f"/model.{head_index}/cv{branch}.{i}/cv{branch}.{i}.2/Conv" for i in scales for branch in (2, 3)
-            ]
+            scales = range(len(head.one2one_cv2 if one2one else head.cv2))
+            if one2one:
+                end_nodes = [
+                    f"/model.{head_index}/one2one_cv{branch}.{i}/one2one_cv{branch}.{i}.2/Conv"
+                    for branch in (2, 3)
+                    for i in scales
+                ]
+            elif task in {"segment", "pose", "obb"}:
+                # reg/cls/extra triple per scale (extra = mask coeffs, keypoints, or angle); segment adds prototypes.
+                end_nodes = [
+                    f"/model.{head_index}/cv{branch}.{i}/cv{branch}.{i}.2/Conv" for i in scales for branch in (2, 3, 4)
+                ]
+                if task == "segment":
+                    end_nodes.append(f"/model.{head_index}/proto/cv3/act/Mul")
+            else:
+                end_nodes = [
+                    f"/model.{head_index}/cv{branch}.{i}/cv{branch}.{i}.2/Conv" for i in scales for branch in (2, 3)
+                ]
         self.args.opset = 11
         f_onnx = Path(self.export_onnx())
         output_dir = self.file.parent / f"{self.file.stem}_hailo_model"
@@ -1526,11 +1547,15 @@ class Exporter:
             if one2one:
                 outputs = ", ".join(f"output_layer{i + 1}" for i in range(len(end_nodes)))
                 model_script.append(f"quantization_param([{outputs}], precision_mode=a16_w16)")
+            elif task == "classify":
+                pass  # softmax is already the graph output; no NMS or activation changes needed
             else:
                 outputs = [layer.inputs[0].rsplit("/", 1)[-1] for layer in runner.get_hn_model().get_output_layers()]
-                if segment:
+                if task in {"segment", "pose", "obb"}:
+                    # Bake sigmoid into the class convs only (position 1 of each per-scale reg/cls/extra triple).
+                    # Mask coeffs, prototypes, keypoints and angles stay raw and are decoded on the host.
                     model_script.extend(
-                        f"change_output_activation({outputs[i]}, sigmoid)" for i in range(1, len(outputs) - 1, 3)
+                        f"change_output_activation({outputs[i]}, sigmoid)" for i in range(1, 3 * len(scales), 3)
                     )
                 else:
                     nms_config = output_dir / "nms_config.json"
@@ -1579,7 +1604,7 @@ class Exporter:
             (output_dir / f"{self.file.stem}.hef").write_bytes(runner.compile())
             YAML.save(
                 output_dir / "metadata.yaml",
-                {**self.metadata, "hailo_arch": self.args.name, "nms": not (one2one or segment)},
+                {**self.metadata, "hailo_arch": self.args.name, "nms": task == "detect" and not one2one},
             )
             return str(output_dir)
         finally:

--- a/ultralytics/nn/backends/hailo.py
+++ b/ultralytics/nn/backends/hailo.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from contextlib import ExitStack
 from pathlib import Path
 
@@ -46,9 +47,9 @@ class HailoBackend(BaseBackend):
             from ultralytics.utils import YAML
 
             self.apply_metadata(YAML.load(metadata_file))
-        if self.task and self.task not in {"detect", "segment"}:
+        if self.task and self.task not in {"detect", "segment", "pose", "obb", "classify"}:
             raise ValueError(
-                f"Hailo inference only supports detection and segmentation models, not task='{self.task}'."
+                f"Hailo inference only supports detect, segment, pose, obb and classify tasks, not task='{self.task}'."
             )
 
         self.hef = HEF(str(hef_file))
@@ -64,11 +65,12 @@ class HailoBackend(BaseBackend):
             self.model = stack.enter_context(InferVStreams(network_group, input_params, output_params))
             self._stack = stack.pop_all()
         self._anchors = None
-        if self.task == "segment":
+        if self.task in {"segment", "pose", "obb"}:
             from ultralytics.nn.modules import DFL
 
             self._dfl = DFL()
-        self.end2end = self.task != "segment"  # segmentation returns dense output for the predictor's NMS
+        # segmentation, pose and OBB return a dense tensor for the predictor's NMS; detect and classify do not
+        self.end2end = self.task not in {"segment", "pose", "obb"}
 
     def __del__(self):
         """Release the Hailo pipeline and device."""
@@ -82,6 +84,12 @@ class HailoBackend(BaseBackend):
         outputs = [results[x.name] for x in self.output_infos]
         if self.task == "segment":
             return self._decode_segment(outputs)
+        if self.task == "pose":
+            return self._decode_pose(outputs)
+        if self.task == "obb":
+            return self._decode_obb(outputs)
+        if self.task == "classify":
+            return torch.from_numpy(outputs[0]).reshape(outputs[0].shape[0], -1)  # on-chip softmax probabilities
         return self._decode_raw(outputs) if not self.metadata.get("nms", False) else self._decode_nms(outputs[0])
 
     def _decode_nms(self, output: list) -> np.ndarray:
@@ -105,24 +113,56 @@ class HailoBackend(BaseBackend):
             predictions[i, : len(frame)] = frame
         return predictions
 
+    def _decode_boxes(self, reg_maps: list[torch.Tensor], angle: torch.Tensor | None = None) -> torch.Tensor:
+        """Run DFL and box decoding on cached anchors, returning (B, A, 4) xywh boxes (rotated if angle given)."""
+        from ultralytics.utils.tal import dist2bbox, dist2rbox, make_anchors
+
+        if self._anchors is None:
+            strides = [self.input_info.shape[0] / m.shape[2] for m in reg_maps]
+            self._anchors = make_anchors(reg_maps, strides)
+        anchors, stride_tensor = self._anchors
+        dist = self._dfl(torch.cat([m.flatten(2) for m in reg_maps], 2)).transpose(1, 2)
+        if angle is not None:
+            return dist2rbox(dist, angle, anchors) * stride_tensor
+        return dist2bbox(dist, anchors, xywh=True) * stride_tensor
+
     def _decode_segment(self, outputs: list[np.ndarray]) -> list[torch.Tensor]:
         """Decode raw segmentation tensors (reg, cls, coeff per scale + prototypes) for the predictor's NMS."""
-        from ultralytics.utils.tal import dist2bbox, make_anchors
-
         proto = torch.from_numpy(outputs[-1]).permute(0, 3, 1, 2)
         k = len(outputs) - 1
         reg_maps = [torch.from_numpy(x).permute(0, 3, 1, 2) for x in outputs[0:k:3]]
         cls_maps = [torch.from_numpy(x).permute(0, 3, 1, 2) for x in outputs[1:k:3]]
         cof_maps = [torch.from_numpy(x).permute(0, 3, 1, 2) for x in outputs[2:k:3]]
-        if self._anchors is None:
-            strides = [self.input_info.shape[0] / x.shape[2] for x in reg_maps]
-            self._anchors = make_anchors(reg_maps, strides)
-        anchors, stride_tensor = self._anchors
-        dist = self._dfl(torch.cat([x.flatten(2) for x in reg_maps], 2)).transpose(1, 2)
-        boxes = dist2bbox(dist, anchors, xywh=True) * stride_tensor
+        boxes = self._decode_boxes(reg_maps)
         cls = torch.cat([x.flatten(2) for x in cls_maps], 2).transpose(1, 2)  # sigmoid baked in at export
         cof = torch.cat([x.flatten(2) for x in cof_maps], 2).transpose(1, 2)
         return [torch.cat((boxes, cls, cof), 2).transpose(1, 2), proto]
+
+    def _decode_pose(self, outputs: list[np.ndarray]) -> torch.Tensor:
+        """Decode raw pose tensors (reg, cls, kpt per scale) into the dense output the predictor's NMS expects."""
+        maps = [torch.from_numpy(x).permute(0, 3, 1, 2) for x in outputs]
+        reg_maps, cls_maps, kpt_maps = maps[0::3], maps[1::3], maps[2::3]
+        boxes = self._decode_boxes(reg_maps)
+        anchors, stride_tensor = self._anchors
+        cls = torch.cat([m.flatten(2) for m in cls_maps], 2).transpose(1, 2)  # sigmoid baked in at export
+        kpts = torch.cat([m.flatten(2) for m in kpt_maps], 2).transpose(1, 2)  # (B, A, nk) raw
+        n_kpt, ndim = self.kpt_shape
+        b, a, _ = kpts.shape
+        y = kpts.view(b, a, n_kpt, ndim)
+        # Pose.kpts_decode: xy = (raw * 2 + (anchor - 0.5)) * stride; visibility sigmoid is applied on the host
+        xy = (y[..., :2] * 2.0 + (anchors.view(a, 1, 2) - 0.5)) * stride_tensor.view(a, 1, 1)
+        kpts = torch.cat((xy, y[..., 2:3].sigmoid()), -1) if ndim == 3 else xy
+        return torch.cat((boxes, cls, kpts.view(b, a, -1)), 2).transpose(1, 2)
+
+    def _decode_obb(self, outputs: list[np.ndarray]) -> torch.Tensor:
+        """Decode raw OBB tensors (reg, cls, angle per scale) into the dense output the rotated NMS expects."""
+        maps = [torch.from_numpy(x).permute(0, 3, 1, 2) for x in outputs]
+        reg_maps, cls_maps, ang_maps = maps[0::3], maps[1::3], maps[2::3]
+        angle = torch.cat([m.flatten(2) for m in ang_maps], 2).transpose(1, 2)  # (B, A, 1) raw
+        angle = (angle.sigmoid() - 0.25) * math.pi  # OBB head angle squash, applied on the host
+        boxes = self._decode_boxes(reg_maps, angle)  # rotated xywh
+        cls = torch.cat([m.flatten(2) for m in cls_maps], 2).transpose(1, 2)  # sigmoid baked in at export
+        return torch.cat((boxes, cls, angle), 2).transpose(1, 2)
 
     def _decode_raw(self, outputs: list[np.ndarray]) -> np.ndarray:
         """Decode branch-first YOLO26 regression and class outputs."""


### PR DESCRIPTION
## Summary

Follow-up to #25259, extending the Hailo integration to the last three task heads that Axelera already covers: pose, OBB, and classification. This closes the task matrix for the direct exporter, so `format="hailo"` now handles detection, segmentation, pose, OBB, and classification, and users keep asking for these on the Hailo forum.

All three fold into the per-task pattern that #25259 left behind, so each one is a thin branch, not a parallel stack:

- `export_hailo` gains pose and OBB (the reg/cls/extra triple per scale, like segmentation minus the prototypes) and classification. Pose and OBB keep the same `nms: false` raw-tensor contract as segmentation, with the sigmoid baked into the class convs only. Classification is cut at the head `Softmax`: the DFC runs the softmax on chip, so the HEF returns class probabilities directly. YOLO26 pose and OBB are rejected next to YOLO26 segmentation through the existing terminal-head owner (`Segment26`/`Pose26`/`OBB26`); YOLO26 classification uses the same `Classify` head as YOLO11 and is accepted.
- `HailoBackend` gets `_decode_pose` and `_decode_obb`, and the box path that segmentation, pose and OBB share now lives in one `_decode_boxes` helper (DFL + `dist2bbox`, or `dist2rbox` when an angle is passed). Keypoints follow `Pose.kpts_decode` (the visibility sigmoid runs on the host, its channel is interleaved with x, y). OBB angle is the head squash `(sigmoid - 0.25) * pi`, applied on the host, then `dist2rbox`. Classification is a reshape of the on-chip probabilities. Each decode returns the dense tensor the existing predictor NMS already expects, so nothing downstream changes.
- Raw tensors are bucketed by position (reg/cls/extra per scale), the same ordering `_decode_segment` already relies on. This matters for single-class OBB, where the angle channel and the class channel are both width 1 and cannot be told apart by shape.
- Docs: pose/OBB/classification rows in both tables, task-specific output paths, and the Hailo entry in the model-deployment-options guide. Hardware claims distinguish the Hailo-8L/DFC 3.33 validation from targets that still require matching compiler and device validation. The rejection message also names YOLO26 for classification, same as the code.
- Release: bumps Ultralytics to `8.4.101` so the matching Portal runtime pin can publish after this PR merges.

Deleted: the inline `make_anchors` + DFL + `dist2bbox` block in `_decode_segment`, folded into the shared `_decode_boxes` helper now reused by the pose and OBB decoders. Net growth is capability-matrix expansion (three task heads plus their host decode) that reuses the existing per-task Hailo pattern rather than adding new machinery.

## Validation

The host decoders reproduce the official PyTorch head output exactly (forward hooks feed the raw branch tensors, in export order and with the class convs sigmoided to match the baked HEF activation, into each decode):

| model                         | max abs Δ vs PyTorch                       |
| ----------------------------- | ------------------------------------------ |
| yolov8n-pose / yolo11n-pose   | 0.0 (the DFL module matches the head's DFL) |
| yolov8n-obb / yolo11n-obb     | ~1e-14 (`dist2rbox` float noise)           |
| yolov8n-cls / yolo11n-cls / yolo26n-cls | 0.0                              |

On the device (Hailo-8L PCIe, HailoRT 4.23, DFC 3.33, in-domain calibration), INT8 HEFs retain the following share of their PyTorch metric under the same evaluation protocol:

| task     | metric              | YOLOv8n              | YOLO11n              |
| -------- | ------------------- | ------------------- | ------------------- |
| pose     | box-mAP50 retention | 98.1% (0.4831/0.4924) | 90.8% (0.4541/0.5002) |
| pose     | mean keypoint dist @640 | 4.3 px          | 6.2 px              |
| obb      | mAP50 retention (dota128) | ~100% (0.995/0.995) | 96.9%          |
| classify | top1 retention (ImageNet val) | 92.6%     | 95.4%               |

A few notes from the measurements: the pose calibration default is `coco8-pose` (8 images), so pass a larger `data=` for production exports; DOTA8 has only 4 val images and saturates mAP50 at 0.995 for both models, so OBB is measured on DOTA128, and the angle error stays around 1.6° (YOLOv8) / 2.9° (YOLO11) on elongated boxes (near-square boxes have ambiguous orientation and are not counted). `predict` returns boxes, masks, keypoints and rotated boxes through the standard pipeline. `uvx ruff check` and `uvx ruff format --check` pass on the changed files.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds Hailo HEF export and inference support for YOLOv8 and YOLO11 pose, OBB, and classification models, extending the existing detection and segmentation integration.

### 📊 Key Changes
- Expands Hailo exporter validation and documentation to support pose, OBB, and classification tasks.
- Adds task-specific Hailo output handling, including classification softmax outputs and raw pose/OBB head tensors.
- Implements host-side decoding for pose keypoints and oriented bounding boxes, including DFL, anchors, angles, and visibility scores.
- Updates Hailo backend task support, end-to-end behavior, metadata, and NMS handling.
- Documents supported model families, hardware targets, output formats, and current YOLO26 limitations.

### 🎯 Purpose & Impact
- Enables deployment of more Ultralytics computer vision tasks, validated on Hailo-8L with HailoRT 4.23 and DFC 3.33.
- Provides consistent Ultralytics inference behavior for Hailo-exported pose, OBB, and classification models.
- Improves edge deployment coverage for applications requiring keypoint estimation, rotated detection, or image classification.
- Marks the new task paths on other compiler generations and devices as unvalidated instead of implying production support.