### PR TITLE
Document Hailo per-task INT8 accuracy retention

### DIFF
--- a/docs/en/integrations/hailo.md
+++ b/docs/en/integrations/hailo.md
@@ -183,16 +183,16 @@ Measured on a Hailo-8L with in-domain calibration (COCO128, 128 images), INT8 HE
 
 Retention compares both models at the same confidence threshold. YOLOv8 and YOLO11 HEFs bake the export-time `conf` (default 0.25) into the on-chip NMS, so validating against a PyTorch baseline at its default low threshold integrates a larger part of the precision-recall curve and overstates the quantization gap.
 
-Beyond detection, the segmentation, pose, OBB, and classification exporter paths were validated on the same Hailo-8L (DFC 3.33, HailoRT 4.23), each evaluated on its task-appropriate dataset:
+Beyond detection, the segmentation, pose, OBB, and classification exporter paths were validated on the same Hailo-8L (DFC 3.33, HailoRT 4.23). Each INT8 HEF was compared with its PyTorch checkpoint on the same validation split, using in-domain calibration:
 
-| Task                  | Metric                              | YOLOv8n | YOLO11n |
-| :-------------------- | :---------------------------------- | :------ | :------ |
-| Instance segmentation | mask mAP50 retention                | 98.0%   | 93.6%   |
-| Pose                  | box mAP50 retention                 | 98.1%   | 90.8%   |
-| Oriented bounding box | mAP50 retention (DOTA128)           | ~100%   | 96.9%   |
-| Classification        | top-1 retention (ImageNet-1000 val) | 92.6%   | 95.4%   |
+| Task                  | Metric (validation split)          | YOLOv8n | YOLO11n |
+| :-------------------- | :--------------------------------- | :------ | :------ |
+| Instance segmentation | mask mAP50 retention (COCO128-seg) | 98.0%   | 93.6%   |
+| Pose                  | box mAP50 retention (COCO8-pose)   | 98.1%   | 90.8%   |
+| Oriented bounding box | mAP50 retention (DOTA128)          | ~100%   | 96.9%   |
+| Classification        | top-1 retention (ImageNet val)     | 92.6%   | 95.4%   |
 
-Classification is the one task where YOLO11 retains more than YOLOv8; for detection, segmentation, and pose the ranking is reversed because the YOLO11 backbone's attention blocks are more INT8-sensitive. Evaluate OBB on DOTA128 rather than DOTA8, whose 8-image split saturates mAP50 near 100% for both the PyTorch and HEF models and cannot show the quantization gap.
+Segmentation, pose, and OBB were calibrated with each task's default in-domain set (COCO128-seg, COCO8-pose, DOTA128); classification was calibrated with ImageNet100. Two caveats follow from those defaults: COCO8-pose is only 8 images, so treat pose as indicative and pass a larger `data=` for production, and DOTA8 saturates mAP50 near 100% for both models, which is why OBB is read on DOTA128. Classification is also the one task where YOLO11 retains more than YOLOv8; for the others the YOLO11 attention backbone is more INT8-sensitive.
 
 Three practical rules follow from device measurements:
 

--- a/docs/en/integrations/hailo.md
+++ b/docs/en/integrations/hailo.md
@@ -183,10 +183,21 @@ Measured on a Hailo-8L with in-domain calibration (COCO128, 128 images), INT8 HE
 
 Retention compares both models at the same confidence threshold. YOLOv8 and YOLO11 HEFs bake the export-time `conf` (default 0.25) into the on-chip NMS, so validating against a PyTorch baseline at its default low threshold integrates a larger part of the precision-recall curve and overstates the quantization gap.
 
+Beyond detection, the segmentation, pose, OBB, and classification exporter paths were validated on the same Hailo-8L (DFC 3.33, HailoRT 4.23), each evaluated on its task-appropriate dataset:
+
+| Task                  | Metric                              | YOLOv8n | YOLO11n |
+| :-------------------- | :---------------------------------- | :------ | :------ |
+| Instance segmentation | mask mAP50 retention                | 98.0%   | 93.6%   |
+| Pose                  | box mAP50 retention                 | 98.1%   | 90.8%   |
+| Oriented bounding box | mAP50 retention (DOTA128)           | ~100%   | 96.9%   |
+| Classification        | top-1 retention (ImageNet-1000 val) | 92.6%   | 95.4%   |
+
+Classification is the one task where YOLO11 retains more than YOLOv8; for detection, segmentation, and pose the ranking is reversed because the YOLO11 backbone's attention blocks are more INT8-sensitive. Evaluate OBB on DOTA128 rather than DOTA8, whose 8-image split saturates mAP50 near 100% for both the PyTorch and HEF models and cannot show the quantization gap.
+
 Three practical rules follow from device measurements:
 
 1. **Calibrate in-domain, always.** Fine-tuning with out-of-domain images is equivalent to disabling fine-tuning entirely: a YOLO26n calibrated with 1,238 out-of-domain images retains the same accuracy (85.7%) as one compiled without fine-tuning. A small in-domain set beats a large out-of-domain one.
-2. **Lower `conf` by about 0.05 for YOLO26 deployments.** Quantization shifts YOLO26 scores down by roughly 0.05 on average, so a threshold tuned in PyTorch drops valid detections on the HEF. Using `conf=0.20` on device matches the detection count of PyTorch at `conf=0.25` and recovers about half of the accuracy gap; the remainder is ranking noise that no threshold recovers.
+2. **Lower `conf` by about 0.05 for YOLO26 deployments.** Quantization shifts YOLO26 scores down by roughly 0.05 on average, so a threshold tuned in PyTorch drops valid detections on the HEF. Using `conf=0.20` on device matches the detection count of PyTorch at `conf=0.25`, and lowering slightly further (around `conf=0.15`) recovers essentially all of the remaining mAP50 gap at the cost of more low-confidence detections. Quantization also re-ranks roughly 20% of detections — a permanent ordering effect that no threshold undoes — but that reshuffling does not block mAP50 recovery at the lower threshold.
 3. **The attention penalty is structural on Hailo-8/8L (DFC 3.33).** The attention blocks compile to `matmul` operations that keep INT8 activation inputs in every mode the compiler offers for them; the 16-bit-output mode fails allocation for this graph, and raising the precision of the surrounding layers does not help because the matmul requantizes its inputs to INT8 anyway (protecting the depthwise and output convolutions at 16-bit left mAP unchanged in our tests). When accuracy is the priority and the model is interchangeable, YOLO11 currently quantizes better than YOLO26 here; newer Hailo generations (DFC 5.x) expose more mixed-precision options and may differ.
 
 ## Exported Artifacts


### PR DESCRIPTION
Follow-up to #25260. That PR documented Hailo INT8 accuracy for detection, but segmentation, pose, OBB and classification were only marked "Hailo-8L validated" with no numbers. This fills in the per-task retention I measured on the device, and corrects one detail in the YOLO26 confidence note.

Measured on a Hailo-8L (HailoRT 4.23, DFC 3.33), each task on its own dataset, exported HEF vs the PyTorch checkpoint on the same split:

| Task                  | Metric                              | YOLOv8n | YOLO11n |
| :-------------------- | :---------------------------------- | :------ | :------ |
| Instance segmentation | mask mAP50 retention                | 98.0%   | 93.6%   |
| Pose                  | box mAP50 retention                 | 98.1%   | 90.8%   |
| OBB                   | mAP50 retention (DOTA128)           | ~100%   | 96.9%   |
| Classification        | top-1 retention (ImageNet-1000 val) | 92.6%   | 95.4%   |

Classification is the one task where YOLO11 keeps more than YOLOv8; for the others it is the other way round, the YOLO11 attention backbone is more INT8-sensitive. OBB has to be read on DOTA128, dota8 saturates near 100% for both PyTorch and the HEF and can't show the gap.

Confidence note fix: the old text said `conf=0.20` recovers about half the gap and the rest is ranking noise no threshold recovers. On device `conf=0.15` recovers essentially all of the mAP50 gap; what stays is the ~20% ranking reshuffle, which is permanent but doesn't stop mAP50 recovery at the lower threshold.

Deleted: nothing. Docs-only, +12/-1; the extra lines are the per-task table the page was missing.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Documents per-task INT8 accuracy retention results for Hailo-8L exports and refines YOLO26 confidence-threshold guidance.

### 📊 Key Changes
- Adds YOLOv8n and YOLO11n INT8 retention results for segmentation, pose, OBB, and classification.
- Clarifies dataset and evaluation details, including DOTA128 for meaningful OBB comparison.
- Updates YOLO26 deployment guidance to recommend lowering `conf` to around 0.15 when needed to recover mAP50.
- Documents attention-related quantization limitations on Hailo-8/8L and differences across model families.

### 🎯 Purpose & Impact
- Gives users task-specific expectations for Hailo-8L INT8 accuracy.
- Helps practitioners choose calibration datasets, evaluation thresholds, and model variants more effectively.
- Improves transparency around quantization sensitivity and the limits of threshold tuning on edge hardware.