### PR TITLE
Sample validation results across F1 ranks

### DIFF
--- a/docs/en/reference/utils/callbacks/platform.md
+++ b/docs/en/reference/utils/callbacks/platform.md
@@ -24,6 +24,10 @@ keywords: platform callbacks, training callbacks, console logging, YOLO11 traini
 
 <br><br><hr><br>
 
+## ::: ultralytics.utils.callbacks.platform._validation_payload
+
+<br><br><hr><br>
+
 ## ::: ultralytics.utils.callbacks.platform._sanitize_json_value
 
 <br><br><hr><br>

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -771,25 +771,6 @@ def test_platform_job_transport(monkeypatch, tmp_path):
     }
 
 
-def test_platform_validation_payload():
-    """Test exact gallery extremes and bounded sampling across the full F1 rank distribution."""
-    from ultralytics.utils.callbacks import platform
-
-    image_metrics = {f"{i:032x}_image.jpg": {"f1": i / 9, "tp": i, "fp": 9 - i, "fn": 0} for i in range(10)}
-    validation = platform._validation_payload(image_metrics, sample_limit=5, extremes_limit=2)
-    assert validation["population"] == 10
-    assert validation["sampling"] == "f1_rank"
-    assert [row[1] for row in validation["rows"]] == [0, 2, 4, 7, 9]
-    assert [row[1] for row in validation["extremes"]["worst"]] == [0, 1]
-    assert [row[1] for row in validation["extremes"]["best"]] == [9, 8]
-
-    large = {f"{i:032x}.jpg": {"f1": i / 5_999, "tp": i, "fp": 0, "fn": 0} for i in range(6_000)}
-    bounded = platform._validation_payload(large)
-    assert len(bounded["rows"]) == 5_000
-    assert len(bounded["extremes"]["worst"]) == len(bounded["extremes"]["best"]) == 100
-    assert bounded["rows"][0][1] == 0 and bounded["rows"][-1][1] == 5_999
-
-
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")
 @pytest.mark.skipif(IS_JETSON or IS_RASPBERRYPI, reason="Edge devices not intended for training")
 def test_train_scratch():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -771,6 +771,25 @@ def test_platform_job_transport(monkeypatch, tmp_path):
     }
 
 
+def test_platform_validation_payload():
+    """Test exact gallery extremes and bounded sampling across the full F1 rank distribution."""
+    from ultralytics.utils.callbacks import platform
+
+    image_metrics = {f"{i:032x}_image.jpg": {"f1": i / 9, "tp": i, "fp": 9 - i, "fn": 0} for i in range(10)}
+    validation = platform._validation_payload(image_metrics, sample_limit=5, extremes_limit=2)
+    assert validation["population"] == 10
+    assert validation["sampling"] == "f1_rank"
+    assert [row[1] for row in validation["rows"]] == [0, 2, 4, 7, 9]
+    assert [row[1] for row in validation["extremes"]["worst"]] == [0, 1]
+    assert [row[1] for row in validation["extremes"]["best"]] == [9, 8]
+
+    large = {f"{i:032x}.jpg": {"f1": i / 5_999, "tp": i, "fp": 0, "fn": 0} for i in range(6_000)}
+    bounded = platform._validation_payload(large)
+    assert len(bounded["rows"]) == 5_000
+    assert len(bounded["extremes"]["worst"]) == len(bounded["extremes"]["best"]) == 100
+    assert bounded["rows"][0][1] == 0 and bounded["rows"][-1][1] == 5_999
+
+
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")
 @pytest.mark.skipif(IS_JETSON or IS_RASPBERRYPI, reason="Edge devices not intended for training")
 def test_train_scratch():

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -6,7 +6,6 @@ import re
 import socket
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from heapq import nlargest
 from math import isfinite
 from pathlib import Path
 from time import sleep, time
@@ -172,6 +171,25 @@ def _interp_plot(plot, n=101):
         result["ap"] = plot["ap"]  # Keep AP values as-is (per-class scalars)
 
     return result
+
+
+def _validation_payload(image_metrics, sample_limit=5_000, extremes_limit=100):
+    """Return exact F1 extremes and an evenly ranked sample for correlation analysis."""
+    ranked = sorted(image_metrics.items(), key=lambda item: (item[1]["f1"], item[0]))
+    if len(ranked) > sample_limit:
+        sample = [ranked[round(i * (len(ranked) - 1) / (sample_limit - 1))] for i in range(sample_limit)]
+    else:
+        sample = ranked
+
+    def rows(items):
+        return [[Path(name).stem.split("_", 1)[0], metric["tp"], metric["fp"], metric["fn"]] for name, metric in items]
+
+    return {
+        "population": len(ranked),
+        "sampling": "f1_rank",
+        "rows": rows(sample),
+        "extremes": {"worst": rows(ranked[:extremes_limit]), "best": rows(reversed(ranked[-extremes_limit:]))},
+    }
 
 
 def _sanitize_json_value(value):
@@ -555,18 +573,7 @@ def on_train_end(trainer):
     best_epoch = max(0, getattr(getattr(trainer, "stopper", None), "best_epoch", trainer.epoch + 1) - 1)
 
     image_metrics = trainer.validator.metrics.box.image_metrics if trainer.args.task == "detect" else {}
-    cohort = min(25_000, (len(image_metrics) + 1) // 2)
-    worst = nlargest(cohort, image_metrics.items(), key=lambda item: (-item[1]["f1"], item[1]["fp"] + item[1]["fn"]))
-    worst_names = {name for name, _ in worst}
-    best = nlargest(
-        cohort,
-        ((name, metric) for name, metric in image_metrics.items() if name not in worst_names),
-        key=lambda item: (item[1]["f1"], item[1]["tp"]),
-    )
-    rows = [
-        [Path(name).stem.split("_", 1)[0], metric["tp"], metric["fp"], metric["fn"]] for name, metric in worst + best
-    ]
-    validation = {"population": len(image_metrics), "rows": rows}
+    validation = _validation_payload(image_metrics)
     _send(
         "training_complete",
         {
@@ -574,7 +581,7 @@ def on_train_end(trainer):
                 "metrics": {**trainer.metrics, "fitness": trainer.fitness},
                 "bestEpoch": best_epoch,
                 "bestFitness": trainer.best_fitness,
-                **({"validation": validation} if rows else {}),
+                **({"validation": validation} if validation["rows"] else {}),
                 **(artifact or {}),
             },
             "classNames": class_names,


### PR DESCRIPTION
## Summary

- replace the 25,000-lowest/25,000-highest correlation payload with at most 5,000 rows selected at even ranks across the full per-image F1 distribution
- retain exact worst 100 and best 100 cohorts separately for visual inspection
- identify the rank-sampling contract so Platform can distinguish it from legacy tail-only results
- extend the existing Platform callback test with exact cohort, rank coverage, endpoint, and size-bound assertions

## Core Principles

Deleted: the two 25,000-row heap selections, their exclusion set, the 50,000-row tail payload, and the now-unused `heapq.nlargest` import.

Reused: the existing final-validator `image_metrics`, `training_complete` callback, compact `[hash, TP, FP, FN]` row format, and one payload. The new fields are required because gallery extremes and an unbiased correlation sample have different selection semantics and cannot truthfully share one row set.

## Validation

- `ruff format --check ultralytics/utils/callbacks/platform.py tests/test_python.py`
- `ruff check ultralytics/utils/callbacks/platform.py tests/test_python.py`
- `python -m pytest tests/test_python.py -k platform -q` — 3 passed
- `git diff --check`

## Dependent consumer

- ultralytics/portal#2955

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📈 Improves training validation data sent to the Ultralytics Platform with deterministic F1-ranked sampling and clearer best/worst image metrics.

### 📊 Key Changes

- Added a new `_validation_payload` helper to organize per-image validation metrics.
- Replaced the previous worst/best image selection logic with:
  - Evenly distributed sampling across F1-ranked results, capped at 5,000 images.
  - Up to 100 exact worst and best examples.
  - Deterministic ordering for consistent analysis.
- Included sampling metadata and total validation population size in the payload.
- Documented `_validation_payload` in the platform callback API reference.
- Removed the previous `heapq.nlargest` dependency from the callback module.

### 🎯 Purpose & Impact

- 🔍 Provides the Platform with a more representative view of validation performance, especially for large datasets.
- 📊 Preserves detailed examples of the strongest and weakest predictions for easier error analysis.
- ⚡ Limits payload size while retaining useful dataset-wide trends.
- ✅ Produces stable, reproducible validation reports across training runs.
- 🛡️ Maintains compatibility by sending validation data only when image metrics are available.