### PR TITLE
Follow HTTP 308 redirects in autocast_list URL sources

### DIFF
--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -642,12 +642,10 @@ def autocast_list(source: list[Any]) -> list[Image.Image | np.ndarray]:
     files = []
     for im in source:
         if isinstance(im, (str, Path)):  # filename or uri
-            if str(im).startswith("http"):  # requests follows HTTP 308 redirects that urllib drops before Python 3.11
+            if str(im).startswith("http"):  # requests follows HTTP 308 redirects that urllib lacks pre-3.11
                 import requests  # scoped as slow import
 
-                response = requests.get(im)
-                response.raise_for_status()
-                im = BytesIO(response.content)
+                im = BytesIO(requests.get(im).content)
             files.append(ImageOps.exif_transpose(Image.open(im)))
         elif isinstance(im, (Image.Image, np.ndarray)):  # PIL or np Image
             files.append(im)

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -8,6 +8,7 @@ import os
 import time
 import urllib
 from dataclasses import dataclass
+from io import BytesIO
 from pathlib import Path
 from threading import Thread
 from typing import Any
@@ -641,9 +642,13 @@ def autocast_list(source: list[Any]) -> list[Image.Image | np.ndarray]:
     files = []
     for im in source:
         if isinstance(im, (str, Path)):  # filename or uri
-            files.append(
-                ImageOps.exif_transpose(Image.open(urllib.request.urlopen(im) if str(im).startswith("http") else im))
-            )
+            if str(im).startswith("http"):  # requests follows HTTP 308 redirects that urllib drops before Python 3.11
+                import requests  # scoped as slow import
+
+                response = requests.get(im)
+                response.raise_for_status()
+                im = BytesIO(response.content)
+            files.append(ImageOps.exif_transpose(Image.open(im)))
         elif isinstance(im, (Image.Image, np.ndarray)):  # PIL or np Image
             files.append(im)
         else:


### PR DESCRIPTION
## summary

`autocast_list` loaded list-of-URL predict sources (`model(["https://ultralytics.com/images/bus.jpg"])`) with a bare `urllib.request.urlopen`, which raises an uncaught `HTTPError` on any HTTP 308 redirect on Python 3.8-3.10 (urllib gained 308 support only in 3.11). This swaps the HTTP branch to a single scoped `requests.get(im).content` read (the same library the download path already uses), so 308-serving sources are followed on every supported Python. Failures still surface: network errors raise from `requests` with the URL named, and non-image responses raise from `PIL.Image.open`.

Verified empirically: plain URLs load, an `httpbin.org` 308 redirect to `zidane.jpg` is followed and decodes to the correct 1280x720 image, and mixed path/PIL/ndarray list sources are unchanged.

Deleted: the bare `urllib.request.urlopen` HTTP call in `autocast_list`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves remote image loading by using `requests` to handle HTTP redirects reliably. 🔗

### 📊 Key Changes

- Added `BytesIO` to convert downloaded image content into an in-memory file.
- Updated `autocast_list` to download HTTP images with `requests`.
- Preserved EXIF orientation correction with `ImageOps.exif_transpose`.
- Imports `requests` only when a remote URL is processed, minimizing startup overhead.

### 🎯 Purpose & Impact

- ✅ Supports HTTP 308 redirects that older `urllib` versions may not follow correctly.
- 🌐 Makes loading images from remote URLs more reliable.
- ⚡ Keeps local file and in-memory image handling unchanged.
- 📦 Adds a runtime dependency on `requests` for HTTP image inputs.