### PR TITLE
Add Hailo semantic segmentation export and inference for YOLO26

### DIFF
--- a/docs/en/guides/model-deployment-options.md
+++ b/docs/en/guides/model-deployment-options.md
@@ -56,7 +56,7 @@ Here is a short description of each format and when to reach for it. For the ful
 - **[DEEPX](../integrations/deepx.md)** (`deepx`): Targets DEEPX NPU hardware with INT8 quantization for embedded edge inference.
 - **[Qualcomm QNN](../integrations/qnn.md)** (`qnn`): On-device inference on Snapdragon Hexagon NPU, Adreno GPU, and CPU through the Qualcomm AI stack.
 
-The [Hailo integration](../integrations/hailo.md) exports YOLO detection, segmentation, pose, OBB, and classification models directly to Hailo HEF; see its compatibility table for validated models and targets. The [Ambarella integration](../integrations/ambarella.md) follows an ONNX-first workflow and compiles ONNX exports to the AmbaPB format with Ambarella's CVflow toolchain for CVflow® SoCs such as the CV72, optionally using SpongeTorch compression-aware training.
+The [Hailo integration](../integrations/hailo.md) exports YOLO detection, segmentation, pose, OBB, classification, and semantic segmentation models directly to Hailo HEF; see its compatibility table for validated models and targets. The [Ambarella integration](../integrations/ambarella.md) follows an ONNX-first workflow and compiles ONNX exports to the AmbaPB format with Ambarella's CVflow toolchain for CVflow® SoCs such as the CV72, optionally using SpongeTorch compression-aware training.
 
 ## Deployment Options Compared
 

--- a/docs/en/integrations/hailo.md
+++ b/docs/en/integrations/hailo.md
@@ -1,12 +1,12 @@
 ---
 comments: true
-description: Export Ultralytics YOLO detection, segmentation, pose, OBB, and classification models directly to Hailo HEF for computer vision and edge AI.
+description: Export Ultralytics YOLO detection, segmentation, pose, OBB, classification, and semantic segmentation models directly to Hailo HEF for computer vision and edge AI.
 keywords: Hailo export, Hailo HEF, export YOLO to Hailo, YOLO Hailo, Hailo-8, Hailo-8L, Hailo-10, Hailo-15, Raspberry Pi AI Kit, Raspberry Pi AI HAT+, Hailo Dataflow Compiler, Hailo DFC, HailoRT, Hailo AI accelerator, edge AI, embedded AI, computer vision, object detection, instance segmentation, pose estimation, oriented bounding box, image classification, model quantization, INT8 quantization, Ultralytics YOLO, YOLO26, YOLO11, YOLOv8
 ---
 
 # Hailo Export for Ultralytics YOLO Models
 
-Hailo AI accelerators run compiled Hailo Executable Format (HEF) models on edge devices such as the [Raspberry Pi AI Kit](https://www.raspberrypi.com/products/ai-kit/) and [AI HAT+](https://www.raspberrypi.com/documentation/accessories/ai-hat-plus.html). Ultralytics exports YOLO detection, segmentation, pose, OBB, and classification models directly to HEF with the Hailo Dataflow Compiler (DFC).
+Hailo AI accelerators run compiled Hailo Executable Format (HEF) models on edge devices such as the [Raspberry Pi AI Kit](https://www.raspberrypi.com/products/ai-kit/) and [AI HAT+](https://www.raspberrypi.com/documentation/accessories/ai-hat-plus.html). Ultralytics exports YOLO detection, segmentation, pose, OBB, classification, and semantic segmentation models directly to HEF with the Hailo Dataflow Compiler (DFC).
 
 Hailo deployment is designed for computer vision at the edge: cameras, robots, industrial systems, gateways, and other devices that need local object detection without sending every frame to the cloud. A compiled HEF contains the quantized network, hardware allocation, scheduling, and optional HailoRT post-processing needed by the selected accelerator.
 
@@ -43,7 +43,7 @@ The exporter performs these stages automatically:
 5. Compiles the optimized graph for the selected Hailo accelerator.
 6. Saves the HEF with Ultralytics metadata and removes the intermediate ONNX file.
 
-YOLOv8 and YOLO11 detection models use HailoRT YOLO NMS in the compiled pipeline. YOLO26 detection models use their NMS-free one-to-one outputs, so the exporter selects a different output and quantization path automatically. YOLOv8/YOLO11 segmentation, pose, and OBB compile the raw head tensors, which Ultralytics decodes at inference, and YOLOv8/YOLO11/YOLO26 classification runs softmax on chip so the HEF returns class probabilities directly. Users do not need to find ONNX end nodes, write a Hailo model script (`.alls`), or create an NMS JSON manually.
+YOLOv8 and YOLO11 detection models use HailoRT YOLO NMS in the compiled pipeline. YOLO26 detection models use their NMS-free one-to-one outputs, so the exporter selects a different output and quantization path automatically. YOLOv8/YOLO11 segmentation, pose, and OBB compile the raw head tensors, which Ultralytics decodes at inference, and YOLOv8/YOLO11/YOLO26 classification runs softmax on chip so the HEF returns class probabilities directly. For YOLO26 semantic segmentation the exporter follows the accelerator: Hailo-8/8L (DFC v3.x) cannot compile the head's bilinear upsample, so it returns the classifier logits and Ultralytics runs the upsample and argmax on the host, while Hailo-10/15 (DFC v5.x) compile them on chip and return a compact class map directly. Users do not need to find ONNX end nodes, write a Hailo model script (`.alls`), or create an NMS JSON manually.
 
 ## Installation
 
@@ -100,7 +100,7 @@ model.export(format="hailo", name="hailo8l", imgsz=640)
 
 ## Supported Models and Hardware
 
-The Hailo ecosystem covers a broad range of computer vision workloads, but the Ultralytics `format="hailo"` exporter currently validates standard YOLO detection, segmentation, pose, OBB, and classification heads. The task table describes the available exporter paths; hardware validation is listed separately below.
+The Hailo ecosystem covers a broad range of computer vision workloads, but the Ultralytics `format="hailo"` exporter currently validates standard YOLO detection, segmentation, pose, OBB, classification, and semantic segmentation heads. The task table describes the available exporter paths; hardware validation is listed separately below.
 
 | Ultralytics task          | Direct Hailo export | Supported model families | Notes                                                                                        |
 | :------------------------ | :-----------------: | :----------------------- | :------------------------------------------------------------------------------------------- |
@@ -109,7 +109,7 @@ The Hailo ecosystem covers a broad range of computer vision workloads, but the U
 | Image classification      |         ✅          | YOLOv8, YOLO11, YOLO26   | Softmax runs on chip; the HEF returns class probabilities directly                           |
 | Pose estimation           |         ✅          | YOLOv8, YOLO11           | Raw head tensors decoded by Ultralytics at inference; YOLO26-pose is not currently supported |
 | Oriented object detection |         ✅          | YOLOv8, YOLO11           | Raw head tensors decoded by Ultralytics at inference; YOLO26-OBB is not currently supported  |
-| Semantic segmentation     |         ❌          | —                        | Not yet supported by the direct exporter                                                     |
+| Semantic segmentation     |         ✅          | YOLO26                   | Per-pixel class map; Hailo-8/8L returns logits (host argmax), Hailo-10/15 bakes the map      |
 
 Specialized detection families such as YOLOv10, YOLO-World, YOLOE, and RT-DETR are also ❌ unsupported. Ultralytics rejects these tasks and model families before compilation instead of producing an unvalidated HEF.
 
@@ -121,8 +121,9 @@ Specialized detection families such as YOLOv10, YOLO-World, YOLOE, and RT-DETR a
 | YOLOv8-pose / YOLO11-pose            | Hailo-8L validated |    Not validated    | Raw pose tensors, decoded by Ultralytics at inference         |
 | YOLOv8-obb / YOLO11-obb              | Hailo-8L validated |    Not validated    | Raw OBB tensors, decoded by Ultralytics at inference          |
 | YOLOv8-cls / YOLO11-cls / YOLO26-cls | Hailo-8L validated |    Not validated    | On-chip softmax; HEF returns class probabilities              |
+| YOLO26-sem                           | Hailo-8L validated |    Not validated    | Class map; Hailo-8/8L returns logits, Hailo-10/15 bakes it    |
 
-Pose, OBB, and classification were validated on Hailo-8L with HailoRT 4.23 and DFC 3.33. The exporter accepts the other listed targets, but those new task paths require validation with the matching compiler and device before production use.
+Pose, OBB, classification, and YOLO26 semantic segmentation (Hailo-8/8L path) were validated on Hailo-8L with HailoRT 4.23 and DFC 3.33. The exporter accepts the other listed targets, but those new task paths require validation with the matching compiler and device before production use.
 
 Select one of these `name` values:
 
@@ -156,7 +157,7 @@ Hailo compilation is hardware-specific and uses a fixed input shape. Keep these 
 - Calibration images should represent the lighting, viewpoints, objects, and backgrounds expected in production.
 - A HEF compiled with one `imgsz` does not become dynamically resizable at runtime.
 - Custom class counts are supported because Ultralytics generates post-processing configuration from the model metadata.
-- Detection models with standard Ultralytics `Detect` heads, YOLOv8/YOLO11 segmentation, pose, and OBB models, and YOLOv8/YOLO11/YOLO26 classification models are supported; YOLO26 segmentation, pose, and oriented bounding box, along with YOLO-World, YOLOE, YOLOv10, and RT-DETR exports, are not currently supported.
+- Detection models with standard Ultralytics `Detect` heads, YOLOv8/YOLO11 segmentation, pose, and OBB models, and YOLOv8/YOLO11/YOLO26 classification models, and YOLO26 semantic segmentation models are supported; YOLO26 instance segmentation, pose, and oriented bounding box, along with YOLO-World, YOLOE, YOLOv10, and RT-DETR exports, are not currently supported.
 - Hailo-8/8L and Hailo-10/15 artifacts are compiled by different DFC generations and are not interchangeable.
 
 ## Calibration and INT8 Quantization
@@ -202,7 +203,7 @@ yolo11n_hailo_model/
 
 - `*.hef` is the compiled model loaded by HailoRT.
 - `metadata.yaml` preserves model names, task, input size, stride, and Hailo target information.
-- `nms_config.json` records the generated HailoRT NMS configuration for YOLOv8 and YOLO11 detection models. YOLO26 detection and all non-detection tasks (segmentation, pose, OBB, classification) do not use this file.
+- `nms_config.json` records the generated HailoRT NMS configuration for YOLOv8 and YOLO11 detection models. YOLO26 detection and all non-detection tasks (segmentation, pose, OBB, classification, semantic) do not use this file.
 
 The intermediate ONNX graph is removed after compilation.
 
@@ -224,7 +225,7 @@ model = YOLO("yolo11n_hailo_model")
 results = model.predict("path/to/image.jpg")
 ```
 
-For detection models, the backend converts YOLOv8 and YOLO11 HailoRT NMS output and decodes YOLO26 one-to-one outputs automatically. It decodes raw segmentation, pose, and OBB tensors and returns on-chip classification probabilities through the standard Ultralytics results pipeline. TAPPAS, GStreamer, and the Raspberry Pi `picamera2.devices.Hailo` helper remain available for application-specific pipelines.
+For detection models, the backend converts YOLOv8 and YOLO11 HailoRT NMS output and decodes YOLO26 one-to-one outputs automatically. It decodes raw segmentation, pose, and OBB tensors, returns on-chip classification probabilities, and produces the semantic class map (host argmax on Hailo-8/8L, baked on chip for Hailo-10/15) through the standard Ultralytics results pipeline. TAPPAS, GStreamer, and the Raspberry Pi `picamera2.devices.Hailo` helper remain available for application-specific pipelines.
 
 For a GStreamer deployment, pass the HEF to `hailonet`:
 
@@ -341,7 +342,7 @@ A supported GPU greatly reduces DFC optimization time. CPU compilation is possib
 
 ### Which YOLO models support Hailo export?
 
-Direct export supports detection models with the standard YOLOv8, YOLO11, or YOLO26 detection head, YOLOv8/YOLO11 segmentation, pose, and OBB models, and YOLOv8/YOLO11/YOLO26 classification models. This includes custom-trained models built from those standard architectures. YOLO26 segmentation, pose, and OBB, along with YOLOv10, YOLO-World, YOLOE, and RT-DETR, are rejected rather than producing an unvalidated HEF.
+Direct export supports detection models with the standard YOLOv8, YOLO11, or YOLO26 detection head, YOLOv8/YOLO11 segmentation, pose, and OBB models, and YOLOv8/YOLO11/YOLO26 classification models. This includes custom-trained models built from those standard architectures. YOLO26 semantic segmentation models are also supported. YOLO26 instance segmentation, pose, and OBB, along with YOLOv10, YOLO-World, YOLOE, and RT-DETR, are rejected rather than producing an unvalidated HEF.
 
 ### Can I export a custom-trained YOLO model?
 
@@ -371,7 +372,7 @@ Download the compiler wheel for your hardware generation from the Hailo Develope
 
 Ultralytics Hailo export provides a direct path from a trained YOLO model to a deployable HEF:
 
-1. Load a YOLOv8, YOLO11, or YOLO26 detection or classification model, or a YOLOv8/YOLO11 segmentation, pose, or OBB model.
+1. Load a YOLOv8, YOLO11, or YOLO26 detection or classification model, a YOLOv8/YOLO11 segmentation, pose, or OBB model, or a YOLO26 semantic segmentation model.
 2. Export with `format="hailo"` and select the target architecture.
 3. Calibrate and compile locally with the matching DFC, or use managed export in Ultralytics Platform.
 4. Copy the HEF and `metadata.yaml` to the Hailo-powered edge device.

--- a/docs/en/integrations/hailo.md
+++ b/docs/en/integrations/hailo.md
@@ -43,7 +43,7 @@ The exporter performs these stages automatically:
 5. Compiles the optimized graph for the selected Hailo accelerator.
 6. Saves the HEF with Ultralytics metadata and removes the intermediate ONNX file.
 
-YOLOv8 and YOLO11 detection models use HailoRT YOLO NMS in the compiled pipeline. YOLO26 detection models use their NMS-free one-to-one outputs, so the exporter selects a different output and quantization path automatically. YOLOv8/YOLO11 segmentation, pose, and OBB compile the raw head tensors, which Ultralytics decodes at inference, and YOLOv8/YOLO11/YOLO26 classification runs softmax on chip so the HEF returns class probabilities directly. For YOLO26 semantic segmentation the exporter follows the accelerator: Hailo-8/8L (DFC v3.x) cannot compile the head's bilinear upsample, so it returns the classifier logits and Ultralytics runs the upsample and argmax on the host, while Hailo-10/15 (DFC v5.x) compile them on chip and return a compact class map directly. Users do not need to find ONNX end nodes, write a Hailo model script (`.alls`), or create an NMS JSON manually.
+YOLOv8 and YOLO11 detection models use HailoRT YOLO NMS in the compiled pipeline. YOLO26 detection models use their NMS-free one-to-one outputs, so the exporter selects a different output and quantization path automatically. YOLOv8/YOLO11 segmentation, pose, and OBB compile the raw head tensors, which Ultralytics decodes at inference, and YOLOv8/YOLO11/YOLO26 classification runs softmax on chip so the HEF returns class probabilities directly. For YOLO26 semantic segmentation the exporter follows the accelerator: Hailo-8/8L (DFC v3.x) return classifier logits for host upsampling and reduction, while Hailo-10/15 (DFC v5.x) compile multi-class ArgMax heads on chip and return a compact class map. Single-class heads use the host-logit path on every target because they require a threshold instead of ArgMax. Users do not need to find ONNX end nodes, write a Hailo model script (`.alls`), or create an NMS JSON manually.
 
 ## Installation
 
@@ -109,7 +109,7 @@ The Hailo ecosystem covers a broad range of computer vision workloads, but the U
 | Image classification      |         ✅          | YOLOv8, YOLO11, YOLO26   | Softmax runs on chip; the HEF returns class probabilities directly                           |
 | Pose estimation           |         ✅          | YOLOv8, YOLO11           | Raw head tensors decoded by Ultralytics at inference; YOLO26-pose is not currently supported |
 | Oriented object detection |         ✅          | YOLOv8, YOLO11           | Raw head tensors decoded by Ultralytics at inference; YOLO26-OBB is not currently supported  |
-| Semantic segmentation     |         ✅          | YOLO26                   | Per-pixel class map; Hailo-8/8L returns logits (host argmax), Hailo-10/15 bakes the map      |
+| Semantic segmentation     |         ✅          | YOLO26                   | Hailo-8/8L and single-class heads return logits; Hailo-10/15 bakes multi-class maps          |
 
 Specialized detection families such as YOLOv10, YOLO-World, YOLOE, and RT-DETR are also ❌ unsupported. Ultralytics rejects these tasks and model families before compilation instead of producing an unvalidated HEF.
 
@@ -121,7 +121,7 @@ Specialized detection families such as YOLOv10, YOLO-World, YOLOE, and RT-DETR a
 | YOLOv8-pose / YOLO11-pose            | Hailo-8L validated |    Not validated    | Raw pose tensors, decoded by Ultralytics at inference         |
 | YOLOv8-obb / YOLO11-obb              | Hailo-8L validated |    Not validated    | Raw OBB tensors, decoded by Ultralytics at inference          |
 | YOLOv8-cls / YOLO11-cls / YOLO26-cls | Hailo-8L validated |    Not validated    | On-chip softmax; HEF returns class probabilities              |
-| YOLO26-sem                           | Hailo-8L validated |    Not validated    | Class map; Hailo-8/8L returns logits, Hailo-10/15 bakes it    |
+| YOLO26-sem                           | Hailo-8L validated |    Not validated    | Logits, or a baked multi-class map on Hailo-10/15             |
 
 Pose, OBB, classification, and YOLO26 semantic segmentation (Hailo-8/8L path) were validated on Hailo-8L with HailoRT 4.23 and DFC 3.33. The exporter accepts the other listed targets, but those new task paths require validation with the matching compiler and device before production use.
 
@@ -225,7 +225,7 @@ model = YOLO("yolo11n_hailo_model")
 results = model.predict("path/to/image.jpg")
 ```
 
-For detection models, the backend converts YOLOv8 and YOLO11 HailoRT NMS output and decodes YOLO26 one-to-one outputs automatically. It decodes raw segmentation, pose, and OBB tensors, returns on-chip classification probabilities, and produces the semantic class map (host argmax on Hailo-8/8L, baked on chip for Hailo-10/15) through the standard Ultralytics results pipeline. TAPPAS, GStreamer, and the Raspberry Pi `picamera2.devices.Hailo` helper remain available for application-specific pipelines.
+For detection models, the backend converts YOLOv8 and YOLO11 HailoRT NMS output and decodes YOLO26 one-to-one outputs automatically. It decodes raw segmentation, pose, and OBB tensors, returns on-chip classification probabilities, and produces semantic class maps through host reduction on Hailo-8/8L and all single-class heads or an on-chip ArgMax for multi-class Hailo-10/15 heads. TAPPAS, GStreamer, and the Raspberry Pi `picamera2.devices.Hailo` helper remain available for application-specific pipelines.
 
 For a GStreamer deployment, pass the HEF to `hailonet`:
 
@@ -302,7 +302,7 @@ Model and pipeline choices often matter more than compiler flags:
 | `conf`     | `float`       | `0.25`        | YOLOv8/YOLO11 HailoRT NMS confidence threshold     |
 | `iou`      | `float`       | `0.7`         | YOLOv8/YOLO11 HailoRT NMS IoU threshold            |
 
-For detection export, YOLOv8 and YOLO11 receive HailoRT NMS, while YOLO26 keeps its NMS-free one-to-one outputs. Segmentation, pose, and OBB use raw head tensors, classification returns on-chip probabilities, and semantic segmentation returns raw logits on Hailo-8/8L or baked class maps on Hailo-10/15. Do not pass `end2end`; explicit overrides are rejected. Dynamic shapes, batches larger than one, embedded Ultralytics NMS, FP16, and FP32 are also unsupported.
+For detection export, YOLOv8 and YOLO11 receive HailoRT NMS, while YOLO26 keeps its NMS-free one-to-one outputs. Segmentation, pose, and OBB use raw head tensors, classification returns on-chip probabilities, and semantic segmentation returns raw logits on Hailo-8/8L and all single-class heads or baked class maps for multi-class Hailo-10/15 heads. Do not pass `end2end`; explicit overrides are rejected. Dynamic shapes, batches larger than one, embedded Ultralytics NMS, FP16, and FP32 are also unsupported.
 
 ## Troubleshooting Hailo Export
 

--- a/docs/en/integrations/hailo.md
+++ b/docs/en/integrations/hailo.md
@@ -12,7 +12,7 @@ Hailo deployment is designed for computer vision at the edge: cameras, robots, i
 
 !!! note "Compare newer edge accelerators"
 
-    For new hardware deployments, also evaluate [Axelera](axelera.md) and [DeepX](deepx.md), which target newer edge accelerator platforms and may offer higher performance. Hailo recommends at least 1,024 representative calibration images for best accuracy; the default COCO128 dataset is suitable only for quick testing.
+    For new hardware deployments, also evaluate [Axelera](axelera.md) and [DeepX](deepx.md), which target newer edge accelerator platforms and may offer higher performance. Hailo recommends at least 1,024 representative calibration images for best accuracy; the built-in task-specific datasets are suitable only for quick testing.
 
 ## Why Deploy Ultralytics YOLO on Hailo?
 
@@ -82,11 +82,11 @@ The equivalent CLI command is:
 yolo export model=yolo11n.pt format=hailo name=hailo8l
 ```
 
-Hailo export is INT8-only. Ultralytics automatically downloads the default COCO128 calibration dataset when `data` is not provided. For custom models, use representative training or validation images:
+Hailo export is INT8-only. Ultralytics automatically downloads a task-specific calibration dataset when `data` is not provided. For custom models, use representative training or validation images:
 
 !!! danger "Use at least 1,024 calibration images for best accuracy"
 
-    Ultralytics forces DFC optimization level 2 and configures fine-tuning to use the actual calibration dataset size. Hailo recommends at least 1,024 diverse images; the default COCO128 dataset compiles at level 2 but may produce box-regression accuracy loss. For production HEF exports, pass a representative dataset using `data="path/to/dataset.yaml"`.
+    Ultralytics forces DFC optimization level 2 and configures fine-tuning to use the actual calibration dataset size. Hailo recommends at least 1,024 diverse images; the built-in lightweight datasets compile at level 2 but may not represent the production domain. For production HEF exports, pass a representative dataset using `data="path/to/dataset.yaml"`.
 
 ```python
 model.export(format="hailo", name="hailo8l", data="path/to/dataset.yaml")
@@ -290,19 +290,19 @@ Model and pipeline choices often matter more than compiler flags:
 
 ## Export Arguments
 
-| Argument   | Type          | Default   | Description                                        |
-| :--------- | :------------ | :-------- | :------------------------------------------------- |
-| `name`     | `str`         | `hailo8l` | Target Hailo accelerator architecture              |
-| `imgsz`    | `int`, `list` | `640`     | Fixed model input size                             |
-| `data`     | `str`         | `coco128` | Calibration dataset YAML                           |
-| `fraction` | `float`       | `1.0`     | Fraction of calibration images to use              |
-| `quantize` | `int`         | `8`       | Hailo export uses INT8 quantization                |
-| `opset`    | `int`         | `11`      | Fixed ONNX opset required by the Hailo translation |
-| `simplify` | `bool`        | `True`    | Simplify the intermediate ONNX graph               |
-| `conf`     | `float`       | `0.25`    | YOLOv8/YOLO11 HailoRT NMS confidence threshold     |
-| `iou`      | `float`       | `0.7`     | YOLOv8/YOLO11 HailoRT NMS IoU threshold            |
+| Argument   | Type          | Default       | Description                                        |
+| :--------- | :------------ | :------------ | :------------------------------------------------- |
+| `name`     | `str`         | `hailo8l`     | Target Hailo accelerator architecture              |
+| `imgsz`    | `int`, `list` | `640`         | Fixed model input size                             |
+| `data`     | `str`         | task-specific | Calibration dataset YAML                           |
+| `fraction` | `float`       | `1.0`         | Fraction of calibration images to use              |
+| `quantize` | `int`         | `8`           | Hailo export uses INT8 quantization                |
+| `opset`    | `int`         | `11`          | Fixed ONNX opset required by the Hailo translation |
+| `simplify` | `bool`        | `True`        | Simplify the intermediate ONNX graph               |
+| `conf`     | `float`       | `0.25`        | YOLOv8/YOLO11 HailoRT NMS confidence threshold     |
+| `iou`      | `float`       | `0.7`         | YOLOv8/YOLO11 HailoRT NMS IoU threshold            |
 
-For detection export, YOLOv8 and YOLO11 receive HailoRT NMS, while YOLO26 keeps its NMS-free one-to-one outputs. Segmentation, pose, and OBB use raw head tensors, and classification returns on-chip probabilities. Do not pass `end2end`; explicit overrides are rejected. Dynamic shapes, batches larger than one, embedded Ultralytics NMS, FP16, and FP32 are also unsupported.
+For detection export, YOLOv8 and YOLO11 receive HailoRT NMS, while YOLO26 keeps its NMS-free one-to-one outputs. Segmentation, pose, and OBB use raw head tensors, classification returns on-chip probabilities, and semantic segmentation returns raw logits on Hailo-8/8L or baked class maps on Hailo-10/15. Do not pass `end2end`; explicit overrides are rejected. Dynamic shapes, batches larger than one, embedded Ultralytics NMS, FP16, and FP32 are also unsupported.
 
 ## Troubleshooting Hailo Export
 

--- a/docs/en/integrations/hailo.md
+++ b/docs/en/integrations/hailo.md
@@ -164,7 +164,7 @@ Hailo compilation is hardware-specific and uses a fixed input shape. Keep these 
 
 Hailo HEF export uses INT8 quantization to map the YOLO network efficiently onto the accelerator. The calibration dataset estimates activation ranges; it does not retrain the model or require labels during compilation.
 
-When `data` is omitted, Ultralytics uses COCO128 as a convenient lightweight calibration dataset. For a custom computer vision model, point `data` to its dataset YAML so the compiler observes representative images from the actual deployment domain:
+When `data` is omitted, Ultralytics uses a task-specific lightweight calibration dataset, such as COCO128 for detection or cityscapes8 for semantic segmentation. For a custom computer vision model, point `data` to its dataset YAML so the compiler observes representative images from the actual deployment domain:
 
 ```python
 model.export(format="hailo", name="hailo8l", data="my_dataset.yaml")

--- a/docs/en/integrations/index.md
+++ b/docs/en/integrations/index.md
@@ -75,7 +75,7 @@ Welcome to the Ultralytics Integrations page! This page provides an overview of 
 
 - [Gradio](gradio.md): Deploy Ultralytics models with Gradio for real-time, interactive object detection demos.
 
-- [Hailo](hailo.md): Export Ultralytics YOLO detection, segmentation, pose, OBB, and classification models directly to Hailo HEF; see the integration guide for validated models and targets.
+- [Hailo](hailo.md): Export Ultralytics YOLO detection, segmentation, pose, OBB, classification, and semantic segmentation models directly to Hailo HEF; see the integration guide for validated models and targets.
 
 - [MNN](mnn.md): Developed by [Alibaba](https://www.alibabagroup.com/), MNN is a highly efficient and lightweight deep learning framework. It supports inference and training of deep learning models and has industry-leading performance for inference and training on-device.
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -611,6 +611,8 @@ class Exporter:
                     "Hailo export currently supports YOLOv8/YOLO11/YOLO26 detection and classification models, "
                     "YOLOv8/YOLO11 segmentation, pose, and OBB models, and YOLO26 semantic segmentation models."
                 )
+            if model.task == "semantic" and not family.startswith("yolo26"):
+                raise ValueError("Hailo export supports semantic segmentation only for YOLO26 models.")
             if self.args.end2end is not None:
                 raise ValueError(
                     "Hailo export selects the model output path automatically; remove the end2end argument."

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1514,10 +1514,9 @@ class Exporter:
             # (1, nc) probabilities as the PyTorch model. The DFC translates the softmax to a native layer.
             end_nodes = [f"/model.{head_index}/Softmax"]
         elif task == "semantic":
-            # Hailo-15/10 (DFC 5.x) compile the head's bilinear upsample and argmax, so bake them and emit
-            # the compact class map on chip. Hailo-8/8L (DFC 3.x) cannot compile the bilinear Resize, so cut
-            # at the classifier logits and run the upsample + argmax on the host. Single-class heads argmax to a
-            # threshold instead of an ArgMax node, so they always take the host path.
+            # Multi-class Hailo-15/10 (DFC 5.x) heads compile the bilinear upsample and ArgMax on chip. Hailo-8/8L
+            # (DFC 3.x) cannot compile the Resize, and single-class heads use a threshold instead of ArgMax, so both
+            # cut at the classifier logits and run the reduction on the host.
             head.bake_argmax = head.nc > 1 and self.args.name in {"hailo10h", "hailo15h", "hailo15l"}
             end_nodes = [
                 f"/model.{head_index}/ArgMax"

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -603,13 +603,13 @@ class Exporter:
             if task26:
                 raise ValueError(f"Hailo export does not currently support YOLO26 {task26} models.")
             if (
-                model.task not in {"detect", "segment", "pose", "obb", "classify"}
-                or type(model.model[-1]) not in {Detect, Segment, Pose, OBB, Classify}
+                model.task not in {"detect", "segment", "pose", "obb", "classify", "semantic"}
+                or type(model.model[-1]) not in {Detect, Segment, Pose, OBB, Classify, SemanticSegment}
                 or not family.startswith(("yolov8", "yolo11", "yolo26"))
             ):
                 raise ValueError(
-                    "Hailo export currently supports YOLOv8/YOLO11/YOLO26 detection and classification models "
-                    "and YOLOv8/YOLO11 segmentation, pose, and OBB models."
+                    "Hailo export currently supports YOLOv8/YOLO11/YOLO26 detection and classification models, "
+                    "YOLOv8/YOLO11 segmentation, pose, and OBB models, and YOLO26 semantic segmentation models."
                 )
             if self.args.end2end is not None:
                 raise ValueError(
@@ -1511,6 +1511,17 @@ class Exporter:
             # The Classify head ends in Gemm -> Softmax; cut at the Softmax so the HEF returns the same
             # (1, nc) probabilities as the PyTorch model. The DFC translates the softmax to a native layer.
             end_nodes = [f"/model.{head_index}/Softmax"]
+        elif task == "semantic":
+            # Hailo-15/10 (DFC 5.x) compile the head's bilinear upsample and argmax, so bake them and emit
+            # the compact class map on chip. Hailo-8/8L (DFC 3.x) cannot compile the bilinear Resize, so cut
+            # at the classifier logits and run the upsample + argmax on the host. Single-class heads argmax to a
+            # threshold instead of an ArgMax node, so they always take the host path.
+            head.bake_argmax = head.nc > 1 and self.args.name in {"hailo10h", "hailo15h", "hailo15l"}
+            end_nodes = [
+                f"/model.{head_index}/ArgMax"
+                if head.bake_argmax
+                else f"/model.{head_index}/classifier/classifier.1/Conv"
+            ]
         else:
             scales = range(len(head.one2one_cv2 if one2one else head.cv2))
             if one2one:
@@ -1547,8 +1558,8 @@ class Exporter:
             if one2one:
                 outputs = ", ".join(f"output_layer{i + 1}" for i in range(len(end_nodes)))
                 model_script.append(f"quantization_param([{outputs}], precision_mode=a16_w16)")
-            elif task == "classify":
-                pass  # softmax is already the graph output; no NMS or activation changes needed
+            elif task in {"classify", "semantic"}:
+                pass  # softmax/class-map is already the graph output; no NMS or activation changes needed
             else:
                 outputs = [layer.inputs[0].rsplit("/", 1)[-1] for layer in runner.get_hn_model().get_output_layers()]
                 if task in {"segment", "pose", "obb"}:
@@ -1604,7 +1615,12 @@ class Exporter:
             (output_dir / f"{self.file.stem}.hef").write_bytes(runner.compile())
             YAML.save(
                 output_dir / "metadata.yaml",
-                {**self.metadata, "hailo_arch": self.args.name, "nms": task == "detect" and not one2one},
+                {
+                    **self.metadata,
+                    "hailo_arch": self.args.name,
+                    "nms": task == "detect" and not one2one,
+                    "semantic_baked": task == "semantic" and head.bake_argmax,
+                },
             )
             return str(output_dir)
         finally:

--- a/ultralytics/nn/backends/hailo.py
+++ b/ultralytics/nn/backends/hailo.py
@@ -94,10 +94,10 @@ class HailoBackend(BaseBackend):
         if self.task == "semantic":
             out = torch.from_numpy(outputs[0])
             if self.metadata.get("semantic_baked"):
-                # Hailo-10/15 baked the upsample and argmax on chip; return the class map for the predictor.
+                # Multi-class Hailo-10/15 baked the upsample and argmax on chip; return the class map.
                 return out.reshape(out.shape[0], out.shape[1], out.shape[2])
-            # Hailo-8/8L returns raw stride-8 classifier logits; hand them to the predictor's own bilinear
-            # upsample + argmax (and letterbox) path unchanged, so results match the PyTorch model exactly.
+            # Hailo-8/8L and single-class heads return raw stride-8 logits; hand them to the predictor's existing
+            # bilinear upsample, letterbox removal, and class reduction so results match the PyTorch model exactly.
             return out.permute(0, 3, 1, 2)
         return self._decode_raw(outputs) if not self.metadata.get("nms", False) else self._decode_nms(outputs[0])
 

--- a/ultralytics/nn/backends/hailo.py
+++ b/ultralytics/nn/backends/hailo.py
@@ -47,9 +47,10 @@ class HailoBackend(BaseBackend):
             from ultralytics.utils import YAML
 
             self.apply_metadata(YAML.load(metadata_file))
-        if self.task and self.task not in {"detect", "segment", "pose", "obb", "classify"}:
+        if self.task and self.task not in {"detect", "segment", "pose", "obb", "classify", "semantic"}:
             raise ValueError(
-                f"Hailo inference only supports detect, segment, pose, obb and classify tasks, not task='{self.task}'."
+                f"Hailo inference only supports detect, segment, pose, obb, classify and semantic tasks, "
+                f"not task='{self.task}'."
             )
 
         self.hef = HEF(str(hef_file))
@@ -90,6 +91,18 @@ class HailoBackend(BaseBackend):
             return self._decode_obb(outputs)
         if self.task == "classify":
             return torch.from_numpy(outputs[0]).reshape(outputs[0].shape[0], -1)  # on-chip softmax probabilities
+        if self.task == "semantic":
+            out = torch.from_numpy(outputs[0])
+            dtype = torch.uint8 if len(self.names) <= 256 else torch.int32
+            if self.metadata.get("semantic_baked"):
+                # Full-resolution class map baked on chip (Hailo-10/15); return it directly.
+                return out.reshape(out.shape[0], out.shape[1], out.shape[2]).to(dtype)
+            # Hailo-8/8L returns raw classifier logits: reduce on the host (argmax, or a threshold for a single
+            # class, matching the head) into a low-resolution class map the predictor nearest-resizes. Host
+            # reduction + nearest upsample stay cheap enough for edge hosts like the Raspberry Pi.
+            logits = out.permute(0, 3, 1, 2)
+            cls = logits.argmax(1) if logits.shape[1] > 1 else logits.squeeze(1) > 0
+            return cls.to(dtype)
         return self._decode_raw(outputs) if not self.metadata.get("nms", False) else self._decode_nms(outputs[0])
 
     def _decode_nms(self, output: list) -> np.ndarray:

--- a/ultralytics/nn/backends/hailo.py
+++ b/ultralytics/nn/backends/hailo.py
@@ -93,16 +93,12 @@ class HailoBackend(BaseBackend):
             return torch.from_numpy(outputs[0]).reshape(outputs[0].shape[0], -1)  # on-chip softmax probabilities
         if self.task == "semantic":
             out = torch.from_numpy(outputs[0])
-            dtype = torch.uint8 if len(self.names) <= 256 else torch.int32
             if self.metadata.get("semantic_baked"):
-                # Full-resolution class map baked on chip (Hailo-10/15); return it directly.
-                return out.reshape(out.shape[0], out.shape[1], out.shape[2]).to(dtype)
-            # Hailo-8/8L returns raw classifier logits: reduce on the host (argmax, or a threshold for a single
-            # class, matching the head) into a low-resolution class map the predictor nearest-resizes. Host
-            # reduction + nearest upsample stay cheap enough for edge hosts like the Raspberry Pi.
-            logits = out.permute(0, 3, 1, 2)
-            cls = logits.argmax(1) if logits.shape[1] > 1 else logits.squeeze(1) > 0
-            return cls.to(dtype)
+                # Hailo-10/15 baked the upsample and argmax on chip; return the class map for the predictor.
+                return out.reshape(out.shape[0], out.shape[1], out.shape[2])
+            # Hailo-8/8L returns raw stride-8 classifier logits; hand them to the predictor's own bilinear
+            # upsample + argmax (and letterbox) path unchanged, so results match the PyTorch model exactly.
+            return out.permute(0, 3, 1, 2)
         return self._decode_raw(outputs) if not self.metadata.get("nms", False) else self._decode_nms(outputs[0])
 
     def _decode_nms(self, output: list) -> np.ndarray:

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -1830,9 +1830,7 @@ class SemanticSegment(nn.Module):
 
     export = False  # export mode
     format = None  # export format
-    bake_argmax = (
-        False  # export: emit a baked [B, H, W] class map (set by the exporter for TensorRT>=10 and Hailo-10/15)
-    )
+    bake_argmax = False  # export: emit [B, H, W] class map (TensorRT>=10 and multi-class Hailo-10/15)
 
     def __init__(self, nc=19, ch=()):
         """Initialize the semantic segmentation head.
@@ -1860,9 +1858,9 @@ class SemanticSegment(nn.Module):
 
         Returns:
             (torch.Tensor | tuple): Logits of shape [B, nc, H/8, W/8] during training (or a (main, aux) tuple when
-                aux_head is present) and inference. ONNX, MNN, TensorRT>=10, and Hailo-10/15 export bake in the argmax
-                and return a compact class map of shape [B, H, W] (uint8 when nc <= 256, else int32). Other export
-                formats return upsampled logits of shape [B, nc, H, W].
+                aux_head is present) and inference. ONNX, MNN, TensorRT>=10, and multi-class Hailo-10/15 export bake in
+                the class reduction and return a compact map of shape [B, H, W] (uint8 when nc <= 256, else int32).
+                Other export formats return upsampled logits of shape [B, nc, H, W].
         """
         # Classify
         logits = self.classifier(x[0])  # [B, nc, H/8, W/8]
@@ -1872,9 +1870,9 @@ class SemanticSegment(nn.Module):
             return logits
         if self.export:
             y = F.interpolate(logits, scale_factor=8, mode="bilinear", align_corners=False)  # [B, nc, H, W]
-            # Bake argmax: emit [B, H, W] class map, shrinking the D2H copy ~80x. ONNX/MNN and Hailo-10/15
-            # preserve the integer output; TensorRT only supports uint8 graph outputs on TRT>=10, so engine and
-            # Hailo are gated by the exporter (Hailo-8/8L cannot compile the upsample, so it keeps raw logits).
+            # Bake class reduction: emit [B, H, W] map, shrinking the D2H copy ~80x. ONNX/MNN and multi-class
+            # Hailo-10/15 preserve the integer output; TensorRT supports uint8 graph outputs only on TRT>=10, so
+            # engine and Hailo baking are gated by the exporter.
             if self.format in {"onnx", "mnn"} or (self.format in {"engine", "hailo"} and self.bake_argmax):
                 cls = y.argmax(1) if self.nc > 1 else y.squeeze(1) > 0
                 return cls.to(torch.uint8 if self.nc <= 256 else torch.int32)

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -1860,9 +1860,9 @@ class SemanticSegment(nn.Module):
 
         Returns:
             (torch.Tensor | tuple): Logits of shape [B, nc, H/8, W/8] during training (or a (main, aux) tuple when
-                aux_head is present) and inference. ONNX, MNN, TensorRT>=10, and Hailo-10/15 export bake in the argmax and return a
-                compact class map of shape [B, H, W] (uint8 when nc <= 256, else int32). Other export formats return
-                upsampled logits of shape [B, nc, H, W].
+                aux_head is present) and inference. ONNX, MNN, TensorRT>=10, and Hailo-10/15 export bake in the argmax
+                and return a compact class map of shape [B, H, W] (uint8 when nc <= 256, else int32). Other export
+                formats return upsampled logits of shape [B, nc, H, W].
         """
         # Classify
         logits = self.classifier(x[0])  # [B, nc, H/8, W/8]

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -1830,7 +1830,9 @@ class SemanticSegment(nn.Module):
 
     export = False  # export mode
     format = None  # export format
-    bake_argmax = False  # export: emit a baked [B, H, W] class map (set by the exporter for TensorRT>=10)
+    bake_argmax = (
+        False  # export: emit a baked [B, H, W] class map (set by the exporter for TensorRT>=10 and Hailo-10/15)
+    )
 
     def __init__(self, nc=19, ch=()):
         """Initialize the semantic segmentation head.
@@ -1858,7 +1860,7 @@ class SemanticSegment(nn.Module):
 
         Returns:
             (torch.Tensor | tuple): Logits of shape [B, nc, H/8, W/8] during training (or a (main, aux) tuple when
-                aux_head is present) and inference. ONNX, MNN, and TensorRT>=10 export bake in the argmax and return a
+                aux_head is present) and inference. ONNX, MNN, TensorRT>=10, and Hailo-10/15 export bake in the argmax and return a
                 compact class map of shape [B, H, W] (uint8 when nc <= 256, else int32). Other export formats return
                 upsampled logits of shape [B, nc, H, W].
         """
@@ -1870,9 +1872,10 @@ class SemanticSegment(nn.Module):
             return logits
         if self.export:
             y = F.interpolate(logits, scale_factor=8, mode="bilinear", align_corners=False)  # [B, nc, H, W]
-            # Bake argmax: emit [B, H, W] class map, shrinking the D2H copy ~80x. ONNX/MNN preserve the
-            # integer output; TensorRT only supports uint8 graph outputs on TRT>=10, so engine is gated by the exporter.
-            if self.format in {"onnx", "mnn"} or (self.format == "engine" and self.bake_argmax):
+            # Bake argmax: emit [B, H, W] class map, shrinking the D2H copy ~80x. ONNX/MNN and Hailo-10/15
+            # preserve the integer output; TensorRT only supports uint8 graph outputs on TRT>=10, so engine and
+            # Hailo are gated by the exporter (Hailo-8/8L cannot compile the upsample, so it keeps raw logits).
+            if self.format in {"onnx", "mnn"} or (self.format in {"engine", "hailo"} and self.bake_argmax):
                 cls = y.argmax(1) if self.nc > 1 else y.squeeze(1) > 0
                 return cls.to(torch.uint8 if self.nc <= 256 else torch.int32)
             return y


### PR DESCRIPTION
## Summary

Follow-up to #25276, adding Hailo export and inference for YOLO26 semantic segmentation (`SemanticSegment`). Axelera already covers this task, so it adds semantic segmentation to the Hailo task set, and it is a common edge workload on Raspberry Pi hosts.

The head produces classifier logits at stride 8, then a bilinear upsample and an argmax. The Hailo path splits by accelerator, because the two compiler generations differ on that upsample:

- `export_hailo` gets a `semantic` branch. On **Hailo-8/8L** (DFC v3.x) the bilinear `Resize` does not compile, so the exporter cuts at the classifier logits conv and exports the raw logits; Ultralytics runs the upsample and class reduction on the host. On multi-class **Hailo-10/15** (DFC v5.x) the `Resize` and ArgMax compile, so the exporter bakes them and the HEF returns a compact class map directly. The single-class threshold is not an ArgMax node, so those heads also return logits for host reduction. The class heads already carry a `bake_argmax` flag for the TensorRT path, so this reuses it (`head.py` adds `hailo` to the same one-line gate).
- `HailoBackend` reads a `semantic_baked` flag from the metadata: for baked multi-class Hailo-10/15 targets it returns the class map as-is, and for Hailo-8/8L or any single-class head it returns the raw stride-8 logits, which the existing `SemanticSegmentationValidator`/predictor upsamples with bilinear interpolation, letterbox-crops, and reduces classes exactly as for the PyTorch model. So there is no new decode code in the predict or val paths and both paths match the model.
- Docs: a semantic row in both tables, the export-flow and FAQ paragraphs, the compatibility notes, and the artifacts/inference notes. I also updated the two other places that list the Hailo task set (the integrations index and the model-deployment-options guide) so they stay in sync with the integration page.

Deleted: nothing — this adds a Hailo `semantic` task to the existing per-format exporter/backend dispatch, and reuses the `SemanticSegment.bake_argmax` gate and the existing semantic logits/class-map postprocessing paths rather than adding parallel decode code, the Hailo-8/8L and single-class paths just return logits to that predictor, so there is no new host decode logic at all.

## Validation

Measured on Cityscapes (`cityscapes8`, the 4 val images).

**Hailo-8/8L — validated on device** (Hailo-8L PCIe, HailoRT 4.23, DFC 3.33):

- `yolo val task=semantic` runs end to end through the standard pipeline: **mIoU 0.612, pixel accuracy 0.964**, with 25.0 ms inference and 49.3 ms host post-processing per image. On a fixed 1024×1024 protocol the on-device HEF stays close to PyTorch (64.6 vs 64.9).
- The host post-processing is the bilinear upsample of the stride-8 logits to full resolution, which is heavy (~49 ms here and more on a Pi); multi-class Hailo-10/15 avoid it by baking the upsample and ArgMax on chip; single-class heads still use host reduction, and smaller models keep it lighter. Quantization is close to lossless (`yolo26s-sem` at opt0 matched its PyTorch mIoU exactly).

**Hailo-10/15 — emulated, not yet on silicon:** I do not have Hailo-10/15 hardware. The multi-class baked path compiles for `hailo15h`/`hailo10h` and the numerically-quantized emulation (`SDK_QUANTIZED`) gives mIoU 64.4 with 99.4% pixel agreement against PyTorch (in my case the emulator stayed within about 0.25 mIoU of the real Hailo-8L chip on the same model, so I trust the accuracy, but the on-device throughput is unmeasured). The docs mark these targets as not validated.

Two notes for anyone exporting this: the val set here is only 4 images (full Cityscapes needs registration), so treat the absolute numbers as indicative. Also, `opt2` fine-tuning at 1024 runs out of memory on an 8 GB GPU for the `s`/`m` sizes (the `n` model fits), opt0 is already near-lossless.

`uvx ruff check` and `uvx ruff format --check` pass on the changed files.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds direct Hailo export and inference support for YOLO26 semantic segmentation models across compatible Hailo hardware.

### 📊 Key Changes
- Extends Hailo export validation and documentation to support the `semantic` task for YOLO26.
- Adds hardware-specific handling: multi-class Hailo-10/15 compile a compact class map on chip, while Hailo-8/8L and single-class heads return logits for host-side reduction.
- Updates the Hailo backend to decode semantic segmentation outputs and return compact class maps.
- Extends `SemanticSegment` export behavior for multi-class Hailo ArgMax output and records `semantic_baked` metadata.
- Documents supported models, targets, output behavior, and inference workflows.

### 🎯 Purpose & Impact
- Enables efficient YOLO26 semantic segmentation deployment on Hailo accelerators and edge devices.
- Reduces host-device transfer overhead when hardware supports baked class-map output.
- Preserves compatibility with Hailo-8/8L through host-side post-processing.
- Provides users with clearer export limitations, hardware compatibility guidance, and standard Ultralytics inference integration.