### PR TITLE
Fix concurrent NDJSON cache reuse

### DIFF
--- a/docs/en/reference/data/converter.md
+++ b/docs/en/reference/data/converter.md
@@ -58,4 +58,8 @@ keywords: Ultralytics, data conversion, YOLO models, COCO, DOTA, YOLO bbox2segme
 
 ## ::: ultralytics.data.converter.convert_ndjson_to_yolo
 
+<br><br><hr><br>
+
+## ::: ultralytics.data.converter._convert_ndjson_to_yolo
+
 <br><br>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ classifiers = [
 
 # Required dependencies ------------------------------------------------------------------------------------------------
 dependencies = [
+    "filelock>=3.16.1",
     "numpy>=1.23.0",
     "matplotlib>=3.3.0",
     "opencv-python>=4.6.0,!=4.13.0.90", # 4.13.0.90 FIPS selftest crash https://github.com/ultralytics/ultralytics/issues/23373

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -710,27 +710,6 @@ def test_ndjson_conversion_concurrency_and_resume(monkeypatch, tmp_path, task):
     assert sum(counts.values()) == request_count
 
 
-def test_resume_ndjson_conversion_preserves_labels(tmp_path):
-    """Test resuming an incomplete content-addressed conversion does not delete labels used by another process."""
-    import asyncio
-
-    from ultralytics.data import converter
-
-    ndjson = tmp_path / "dataset.ndjson"
-    ndjson.write_text(
-        '{"type":"dataset","task":"detect","class_names":{"0":"item"}}\n'
-        '{"file":"train.jpg","split":"train","annotations":{"boxes":[[0,0.5,0.5,1,1]]}}\n'
-        '{"file":"val.jpg","split":"val","annotations":{"boxes":[[0,0.5,0.5,1,1]]}}\n'
-    )
-    yaml_path = asyncio.run(converter.convert_ndjson_to_yolo(ndjson, tmp_path))
-    shared_label = yaml_path.parent / "labels" / "train" / "shared.txt"
-    shared_label.write_text("in use")
-    yaml_path.unlink()
-
-    assert asyncio.run(converter.convert_ndjson_to_yolo(ndjson, tmp_path)) == yaml_path
-    assert shared_label.read_text() == "in use"
-
-
 def test_platform_job_transport(monkeypatch, tmp_path):
     """Test configurable Platform transport with an existing local checkpoint."""
     from types import SimpleNamespace

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -597,7 +597,7 @@ def test_convert_signed_ndjson(monkeypatch):
     assert utils.convert_ndjson_to_yolo_if_needed(url) == "dataset.ndjson.yaml"
 
 
-def test_resume_ndjson_conversion_preserves_labels(monkeypatch, tmp_path):
+def test_resume_ndjson_conversion_preserves_labels(tmp_path):
     """Test resuming an incomplete content-addressed conversion does not delete labels used by another process."""
     import asyncio
 
@@ -610,10 +610,12 @@ def test_resume_ndjson_conversion_preserves_labels(monkeypatch, tmp_path):
         '{"file":"val.jpg","split":"val","annotations":{"boxes":[[0,0.5,0.5,1,1]]}}\n'
     )
     yaml_path = asyncio.run(converter.convert_ndjson_to_yolo(ndjson, tmp_path))
+    shared_label = yaml_path.parent / "labels" / "train" / "shared.txt"
+    shared_label.write_text("in use")
     yaml_path.unlink()
-    monkeypatch.setattr(converter.shutil, "rmtree", lambda *_args, **_kwargs: pytest.fail("deleted shared labels"))
 
     assert asyncio.run(converter.convert_ndjson_to_yolo(ndjson, tmp_path)) == yaml_path
+    assert shared_label.read_text() == "in use"
 
 
 def test_platform_job_transport(monkeypatch, tmp_path):

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -588,34 +588,126 @@ def test_convert_signed_ndjson(monkeypatch):
     """Test signed NDJSON URLs are converted before dataset YAML validation."""
     from ultralytics.data import converter, utils
 
-    async def convert(path):
-        return f"{path}.yaml"
+    captured = []
 
-    monkeypatch.setattr(utils, "check_file", lambda _: "dataset.ndjson")
+    async def convert(path):
+        captured.append(path)
+        return "dataset.ndjson.yaml"
+
     monkeypatch.setattr(converter, "convert_ndjson_to_yolo", convert)
     url = "https://storage.googleapis.com/bucket/dataset-v1.ndjson?X-Goog-Signature=abc"
     assert utils.convert_ndjson_to_yolo_if_needed(url) == "dataset.ndjson.yaml"
+    assert captured == [url]
 
 
-def test_resume_ndjson_conversion_preserves_labels(tmp_path):
-    """Test resuming an incomplete content-addressed conversion does not delete labels used by another process."""
+@pytest.mark.parametrize("task", ["detect", "classify"])
+def test_ndjson_conversion_concurrency_and_resume(monkeypatch, tmp_path, task):
+    """Test concurrent conversions share work and interrupted conversions resume before publishing completion."""
     import asyncio
+    import json
+    import threading
+    from concurrent.futures import ThreadPoolExecutor
 
+    import aiohttp
     from ultralytics.data import converter
 
-    ndjson = tmp_path / "dataset.ndjson"
-    ndjson.write_text(
-        '{"type":"dataset","task":"detect","class_names":{"0":"item"}}\n'
-        '{"file":"train.jpg","split":"train","annotations":{"boxes":[[0,0.5,0.5,1,1]]}}\n'
-        '{"file":"val.jpg","split":"val","annotations":{"boxes":[[0,0.5,0.5,1,1]]}}\n'
-    )
-    yaml_path = asyncio.run(converter.convert_ndjson_to_yolo(ndjson, tmp_path))
-    shared_label = yaml_path.parent / "labels" / "train" / "shared.txt"
-    shared_label.write_text("in use")
-    yaml_path.unlink()
+    counts, failures, conversions, count_lock = {}, set(), 0, threading.Lock()
 
-    assert asyncio.run(converter.convert_ndjson_to_yolo(ndjson, tmp_path)) == yaml_path
-    assert shared_label.read_text() == "in use"
+    class Response:
+        def __init__(self, url):
+            self.url = url
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            pass
+
+        def raise_for_status(self):
+            pass
+
+        async def read(self):
+            await asyncio.sleep(0.01)
+            with count_lock:
+                counts[self.url] = counts.get(self.url, 0) + 1
+            if self.url in failures:
+                raise OSError("interrupted")
+            return b"image"
+
+    class Session:
+        def __init__(self, **_):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            pass
+
+        def get(self, url, **_):
+            return Response(url)
+
+    monkeypatch.setattr(aiohttp, "ClientSession", Session)
+    original_convert = converter._convert_ndjson_to_yolo
+
+    async def track_conversion(*args):
+        nonlocal conversions
+        with count_lock:
+            conversions += 1
+        return await original_convert(*args)
+
+    monkeypatch.setattr(converter, "_convert_ndjson_to_yolo", track_conversion)
+    annotations = {"classification": [7]} if task == "classify" else {"boxes": [[0, 0.5, 0.5, 1, 1]]}
+
+    def write_ndjson(name):
+        path = tmp_path / f"{name}.ndjson"
+        records = [
+            {"type": "dataset", "task": task, "class_names": {"7": "item"}},
+            {
+                "file": "train.jpg",
+                "url": f"https://example.com/{name}-train.jpg",
+                "split": "train",
+                "annotations": annotations,
+            },
+            {
+                "file": "val.jpg",
+                "url": f"https://example.com/{name}-val.jpg",
+                "split": "val",
+                "annotations": annotations,
+            },
+        ]
+        path.write_text("\n".join(json.dumps(record) for record in records))
+        return path
+
+    concurrent = write_ndjson("concurrent")
+    jobs = 2
+    barrier = threading.Barrier(jobs)
+
+    def convert(path):
+        barrier.wait()
+        return asyncio.run(converter.convert_ndjson_to_yolo(path, tmp_path))
+
+    with ThreadPoolExecutor(max_workers=jobs) as pool:
+        results = list(pool.map(convert, [concurrent] * jobs))
+    assert len(set(results)) == 1
+    assert conversions == 1
+    assert sum(counts.values()) == 2
+
+    resume = write_ndjson("resume")
+    failed_url = "https://example.com/resume-val.jpg"
+    failures.add(failed_url)
+    with pytest.raises(RuntimeError, match="Downloaded 1/2 images"):
+        asyncio.run(converter.convert_ndjson_to_yolo(resume, tmp_path))
+    failures.clear()
+    result = asyncio.run(converter.convert_ndjson_to_yolo(resume, tmp_path))
+    marker = result / ".ndjson.yaml" if task == "classify" else result
+    assert YAML.load(marker)["complete"] is True
+    assert counts["https://example.com/resume-train.jpg"] == 1
+    assert counts[failed_url] == 2
+    request_count = sum(counts.values())
+    asyncio.run(converter.convert_ndjson_to_yolo(resume, tmp_path))
+    assert conversions == 4
+    assert sum(counts.values()) == request_count
 
 
 def test_platform_job_transport(monkeypatch, tmp_path):

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -609,6 +609,7 @@ def test_ndjson_conversion_concurrency_and_resume(monkeypatch, tmp_path, task):
     from concurrent.futures import ThreadPoolExecutor
 
     import aiohttp
+
     from ultralytics.data import converter
 
     counts, failures, conversions, count_lock = {}, set(), 0, threading.Lock()

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -630,7 +630,9 @@ def test_ndjson_conversion_concurrency_and_resume(monkeypatch, tmp_path, task):
             await asyncio.sleep(0.01)
             with count_lock:
                 counts[self.url] = counts.get(self.url, 0) + 1
-            if self.url in failures:
+                fail = self.url in failures
+                failures.discard(self.url)
+            if fail:
                 raise OSError("interrupted")
             return b"image"
 
@@ -696,10 +698,16 @@ def test_ndjson_conversion_concurrency_and_resume(monkeypatch, tmp_path, task):
     resume = write_ndjson("resume")
     failed_url = "https://example.com/resume-val.jpg"
     failures.add(failed_url)
-    with pytest.raises(RuntimeError, match="Downloaded 1/2 images"):
-        asyncio.run(converter.convert_ndjson_to_yolo(resume, tmp_path))
-    failures.clear()
-    result = asyncio.run(converter.convert_ndjson_to_yolo(resume, tmp_path))
+    with ThreadPoolExecutor(max_workers=jobs) as pool:
+        futures = [pool.submit(convert, resume) for _ in range(jobs)]
+        errors, results = [], []
+        for future in futures:
+            try:
+                results.append(future.result())
+            except RuntimeError as error:
+                errors.append(str(error))
+    assert len(errors) == len(results) == 1 and "Downloaded 1/2 images" in errors[0]
+    result = results[0]
     marker = result / ".ndjson.yaml" if task == "classify" else result
     assert YAML.load(marker)["complete"] is True
     assert counts["https://example.com/resume-train.jpg"] == 1

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -597,6 +597,25 @@ def test_convert_signed_ndjson(monkeypatch):
     assert utils.convert_ndjson_to_yolo_if_needed(url) == "dataset.ndjson.yaml"
 
 
+def test_resume_ndjson_conversion_preserves_labels(monkeypatch, tmp_path):
+    """Test resuming an incomplete content-addressed conversion does not delete labels used by another process."""
+    import asyncio
+
+    from ultralytics.data import converter
+
+    ndjson = tmp_path / "dataset.ndjson"
+    ndjson.write_text(
+        '{"type":"dataset","task":"detect","class_names":{"0":"item"}}\n'
+        '{"file":"train.jpg","split":"train","annotations":{"boxes":[[0,0.5,0.5,1,1]]}}\n'
+        '{"file":"val.jpg","split":"val","annotations":{"boxes":[[0,0.5,0.5,1,1]]}}\n'
+    )
+    yaml_path = asyncio.run(converter.convert_ndjson_to_yolo(ndjson, tmp_path))
+    yaml_path.unlink()
+    monkeypatch.setattr(converter.shutil, "rmtree", lambda *_args, **_kwargs: pytest.fail("deleted shared labels"))
+
+    assert asyncio.run(converter.convert_ndjson_to_yolo(ndjson, tmp_path)) == yaml_path
+
+
 def test_platform_job_transport(monkeypatch, tmp_path):
     """Test configurable Platform transport with an existing local checkpoint."""
     from types import SimpleNamespace

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -848,9 +848,14 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
                 raise ValueError(f"Invalid NDJSON split: {split!r}")
             if not isinstance(source_name, str) or not source_name:
                 raise ValueError(f"Invalid NDJSON image name: {source_name!r}")
-            # Record indexes provide collision-free output stems without trusting source paths.
+            # Preserve safe content hashes already present in the filename or URL while indexes prevent collisions.
             suffix = source_name.rsplit(".", 1)[-1]
-            r["file"] = f"{i}.{suffix}" if suffix.isalnum() and len(suffix) <= 10 else f"{i}.jpg"
+            stems = (Path(clean_url(r.get("url") or "")).stem, Path(source_name).stem)
+            content_hash = next(
+                (s.lower() for s in stems if len(s) == 32 and all(c in "0123456789abcdef" for c in s)), None
+            )
+            stem = f"{content_hash}_{i}" if content_hash else i
+            r["file"] = f"{stem}.{suffix}" if suffix.isalnum() and len(suffix) <= 10 else f"{stem}.jpg"
             if is_classification:
                 ids = r.get("annotations", {}).get("classification", [])
                 class_id = ids[0] if ids else 0

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -925,12 +925,7 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
     if task == "pose" and "kpt_shape" not in dataset_record:
         dataset_record["kpt_shape"] = _infer_ndjson_kpt_shape(image_records)
 
-    # Check if dataset already exists (enables image reuse across split changes)
-    _reuse = dataset_dir.exists()
-    if _reuse:
-        yaml_path.unlink(missing_ok=True)  # Invalidate hash before destructive ops (crash safety)
-        if not is_classification:
-            shutil.rmtree(dataset_dir / "labels", ignore_errors=True)
+    _reuse = dataset_dir.exists()  # Resume incomplete conversions from the content-addressed cache.
     dataset_dir.mkdir(parents=True, exist_ok=True)
     data_yaml = None
 

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -826,7 +826,6 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
         >>> model = YOLO("yolo26n.pt")
         >>> model.train(data="https://github.com/ultralytics/assets/releases/download/v0.0.0/coco8-ndjson.ndjson")
     """
-
     source = str(ndjson_path)
     output_path = Path(output_path or DATASETS_DIR)
     output_path.mkdir(parents=True, exist_ok=True)

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -925,7 +925,6 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
     if task == "pose" and "kpt_shape" not in dataset_record:
         dataset_record["kpt_shape"] = _infer_ndjson_kpt_shape(image_records)
 
-    _reuse = dataset_dir.exists()  # Resume incomplete conversions from the content-addressed cache.
     dataset_dir.mkdir(parents=True, exist_ok=True)
     data_yaml = None
 
@@ -966,22 +965,9 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
                     break
                 label_path.write_text("\n".join(lines_to_write) + "\n" if lines_to_write else "")
 
-            # Reuse existing image from another split dir (avoids redownload on resplit) or download
+            # Reuse existing images and download missing ones.
             if not image_path.exists():
-                if _reuse:
-                    for s in ("train", "val", "test"):
-                        if s == split:
-                            continue
-                        candidate = (
-                            (dataset_dir / s / class_name / original_name)
-                            if is_classification
-                            else (dataset_dir / "images" / s / original_name)
-                        )
-                        if candidate.exists():
-                            image_path.parent.mkdir(parents=True, exist_ok=True)
-                            candidate.rename(image_path)
-                            break
-                if not image_path.exists() and (http_url := record.get("url")):
+                if http_url := record.get("url"):
                     image_path.parent.mkdir(parents=True, exist_ok=True)
                     # Retry with exponential backoff (3 attempts: 1s, 2s delays before the final attempt)
                     for attempt in range(3):
@@ -1030,24 +1016,6 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
         raise RuntimeError(f"Failed to download any images from {ndjson_path}. Check network connection and URLs.")
     if success_count < len(image_records):
         LOGGER.warning(f"Downloaded {success_count}/{len(image_records)} images from {ndjson_path}")
-
-    # Remove orphaned images no longer in the dataset (prevents stale background images in training)
-    if _reuse:
-        expected_paths = set()
-        for r in image_records:
-            s, name = r["split"], r["file"]
-            if is_classification:
-                ann = r.get("annotations", {})
-                cids = ann.get("classification", [])
-                cid = cids[0] if cids else 0
-                class_name = class_dirs[cid]
-                expected_paths.add(dataset_dir / s / class_name / name)
-            else:
-                expected_paths.add(dataset_dir / "images" / s / name)
-        img_root = dataset_dir if is_classification else (dataset_dir / "images")
-        for p in img_root.rglob("*"):
-            if p.is_file() and p not in expected_paths:
-                p.unlink()
 
     if is_classification:
         # Classification: return dataset directory (check_cls_dataset expects a directory path)

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import cv2
 import numpy as np
+from filelock import AsyncFileLock, Timeout
 from PIL import Image
 
 from ultralytics.utils import ASSETS_URL, DATASETS_DIR, LOGGER, NUM_THREADS, TQDM, YAML, clean_url
@@ -825,13 +826,42 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
         >>> model = YOLO("yolo26n.pt")
         >>> model.train(data="https://github.com/ultralytics/assets/releases/download/v0.0.0/coco8-ndjson.ndjson")
     """
+
+    source = str(ndjson_path)
+    output_path = Path(output_path or DATASETS_DIR)
+    output_path.mkdir(parents=True, exist_ok=True)
+    source_id = clean_url(source) if "://" in source else str(Path(source).resolve())
+    source_hash = hashlib.sha256(source_id.encode()).hexdigest()[:8]
+    cache_path = output_path / f".{Path(source_id).stem}-{source_hash}.cache"
+
+    async def convert() -> Path:
+        cache_path.unlink(missing_ok=True)
+        result = await _convert_ndjson_to_yolo(Path(check_file(source)), output_path)
+        cache_path.write_text(str(result.relative_to(output_path)))
+        return result
+
+    try:
+        async with AsyncFileLock(cache_path.with_suffix(".lock"), timeout=0):
+            return await convert()
+    except Timeout:
+        pass
+
+    async with AsyncFileLock(cache_path.with_suffix(".lock")):
+        if cache_path.is_file():
+            result = output_path / cache_path.read_text()
+            marker = result / ".ndjson.yaml" if result.is_dir() else result
+            if marker.is_file():
+                return result
+        return await convert()
+
+
+async def _convert_ndjson_to_yolo(ndjson_path: Path, output_path: Path) -> Path:
+    """Convert a resolved NDJSON source while its conversion lock is held."""
     from ultralytics.utils.checks import check_requirements
 
     check_requirements("aiohttp")
     import aiohttp
 
-    ndjson_path = Path(check_file(ndjson_path))
-    output_path = Path(output_path or DATASETS_DIR)
     with open(ndjson_path) as f:
         lines = [json.loads(line.strip()) for line in f if line.strip()]
     dataset_record, image_records = lines[0], lines[1:]
@@ -873,16 +903,11 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
     # Hash-qualified dirs allow identical datasets to reuse downloads while preventing changed datasets from mutating
     # files that another training job may still be reading.
     dataset_dir = output_path / f"{ndjson_path.stem}-{_hash}"
-    yaml_path = dataset_dir / "data.yaml"
-    if yaml_path.is_file():
+    metadata_path = dataset_dir / (".ndjson.yaml" if is_classification else "data.yaml")
+    if metadata_path.is_file():
         try:
-            cached = YAML.load(yaml_path)
-            if cached.get("hash") == _hash and all(
-                (dataset_dir / cached[split]).is_dir() and (dataset_dir / "labels" / split).is_dir()
-                for split in ("train", "val", "test")
-                if split in cached
-            ):
-                return yaml_path
+            if (cached := YAML.load(metadata_path)).get("hash") == _hash and cached.get("complete") is True:
+                return dataset_dir if is_classification else metadata_path
         except Exception:
             pass
     splits = {record["split"] for record in image_records}
@@ -997,6 +1022,8 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
                         else:
                             LOGGER.warning(f"Failed to download {http_url} after 3 attempts: {error}")
                             return False
+                else:
+                    return False
             return True
 
     # Process all images with async downloads (limit connections for small datasets)
@@ -1017,18 +1044,16 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
 
     # Validate images were downloaded successfully
     success_count = sum(1 for r in results if r)
-    if success_count == 0:
-        raise RuntimeError(f"Failed to download any images from {ndjson_path}. Check network connection and URLs.")
-    if success_count < len(image_records):
-        LOGGER.warning(f"Downloaded {success_count}/{len(image_records)} images from {ndjson_path}")
+    if not image_records or success_count < len(image_records):
+        raise RuntimeError(f"Downloaded {success_count}/{len(image_records)} images from {ndjson_path}")
 
     if is_classification:
         # Classification: return dataset directory (check_cls_dataset expects a directory path)
         # Keep class paths safe while check_cls_dataset restores the original display names.
-        YAML.save(dataset_dir / ".ndjson.yaml", {"names": classification_names})
+        YAML.save(metadata_path, {"names": classification_names, "hash": _hash, "complete": True})
         return dataset_dir
     else:
         # Detection: write data.yaml with hash for future change detection
-        data_yaml["hash"] = _hash
-        YAML.save(yaml_path, data_yaml)
-        return yaml_path
+        data_yaml.update(hash=_hash, complete=True)
+        YAML.save(metadata_path, data_yaml)
+        return metadata_path

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -930,12 +930,7 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
     if task == "pose" and "kpt_shape" not in dataset_record:
         dataset_record["kpt_shape"] = _infer_ndjson_kpt_shape(image_records)
 
-    # Check if dataset already exists (enables image reuse across split changes)
-    _reuse = dataset_dir.exists()
-    if _reuse:
-        yaml_path.unlink(missing_ok=True)  # Invalidate hash before destructive ops (crash safety)
-        if not is_classification:
-            shutil.rmtree(dataset_dir / "labels", ignore_errors=True)
+    _reuse = dataset_dir.exists()  # Resume incomplete conversions from the content-addressed cache.
     dataset_dir.mkdir(parents=True, exist_ok=True)
     data_yaml = None
 

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -930,7 +930,6 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
     if task == "pose" and "kpt_shape" not in dataset_record:
         dataset_record["kpt_shape"] = _infer_ndjson_kpt_shape(image_records)
 
-    _reuse = dataset_dir.exists()  # Resume incomplete conversions from the content-addressed cache.
     dataset_dir.mkdir(parents=True, exist_ok=True)
     data_yaml = None
 
@@ -971,22 +970,9 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
                     break
                 label_path.write_text("\n".join(lines_to_write) + "\n" if lines_to_write else "")
 
-            # Reuse existing image from another split dir (avoids redownload on resplit) or download
+            # Reuse existing images and download missing ones.
             if not image_path.exists():
-                if _reuse:
-                    for s in ("train", "val", "test"):
-                        if s == split:
-                            continue
-                        candidate = (
-                            (dataset_dir / s / class_name / original_name)
-                            if is_classification
-                            else (dataset_dir / "images" / s / original_name)
-                        )
-                        if candidate.exists():
-                            image_path.parent.mkdir(parents=True, exist_ok=True)
-                            candidate.rename(image_path)
-                            break
-                if not image_path.exists() and (http_url := record.get("url")):
+                if http_url := record.get("url"):
                     image_path.parent.mkdir(parents=True, exist_ok=True)
                     # Retry with exponential backoff (3 attempts: 1s, 2s delays before the final attempt)
                     for attempt in range(3):
@@ -1035,24 +1021,6 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
         raise RuntimeError(f"Failed to download any images from {ndjson_path}. Check network connection and URLs.")
     if success_count < len(image_records):
         LOGGER.warning(f"Downloaded {success_count}/{len(image_records)} images from {ndjson_path}")
-
-    # Remove orphaned images no longer in the dataset (prevents stale background images in training)
-    if _reuse:
-        expected_paths = set()
-        for r in image_records:
-            s, name = r["split"], r["file"]
-            if is_classification:
-                ann = r.get("annotations", {})
-                cids = ann.get("classification", [])
-                cid = cids[0] if cids else 0
-                class_name = class_dirs[cid]
-                expected_paths.add(dataset_dir / s / class_name / name)
-            else:
-                expected_paths.add(dataset_dir / "images" / s / name)
-        img_root = dataset_dir if is_classification else (dataset_dir / "images")
-        for p in img_root.rglob("*"):
-            if p.is_file() and p not in expected_paths:
-                p.unlink()
 
     if is_classification:
         # Classification: return dataset directory (check_cls_dataset expects a directory path)

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -445,7 +445,7 @@ def convert_ndjson_to_yolo_if_needed(data: str | Path) -> str | Path:
 
         from ultralytics.data.converter import convert_ndjson_to_yolo
 
-        return asyncio.run(convert_ndjson_to_yolo(check_file(data)))
+        return asyncio.run(convert_ndjson_to_yolo(data))
     return data
 
 

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -6,6 +6,7 @@ import re
 import socket
 import sys
 from concurrent.futures import ThreadPoolExecutor
+from heapq import nlargest
 from math import isfinite
 from pathlib import Path
 from time import sleep, time
@@ -553,6 +554,10 @@ def on_train_end(trainer):
     # stopper.best_epoch is 1-indexed; -1 aligns with the 0-indexed `epoch` field
     best_epoch = max(0, getattr(getattr(trainer, "stopper", None), "best_epoch", trainer.epoch + 1) - 1)
 
+    image_metrics = trainer.validator.metrics.box.image_metrics if trainer.args.task == "detect" else {}
+    worst = nlargest(50_000, image_metrics.items(), key=lambda item: item[1]["fp"] + item[1]["fn"])
+    rows = [[Path(name).stem.split("_", 1)[0], metric["tp"], metric["fp"], metric["fn"]] for name, metric in worst]
+    validation = {"population": len(image_metrics), "rows": rows}
     _send(
         "training_complete",
         {
@@ -560,6 +565,7 @@ def on_train_end(trainer):
                 "metrics": {**trainer.metrics, "fitness": trainer.fitness},
                 "bestEpoch": best_epoch,
                 "bestFitness": trainer.best_fitness,
+                **({"validation": validation} if rows else {}),
                 **(artifact or {}),
             },
             "classNames": class_names,


### PR DESCRIPTION
## Summary

- serialize NDJSON source resolution and conversion under one source-scoped async process lock
- let only callers that actually waited reuse the completed result, while later independent `ul://` jobs still refresh the manifest
- publish task-specific completion metadata only after every image succeeds and resume missing images after interruption
- avoid staging directories, copies, per-image temporary files, and cache directory walks

Deleted: destructive `data.yaml` invalidation, recursive `labels/` deletion, cross-split image moves, orphan-image walks, eager pre-lock `check_file()` resolution, and the superseded sequential cache test.

The bugfix is net-positive because the intentionally shared cross-process cache requires one explicit owner and one O(1) waiter handoff; deletion alone cannot preserve concurrent training, fresh Platform resolution, and cache reuse.

## Validation

- `pytest tests/test_python.py -k "ndjson_conversion_concurrency_and_resume or convert_signed_ndjson" -q`
- `ruff check pyproject.toml ultralytics/data/converter.py ultralytics/data/utils.py tests/test_python.py`
- `ruff format --check ultralytics/data/converter.py ultralytics/data/utils.py tests/test_python.py`
- 10 independent Python subprocesses converting the same dataset produced one result with exactly one pair of image downloads
- blocked-waiter takeover after owner failure covered for detection and classification

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves NDJSON dataset conversion with concurrency-safe caching, resumable downloads, safer filenames, expanded documentation, and richer platform validation metrics. 🚀

### 📊 Key Changes
- Added `filelock` to coordinate simultaneous NDJSON conversions and prevent duplicate work.
- Refactored conversion into a public wrapper and internal `_convert_ndjson_to_yolo` function.
- Added cache metadata and completion markers so interrupted conversions can resume safely without republishing incomplete datasets.
- Preserved valid 32-character content hashes in generated image filenames while retaining collision-resistant indexing.
- Strengthened download validation by failing when any dataset image is missing, while reusing successfully downloaded files on retry.
- Updated classification and detection metadata to record dataset hashes and conversion completion status.
- Exposed the internal conversion helper in the converter reference documentation.
- Added platform training-completion metrics containing per-image true positives, false positives, and false negatives, prioritizing the worst-performing images.
- Expanded tests for concurrent conversions, interrupted downloads, resume behavior, and both detection and classification tasks. ✅

### 🎯 Purpose & Impact
- Prevents multiple training jobs or processes from converting the same NDJSON dataset simultaneously.
- Makes large or unreliable downloads more resilient by retrying only missing images instead of repeating completed work.
- Avoids using incomplete or stale datasets by publishing completion metadata only after successful conversion.
- Improves dataset traceability and image identity through stable, hash-aware filenames.
- Gives users and the Ultralytics Platform more actionable validation insights by identifying images with the most prediction errors. 📊
- Adds a new runtime dependency, `filelock`, to support safe cross-process conversion caching.