### PR TITLE
Fix fuzz subprocess source and signatures

### DIFF
--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -426,7 +426,9 @@ def run_trial(trial, timeout=None):
 
     cmd = [*_YOLO_CLI_COMMAND, *argv]
     env = {**os.environ, "YOLO_AUTOINSTALL": "false", "PYTHONFAULTHANDLER": "1"}
-    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, (str(Path(__file__).resolve().parents[2]), os.environ.get("PYTHONPATH")))
+    )
     t0 = time.perf_counter()
     # Own session/group so a timeout kills the whole tree (dataloader workers, export converter subprocesses)
     group = (
@@ -459,7 +461,8 @@ def parse_traceback(stderr):
     block = blocks[-1]
     frames = []
     for path, func in re.findall(r'File "([^"]+)", line \d+, in (\S+)', block):
-        if (frame := path.replace("\\", "/").rpartition("ultralytics/")[-1]) and "/site-packages/" not in frame:
+        _, marker, frame = path.replace("\\", "/").rpartition("ultralytics/")
+        if marker and "/site-packages/" not in frame:
             frames.append(f"ultralytics/{frame}:{func}")
     exc = None
     for line in reversed(block.strip().splitlines()):

--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -426,6 +426,7 @@ def run_trial(trial, timeout=None):
 
     cmd = [*_YOLO_CLI_COMMAND, *argv]
     env = {**os.environ, "YOLO_AUTOINSTALL": "false", "PYTHONFAULTHANDLER": "1"}
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
     t0 = time.perf_counter()
     # Own session/group so a timeout kills the whole tree (dataloader workers, export converter subprocesses)
     group = (
@@ -458,9 +459,8 @@ def parse_traceback(stderr):
     block = blocks[-1]
     frames = []
     for path, func in re.findall(r'File "([^"]+)", line \d+, in (\S+)', block):
-        if "ultralytics" in path:
-            norm = path.replace("\\", "/")
-            frames.append(f"{norm[norm.rindex('ultralytics/') :]}:{func}")
+        if (frame := path.replace("\\", "/").rpartition("ultralytics/")[-1]) and "/site-packages/" not in frame:
+            frames.append(f"ultralytics/{frame}:{func}")
     exc = None
     for line in reversed(block.strip().splitlines()):
         m = re.match(r"^([A-Za-z_][\w.]*(?:Error|Exception|Warning|Interrupt|Exit|SyntaxError))\b", line.strip())


### PR DESCRIPTION
## Summary

- run fuzz CLI subprocesses from the checkout containing the invoked fuzz script
- exclude virtual-environment dependency frames when building Ultralytics traceback signatures
- keep installed-package Ultralytics frames and cross-platform signature normalization intact

Fixes #25293

Deleted: the checkout-name-only traceback match and ambient editable-checkout precedence for fuzz subprocesses.

Net addition justification: three lines are required because subprocess environment construction is already the source owner, and preserving unrelated caller-supplied `PYTHONPATH` entries prevents regression.

## Validation

- `ruff format --check .github/scripts/fuzz.py`
- `ruff check .github/scripts/fuzz.py`
- `python -m py_compile .github/scripts/fuzz.py`
- synthetic Linux/Windows traceback parity, unrelated-frame exclusion, and installed-package Ultralytics-frame retention checks
- subprocess environment check confirming worktree precedence and preservation of an ambient plugin path
- live failing CLI trial from the linked worktree, confirming the child traceback resolves to that worktree

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛠️ Improved fuzz testing to reliably run against the local Ultralytics source and report relevant internal traceback frames.

### 📊 Key Changes

- Added the repository root to `PYTHONPATH` during fuzz trials, ensuring tests use the local codebase rather than an installed package.
- Updated traceback parsing to:
  - Normalize Windows and Unix-style paths.
  - Include only frames from the local `ultralytics` source.
  - Exclude unrelated `site-packages` frames.
  - Produce consistent `ultralytics/...` frame paths.

### 🎯 Purpose & Impact

- ✅ Makes fuzz testing more accurate by targeting the code currently under development.
- 🔍 Improves crash and error reporting by filtering out external dependency frames.
- 🐞 Helps developers identify and reproduce bugs in Ultralytics code more quickly across platforms.