### PR TITLE
Modernize Platform links and Docker workflows

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,4 +56,6 @@ RUN uv pip install --system --no-cache -e "." albumentations faster-coco-eval &&
 # Example (run-gpu-subset): docker run -it --ipc=host --device nvidia.com/gpu=2 --device nvidia.com/gpu=3 $t
 # Note: CDI devices 2,3 appear as cuda:0,1 inside the container.
 # Example (run-with-volume): docker run -it --ipc=host --device nvidia.com/gpu=all -v "$PWD/shared/datasets:/datasets" $t
+# CDI requires Docker >= 28.2.0 and nvidia-container-toolkit >= 1.18.
+# Legacy --gpus all can lose GPU access after host systemd daemon reloads (nvidia-container-toolkit#48).
 # Example (tag-release): t=ultralytics/ultralytics:latest tnew=ultralytics/ultralytics:vX.Y && docker tag $t $tnew && docker push $tnew

--- a/docker/Dockerfile-conda
+++ b/docker/Dockerfile-conda
@@ -39,5 +39,7 @@ ADD https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26n.pt .
 # Example (build): t=ultralytics/ultralytics:latest-conda && docker build -f docker/Dockerfile-conda -t $t .
 # Example (push): docker push $t
 # Example (pull): t=ultralytics/ultralytics:latest-conda && docker pull $t
-# Example (run): docker run -it --ipc=host $t
-# Example (run-with-volume): docker run -it --ipc=host -v "$PWD/shared/datasets:/datasets" $t
+# Example (run): docker run -it --ipc=host --device nvidia.com/gpu=all $t
+# Example (run-with-volume): docker run -it --ipc=host --device nvidia.com/gpu=all -v "$PWD/shared/datasets:/datasets" $t
+# CDI requires Docker >= 28.2.0 and nvidia-container-toolkit >= 1.18.
+# Legacy --gpus all can lose GPU access after host systemd daemon reloads (nvidia-container-toolkit#48).

--- a/docker/Dockerfile-export
+++ b/docker/Dockerfile-export
@@ -22,3 +22,5 @@ RUN uv pip install --system --no-cache -e ".[export]" numpy==1.26.4 && \
 # Example (pull): t=ultralytics/ultralytics:latest-export && docker pull $t
 # Example (run): docker run -it --ipc=host --device nvidia.com/gpu=all $t
 # Example (run-with-volume): docker run -it --ipc=host --device nvidia.com/gpu=all -v "$PWD/shared/datasets:/datasets" $t
+# CDI requires Docker >= 28.2.0 and nvidia-container-toolkit >= 1.18.
+# Legacy --gpus all can lose GPU access after host systemd daemon reloads (nvidia-container-toolkit#48).

--- a/docker/Dockerfile-jetson-jetpack4
+++ b/docker/Dockerfile-jetson-jetpack4
@@ -65,5 +65,5 @@ RUN uv pip install --system \
 # Example (build): t=ultralytics/ultralytics:latest-jetson-jetpack4 && docker build --platform linux/arm64 -f docker/Dockerfile-jetson-jetpack4 -t $t .
 # Example (push): docker push $t
 # Example (pull): t=ultralytics/ultralytics:latest-jetson-jetpack4 && docker pull $t
-# Example (run): docker run -it --ipc=host --runtime=nvidia $t
-# Example (run-with-volume): docker run -it --ipc=host --runtime=nvidia -v "$PWD/shared/datasets:/datasets" $t
+# Example (run-jetson): docker run -it --ipc=host --runtime=nvidia $t
+# Example (run-jetson-with-volume): docker run -it --ipc=host --runtime=nvidia -v "$PWD/shared/datasets:/datasets" $t

--- a/docker/Dockerfile-jetson-jetpack5
+++ b/docker/Dockerfile-jetson-jetpack5
@@ -55,5 +55,5 @@ RUN uv pip install --system \
 # Example (build): t=ultralytics/ultralytics:latest-jetson-jetpack5 && docker build --platform linux/arm64 -f docker/Dockerfile-jetson-jetpack5 -t $t .
 # Example (push): docker push $t
 # Example (pull): t=ultralytics/ultralytics:latest-jetson-jetpack5 && docker pull $t
-# Example (run): docker run -it --ipc=host --runtime=nvidia $t
-# Example (run-with-volume): docker run -it --ipc=host --runtime=nvidia -v "$PWD/shared/datasets:/datasets" $t
+# Example (run-jetson): docker run -it --ipc=host --runtime=nvidia $t
+# Example (run-jetson-with-volume): docker run -it --ipc=host --runtime=nvidia -v "$PWD/shared/datasets:/datasets" $t

--- a/docker/Dockerfile-jetson-jetpack6
+++ b/docker/Dockerfile-jetson-jetpack6
@@ -62,5 +62,5 @@ RUN python3 -m pip install --upgrade pip uv && \
 # Example (build): t=ultralytics/ultralytics:latest-jetson-jetpack6 && docker build --platform linux/arm64 -f docker/Dockerfile-jetson-jetpack6 -t $t .
 # Example (push): docker push $t
 # Example (pull): t=ultralytics/ultralytics:latest-jetson-jetpack6 && docker pull $t
-# Example (run): docker run -it --ipc=host --runtime=nvidia $t
-# Example (run-with-volume): docker run -it --ipc=host --runtime=nvidia -v "$PWD/shared/datasets:/datasets" $t
+# Example (run-jetson): docker run -it --ipc=host --runtime=nvidia $t
+# Example (run-jetson-with-volume): docker run -it --ipc=host --runtime=nvidia -v "$PWD/shared/datasets:/datasets" $t

--- a/docker/Dockerfile-nvidia-arm64
+++ b/docker/Dockerfile-nvidia-arm64
@@ -48,5 +48,9 @@ RUN uv pip install --system \
 # Example (build): t=ultralytics/ultralytics:latest-nvidia-arm64 && docker build --platform linux/arm64 -f docker/Dockerfile-nvidia-arm64 -t $t .
 # Example (push): docker push $t
 # Example (pull): t=ultralytics/ultralytics:latest-nvidia-arm64 && docker pull $t
-# Example (run): docker run -it --ipc=host --runtime=nvidia $t
-# Example (run-with-volume): docker run -it --ipc=host --runtime=nvidia -v "$PWD/shared/datasets:/datasets" $t
+# Example (run-dgx-spark): docker run -it --ipc=host --device nvidia.com/gpu=all $t
+# Example (run-dgx-spark-with-volume): docker run -it --ipc=host --device nvidia.com/gpu=all -v "$PWD/shared/datasets:/datasets" $t
+# Example (run-jetson-thor): docker run -it --ipc=host --runtime=nvidia $t
+# Example (run-jetson-thor-with-volume): docker run -it --ipc=host --runtime=nvidia -v "$PWD/shared/datasets:/datasets" $t
+# CDI requires Docker >= 28.2.0 and nvidia-container-toolkit >= 1.18.
+# Legacy --gpus all can lose GPU access after host systemd daemon reloads (nvidia-container-toolkit#48).

--- a/docker/Dockerfile-runner
+++ b/docker/Dockerfile-runner
@@ -36,6 +36,5 @@ ENTRYPOINT ["sh", "-c", "./config.sh --url https://github.com/ultralytics --toke
 # Example (push): docker push $t
 # Example (pull): t=ultralytics/ultralytics:latest-runner && docker pull $t
 # Example (run): docker run -d --restart unless-stopped -e GITHUB_RUNNER_TOKEN=TOKEN -e GITHUB_RUNNER_NAME=NAME --ipc=host --device nvidia.com/gpu=all $t
-# CDI (--device nvidia.com/gpu=all; needs Docker >= 28.2.0 and nvidia-container-toolkit >= 1.18) instead of legacy
-# --gpus all: CDI puts the device nodes in the container config, so long-lived runners keep GPU access across host
-# systemd daemon-reloads, e.g. apt installs (nvidia-container-toolkit#48)
+# CDI requires Docker >= 28.2.0 and nvidia-container-toolkit >= 1.18.
+# Legacy --gpus all can lose GPU access after host systemd daemon reloads (nvidia-container-toolkit#48).

--- a/docs/en/guides/conda-quickstart.md
+++ b/docs/en/guides/conda-quickstart.md
@@ -88,7 +88,7 @@ sudo docker run -it --ipc=host --device nvidia.com/gpu=all $t                   
 sudo docker run -it --ipc=host --device nvidia.com/gpu=2 --device nvidia.com/gpu=3 $t # specify GPUs
 ```
 
-CDI device requests require Docker >= 28.2.0 and NVIDIA Container Toolkit >= 1.18. On older hosts, use the legacy `--runtime=nvidia --gpus all` flags instead — see the [Docker Quickstart Guide](docker-quickstart.md) for details.
+CDI device requests require Docker >= 28.2.0 and NVIDIA Container Toolkit >= 1.18. The legacy `--gpus all` flag can lose GPU access after host daemon reloads, so upgrade older hosts and use `--device` instead. See the [Docker Quickstart Guide](docker-quickstart.md) for details.
 
 ## Speeding Up Installation with Libmamba
 

--- a/docs/en/guides/conda-quickstart.md
+++ b/docs/en/guides/conda-quickstart.md
@@ -88,7 +88,7 @@ sudo docker run -it --ipc=host --device nvidia.com/gpu=all $t                   
 sudo docker run -it --ipc=host --device nvidia.com/gpu=2 --device nvidia.com/gpu=3 $t # specify GPUs
 ```
 
-CDI device requests require Docker >= 28.2.0 and NVIDIA Container Toolkit >= 1.18. The legacy `--gpus all` flag can lose GPU access after host daemon reloads, so upgrade older hosts and use `--device` instead. See the [Docker Quickstart Guide](docker-quickstart.md) for details.
+On Linux, CDI device requests require Docker >= 28.2.0 and NVIDIA Container Toolkit >= 1.18. The legacy `--gpus all` flag can lose GPU access after host daemon reloads, so upgrade older Linux hosts and use `--device` instead. See the [Docker Quickstart Guide](docker-quickstart.md) for details.
 
 ## Speeding Up Installation with Libmamba
 

--- a/docs/en/guides/docker-quickstart.md
+++ b/docs/en/guides/docker-quickstart.md
@@ -39,12 +39,12 @@ This guide serves as a comprehensive introduction to setting up a Docker environ
 ## Prerequisites
 
 - Make sure Docker is installed on your system. If not, you can download and install it from [Docker's website](https://www.docker.com/products/docker-desktop/).
-- Ensure that your system has an NVIDIA GPU and NVIDIA drivers are installed.
+- For GPU acceleration, ensure that your system has an NVIDIA GPU and [NVIDIA drivers](https://docs.nvidia.com/datacenter/tesla/driver-installation-guide/index.html) installed. CPU images do not require NVIDIA hardware.
 - If you are using NVIDIA Jetson devices, ensure that you have the appropriate JetPack version installed. Refer to the [NVIDIA Jetson guide](nvidia-jetson.md) for more details.
 
 ---
 
-## Setting up Docker with NVIDIA Support
+## Setting up Docker with NVIDIA Support (Optional)
 
 First, verify that the NVIDIA drivers are properly installed by running:
 
@@ -64,32 +64,17 @@ Now, let's install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datace
       | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
         | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
     ```
-    Update the package lists and install the nvidia-container-toolkit package:
+    Update the package lists and install the NVIDIA Container Toolkit:
 
     ```bash
     sudo apt-get update
     ```
 
-    Install the latest version of `nvidia-container-toolkit`:
-
     ```bash
-    sudo apt-get install -y nvidia-container-toolkit \
-      nvidia-container-toolkit-base libnvidia-container-tools \
-      libnvidia-container1
+    sudo apt-get install -y nvidia-container-toolkit
     ```
 
-    ??? info "Optional: Install specific version of nvidia-container-toolkit"
-
-        Optionally, you can install a specific version of the nvidia-container-toolkit by setting the `NVIDIA_CONTAINER_TOOLKIT_VERSION` environment variable:
-
-        ```bash
-        export NVIDIA_CONTAINER_TOOLKIT_VERSION=1.18.1-1
-        sudo apt-get install -y \
-          nvidia-container-toolkit=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
-          nvidia-container-toolkit-base=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
-          libnvidia-container-tools=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
-          libnvidia-container1=${NVIDIA_CONTAINER_TOOLKIT_VERSION}
-        ```
+    Configure the NVIDIA runtime and restart Docker:
 
     ```bash
     sudo nvidia-ctk runtime configure --runtime=docker
@@ -103,34 +88,11 @@ Now, let's install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datace
       | sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo
     ```
 
-    Update the package lists and install the nvidia-container-toolkit package:
-
     ```bash
-    sudo dnf clean expire-cache
-    sudo dnf check-update
+    sudo dnf install -y nvidia-container-toolkit
     ```
 
-    ```bash
-    sudo dnf install \
-      nvidia-container-toolkit \
-      nvidia-container-toolkit-base \
-      libnvidia-container-tools \
-      libnvidia-container1
-    ```
-
-
-    ??? info "Optional: Install specific version of nvidia-container-toolkit"
-
-        Optionally, you can install a specific version of the nvidia-container-toolkit by setting the `NVIDIA_CONTAINER_TOOLKIT_VERSION` environment variable:
-
-          ```bash
-          export NVIDIA_CONTAINER_TOOLKIT_VERSION=1.18.1-1
-          sudo dnf install -y \
-            nvidia-container-toolkit-${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
-            nvidia-container-toolkit-base-${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
-            libnvidia-container-tools-${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
-            libnvidia-container1-${NVIDIA_CONTAINER_TOOLKIT_VERSION}
-          ```
+    Configure the NVIDIA runtime and restart Docker:
 
     ```bash
     sudo nvidia-ctk runtime configure --runtime=docker
@@ -151,29 +113,31 @@ You should see entries such as `nvidia.com/gpu=0` and `nvidia.com/gpu=all`. Disc
 
 ## Installing Ultralytics Docker Images
 
-Ultralytics offers several Docker images optimized for various platforms and use-cases:
+Ultralytics publishes the following images to [Docker Hub](https://hub.docker.com/r/ultralytics/ultralytics/tags). Each image is built from its linked Dockerfile by the [Docker publishing workflow](https://github.com/ultralytics/ultralytics/blob/main/.github/workflows/docker.yml).
 
-- **Dockerfile:** GPU image, ideal for training.
-- **Dockerfile-arm64:** For ARM64 architecture, suitable for devices like [Raspberry Pi](raspberry-pi.md).
-- **Dockerfile-cpu:** CPU-only version for inference and non-GPU environments.
-- **Dockerfile-jetson-jetpack4:** Optimized for [NVIDIA Jetson](nvidia-jetson.md) devices running [NVIDIA JetPack 4](https://developer.nvidia.com/embedded/jetpack-sdk-461).
-- **Dockerfile-jetson-jetpack5:** Optimized for [NVIDIA Jetson](nvidia-jetson.md) devices running [NVIDIA JetPack 5](https://developer.nvidia.com/embedded/jetpack-sdk-512).
-- **Dockerfile-jetson-jetpack6:** Optimized for [NVIDIA Jetson](nvidia-jetson.md) devices running [NVIDIA JetPack 6](https://developer.nvidia.com/embedded/jetpack-sdk-61).
-- **Dockerfile-jupyter:** For interactive development using JupyterLab in the browser.
-- **Dockerfile-nvidia-arm64:** For NVIDIA ARM64 devices such as Jetson AGX Thor and DGX Spark, supporting JetPack 7.0 and DGX OS.
-- **Dockerfile-python:** Minimal Python environment for lightweight applications.
-- **Dockerfile-python-export:** Minimal Python image extended with full export capabilities for YOLO model conversion.
-- **Dockerfile-conda:** Includes [Miniconda3](https://www.anaconda.com/docs/main) and Ultralytics package installed via Conda.
-- **Dockerfile-export:** GPU image with all export format dependencies pre-installed for model conversion and benchmarking.
+| Tag                                                                                                           | Platform and purpose                                                                                                                 | Source                                                                                                                 |
+| ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| [`latest`](https://hub.docker.com/r/ultralytics/ultralytics/tags?name=latest)                                 | Linux AMD64 with CUDA for GPU training and inference                                                                                 | [`Dockerfile`](https://github.com/ultralytics/ultralytics/blob/main/docker/Dockerfile)                                 |
+| [`latest-export`](https://hub.docker.com/r/ultralytics/ultralytics/tags?name=latest-export)                   | Linux AMD64 with CUDA and export dependencies for conversion and benchmarking                                                        | [`Dockerfile-export`](https://github.com/ultralytics/ultralytics/blob/main/docker/Dockerfile-export)                   |
+| [`latest-python`](https://hub.docker.com/r/ultralytics/ultralytics/tags?name=latest-python)                   | Lightweight Linux AMD64 Python image for CPU inference                                                                               | [`Dockerfile-python`](https://github.com/ultralytics/ultralytics/blob/main/docker/Dockerfile-python)                   |
+| [`latest-python-export`](https://hub.docker.com/r/ultralytics/ultralytics/tags?name=latest-python-export)     | Linux AMD64 CPU image with export dependencies                                                                                       | [`Dockerfile-python-export`](https://github.com/ultralytics/ultralytics/blob/main/docker/Dockerfile-python-export)     |
+| [`latest-cpu`](https://hub.docker.com/r/ultralytics/ultralytics/tags?name=latest-cpu)                         | Linux AMD64 CPU image with Bash as the default command                                                                               | [`Dockerfile-cpu`](https://github.com/ultralytics/ultralytics/blob/main/docker/Dockerfile-cpu)                         |
+| [`latest-jupyter`](https://hub.docker.com/r/ultralytics/ultralytics/tags?name=latest-jupyter)                 | Linux AMD64 CPU image with JupyterLab and Ultralytics tutorial notebooks                                                             | [`Dockerfile-jupyter`](https://github.com/ultralytics/ultralytics/blob/main/docker/Dockerfile-jupyter)                 |
+| [`latest-arm64`](https://hub.docker.com/r/ultralytics/ultralytics/tags?name=latest-arm64)                     | Linux ARM64 CPU image for Apple silicon, [Raspberry Pi](raspberry-pi.md), and other ARM64 systems                                    | [`Dockerfile-arm64`](https://github.com/ultralytics/ultralytics/blob/main/docker/Dockerfile-arm64)                     |
+| [`latest-nvidia-arm64`](https://hub.docker.com/r/ultralytics/ultralytics/tags?name=latest-nvidia-arm64)       | Linux ARM64 with NVIDIA GPU support for Jetson AGX Thor, DGX Spark, JetPack 7, and DGX OS                                            | [`Dockerfile-nvidia-arm64`](https://github.com/ultralytics/ultralytics/blob/main/docker/Dockerfile-nvidia-arm64)       |
+| [`latest-jetson-jetpack6`](https://hub.docker.com/r/ultralytics/ultralytics/tags?name=latest-jetson-jetpack6) | Linux ARM64 for [NVIDIA Jetson](nvidia-jetson.md) devices running [JetPack 6](https://developer.nvidia.com/embedded/jetpack-sdk-61)  | [`Dockerfile-jetson-jetpack6`](https://github.com/ultralytics/ultralytics/blob/main/docker/Dockerfile-jetson-jetpack6) |
+| [`latest-jetson-jetpack5`](https://hub.docker.com/r/ultralytics/ultralytics/tags?name=latest-jetson-jetpack5) | Linux ARM64 for [NVIDIA Jetson](nvidia-jetson.md) devices running [JetPack 5](https://developer.nvidia.com/embedded/jetpack-sdk-512) | [`Dockerfile-jetson-jetpack5`](https://github.com/ultralytics/ultralytics/blob/main/docker/Dockerfile-jetson-jetpack5) |
+| [`latest-jetson-jetpack4`](https://hub.docker.com/r/ultralytics/ultralytics/tags?name=latest-jetson-jetpack4) | Linux ARM64 for [NVIDIA Jetson](nvidia-jetson.md) devices running [JetPack 4](https://developer.nvidia.com/embedded/jetpack-sdk-461) | [`Dockerfile-jetson-jetpack4`](https://github.com/ultralytics/ultralytics/blob/main/docker/Dockerfile-jetson-jetpack4) |
+| [`latest-runner`](https://hub.docker.com/r/ultralytics/ultralytics/tags?name=latest-runner)                   | Linux AMD64 CUDA image for a self-hosted GitHub Actions GPU runner                                                                   | [`Dockerfile-runner`](https://github.com/ultralytics/ultralytics/blob/main/docker/Dockerfile-runner)                   |
+| [`latest-runner-cpu`](https://hub.docker.com/r/ultralytics/ultralytics/tags?name=latest-runner-cpu)           | Linux AMD64 image for a self-hosted GitHub Actions CPU runner                                                                        | [`Dockerfile-runner-cpu`](https://github.com/ultralytics/ultralytics/blob/main/docker/Dockerfile-runner-cpu)           |
+
+Tags beginning with `latest` track the most recently published main-branch build. Versioned tags replace the `latest` prefix with an Ultralytics release, such as `VERSION`, `VERSION-cpu`, or `VERSION-jetson-jetpack6`. Use a versioned tag for a reproducible environment.
 
 To pull the latest image:
 
 ```bash
-# Set image name as a variable
-t=ultralytics/ultralytics:latest
-
 # Pull the latest Ultralytics image from Docker Hub
-sudo docker pull $t
+sudo docker pull ultralytics/ultralytics:latest
 ```
 
 ---
@@ -186,31 +150,24 @@ Here's how to execute the Ultralytics Docker container:
 
 ```bash
 # Run without GPU
-sudo docker run -it --ipc=host $t
+sudo docker run -it --ipc=host ultralytics/ultralytics:latest-cpu
 ```
 
 ### Using GPUs
 
 ```bash
 # Run with all GPUs
-sudo docker run -it --ipc=host --device nvidia.com/gpu=all $t
+sudo docker run -it --ipc=host --device nvidia.com/gpu=all ultralytics/ultralytics:latest
 
 # Run specifying which GPUs to use
-sudo docker run -it --ipc=host --device nvidia.com/gpu=2 --device nvidia.com/gpu=3 $t
+sudo docker run -it --ipc=host --device nvidia.com/gpu=2 --device nvidia.com/gpu=3 ultralytics/ultralytics:latest
 ```
 
 The `-it` flag assigns a pseudo-TTY and keeps stdin open, allowing you to interact with the container. The `--ipc=host` flag enables sharing of host's IPC namespace, essential for sharing memory between processes. The `--device nvidia.com/gpu=...` flag grants the container access to the host's GPUs through [CDI](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html).
 
-!!! tip "Older Docker or NVIDIA Container Toolkit versions"
+!!! warning "Use CDI instead of `--gpus all`"
 
-    CDI device requests require Docker >= 28.2.0 (CDI enabled by default) and `nvidia-container-toolkit` >= 1.18 (automatic CDI spec generation). On older hosts, fall back to the legacy flags:
-
-    ```bash
-    # Legacy GPU access on older hosts
-    sudo docker run -it --ipc=host --runtime=nvidia --gpus all $t
-    ```
-
-    Note that legacy `--gpus` containers can lose GPU access (`Failed to initialize NVML: Unknown Error`) when the host reloads systemd, which happens during routine package updates ([nvidia-container-toolkit#48](https://github.com/NVIDIA/nvidia-container-toolkit/issues/48)). CDI includes the device nodes in the container configuration itself, so long-running containers such as training workers or CI runners keep GPU access across reloads.
+    CDI device requests require [Docker >= 28.2.0](https://docs.docker.com/engine/release-notes/28/#2820) (CDI enabled by default) and `nvidia-container-toolkit` >= 1.18 (automatic CDI spec generation). Upgrade older hosts before running GPU containers. The legacy `--gpus all` flag can lose GPU access (`Failed to initialize NVML: Unknown Error`) when the host reloads systemd during routine package updates ([nvidia-container-toolkit#48](https://github.com/NVIDIA/nvidia-container-toolkit/issues/48)). CDI `--device` requests include the device nodes in the container configuration, so long-running containers such as training workers or CI runners keep GPU access across reloads.
 
 ### Note on File Accessibility
 
@@ -218,7 +175,7 @@ To work with files on your local machine within the container, you can use Docke
 
 ```bash
 # Mount a local directory into the container
-sudo docker run -it --ipc=host --device nvidia.com/gpu=all -v /path/on/host:/path/in/container $t
+sudo docker run -it --ipc=host --device nvidia.com/gpu=all -v /path/on/host:/path/in/container ultralytics/ultralytics:latest
 ```
 
 Replace `/path/on/host` with the directory path on your local machine and `/path/in/container` with the desired path inside the Docker container.
@@ -266,7 +223,7 @@ Setup and configuration of an X11 or Wayland display server is outside the scope
         xhost +local:docker && docker run -e DISPLAY=$DISPLAY \
           -v /tmp/.X11-unix:/tmp/.X11-unix \
           -v ~/.Xauthority:/root/.Xauthority \
-          -it --ipc=host $t
+          -it --ipc=host ultralytics/ultralytics:latest
         ```
 
         This command sets the `DISPLAY` environment variable to the host's display, mounts the X11 socket, and maps the `.Xauthority` file to the container. The `xhost +local:docker` command allows the Docker container to access the X11 server.
@@ -279,7 +236,7 @@ Setup and configuration of an X11 or Wayland display server is outside the scope
         ```bash
         xhost +local:docker && docker run -e DISPLAY=$DISPLAY \
           -v $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY:/tmp/$WAYLAND_DISPLAY \
-          --net=host -it --ipc=host $t
+          --net=host -it --ipc=host ultralytics/ultralytics:latest
         ```
 
         This command sets the `DISPLAY` environment variable to the host's display, mounts the Wayland socket, and allows the Docker container to access the Wayland server.
@@ -312,7 +269,7 @@ yolo predict model=yolo26n.pt show=True
 
 ---
 
-You are now set up to use Ultralytics with Docker and ready to take advantage of its capabilities. For alternative installation methods, see the [Ultralytics quickstart documentation](../quickstart.md).
+You are now set up to use Ultralytics with Docker and ready to take advantage of its capabilities. To self-host the Ultralytics web application, see the [Platform On-Premise guide](../platform/integrations/on-premise.md). For alternative Python package installation methods, see the [Ultralytics quickstart documentation](../quickstart.md).
 
 ## FAQ
 
@@ -328,7 +285,7 @@ For detailed steps, refer to our Docker Quickstart Guide.
 
 ### What are the benefits of using Ultralytics Docker images for machine learning projects?
 
-Using Ultralytics Docker images ensures a consistent environment across different machines, replicating the same software and dependencies. This is particularly useful for [collaborating across teams](https://www.ultralytics.com/blog/how-ultralytics-integration-can-enhance-your-workflow), running models on various hardware, and maintaining reproducibility. For GPU-based training, Ultralytics provides optimized Docker images such as `Dockerfile` for general GPU usage and `Dockerfile-jetson` for NVIDIA Jetson devices. Explore [Ultralytics Docker Hub](https://hub.docker.com/r/ultralytics/ultralytics) for more details.
+Using Ultralytics Docker images ensures a consistent environment across different machines, replicating the same software and dependencies. This is particularly useful for [collaborating across teams](https://www.ultralytics.com/blog/how-ultralytics-integration-can-enhance-your-workflow), running models on various hardware, and maintaining reproducibility. Use `latest` for general NVIDIA GPU training or select the image matching your JetPack version for an NVIDIA Jetson device. See the [complete image table](#installing-ultralytics-docker-images) or explore [Ultralytics Docker Hub](https://hub.docker.com/r/ultralytics/ultralytics/tags).
 
 ### How can I run Ultralytics YOLO in a Docker container with GPU support?
 

--- a/docs/en/guides/docker-quickstart.md
+++ b/docs/en/guides/docker-quickstart.md
@@ -74,13 +74,6 @@ Now, let's install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datace
     sudo apt-get install -y nvidia-container-toolkit
     ```
 
-    Configure the NVIDIA runtime and restart Docker:
-
-    ```bash
-    sudo nvidia-ctk runtime configure --runtime=docker
-    sudo systemctl restart docker
-    ```
-
 === "RHEL/CentOS/Fedora/Amazon Linux"
 
     ```bash
@@ -90,13 +83,6 @@ Now, let's install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datace
 
     ```bash
     sudo dnf install -y nvidia-container-toolkit
-    ```
-
-    Configure the NVIDIA runtime and restart Docker:
-
-    ```bash
-    sudo nvidia-ctk runtime configure --runtime=docker
-    sudo systemctl restart docker
     ```
 
 ### Verify CDI Devices with Docker

--- a/docs/en/guides/docker-quickstart.md
+++ b/docs/en/guides/docker-quickstart.md
@@ -153,7 +153,9 @@ The `-it` flag assigns a pseudo-TTY and keeps stdin open, allowing you to intera
 
 !!! warning "Use CDI instead of `--gpus all`"
 
-    CDI device requests require [Docker >= 28.2.0](https://docs.docker.com/engine/release-notes/28/#2820) (CDI enabled by default) and `nvidia-container-toolkit` >= 1.18 (automatic CDI spec generation). Upgrade older hosts before running GPU containers. The legacy `--gpus all` flag can lose GPU access (`Failed to initialize NVML: Unknown Error`) when the host reloads systemd during routine package updates ([nvidia-container-toolkit#48](https://github.com/NVIDIA/nvidia-container-toolkit/issues/48)). CDI `--device` requests include the device nodes in the container configuration, so long-running containers such as training workers or CI runners keep GPU access across reloads.
+    On Linux, CDI device requests require [Docker >= 28.2.0](https://docs.docker.com/engine/release-notes/28/#2820) (CDI enabled by default) and `nvidia-container-toolkit` >= 1.18 (automatic CDI spec generation). Upgrade older Linux hosts before running GPU containers. The legacy `--gpus all` flag can lose GPU access (`Failed to initialize NVML: Unknown Error`) when the host reloads systemd during routine package updates ([nvidia-container-toolkit#48](https://github.com/NVIDIA/nvidia-container-toolkit/issues/48)). CDI `--device` requests include the device nodes in the container configuration, so long-running containers such as training workers or CI runners keep GPU access across reloads.
+
+    [Docker Desktop GPU support on Windows](https://docs.docker.com/desktop/features/gpu/) currently uses `--gpus all` with the WSL 2 backend because NVIDIA CDI devices are not available there. Windows does not use Linux systemd, so the daemon-reload failure above does not apply.
 
 ### Note on File Accessibility
 

--- a/docs/en/modes/export.md
+++ b/docs/en/modes/export.md
@@ -80,7 +80,7 @@ Adjusting these parameters allows for customization of the export process to fit
 
 ## Export Formats
 
-Available YOLO26 export formats are in the table below. You can export to any format using the `format` argument, i.e., `format='onnx'` or `format='engine'`. You can predict or validate directly on exported models, i.e., `yolo predict model=yolo26n.onnx`. Usage examples are shown for your model after export completes. Models can also be exported directly from the browser on [Ultralytics Platform](https://platform.ultralytics.com) without any local setup.
+Available YOLO26 export formats are in the table below. You can export to any format using the `format` argument, i.e., `format='onnx'` or `format='engine'`. You can predict or validate directly on exported models, i.e., `yolo predict model=yolo26n.onnx`. Usage examples are shown for your model after export completes. Models can also be exported directly from the browser on [Ultralytics Platform](../platform/train/models.md#export-model) without any local setup.
 
 {% include "macros/export-table.md" %}
 

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -38,7 +38,7 @@ Here's why you should consider YOLO26's predict mode for your various inference 
 - **Performance:** Engineered for real-time, high-speed processing without sacrificing [accuracy](https://www.ultralytics.com/glossary/accuracy).
 - **Ease of Use:** Intuitive Python and CLI interfaces for rapid deployment and testing.
 - **Highly Customizable:** Various settings and parameters to tune the model's inference behavior according to your specific requirements.
-- **Production Ready:** Deploy models as API endpoints on [Ultralytics Platform](https://platform.ultralytics.com) with auto-scaling and monitoring, or run inference locally.
+- **Production Ready:** Deploy models as [Ultralytics Platform inference endpoints](../platform/deploy/endpoints.md) with auto-scaling and monitoring, or run inference locally.
 
 ### Key Features of Predict Mode
 

--- a/docs/en/modes/track.md
+++ b/docs/en/modes/track.md
@@ -72,7 +72,7 @@ Run tracking on a video with the default BoT-SORT tracker. Swap to another track
         yolo track model=yolo26n.pt source="https://youtu.be/LNwODJXcvt4" tracker="bytetrack.yaml"
         ```
 
-To run the tracker on video streams, use a trained Detect, Segment, Pose, or OBB model such as YOLO26n, YOLO26n-seg, YOLO26n-pose, or YOLO26n-obb. You can train custom models locally or on cloud GPUs through [Ultralytics Platform](https://platform.ultralytics.com).
+To run the tracker on video streams, use a trained Detect, Segment, Pose, or OBB model such as YOLO26n, YOLO26n-seg, YOLO26n-pose, or YOLO26n-obb. You can train custom models locally or with [Ultralytics Platform cloud training](../platform/train/cloud-training.md).
 
 !!! example
 

--- a/docs/en/modes/train.md
+++ b/docs/en/modes/train.md
@@ -31,7 +31,7 @@ Here are some compelling reasons to opt for YOLO26's Train mode:
 - **Versatility:** Train on custom datasets in addition to readily available ones like COCO, VOC, and ImageNet.
 - **User-Friendly:** Simple yet powerful CLI and Python interfaces for a straightforward training experience.
 - **Hyperparameter Flexibility:** A broad range of customizable hyperparameters to fine-tune model performance. For deeper control, you can [customize the trainer](../guides/custom-trainer.md) itself.
-- **Cloud Training:** Train on cloud GPUs through [Ultralytics Platform](https://platform.ultralytics.com) with real-time metrics and automatic checkpointing.
+- **Cloud Training:** Train on cloud GPUs through [Ultralytics Platform](../platform/train/cloud-training.md) with real-time metrics and automatic checkpointing.
 
 ### Key Features of Train Mode
 
@@ -351,7 +351,7 @@ After setting up your logger, you can then proceed with your model training. All
 
 ### Can I train without a local GPU?
 
-Yes. [Ultralytics Platform](https://platform.ultralytics.com) supports cloud training with free credits to get started. Upload your dataset, select a model and GPU, and train directly from the browser. See the [cloud training guide](../platform/train/cloud-training.md) for details.
+Yes. [Ultralytics Platform cloud training](../platform/train/cloud-training.md) includes free credits to get started. Upload your dataset, select a model and GPU, and train directly from the browser.
 
 ### How do I train an [object detection](https://www.ultralytics.com/glossary/object-detection) model using Ultralytics YOLO26?
 

--- a/docs/en/platform/deploy/index.md
+++ b/docs/en/platform/deploy/index.md
@@ -8,7 +8,7 @@ keywords: Ultralytics Platform, deployment, inference, endpoints, monitoring, YO
 
 # Deployment
 
-[Ultralytics Platform](https://platform.ultralytics.com) provides comprehensive deployment options for putting your YOLO models into production. Test models with browser-based inference, deploy to dedicated endpoints across 42 global regions, and monitor performance in real-time.
+[Ultralytics Platform](https://platform.ultralytics.com) provides comprehensive [model deployment options](../../guides/model-deployment-options.md) for putting your YOLO models into production. Test models with browser-based inference, deploy to dedicated endpoints across 42 global regions, and monitor performance in real-time.
 
 <p align="center">
   <br>

--- a/docs/en/platform/deploy/monitoring.md
+++ b/docs/en/platform/deploy/monitoring.md
@@ -8,7 +8,7 @@ keywords: Ultralytics Platform, monitoring, metrics, logs, deployment, performan
 
 # Monitoring
 
-[Ultralytics Platform](https://platform.ultralytics.com) provides monitoring for deployed endpoints. Track request metrics, view logs, and check health status with automatic polling.
+[Ultralytics Platform](https://platform.ultralytics.com) provides [monitoring for deployed endpoints](../../guides/model-monitoring-and-maintenance.md). Track request metrics, view logs, and check health status with automatic polling.
 
 ![Ultralytics Platform Deploy Page Overview Cards And World Map](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/deploy-page-overview-cards-and-world-map.avif)
 

--- a/docs/en/platform/integrations/index.md
+++ b/docs/en/platform/integrations/index.md
@@ -8,7 +8,7 @@ keywords: Ultralytics Platform, integrations, data import, Roboflow, Ultralytics
 
 # Integrations
 
-[Ultralytics Platform](https://platform.ultralytics.com) integrations connect your workspace to other tools and services you already use. Import existing datasets with a single API key, or connect your cloud storage and use the data where it lives — no manual export or re-upload either way.
+[Ultralytics Platform](https://platform.ultralytics.com) [integrations](../../integrations/index.md) connect your workspace to other tools and services you already use. Import existing datasets with a single API key, or connect your cloud storage and use the data where it lives — no manual export or re-upload either way.
 
 ![Ultralytics Platform Settings Integrations Tab](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/settings-integrations-tab.avif)
 

--- a/docs/en/platform/integrations/on-premise.md
+++ b/docs/en/platform/integrations/on-premise.md
@@ -123,17 +123,17 @@ The setup command creates these folders, installs and starts Docker when needed,
 
 The installer runs one container and selects the [official Ultralytics base image](../../guides/docker-quickstart.md) for the host:
 
-| Host                                   | Base image                             |
-| -------------------------------------- | -------------------------------------- |
-| Apple Silicon or ARM64 Linux           | `ultralytics/ultralytics:latest-arm64` |
-| x86-64 CPU                             | `ultralytics/ultralytics:latest-cpu`   |
-| x86-64 with a supported NVIDIA runtime | `ultralytics/ultralytics:latest`       |
+| Host                               | Base image                             |
+| ---------------------------------- | -------------------------------------- |
+| Apple Silicon or ARM64 Linux       | `ultralytics/ultralytics:latest-arm64` |
+| x86-64 CPU                         | `ultralytics/ultralytics:latest-cpu`   |
+| x86-64 with a supported NVIDIA GPU | `ultralytics/ultralytics:latest`       |
 
 The installer tracks the latest official image for each host. The worker adds its connectivity dependencies without reinstalling Ultralytics. It detects CUDA at runtime, so an NVIDIA host still runs one container rather than separate CPU and GPU workers. These lightweight images support local ingest and training; Platform's existing cloud services handle model prediction and export after the best checkpoint uploads.
 
 !!! warning "Use CDI for GPU access"
 
-    CPU setup requires nothing beyond the guided installation. NVIDIA GPU acceleration requires Docker >= 28.2 and NVIDIA Container Toolkit >= 1.18. The installer uses CDI `--device` reservations, not legacy `--gpus all`, so GPU access survives host daemon reloads. Platform detects CDI GPUs automatically; see the [Docker Quickstart Guide](../../guides/docker-quickstart.md#using-gpus) for setup details.
+    CPU setup requires nothing beyond the guided installation. On Linux, NVIDIA GPU acceleration requires Docker >= 28.2 and NVIDIA Container Toolkit >= 1.18. The installer uses CDI `--device` reservations, not legacy `--gpus all`, so GPU access survives host daemon reloads. Docker Desktop on Windows uses its supported NVIDIA device reservation because NVIDIA CDI devices are not available there. Platform detects the supported GPU path automatically; see the [Docker Quickstart Guide](../../guides/docker-quickstart.md#using-gpus) for setup details.
 
 ## Add a Dataset
 

--- a/docs/en/platform/integrations/on-premise.md
+++ b/docs/en/platform/integrations/on-premise.md
@@ -123,13 +123,13 @@ The setup command creates these folders, installs and starts Docker when needed,
 
 The installer runs one container and selects the official Ultralytics base image for the host:
 
-| Host                                   | Base image                              |
-| -------------------------------------- | --------------------------------------- |
-| Apple Silicon or ARM64 Linux           | `ultralytics/ultralytics:8.4.100-arm64` |
-| x86-64 CPU                             | `ultralytics/ultralytics:8.4.100-cpu`   |
-| x86-64 with a supported NVIDIA runtime | `ultralytics/ultralytics:8.4.100`       |
+| Host                                   | Base image                             |
+| -------------------------------------- | -------------------------------------- |
+| Apple Silicon or ARM64 Linux           | `ultralytics/ultralytics:latest-arm64` |
+| x86-64 CPU                             | `ultralytics/ultralytics:latest-cpu`   |
+| x86-64 with a supported NVIDIA runtime | `ultralytics/ultralytics:latest`       |
 
-The installer pins the image matching Platform's Ultralytics version. The worker adds its connectivity dependencies without reinstalling Ultralytics. It detects CUDA at runtime, so an NVIDIA host still runs one container rather than separate CPU and GPU workers. These lightweight images support local ingest and training; Platform's existing cloud services handle model prediction and export after the best checkpoint uploads.
+The installer tracks the latest official image for each host. The worker adds its connectivity dependencies without reinstalling Ultralytics. It detects CUDA at runtime, so an NVIDIA host still runs one container rather than separate CPU and GPU workers. These lightweight images support local ingest and training; Platform's existing cloud services handle model prediction and export after the best checkpoint uploads.
 
 !!! info "Optional GPU acceleration"
 

--- a/docs/en/platform/integrations/on-premise.md
+++ b/docs/en/platform/integrations/on-premise.md
@@ -131,9 +131,9 @@ The installer runs one container and selects the [official Ultralytics base imag
 
 The installer tracks the latest official image for each host. The worker adds its connectivity dependencies without reinstalling Ultralytics. It detects CUDA at runtime, so an NVIDIA host still runs one container rather than separate CPU and GPU workers. These lightweight images support local ingest and training; Platform's existing cloud services handle model prediction and export after the best checkpoint uploads.
 
-!!! info "Optional GPU acceleration"
+!!! warning "Use CDI for GPU access"
 
-    CPU setup requires nothing beyond the guided installation. For NVIDIA GPU acceleration, install current NVIDIA drivers and enable Docker GPU support. Platform detects the GPU automatically.
+    CPU setup requires nothing beyond the guided installation. NVIDIA GPU acceleration requires Docker >= 28.2 and NVIDIA Container Toolkit >= 1.18. The installer uses CDI `--device` reservations, not legacy `--gpus all`, so GPU access survives host daemon reloads. Platform detects CDI GPUs automatically; see the [Docker Quickstart Guide](../../guides/docker-quickstart.md#using-gpus) for setup details.
 
 ## Add a Dataset
 

--- a/docs/en/platform/integrations/on-premise.md
+++ b/docs/en/platform/integrations/on-premise.md
@@ -121,7 +121,7 @@ The setup command creates these folders, installs and starts Docker when needed,
 
 ### Docker Base Images
 
-The installer runs one container and selects the official Ultralytics base image for the host:
+The installer runs one container and selects the [official Ultralytics base image](../../guides/docker-quickstart.md) for the host:
 
 | Host                                   | Base image                             |
 | -------------------------------------- | -------------------------------------- |

--- a/docs/en/platform/train/index.md
+++ b/docs/en/platform/train/index.md
@@ -8,7 +8,7 @@ keywords: Ultralytics Platform, model training, cloud training, YOLO, GPU traini
 
 # Model Training
 
-[Ultralytics Platform](https://platform.ultralytics.com) provides comprehensive tools for training YOLO models, from organizing experiments to running cloud training jobs with real-time metrics streaming.
+[Ultralytics Platform](https://platform.ultralytics.com) provides comprehensive tools for [training YOLO models](../../modes/train.md), from organizing experiments to running cloud training jobs with real-time metrics streaming.
 
 <p align="center">
   <br>

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -76,7 +76,7 @@ Ultralytics offers a variety of installation methods, including pip, conda, and 
         sudo docker run -it --ipc=host --device nvidia.com/gpu=2 --device nvidia.com/gpu=3 $t # specify GPUs
         ```
 
-        CDI device requests require Docker >= 28.2.0 and NVIDIA Container Toolkit >= 1.18. The legacy `--gpus all` flag can lose GPU access after host daemon reloads, so upgrade older hosts and use `--device` instead. See the [Docker Quickstart Guide](guides/docker-quickstart.md) for details.
+        On Linux, CDI device requests require Docker >= 28.2.0 and NVIDIA Container Toolkit >= 1.18. The legacy `--gpus all` flag can lose GPU access after host daemon reloads, so upgrade older Linux hosts and use `--device` instead. See the [Docker Quickstart Guide](guides/docker-quickstart.md) for details.
 
     === "Git clone"
 
@@ -122,7 +122,7 @@ Ultralytics offers a variety of installation methods, including pip, conda, and 
         sudo docker run -it --ipc=host --device nvidia.com/gpu=2 --device nvidia.com/gpu=3 $t # specify GPUs
         ```
 
-        CDI device requests require Docker >= 28.2.0 and NVIDIA Container Toolkit >= 1.18. The legacy `--gpus all` flag can lose GPU access after host daemon reloads, so upgrade older hosts and use `--device` instead. See the [Docker Quickstart Guide](guides/docker-quickstart.md) for details.
+        On Linux, CDI device requests require Docker >= 28.2.0 and NVIDIA Container Toolkit >= 1.18. The legacy `--gpus all` flag can lose GPU access after host daemon reloads, so upgrade older Linux hosts and use `--device` instead. See the [Docker Quickstart Guide](guides/docker-quickstart.md) for details.
 
         The above command initializes a Docker container with the latest `ultralytics` image. The `-it` flags assign a pseudo-TTY and keep stdin open, allowing interaction with the container. The `--ipc=host` flag sets the IPC (Inter-Process Communication) namespace to the host, which is essential for sharing memory between processes. The `--device nvidia.com/gpu=all` flag grants access to all available GPUs inside the container through [CDI](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html), crucial for tasks requiring GPU computation.
 

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -76,7 +76,7 @@ Ultralytics offers a variety of installation methods, including pip, conda, and 
         sudo docker run -it --ipc=host --device nvidia.com/gpu=2 --device nvidia.com/gpu=3 $t # specify GPUs
         ```
 
-        CDI device requests require Docker >= 28.2.0 and NVIDIA Container Toolkit >= 1.18. On older hosts, use the legacy `--runtime=nvidia --gpus all` flags instead — see the [Docker Quickstart Guide](guides/docker-quickstart.md) for details.
+        CDI device requests require Docker >= 28.2.0 and NVIDIA Container Toolkit >= 1.18. The legacy `--gpus all` flag can lose GPU access after host daemon reloads, so upgrade older hosts and use `--device` instead. See the [Docker Quickstart Guide](guides/docker-quickstart.md) for details.
 
     === "Git clone"
 
@@ -122,7 +122,7 @@ Ultralytics offers a variety of installation methods, including pip, conda, and 
         sudo docker run -it --ipc=host --device nvidia.com/gpu=2 --device nvidia.com/gpu=3 $t # specify GPUs
         ```
 
-        CDI device requests require Docker >= 28.2.0 and NVIDIA Container Toolkit >= 1.18. On older hosts, use the legacy `--runtime=nvidia --gpus all` flags instead — see the [Docker Quickstart Guide](guides/docker-quickstart.md) for details.
+        CDI device requests require Docker >= 28.2.0 and NVIDIA Container Toolkit >= 1.18. The legacy `--gpus all` flag can lose GPU access after host daemon reloads, so upgrade older hosts and use `--device` instead. See the [Docker Quickstart Guide](guides/docker-quickstart.md) for details.
 
         The above command initializes a Docker container with the latest `ultralytics` image. The `-it` flags assign a pseudo-TTY and keep stdin open, allowing interaction with the container. The `--ipc=host` flag sets the IPC (Inter-Process Communication) namespace to the host, which is essential for sharing memory between processes. The `--device nvidia.com/gpu=all` flag grants access to all available GPUs inside the container through [CDI](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html), crucial for tasks requiring GPU computation.
 

--- a/docs/en/tasks/classify.md
+++ b/docs/en/tasks/classify.md
@@ -146,7 +146,7 @@ Train YOLO26n-cls on the MNIST160 dataset for 100 [epochs](https://www.ultralyti
 
 ### Dataset format
 
-YOLO classification dataset format can be found in detail in the [Dataset Guide](../datasets/classify/index.md). Classification datasets can also be managed and labeled on [Ultralytics Platform](https://platform.ultralytics.com).
+YOLO classification dataset format can be found in detail in the [Dataset Guide](../datasets/classify/index.md). Classification datasets can also be managed and labeled with [Ultralytics Platform annotation tools](../platform/data/annotation.md).
 
 ## Val
 

--- a/docs/en/tasks/detect.md
+++ b/docs/en/tasks/detect.md
@@ -72,11 +72,11 @@ Train YOLO26n on the COCO8 dataset for 100 [epochs](https://www.ultralytics.com/
         yolo detect train data=coco8.yaml model=yolo26n.yaml pretrained=yolo26n.pt epochs=100 imgsz=640
         ```
 
-See full `train` mode details in the [Train](../modes/train.md) page. Detection models can also be trained on cloud GPUs through [Ultralytics Platform](https://platform.ultralytics.com).
+See full `train` mode details in the [Train](../modes/train.md) page. Detection models can also be trained with [Ultralytics Platform cloud training](../platform/train/cloud-training.md).
 
 ### Dataset format
 
-YOLO detection dataset format can be found in detail in the [Dataset Guide](../datasets/detect/index.md). To convert your existing dataset from other formats (like COCO etc.) to YOLO format, please use [JSON2YOLO](https://github.com/ultralytics/JSON2YOLO) tool by Ultralytics. You can also annotate and manage detection datasets directly on [Ultralytics Platform](https://platform.ultralytics.com) with AI-assisted labeling tools.
+YOLO detection dataset format can be found in detail in the [Dataset Guide](../datasets/detect/index.md). To convert your existing dataset from other formats (like COCO etc.) to YOLO format, please use [JSON2YOLO](https://github.com/ultralytics/JSON2YOLO) tool by Ultralytics. You can also annotate and manage detection datasets with [Ultralytics Platform's AI-assisted annotation tools](../platform/data/annotation.md).
 
 ## Val
 
@@ -197,7 +197,7 @@ See full `export` details in the [Export](../modes/export.md) page.
 
 ### Can I train and deploy detection models without coding?
 
-Yes. [Ultralytics Platform](https://platform.ultralytics.com) provides a browser-based workflow for annotating datasets, training detection models on cloud GPUs, and deploying them to inference endpoints. See the [Platform quickstart](../platform/quickstart.md) to get started.
+Yes. The [Ultralytics Platform quickstart](../platform/quickstart.md) covers a browser-based workflow for annotating datasets, training detection models on cloud GPUs, and deploying them to inference endpoints.
 
 ### How do I train a YOLO26 model on my custom dataset?
 

--- a/docs/en/tasks/obb.md
+++ b/docs/en/tasks/obb.md
@@ -98,7 +98,7 @@ Train YOLO26n-obb on the DOTA8 dataset for 100 [epochs](https://www.ultralytics.
 
 ### Dataset format
 
-OBB dataset format can be found in detail in the [Dataset Guide](../datasets/obb/index.md). The YOLO OBB format designates bounding boxes by their four corner points with coordinates normalized between 0 and 1, following this structure. [Ultralytics Platform](https://platform.ultralytics.com) supports OBB annotation with a dedicated oriented bounding box drawing tool:
+OBB dataset format can be found in detail in the [Dataset Guide](../datasets/obb/index.md). The YOLO OBB format designates bounding boxes by their four corner points with coordinates normalized between 0 and 1, following this structure. [Ultralytics Platform annotation](../platform/data/annotation.md) supports OBB labels with a dedicated oriented bounding box drawing tool:
 
 ```text
 class_index x1 y1 x2 y2 x3 y3 x4 y4

--- a/docs/en/tasks/pose.md
+++ b/docs/en/tasks/pose.md
@@ -94,11 +94,11 @@ Train a YOLO26-pose model on the COCO8-pose dataset. The [COCO8-pose dataset](..
         yolo pose train data=coco8-pose.yaml model=yolo26n-pose.yaml pretrained=yolo26n-pose.pt epochs=100 imgsz=640
         ```
 
-See full `train` mode details in the [Train](../modes/train.md) page. Pose models can also be trained on cloud GPUs through [Ultralytics Platform](https://platform.ultralytics.com).
+See full `train` mode details in the [Train](../modes/train.md) page. Pose models can also be trained with [Ultralytics Platform cloud training](../platform/train/cloud-training.md).
 
 ### Dataset format
 
-YOLO pose dataset format can be found in detail in the [Dataset Guide](../datasets/pose/index.md). To convert your existing dataset from other formats (like [COCO](../datasets/pose/coco.md) etc.) to YOLO format, please use the [JSON2YOLO](https://github.com/ultralytics/JSON2YOLO) tool by Ultralytics. [Ultralytics Platform](https://platform.ultralytics.com) also supports pose annotation with built-in skeleton templates for person, hand, face, and custom keypoint layouts.
+YOLO pose dataset format can be found in detail in the [Dataset Guide](../datasets/pose/index.md). To convert your existing dataset from other formats (like [COCO](../datasets/pose/coco.md) etc.) to YOLO format, please use the [JSON2YOLO](https://github.com/ultralytics/JSON2YOLO) tool by Ultralytics. [Ultralytics Platform annotation](../platform/data/annotation.md) also supports pose labels with built-in skeleton templates for person, hand, face, and custom keypoint layouts.
 
 For custom pose estimation tasks, you can also explore specialized datasets like [Tiger-Pose](../datasets/pose/tiger-pose.md) for animal pose estimation, [Hand Keypoints](../datasets/pose/hand-keypoints.md) for hand tracking, or [Dog-Pose](../datasets/pose/dog-pose.md) for canine pose analysis.
 
@@ -240,7 +240,7 @@ model = YOLO("yolo26n-pose.pt")  # load a pretrained model (recommended for trai
 results = model.train(data="your-dataset.yaml", epochs=100, imgsz=640)
 ```
 
-For comprehensive details on training, refer to the [Train Section](#train). You can also use [Ultralytics Platform](https://platform.ultralytics.com) for a no-code approach to training custom pose estimation models.
+For comprehensive details on training, refer to the [Train Section](#train). You can also use [Ultralytics Platform cloud training](../platform/train/cloud-training.md) for a no-code approach to training custom pose estimation models.
 
 ### How do I validate a trained YOLO26-pose model?
 

--- a/docs/en/tasks/segment.md
+++ b/docs/en/tasks/segment.md
@@ -73,11 +73,11 @@ Train YOLO26n-seg on the COCO8-seg dataset for 100 [epochs](https://www.ultralyt
         yolo segment train data=coco8-seg.yaml model=yolo26n-seg.yaml pretrained=yolo26n-seg.pt epochs=100 imgsz=640
         ```
 
-See full `train` mode details in the [Train](../modes/train.md) page. Segmentation models can also be trained on cloud GPUs through [Ultralytics Platform](https://platform.ultralytics.com).
+See full `train` mode details in the [Train](../modes/train.md) page. Segmentation models can also be trained with [Ultralytics Platform cloud training](../platform/train/cloud-training.md).
 
 ### Dataset format
 
-YOLO segmentation dataset format can be found in detail in the [Dataset Guide](../datasets/segment/index.md). To convert your existing dataset from other formats (like COCO etc.) to YOLO format, please use [JSON2YOLO](https://github.com/ultralytics/JSON2YOLO) tool by Ultralytics. You can also create segmentation masks on [Ultralytics Platform](https://platform.ultralytics.com) using polygon tools and SAM-powered smart annotation.
+YOLO segmentation dataset format can be found in detail in the [Dataset Guide](../datasets/segment/index.md). To convert your existing dataset from other formats (like COCO etc.) to YOLO format, please use [JSON2YOLO](https://github.com/ultralytics/JSON2YOLO) tool by Ultralytics. You can also create segmentation masks with [Ultralytics Platform annotation](../platform/data/annotation.md) using polygon tools and SAM-powered smart annotation.
 
 ## Val
 

--- a/docs/en/tasks/semantic.md
+++ b/docs/en/tasks/semantic.md
@@ -83,11 +83,11 @@ Train YOLO26n-sem on the Cityscapes8 dataset for 100 [epochs](https://www.ultral
         yolo semantic train data=cityscapes8.yaml model=yolo26n-sem.yaml pretrained=yolo26n-sem.pt epochs=100 imgsz=1024
         ```
 
-See full `train` mode details in the [Train](../modes/train.md) page.
+See full `train` mode details in the [Train](../modes/train.md) page. Semantic segmentation models can also be trained with [Ultralytics Platform cloud training](../platform/train/cloud-training.md).
 
 ### Dataset format
 
-Semantic segmentation datasets use single-channel mask images, typically PNG, where each pixel value represents a class ID. Pixels with value 255 are treated as "ignore" and excluded from loss computation. The dataset YAML should specify paths to images and their corresponding mask directories. See the [Semantic Segmentation Dataset Guide](../datasets/semantic/index.md) for format details. Supported datasets include [Cityscapes](../datasets/semantic/cityscapes.md) and [ADE20K](../datasets/semantic/ade20k.md).
+Semantic segmentation datasets use single-channel mask images, typically PNG, where each pixel value represents a class ID. Pixels with value 255 are treated as "ignore" and excluded from loss computation. The dataset YAML should specify paths to images and their corresponding mask directories. See the [Semantic Segmentation Dataset Guide](../datasets/semantic/index.md) for format details. Supported datasets include [Cityscapes](../datasets/semantic/cityscapes.md) and [ADE20K](../datasets/semantic/ade20k.md). You can manage and label semantic datasets with [Ultralytics Platform annotation](../platform/data/annotation.md).
 
 ## Val
 

--- a/docs/en/yolov5/environments/docker-image-quickstart-tutorial.md
+++ b/docs/en/yolov5/environments/docker-image-quickstart-tutorial.md
@@ -119,7 +119,7 @@ Run `nvidia-ctk cdi list` to ensure the GPU CDI devices are available (the toolk
 nvidia-ctk cdi list
 ```
 
-You should see entries such as `nvidia.com/gpu=0` and `nvidia.com/gpu=all`. CDI device requests require Docker >= 28.2.0 and NVIDIA Container Toolkit >= 1.18; on older hosts, use the legacy `--runtime=nvidia --gpus all` flags instead.
+You should see entries such as `nvidia.com/gpu=0` and `nvidia.com/gpu=all`. CDI device requests require Docker >= 28.2.0 and NVIDIA Container Toolkit >= 1.18. The legacy `--gpus all` flag can lose GPU access after host daemon reloads, so upgrade older hosts and use `--device` instead.
 
 ## Step 1: Pull the YOLOv5 Docker Image
 

--- a/docs/en/yolov5/environments/docker-image-quickstart-tutorial.md
+++ b/docs/en/yolov5/environments/docker-image-quickstart-tutorial.md
@@ -39,36 +39,14 @@ Next, install the NVIDIA Container Toolkit. The commands below are typical for D
         | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
     ```
 
-    Update the package lists and install the nvidia-container-toolkit package:
+    Update the package lists and install the NVIDIA Container Toolkit:
 
     ```bash
     sudo apt-get update
     ```
 
-    Install Latest version of nvidia-container-toolkit:
-
     ```bash
-    sudo apt-get install -y nvidia-container-toolkit \
-      nvidia-container-toolkit-base libnvidia-container-tools \
-      libnvidia-container1
-    ```
-
-    ??? info "Optional: Install specific version of nvidia-container-toolkit"
-
-        Optionally, you can install a specific version of the nvidia-container-toolkit by setting the `NVIDIA_CONTAINER_TOOLKIT_VERSION` environment variable:
-
-        ```bash
-        export NVIDIA_CONTAINER_TOOLKIT_VERSION=1.18.1-1
-        sudo apt-get install -y \
-          nvidia-container-toolkit=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
-          nvidia-container-toolkit-base=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
-          libnvidia-container-tools=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
-          libnvidia-container1=${NVIDIA_CONTAINER_TOOLKIT_VERSION}
-        ```
-
-    ```bash
-    sudo nvidia-ctk runtime configure --runtime=docker
-    sudo systemctl restart docker
+    sudo apt-get install -y nvidia-container-toolkit
     ```
 
 === "RHEL/CentOS/Fedora/Amazon Linux"
@@ -78,37 +56,8 @@ Next, install the NVIDIA Container Toolkit. The commands below are typical for D
       | sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo
     ```
 
-    Update the package lists and install the nvidia-container-toolkit package:
-
     ```bash
-    sudo dnf clean expire-cache
-    sudo dnf check-update
-    ```
-
-    ```bash
-    sudo dnf install \
-      nvidia-container-toolkit \
-      nvidia-container-toolkit-base \
-      libnvidia-container-tools \
-      libnvidia-container1
-    ```
-
-    ??? info "Optional: Install specific version of nvidia-container-toolkit"
-
-        Optionally, you can install a specific version of the nvidia-container-toolkit by setting the `NVIDIA_CONTAINER_TOOLKIT_VERSION` environment variable:
-
-        ```bash
-        export NVIDIA_CONTAINER_TOOLKIT_VERSION=1.18.1-1
-        sudo dnf install -y \
-          nvidia-container-toolkit-${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
-          nvidia-container-toolkit-base-${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
-          libnvidia-container-tools-${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
-          libnvidia-container1-${NVIDIA_CONTAINER_TOOLKIT_VERSION}
-        ```
-
-    ```bash
-    sudo nvidia-ctk runtime configure --runtime=docker
-    sudo systemctl restart docker
+    sudo dnf install -y nvidia-container-toolkit
     ```
 
 ### Verify CDI Devices with Docker

--- a/docs/en/yolov5/environments/docker-image-quickstart-tutorial.md
+++ b/docs/en/yolov5/environments/docker-image-quickstart-tutorial.md
@@ -68,7 +68,7 @@ Run `nvidia-ctk cdi list` to ensure the GPU CDI devices are available (the toolk
 nvidia-ctk cdi list
 ```
 
-You should see entries such as `nvidia.com/gpu=0` and `nvidia.com/gpu=all`. CDI device requests require Docker >= 28.2.0 and NVIDIA Container Toolkit >= 1.18. The legacy `--gpus all` flag can lose GPU access after host daemon reloads, so upgrade older hosts and use `--device` instead.
+You should see entries such as `nvidia.com/gpu=0` and `nvidia.com/gpu=all`. On Linux, CDI device requests require Docker >= 28.2.0 and NVIDIA Container Toolkit >= 1.18. The legacy `--gpus all` flag can lose GPU access after host daemon reloads, so upgrade older Linux hosts and use `--device` instead.
 
 ## Step 1: Pull the YOLOv5 Docker Image
 


### PR DESCRIPTION
## Summary

- align Platform On Premise image references with the rolling `latest`, `latest-cpu`, and `latest-arm64` installer contract
- replace generic Platform homepage links with exact annotation, training, export, endpoint, deployment, monitoring, and integration destinations
- document all 13 actively published Docker images with Docker Hub and source Dockerfile links
- use CDI `--device` for Linux NVIDIA containers, retain Docker Desktop's supported Windows GPU reservation and Jetson's required NVIDIA runtime, and document each boundary
- backlink the Docker and Platform On Premise guides in both directions

## Validation

- strict documentation build: 632 pages, no issues
- Docker guide table matches all 13 active publish-matrix tags and Dockerfiles
- all 13 documented tags return successfully from the Docker Hub API
- all relative links in the 19 changed Markdown files resolve
- repository-pinned Prettier 3.6.2 formatting
- `git diff --check`

Deleted: three stale `8.4.100` image pins, the inactive Conda image listing, redundant and pinned NVIDIA Toolkit installation branches, legacy runtime registration and Docker restart steps, undefined Docker image-variable indirection, generic Platform homepage links, and the unsafe Linux `--gpus all` fallback command.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🐳 Updates Ultralytics Docker guidance and documentation to standardize NVIDIA GPU access with CDI, clarify available images, and improve links to Platform workflows.

### 📊 Key Changes

- Recommends Docker CDI GPU reservations using `--device nvidia.com/gpu=all` instead of legacy `--gpus all` on supported Linux systems.
- Documents CDI requirements: Docker 28.2.0 or newer and NVIDIA Container Toolkit 1.18 or newer.
- Explains that legacy GPU flags may lose access after host systemd daemon reloads, while CDI is more reliable for long-running containers and CI runners.
- Updates Docker examples for:
  - Standard GPU, export, Conda, and runner images.
  - DGX Spark and Jetson Thor hardware.
  - Jetson JetPack 4, 5, and 6 images.
- Renames Jetson-specific run examples for clearer platform identification.
- Simplifies NVIDIA Container Toolkit installation instructions across Docker and YOLOv5 documentation.
- Reworks the Docker Quickstart image section into a table covering CPU, GPU, ARM64, Jetson, export, Jupyter, and GitHub Actions runner images.
- Documents `latest` versus versioned Docker tags, recommending versioned tags for reproducible environments.
- Clarifies that NVIDIA GPU setup is optional and CPU images do not require NVIDIA hardware.
- Replaces broad [Ultralytics Platform](https://platform.ultralytics.com) links with more specific documentation for annotation, cloud training, model export, deployment, monitoring, and integrations.
- Adds guidance for self-hosting the Ultralytics web application through the Platform On-Premise guide.

### 🎯 Purpose & Impact

- 🚀 Improves GPU reliability for training, inference, export, and long-running CI workloads in Docker.
- 🛠️ Helps users choose the correct image for their hardware and use case more easily.
- 🔁 Makes Docker environments easier to reproduce by clearly distinguishing rolling `latest` tags from versioned releases.
- 📚 Makes setup instructions more accurate, concise, and easier to navigate for both CPU and GPU users.
- ☁️ Improves discoverability of Ultralytics Platform capabilities, including dataset annotation, cloud training, deployment, and monitoring.
- ⚠️ Linux users on older Docker or NVIDIA Container Toolkit versions may need to upgrade before using CDI-based GPU commands. Windows Docker Desktop continues to use its supported `--gpus all` workflow.