### PR TITLE
Bump actions/setup-python from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         model: [yolo26n]
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         if: matrix.os != 'cpu-latest'
         with:
           python-version: ${{ matrix.python }}
@@ -150,7 +150,7 @@ jobs:
             torchvision: "0.9.0"
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         if: matrix.os != 'cpu-latest'
         with:
           python-version: ${{ matrix.python }}
@@ -304,7 +304,7 @@ jobs:
             torchvision: "0.26.0"
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         if: matrix.os != 'cpu-latest'
         with:
           python-version: ${{ matrix.python }}
@@ -371,7 +371,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
       - uses: ultralytics/actions/setup-uv@main

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -56,7 +56,7 @@ jobs:
         shell: bash # multi-line run blocks and ${GITHUB_WORKSPACE} expansion on all three OSes
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
       - uses: ultralytics/actions/setup-uv@main

--- a/.github/workflows/merge-main-into-prs.yml
+++ b/.github/workflows/merge-main-into-prs.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.repository == 'ultralytics/ultralytics'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
       - name: Install requirements

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       previous_tag: ${{ steps.check_pypi.outputs.previous_tag }}
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
       - uses: ultralytics/actions/setup-uv@main
@@ -73,7 +73,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
       - uses: ultralytics/actions/setup-uv@main
@@ -133,7 +133,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
       - uses: ultralytics/actions/setup-uv@main


### PR DESCRIPTION
Bump actions/setup-python from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔧 Updates GitHub Actions workflows to use `actions/setup-python@v7` consistently.

### 📊 Key Changes

- Replaced `actions/setup-python@v6` with `actions/setup-python@v7` across:
  - Continuous integration (`ci.yml`)
  - Fuzz testing (`fuzz.yml`)
  - Main-branch synchronization (`merge-main-into-prs.yml`)
  - Package publishing (`publish.yml`)
- No changes were made to Ultralytics runtime code, models, or user-facing APIs.

### 🎯 Purpose & Impact

- 🚀 Keeps the project’s automation workflows aligned with the latest supported Python setup action.
- ✅ Improves consistency across testing, fuzzing, merging, and release pipelines.
- 📦 Helps maintain reliable Python environment setup for development and package publishing.
- 👥 No direct impact on users running YOLO26 or other Ultralytics models; benefits are primarily for contributors and maintainers.