### PR TITLE
Fix RT-DETR augmented prediction fallback

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -536,7 +536,7 @@ class DetectionModel(BaseModel):
         Returns:
             (tuple[torch.Tensor, None]): Augmented inference output and None for train output.
         """
-        if getattr(self, "end2end", False) or self.__class__.__name__ != "DetectionModel":
+        if getattr(self, "end2end", False) or type(self.model[-1]) is not Detect:
             LOGGER.warning("Model does not support 'augment=True', reverting to single-scale prediction.")
             return self._predict_once(x)
         img_size = x.shape[-2:]  # height, width


### PR DESCRIPTION
## Summary
- replace the brittle model class-name check with the detection head that owns augmented inference
- fall back to single-scale prediction for legacy RT-DETR checkpoints

## Validation
- reproduced the exact RT-DETR fuzz command before the change
- reran the exact command successfully after the change
- pytest -q tests/test_python.py::test_predict_img (7 passed)
- ruff check ultralytics/nn/tasks.py

Deleted: brittle DetectionModel class-name capability check.

Fixes #25271

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves augmented inference validation by checking the model’s final layer type directly. 🔍

### 📊 Key Changes

- Replaced the class-name check with a type check for the final model layer.
- Augmented prediction now only runs when the last layer is exactly `Detect`.
- Unsupported models continue with single-scale prediction and receive a warning.

### 🎯 Purpose & Impact

- Makes `augment=True` compatibility checks more reliable and precise. ✅
- Prevents augmented inference from being incorrectly enabled for models with incompatible detection heads.
- Preserves existing behavior for end-to-end and unsupported models while improving maintainability.