### PR TITLE
Relabel classification samples for single-class training

### DIFF
--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -1027,6 +1027,8 @@ class ClassificationDataset:
         self.samples = self.verify_images()  # filter out bad images
         if is_ndjson:
             self.samples = [(f, int(Path(f).parent.name)) for f, _ in self.samples]
+        if args.single_cls:
+            self.samples = [(f, 0) for f, _ in self.samples]
         self.samples = [[*list(x), Path(x[0]).with_suffix(".npy"), None] for x in self.samples]  # file, index, npy, im
         if self.cache_ram:
             self.cache_images()

--- a/ultralytics/models/yolo/classify/train.py
+++ b/ultralytics/models/yolo/classify/train.py
@@ -144,10 +144,14 @@ class ClassificationTrainer(BaseTrainer):
                 f"See https://docs.ultralytics.com/datasets/classify for cls dataset format."
             )
 
+        if self.args.single_cls:
+            for sample in dataset.samples:
+                sample[1] = 0
+
         # Filter out samples with class indices >= nc (prevents CUDA assertion errors)
         nc = self.data.get("nc", 0)
         dataset_nc = len(dataset.base.classes)
-        if nc and dataset_nc > nc:
+        if not self.args.single_cls and nc and dataset_nc > nc:
             extra_classes = dataset.base.classes[nc:]
             original_count = len(dataset.samples)
             dataset.samples = [s for s in dataset.samples if s[1] < nc]

--- a/ultralytics/models/yolo/classify/train.py
+++ b/ultralytics/models/yolo/classify/train.py
@@ -144,14 +144,10 @@ class ClassificationTrainer(BaseTrainer):
                 f"See https://docs.ultralytics.com/datasets/classify for cls dataset format."
             )
 
-        if self.args.single_cls:
-            for sample in dataset.samples:
-                sample[1] = 0
-
         # Filter out samples with class indices >= nc (prevents CUDA assertion errors)
         nc = self.data.get("nc", 0)
-        dataset_nc = len(dataset.base.classes)
-        if not self.args.single_cls and nc and dataset_nc > nc:
+        dataset_nc = max(x[1] for x in dataset.samples) + 1
+        if nc and dataset_nc > nc:
             extra_classes = dataset.base.classes[nc:]
             original_count = len(dataset.samples)
             dataset.samples = [s for s in dataset.samples if s[1] < nc]


### PR DESCRIPTION
## Summary
- normalize classification labels at the dataset sample owner when single_cls=True
- derive mismatch validation from the labels actually exposed by the dataset

## Validation
- both exact fuzz commands complete one training epoch successfully
- standalone ClassificationDataset returns only class zero with single_cls=True and preserves multiclass labels otherwise
- ruff check ultralytics/data/dataset.py ultralytics/models/yolo/classify/train.py

Deleted: the base-folder class-count proxy from sample-label validation; the trainer now validates the labels the dataset actually exposes.

Fixes #25270
Fixes #25287

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves single-class dataset handling and makes classification class-count validation more reliable. ✅

### 📊 Key Changes

- When `single_cls` is enabled, all dataset samples are now assigned to class `0`.
- Classification training now determines the dataset’s class count from sample labels rather than the full class list.
- Existing filtering for classes exceeding the configured number of classes remains in place.

### 🎯 Purpose & Impact

- Enables more consistent single-class training across supported dataset formats.
- Reduces class-count mismatches that could cause CUDA assertion errors during classification training.
- Improves robustness when datasets contain only a subset of the classes defined in their metadata. 🚀