### PR TITLE
Raise clean error when mask_ratio exceeds imgsz

### DIFF
--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -2318,6 +2318,10 @@ class Format(BaseTransform):
         nl = params.get("nl", 0)
 
         if self.return_mask:
+            if self.mask_ratio > min(h, w):
+                raise ValueError(
+                    f"mask_ratio={self.mask_ratio} downsamples imgsz={(h, w)} masks to zero size; use mask_ratio <= {min(h, w)}"
+                )
             if nl:
                 masks, instances, cls = self._format_segments(instances, cls, w, h)
                 masks = torch.from_numpy(masks)

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -360,19 +360,12 @@ def polygon2mask(
 
     Returns:
         (np.ndarray): A binary mask of the specified image size with the polygons filled in.
-
-    Raises:
-        ValueError: If downsample_ratio exceeds the mask dimensions, downsampling the mask to zero size.
     """
-    nh, nw = (imgsz[0] // downsample_ratio, imgsz[1] // downsample_ratio)
-    if nh < 1 or nw < 1:
-        raise ValueError(
-            f"mask_ratio={downsample_ratio} downsamples imgsz={imgsz} masks to zero size; use mask_ratio <= {min(imgsz)}"
-        )
     mask = np.zeros(imgsz, dtype=np.uint8)
     polygons = np.asarray(polygons, dtype=np.int32)
     polygons = polygons.reshape((polygons.shape[0], -1, 2))
     cv2.fillPoly(mask, polygons, color=color)
+    nh, nw = (imgsz[0] // downsample_ratio, imgsz[1] // downsample_ratio)
     # Note: fillPoly first then resize is trying to keep the same loss calculation method when mask-ratio=1
     return cv2.resize(mask, (nw, nh))
 

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -360,12 +360,19 @@ def polygon2mask(
 
     Returns:
         (np.ndarray): A binary mask of the specified image size with the polygons filled in.
+
+    Raises:
+        ValueError: If downsample_ratio exceeds the mask dimensions, downsampling the mask to zero size.
     """
     mask = np.zeros(imgsz, dtype=np.uint8)
     polygons = np.asarray(polygons, dtype=np.int32)
     polygons = polygons.reshape((polygons.shape[0], -1, 2))
     cv2.fillPoly(mask, polygons, color=color)
     nh, nw = (imgsz[0] // downsample_ratio, imgsz[1] // downsample_ratio)
+    if nh < 1 or nw < 1:
+        raise ValueError(
+            f"mask_ratio={downsample_ratio} downsamples imgsz={imgsz} masks to zero size; use mask_ratio <= {min(imgsz)}"
+        )
     # Note: fillPoly first then resize is trying to keep the same loss calculation method when mask-ratio=1
     return cv2.resize(mask, (nw, nh))
 

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -364,15 +364,15 @@ def polygon2mask(
     Raises:
         ValueError: If downsample_ratio exceeds the mask dimensions, downsampling the mask to zero size.
     """
-    mask = np.zeros(imgsz, dtype=np.uint8)
-    polygons = np.asarray(polygons, dtype=np.int32)
-    polygons = polygons.reshape((polygons.shape[0], -1, 2))
-    cv2.fillPoly(mask, polygons, color=color)
     nh, nw = (imgsz[0] // downsample_ratio, imgsz[1] // downsample_ratio)
     if nh < 1 or nw < 1:
         raise ValueError(
             f"mask_ratio={downsample_ratio} downsamples imgsz={imgsz} masks to zero size; use mask_ratio <= {min(imgsz)}"
         )
+    mask = np.zeros(imgsz, dtype=np.uint8)
+    polygons = np.asarray(polygons, dtype=np.int32)
+    polygons = polygons.reshape((polygons.shape[0], -1, 2))
+    cv2.fillPoly(mask, polygons, color=color)
     # Note: fillPoly first then resize is trying to keep the same loss calculation method when mask-ratio=1
     return cv2.resize(mask, (nw, nh))
 


### PR DESCRIPTION
Fuzzing in #25056 flagged that segmentation training with a large `mask_ratio` crashes deep inside OpenCV with a raw assertion instead of a clean message. `polygon2mask` computes the downsampled mask size as `imgsz // downsample_ratio`, so `mask_ratio=2215` at `imgsz=32` produces a `(0, 0)` resize target and `cv2.resize` fails with `(-215:Assertion failed) inv_scale_x > 0`. I reproduced this on current `main` for both `yolo train segment` and `yolo val segment`, since the `Format` transform carries `mask_ratio` into both the train and val pipelines. The existing `CFG_INT_MIN` floor from #25114 bounds `mask_ratio` from below, but this failure is a joint constraint between `mask_ratio` and `imgsz` that per key cfg checks cannot express.

The fix raises a clean, actionable `ValueError` in the shared `Format` transform before any mask allocation: `mask_ratio=2215 downsamples imgsz=(32, 32) masks to zero size; use mask_ratio <= 32`. The shared formatter covers train, val, overlap, non-overlap, and empty-label paths before any zero-sized mask is created. Kills fuzz signature `bd26ec83a80e` from #25056, leaving the rolling issue open. Deleted: the utility-local `polygon2mask` validation branch and exception docstring added in the initial revision; the joint check is relocated to the shared `Format` owner. The final bugfix is four lines because the invalid combination must still be rejected.

Verified empirically:

- `python .github/scripts/fuzz.py repro "train segment model=yolo26n-seg.pt imgsz=32 epochs=1 batch=4 workers=2 cache=disk data=coco8-seg.yaml mask_ratio=2215 compile=🚀 nbs=3644"` classified `bug-candidate` before and `expected` after the fix on all 3 replays
- `yolo train segment` and `yolo val segment` with `mask_ratio=2215` at `imgsz=32` now exit with the one line ValueError above instead of the raw cv2 assertion, and `mask_ratio=4` runs to completion unchanged
- `ruff format` and `ruff check` pass, `pytest tests/test_engine.py tests/test_cli.py` fully green locally

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Raise a clear `ValueError` when `downsample_ratio` would reduce a polygon mask to zero dimensions.

### 📊 Key Changes
- Validates downsampled mask dimensions in the shared `Format` transform.
- Reports the configured `mask_ratio`, input `imgsz`, and the maximum supported ratio in the error message.
- Covers overlap, non-overlap, and empty-label segmentation masks.

### 🎯 Purpose & Impact
- Prevents an unclear downstream OpenCV resize failure when `mask_ratio` exceeds `imgsz`.
- Gives users actionable guidance to correct their configuration.
- Improves robustness for segmentation workflows with small images or large mask ratios.