### PR TITLE
Warn when RKNN export lowers a user-specified opset

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1400,6 +1400,8 @@ class Exporter:
         """Export YOLO model to RKNN format with optional INT8 quantization."""
         from ultralytics.utils.export.rknn import onnx2rknn
 
+        if self.args.opset and self.args.opset > 19:
+            LOGGER.warning(f"{prefix} rknn-toolkit2 requires opset<=19, setting opset=19.")
         self.args.opset = min(self.args.opset or 19, 19)  # rknn-toolkit expects opset<=19
         self.im = self.im[:1]  # RKNN Toolkit expands the batch after calibrating the batch-1 ONNX model
         f_onnx = self.export_onnx()


### PR DESCRIPTION
## Summary

`export_rknn()` silently caps `opset>19` down to 19, a hard rknn-toolkit2 constraint. A user who explicitly passes e.g. `opset=21` gets an opset-19 model with no indication that their argument was overridden. This PR logs a warning before lowering:

```
WARNING ⚠️ RKNN: rknn-toolkit2 requires opset<=19, setting opset=19.
```

The message follows the existing in-method exporter warning conventions (format prefix + "requires X, setting Y" phrasing, matching the IMX and Edge TPU warnings). No warning is emitted when `opset` is unset or already <=19.

Deleted: nothing — the opset cap itself is a required rknn-toolkit2 constraint, and this purely additive 2-line change only surfaces the previously silent override, so there was no code to delete or relocate.

## Test
- `yolo export model=yolo26n.pt format=rknn opset=21` → warning printed once, export proceeds at opset 19.
- Default `opset` (unset) and `opset<=19` → no warning.
- `ruff format` / `ruff check` pass.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Warn users when RKNN export must lower a user-specified ONNX opset to meet RKNN Toolkit requirements.

### 📊 Key Changes
- Adds a warning when `opset` is explicitly set above 19 during RKNN export.
- Preserves the existing behavior of limiting RKNN exports to opset 19 or lower.

### 🎯 Purpose & Impact
- Makes automatic opset adjustment visible to users and improves export transparency.
- Helps prevent confusion when the requested opset cannot be supported by `rknn-toolkit2`.
- Applies only to RKNN exports and does not change supported behavior for other export formats.