### PR TITLE
Warn when RKNN export lowers a user-specified opset

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1400,6 +1400,8 @@ class Exporter:
         """Export YOLO model to RKNN format with optional INT8 quantization."""
         from ultralytics.utils.export.rknn import onnx2rknn
 
+        if self.args.opset and self.args.opset > 19:
+            LOGGER.warning(f"{prefix} rknn-toolkit2 requires opset<=19, setting opset=19.")
         self.args.opset = min(self.args.opset or 19, 19)  # rknn-toolkit expects opset<=19
         self.im = self.im[:1]  # RKNN Toolkit expands the batch after calibrating the batch-1 ONNX model
         f_onnx = self.export_onnx()


### PR DESCRIPTION
## Summary

`export_rknn()` silently caps `opset>19` down to 19 (a hard rknn-toolkit2 constraint). A user who explicitly passes e.g. `opset=21` gets an opset-19 model with no indication that their argument was overridden. This PR logs a warning before lowering:

```
WARNING ⚠️ RKNN: rknn-toolkit2 requires opset<=19, setting opset=19.
```

The message follows the existing in-method exporter warning conventions (format prefix + "requires X, setting Y" phrasing, matching the IMX/Edge TPU warnings). No warning is emitted when `opset` is unset or already <=19.

Deleted: nothing — the opset cap itself is a hard rknn-toolkit2 constraint that must stay; this purely additive 2-line change only surfaces the previously silent override, so there was no code to delete or relocate.

## Test

`yolo export model=yolo26n.pt format=rknn opset=21` → warning printed, export proceeds at opset 19. Default `opset` (unset) and `opset<=19` produce no warning. `ruff format` / `ruff check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Warn users when RKNN export reduces a requested ONNX opset to the maximum supported opset 19.

### 📊 Key Changes
- Adds a warning when `self.args.opset` is explicitly set above 19 during RKNN export.
- Retains the existing behavior of clamping the RKNN export opset to 19.

### 🎯 Purpose & Impact
- Improves transparency by informing users why their requested opset is not used.
- Helps prevent confusion and makes RKNN export behavior easier to diagnose.
- Does not change the resulting RKNN compatibility logic or affect requests for opset 19 and below.