### PR TITLE
Capture best and worst validation images

### DIFF
--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -555,8 +555,16 @@ def on_train_end(trainer):
     best_epoch = max(0, getattr(getattr(trainer, "stopper", None), "best_epoch", trainer.epoch + 1) - 1)
 
     image_metrics = trainer.validator.metrics.box.image_metrics if trainer.args.task == "detect" else {}
-    worst = nlargest(50_000, image_metrics.items(), key=lambda item: item[1]["fp"] + item[1]["fn"])
-    rows = [[Path(name).stem.split("_", 1)[0], metric["tp"], metric["fp"], metric["fn"]] for name, metric in worst]
+    worst = nlargest(25_000, image_metrics.items(), key=lambda item: (-item[1]["f1"], item[1]["fp"] + item[1]["fn"]))
+    worst_names = {name for name, _ in worst}
+    best = nlargest(
+        25_000,
+        ((name, metric) for name, metric in image_metrics.items() if name not in worst_names),
+        key=lambda item: (item[1]["f1"], item[1]["tp"]),
+    )
+    rows = [
+        [Path(name).stem.split("_", 1)[0], metric["tp"], metric["fp"], metric["fn"]] for name, metric in worst + best
+    ]
     validation = {"population": len(image_metrics), "rows": rows}
     _send(
         "training_complete",

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -555,10 +555,11 @@ def on_train_end(trainer):
     best_epoch = max(0, getattr(getattr(trainer, "stopper", None), "best_epoch", trainer.epoch + 1) - 1)
 
     image_metrics = trainer.validator.metrics.box.image_metrics if trainer.args.task == "detect" else {}
-    worst = nlargest(25_000, image_metrics.items(), key=lambda item: (-item[1]["f1"], item[1]["fp"] + item[1]["fn"]))
+    cohort = min(25_000, (len(image_metrics) + 1) // 2)
+    worst = nlargest(cohort, image_metrics.items(), key=lambda item: (-item[1]["f1"], item[1]["fp"] + item[1]["fn"]))
     worst_names = {name for name, _ in worst}
     best = nlargest(
-        25_000,
+        cohort,
         ((name, metric) for name, metric in image_metrics.items() if name not in worst_names),
         key=lambda item: (item[1]["f1"], item[1]["tp"]),
     )


### PR DESCRIPTION
## Summary

- replace the error-only worst-50,000 selection with disjoint best and worst cohorts
- retain up to 25,000 lowest-F1 images, tie-breaking by highest FP + FN
- retain up to 25,000 highest-F1 remaining images, tie-breaking by highest TP
- preserve every image exactly once when the validation population is 50,000 or smaller
- keep the existing 50,000-row transport and Portal storage contract unchanged

## Performance

Both selections use bounded `heapq.nlargest` over the existing final validation metrics. Selection storage remains capped at 50,000 entries; there is no image processing, metric recomputation, per-epoch work, new transport, or schema change.

## Validation

- Ruff check and format passed
- Python compilation and git diff checks passed
- no tests are added; the existing row contract is unchanged
- exact-head Codex adversarial review and CI will gate merge

Deleted: the one-sided worst-50,000 ranking.

Reused: existing per-image F1/TP/FP/FN metrics, final `on_train_end` callback, compact row schema, and 50,000-row bound.

Net-positive justification: a comparison cohort did not exist; the change replaces the existing selector in its owner without adding a protocol, schema, serializer, or metric path.

Release note: this PR intentionally does not bump the package version.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📊 Training-complete reports now include balanced best- and worst-performing validation images instead of only error-heavy examples.

### 📊 Key Changes

- Splits validation images into two cohorts, capped at 25,000 images each.
- Selects the worst-performing images using low F1 scores and high false-positive/false-negative counts.
- Selects the best-performing images using high F1 scores and true-positive counts.
- Includes both cohorts in the `training_complete` report while preserving true-positive, false-positive, and false-negative metrics.

### 🎯 Purpose & Impact

- 🧭 Provides a more representative view of model performance across both successes and failures.
- 🔍 Helps users identify challenging images and understand where the model performs well.
- 📈 Improves training analysis in the Ultralytics Platform without changing model training or validation behavior.
- ⚡ Limits report size for large datasets by capping each cohort at 25,000 images.