### PR TITLE
Validate RT-DETR ONNX opset before export

### DIFF
--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -175,6 +175,7 @@ EXPECTED_MODULES = (
     "ultralytics/engine/trainer.py:_setup_train",  # trainer validation of batch/imgsz interplay before training
     "ultralytics/engine/exporter.py:validate_args",  # exporter's intentional per-format argument validation
     "ultralytics/engine/exporter.py:__call__",  # intentional compat asserts; per-format bugs raise in deeper frames
+    "ultralytics/engine/exporter.py:export_onnx",  # resolved ONNX opset validation before conversion
 )
 NETWORK_MARKERS = (  # specific download/network signatures only; bare ConnectionError is raised for local sources too
     "urlopen error",

--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -175,7 +175,6 @@ EXPECTED_MODULES = (
     "ultralytics/engine/trainer.py:_setup_train",  # trainer validation of batch/imgsz interplay before training
     "ultralytics/engine/exporter.py:validate_args",  # exporter's intentional per-format argument validation
     "ultralytics/engine/exporter.py:__call__",  # intentional compat asserts; per-format bugs raise in deeper frames
-    "ultralytics/engine/exporter.py:export_onnx",  # resolved ONNX opset validation before conversion
 )
 NETWORK_MARKERS = (  # specific download/network signatures only; bare ConnectionError is raised for local sources too
     "urlopen error",
@@ -502,6 +501,7 @@ def classify(trial, rc, stderr):
         (exc == "NotImplementedError" and re.search(r"not supported|(?:doesn't|does not) support", stderr))
         or (exc == "NotImplementedError" and "not found in list of available optimizers" in stderr)
         or (exc == "ValueError" and "Expected `mode` to be `flip` or `mixup`" in stderr)
+        or (exc == "AssertionError" and "RTDETR export requires opset>=16" in stderr)
         or (exc in EXPECTED_TYPES and frames and frames[-1].startswith(EXPECTED_MODULES))
     ):
         return "expected", None, None  # clean validation errors are expected only for trials we actually mutated

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -583,6 +583,8 @@ class Exporter:
         # Argument compatibility checks
         fmt_keys = dict(zip(fmts_dict["Argument"], fmts_dict["Arguments"]))[fmt]
         validate_args(fmt, self.args, fmt_keys)
+        if isinstance(model.model[-1], RTDETRDecoder) and self.args.opset is not None:
+            assert self.args.opset >= 16, "RTDETR export requires opset>=16"
         if fmt in {"deepx", "axelera", "imx", "edgetpu", "qnn", "hailo"} and self.args.quantize not in {8, "w8a16"}:
             if self.args.quantize == 32:
                 raise ValueError(
@@ -1322,7 +1324,7 @@ class Exporter:
         # Export to ONNX
         if isinstance(self.model.model[-1], RTDETRDecoder):
             self.args.opset = self.args.opset or 19
-            assert 16 <= self.args.opset <= 19, "RTDETR export requires opset>=16;<=19"
+            assert self.args.opset <= 19, "RTDETR TensorFlow export requires opset<=19"
         self.args.simplify = True
         f_onnx = self.export_onnx()  # ensure ONNX is available
         keras_model = onnx2saved_model(

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -583,8 +583,6 @@ class Exporter:
         # Argument compatibility checks
         fmt_keys = dict(zip(fmts_dict["Argument"], fmts_dict["Arguments"]))[fmt]
         validate_args(fmt, self.args, fmt_keys)
-        if isinstance(model.model[-1], RTDETRDecoder) and self.args.opset is not None:
-            assert self.args.opset >= 16, "RTDETR export requires opset>=16"
         if fmt in {"deepx", "axelera", "imx", "edgetpu", "qnn", "hailo"} and self.args.quantize not in {8, "w8a16"}:
             if self.args.quantize == 32:
                 raise ValueError(
@@ -985,6 +983,7 @@ class Exporter:
         from ultralytics.utils.export.engine import best_onnx_opset, torch2onnx
 
         opset = self.args.opset or best_onnx_opset(onnx, cuda="cuda" in self.device.type, quantize=self.args.quantize)
+        assert not isinstance(self.model.model[-1], RTDETRDecoder) or opset >= 16, "RTDETR export requires opset>=16"
         LOGGER.info(f"\n{prefix} starting export with onnx {onnx.__version__} opset {opset}...")
         if self.args.nms:
             assert TORCH_1_13, f"'nms=True' ONNX export requires torch>=1.13 (found torch=={TORCH_VERSION})"


### PR DESCRIPTION
## Summary
- validate the resolved RT-DETR opset at the ONNX export owner
- keep the TensorFlow-specific maximum opset requirement in its converter
- classify this intentional ONNX validation frame correctly in the fuzz oracle

## Validation
- both exact opset=12 fuzz commands now exit as expected validation errors
- RT-DETR ONNX export with opset=16 and dynamic=True succeeds
- RT-DETR TorchScript export with ignored opset=15 still succeeds
- ruff check .github/scripts/fuzz.py ultralytics/engine/exporter.py

Deleted: the TensorFlow-only RT-DETR minimum-opset check; the lower bound now validates the final ONNX opset while the TensorFlow-only upper bound stays local.

Fixes #25269
Fixes #25285

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛠️ Improved RTDETR export validation by enforcing compatible ONNX opset versions earlier and clarifying TensorFlow export limits.

### 📊 Key Changes

- Added an explicit check during ONNX export to require opset 16 or newer for RTDETR models.
- Updated TensorFlow SavedModel export validation to separately enforce the maximum supported opset of 19.
- Refined fuzz-testing classification so the new RTDETR opset validation is treated as an expected error.

### 🎯 Purpose & Impact

- ✅ Provides clearer, earlier feedback when an incompatible opset is selected for RTDETR exports.
- 🚀 Prevents unsupported RTDETR ONNX and TensorFlow exports from proceeding and failing later.
- 🔍 Improves automated fuzz testing by distinguishing valid input-validation errors from unexpected failures.
- 📦 Standard ONNX RTDETR exports can use opset 16 or newer, while TensorFlow exports remain limited to opset 19 or lower.