### PR TITLE
Document Platform Slack alerts

### DIFF
--- a/docs/en/platform/account/settings.md
+++ b/docs/en/platform/account/settings.md
@@ -305,6 +305,7 @@ The `Integrations` tab lets you import datasets and projects from external servi
 
 - **Ultralytics HUB** — import your existing datasets and projects from [Ultralytics HUB](../integrations/ultralytics-hub.md).
 - **Roboflow** — import annotated datasets from a [Roboflow](../integrations/roboflow.md) workspace using a Roboflow API key.
+- **Slack** — send selected training, export, and deployment results to a [Slack channel](../integrations/slack.md).
 - **On Premise** — connect Enterprise CPU/GPU workers and keep dataset pixels on your own host. See [On Premise](../integrations/on-premise.md).
 - **Weights & Biases** — experiment-tracking sync (coming soon).
 

--- a/docs/en/platform/deploy/endpoints.md
+++ b/docs/en/platform/deploy/endpoints.md
@@ -62,6 +62,8 @@ stateDiagram-v2
     class Stopped extern
 ```
 
+Connect [Slack alerts](../integrations/slack.md) to receive a message when a deployment becomes ready or fails to start.
+
 ### Region Selection
 
 Choose from 42 regions worldwide. The interactive region map and table show:

--- a/docs/en/platform/integrations/index.md
+++ b/docs/en/platform/integrations/index.md
@@ -2,13 +2,13 @@
 plans: [free, pro, enterprise]
 title: Platform Integrations
 comments: true
-description: Connect Ultralytics Platform to existing tools, cloud storage, and Enterprise On Premise compute and datasets.
-keywords: Ultralytics Platform, integrations, data import, Roboflow, Ultralytics HUB, cloud storage, GCS, Amazon S3, Azure Blob Storage, On Premise, dataset migration, YOLO, computer vision
+description: Connect Ultralytics Platform to Slack, existing tools, cloud storage, and Enterprise On Premise compute and datasets.
+keywords: Ultralytics Platform, integrations, Slack, alerts, data import, Roboflow, Ultralytics HUB, cloud storage, GCS, Amazon S3, Azure Blob Storage, On Premise, dataset migration, YOLO, computer vision
 ---
 
 # Integrations
 
-[Ultralytics Platform](https://platform.ultralytics.com) [integrations](../../integrations/index.md) connect your workspace to other tools and services you already use. Import existing datasets with a single API key, or connect your cloud storage and use the data where it lives — no manual export or re-upload either way.
+[Ultralytics Platform](https://platform.ultralytics.com) [integrations](../../integrations/index.md) connect your workspace to other tools and services you already use. Send job results to Slack, import existing datasets with a single API key, or connect your cloud storage and use the data where it lives.
 
 ![Ultralytics Platform Settings Integrations Tab](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/settings-integrations-tab.avif)
 
@@ -18,21 +18,22 @@ All integrations are managed from your account settings:
 
 1. Go to **Settings > Integrations**
 2. Find the card for the service you want to connect
-3. Paste your API key or storage credential and follow the prompts
+3. Follow the connection prompts
 
 Imports start with a preview so you can review exactly what will be transferred — and confirm you have enough [storage](../account/billing.md) — before anything is imported. Cloud storage connections verify list and read access before anything is saved.
 
 ## Available Integrations
 
-| Integration                                         | What it brings in                                    |
-| --------------------------------------------------- | ---------------------------------------------------- |
-| [**Ultralytics HUB**](ultralytics-hub.md)           | Your datasets, projects, models, and account balance |
-| [**Roboflow**](roboflow.md)                         | Your datasets                                        |
-| [**Google Cloud Storage**](google-cloud-storage.md) | Datasets indexed in place from your GCS buckets      |
-| [**Amazon S3**](amazon-s3.md)                       | Datasets indexed in place from your S3 buckets       |
-| [**Azure Blob Storage**](azure-blob-storage.md)     | Datasets indexed in place from your blob containers  |
-| [**On Premise**](on-premise.md)                     | Local CPU/GPU workers with pixels kept on your host  |
+| Integration                                         | What it does                                        |
+| --------------------------------------------------- | --------------------------------------------------- |
+| [**Slack**](slack.md)                               | Posts selected job results to one Slack channel     |
+| [**Ultralytics HUB**](ultralytics-hub.md)           | Imports datasets, projects, models, and balance     |
+| [**Roboflow**](roboflow.md)                         | Imports datasets                                    |
+| [**Google Cloud Storage**](google-cloud-storage.md) | Indexes datasets in place from your GCS buckets     |
+| [**Amazon S3**](amazon-s3.md)                       | Indexes datasets in place from your S3 buckets      |
+| [**Azure Blob Storage**](azure-blob-storage.md)     | Indexes datasets in place from your blob containers |
+| [**On Premise**](on-premise.md)                     | Runs local CPU/GPU workers while pixels stay local  |
 
-Connect once and the matching content lands in your workspace. Google Cloud Storage, Amazon S3, and Azure Blob Storage connections require a [Pro or Enterprise plan](../account/billing.md#plans).
+Slack alerts are available on every plan. Google Cloud Storage, Amazon S3, and Azure Blob Storage connections require a [Pro or Enterprise plan](../account/billing.md#plans).
 
 A **Weights & Biases** integration is coming soon to sync training runs, metrics, and artifacts with your W&B workspace.

--- a/docs/en/platform/integrations/slack.md
+++ b/docs/en/platform/integrations/slack.md
@@ -17,7 +17,7 @@ You do not need a Slack API key, webhook, or technical setup. Before you start, 
 1. Open [**Settings > Integrations**](https://platform.ultralytics.com/settings?tab=integrations) and find the **Slack** card.
 2. Click **Add to Slack**.
 3. Read the short setup summary and click **Continue to Slack**.
-4. Choose a channel and click **Allow**. Platform requests permission to post only to that channel.
+4. Choose a channel and click **Allow**. Platform requests permission to post only to that channel. If Slack shows **Request approval**, send the request and ask your Slack workspace admin to approve the app.
 5. You are done. All six alerts are enabled; to change them, clear the alerts you do not want and click **Save alerts**.
 
 Platform posts a confirmation in the selected channel as soon as the connection succeeds. Workspace admins manage the connection and alert choices for the whole workspace from the [Integrations tab](../account/settings.md#integrations-tab).
@@ -37,7 +37,7 @@ Platform posts a confirmation in the selected channel as soon as the connection 
 | **Deployment ready**  | A [deployment](../deploy/endpoints.md#deployment-lifecycle) is ready           |
 | **Deployment failed** | A deployment fails to start                                                    |
 
-Each message says what finished and includes a direct link to the related model or deployment in Platform. Failed-job alerts include a short error summary when one is available. Slack delivery does not change the result of the training, export, or deployment; Platform remains the source of truth, and you can review recent events in [Activity](../account/activity.md).
+Each message says what finished and includes a direct link to the related model or deployment in Platform. Failed-job alerts include a short error summary when one is available. Slack delivery does not change the result of the training, export, or deployment. Review the current result from the model's [training](../train/cloud-training.md#monitor-training) or [export](../train/models.md#export-model) page, or from the [Deployments page](../deploy/index.md#deployments-page).
 
 ## Change or Disconnect Slack
 
@@ -48,8 +48,9 @@ To use a different channel, click **Disconnect**, then connect Slack again and c
 ## Troubleshooting
 
 - **The Slack card says an admin must connect it:** ask a Platform workspace admin or owner to complete the connection.
+- **Slack shows Request approval instead of Allow:** send the request and ask your Slack workspace admin to approve the app. You do not need to create an API key or webhook.
 - **Your Slack workspace or channel is missing:** confirm that you are signed in to the correct Slack workspace and that you can add apps to the channel.
 - **The connection worked, but alerts stopped:** reconnect Slack to refresh the channel permission. This is usually needed if the app permission was revoked or the channel was removed.
-- **A job finished without a Slack message:** check the selected alerts in **Settings > Integrations**, then confirm the job result in [Platform Activity](../account/activity.md). Slack alerts are informational and never control job processing.
+- **A job finished without a Slack message:** check the selected alerts in **Settings > Integrations**, then open the related [model](../train/models.md) or [deployment](../deploy/index.md) in Platform. Slack alerts are informational and never control job processing.
 
 Return to the [Platform integrations overview](index.md) to connect data, storage, or On Premise services.

--- a/docs/en/platform/integrations/slack.md
+++ b/docs/en/platform/integrations/slack.md
@@ -1,0 +1,55 @@
+---
+plans: [free, pro, enterprise]
+comments: true
+description: Connect Slack to Ultralytics Platform and choose which training, export, and deployment results are posted to your channel.
+keywords: Ultralytics Platform, Slack, alerts, notifications, training, model export, deployment, YOLO, computer vision
+title: Slack Alerts - Ultralytics Platform
+---
+
+# Slack Integration
+
+Connect [Slack](https://slack.com) to [Ultralytics Platform](https://platform.ultralytics.com) to learn when long-running work finishes without keeping Platform open. You choose one Slack channel and the results that matter to your workspace.
+
+You do not need a Slack API key, webhook, or technical setup. Before you start, sign in to Slack and decide which channel should receive Platform alerts. If you use a team workspace in Platform, you must be a workspace admin or owner.
+
+## Connect Slack
+
+1. Open [**Settings > Integrations**](https://platform.ultralytics.com/settings?tab=integrations) and find the **Slack** card.
+2. Click **Add to Slack**.
+3. Read the short setup summary and click **Continue to Slack**.
+4. Choose a channel and click **Allow**. Platform requests permission to post only to that channel.
+5. You are done. All six alerts are enabled; to change them, clear the alerts you do not want and click **Save alerts**.
+
+Platform posts a confirmation in the selected channel as soon as the connection succeeds. Workspace admins manage the connection and alert choices for the whole workspace from the [Integrations tab](../account/settings.md#integrations-tab).
+
+!!! info "What Slack Allows"
+
+    Slack lets Platform post messages to the channel you choose. Platform cannot read your Slack messages or post to other channels through this connection.
+
+## Available Alerts
+
+| Alert                 | When it is sent                                                                |
+| --------------------- | ------------------------------------------------------------------------------ |
+| **Training complete** | A model [finishes training](../train/cloud-training.md#training-job-lifecycle) |
+| **Training failed**   | A training run stops with an error                                             |
+| **Export complete**   | A [model export](../train/models.md#export-model) is ready                     |
+| **Export failed**     | A model export stops with an error                                             |
+| **Deployment ready**  | A [deployment](../deploy/endpoints.md#deployment-lifecycle) is ready           |
+| **Deployment failed** | A deployment fails to start                                                    |
+
+Each message says what finished and includes a direct link to the related model or deployment in Platform. Failed-job alerts include a short error summary when one is available. Slack delivery does not change the result of the training, export, or deployment; Platform remains the source of truth, and you can review recent events in [Activity](../account/activity.md).
+
+## Change or Disconnect Slack
+
+To change which results are posted, check or uncheck alerts and click **Save alerts**. At least one alert must remain selected.
+
+To use a different channel, click **Disconnect**, then connect Slack again and choose the new channel. Disconnecting stops all Slack alerts immediately and does not affect Platform jobs or resources.
+
+## Troubleshooting
+
+- **The Slack card says an admin must connect it:** ask a Platform workspace admin or owner to complete the connection.
+- **Your Slack workspace or channel is missing:** confirm that you are signed in to the correct Slack workspace and that you can add apps to the channel.
+- **The connection worked, but alerts stopped:** reconnect Slack to refresh the channel permission. This is usually needed if the app permission was revoked or the channel was removed.
+- **A job finished without a Slack message:** check the selected alerts in **Settings > Integrations**, then confirm the job result in [Platform Activity](../account/activity.md). Slack alerts are informational and never control job processing.
+
+Return to the [Platform integrations overview](index.md) to connect data, storage, or On Premise services.

--- a/docs/en/platform/train/cloud-training.md
+++ b/docs/en/platform/train/cloud-training.md
@@ -151,6 +151,8 @@ Training jobs progress through the following statuses:
 | **Failed**    | Training failed (see console logs for details)       |
 | **Cancelled** | Training was cancelled by the user                   |
 
+To receive the completed and failed results without keeping this page open, connect [Slack alerts](../integrations/slack.md).
+
 !!! success "Free Credits"
 
     New accounts receive signup credits — $5 for personal emails and $25 for company emails. [Check your balance](../account/billing.md) in Settings > Billing.

--- a/docs/en/platform/train/models.md
+++ b/docs/en/platform/train/models.md
@@ -207,6 +207,8 @@ Export your model to 19+ deployment formats:
 5. Click **Export**
 6. Download when complete
 
+Connect [Slack alerts](../integrations/slack.md) to receive a message when an export is ready or fails.
+
 ![Ultralytics Platform Model Export Tab Format List](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-model-export-tab-format-list.avif)
 
 ### Supported Formats

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -656,6 +656,7 @@ nav:
           - Monitoring: platform/deploy/monitoring.md
       - Integrations:
           - platform/integrations/index.md
+          - Slack: platform/integrations/slack.md
           - Ultralytics HUB: platform/integrations/ultralytics-hub.md
           - Roboflow: platform/integrations/roboflow.md
           - Google Cloud Storage: platform/integrations/google-cloud-storage.md


### PR DESCRIPTION
## Summary
- add a non-technical Slack alerts guide with a five-step connection flow, permission explanation, alert reference, channel changes, and troubleshooting
- link the guide from Platform settings, the integrations overview, training lifecycle, model exports, and deployment lifecycle
- add Slack to the Platform integrations navigation

Companion feature: ultralytics/portal#2956

## Validation
- `npx prettier@3.6.2 --tab-width 4 --print-width 120 --write <changed docs>`
- `npx prettier@3.6.2 --print-width 120 --write mkdocs.yml`
- `mkdocs build` (succeeds; existing comparison-nav and reference-anchor warnings remain)
- `git diff --check`

Deleted: replaced integration-index copy and its import-only table wording so the shared overview accurately covers both notifications and data integrations. Reused the existing Platform integrations page, Settings documentation, lifecycle sections, and MkDocs navigation rather than adding a second setup surface.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📣 Adds comprehensive documentation for connecting Ultralytics Platform to Slack and receiving job-result alerts.

### 📊 Key Changes

- Added a new Slack integration guide covering:
  - Connecting Slack without an API key or webhook.
  - Selecting a channel and managing alert preferences.
  - Changing or disconnecting the integration.
  - Troubleshooting common setup issues.
- Documented six configurable alerts:
  - Training completed or failed.
  - Model export completed or failed.
  - Deployment ready or failed.
- Added Slack to the Platform integrations overview and navigation.
- Linked Slack alert guidance from training, model export, deployment, and account settings documentation.
- Clarified that Slack alerts are available on all plans and only allow Ultralytics Platform to post to the selected channel.

### 🎯 Purpose & Impact

- 🔔 Users can monitor long-running training, export, and deployment jobs without keeping Ultralytics Platform open.
- ⚙️ Workspace admins can configure alerts centrally and choose which notifications their team receives.
- 🔒 The integration follows a limited-permission model: Platform can post to one selected channel but cannot read messages or post elsewhere.
- 📚 Improves discoverability and setup guidance for Slack notifications across the Platform documentation.