### PR TITLE
Validate classification calibration split

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -923,7 +923,7 @@ class Exporter:
         if self.model.task == "classify":
             import torchvision.transforms as T  # scope for faster 'import ultralytics'
 
-            data = check_cls_dataset(self.args.data)
+            data = check_cls_dataset(self.args.data, split=self.args.split)
             dataset = ClassificationDataset(data[self.args.split or "val"], args=cfg, augment=False)
             # INT8 backends divide images by 255, so emit uint8 [0, 255] center-cropped like classify inference
             dataset.torch_transforms = T.Compose([T.Resize(cfg.imgsz), T.CenterCrop(cfg.imgsz), T.PILToTensor()])


### PR DESCRIPTION
## Summary
- pass the requested classification calibration split to the existing dataset validator
- reuse its missing-test fallback instead of constructing a dataset from None

## Validation
- reproduced the exact OpenVINO INT8 fuzz command before the change
- reran the exact command successfully after the change using the existing test-to-val fallback
- ruff check ultralytics/engine/exporter.py

Deleted: the unchecked classification calibration lookup that bypassed the existing split validator.

Fixes #25286

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves INT8 classification export calibration by using the configured dataset split consistently. ⚙️

### 📊 Key Changes

- Passes `self.args.split` to `check_cls_dataset()` when preparing the INT8 calibration dataloader.
- Continues selecting the requested split, or defaults to the validation split when none is specified.
- Preserves the existing preprocessing pipeline for INT8 calibration images.

### 🎯 Purpose & Impact

- Ensures calibration data matches the user-selected dataset split, such as training, validation, or testing.
- Makes INT8 classification exports more reliable and predictable.
- Helps maintain accurate inference after exporting models to supported INT8 backends. 🚀