### PR TITLE
Faster `ModelEMA` update with batched `_foreach_lerp_`

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -222,7 +222,8 @@ class BaseModel(torch.nn.Module):
             thop = None  # conda support without 'ultralytics-thop' installed
 
         c = m == self.model[-1] and isinstance(x, list)  # is final layer list, copy input as inplace fix
-        flops = thop.profile(m, inputs=[x.copy() if c else x], verbose=False)[0] / 1e9 * 2 if thop else 0  # GFLOPs
+        # profile a copy: thop leaves float64 total_ops/total_params buffers on modules, incl. the shared default_act
+        flops = thop.profile(deepcopy(m), inputs=[x.copy() if c else x], verbose=False)[0] / 1e9 * 2 if thop else 0
         t = time_sync()
         for _ in range(10):
             m(x.copy() if c else x)

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -746,9 +746,9 @@ class ModelEMA:
                 if v.dtype.is_floating_point:  # true for FP16 and FP32
                     ema_v.append(v)
                     model_v.append(msd[k].detach())
-            if TORCH_2_4 and ema_v:  # single batched kernel launch per op instead of one per tensor
+            if ema_v and TORCH_2_0 and (TORCH_2_4 or ema_v[0].device.type != "mps"):  # one kernel launch per op
                 torch._foreach_lerp_(ema_v, model_v, 1 - d)
-            else:  # foreach ops lack MPS support before torch 2.4
+            else:  # _foreach_lerp_ requires torch>=2.0 and, on MPS, torch>=2.4
                 for v, m in zip(ema_v, model_v):
                     v.lerp_(m, 1 - d)
 

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -745,12 +745,12 @@ class ModelEMA:
             for k, v in self.ema.state_dict().items():
                 if v.dtype.is_floating_point:  # true for FP16 and FP32
                     ema_v.append(v)
-                    model_v.append(msd[k].detach())
+                    model_v.append(msd[k])
             if ema_v and TORCH_2_0 and (TORCH_2_4 or ema_v[0].device.type != "mps"):  # one kernel launch per op
                 torch._foreach_lerp_(ema_v, model_v, 1 - d)
-            else:  # _foreach_lerp_ requires torch>=2.0 and, on MPS, torch>=2.4
+            else:  # _foreach_lerp_ needs torch>=2.0 and, on MPS, torch>=2.4
                 for v, m in zip(ema_v, model_v):
-                    v.lerp_(m, 1 - d)
+                    v.mul_(d).add_(m, alpha=1 - d)
 
     def update_attr(self, model, include=(), exclude=("process_group", "reducer")):
         """Copy attributes from model to EMA, with options to include/exclude certain attributes.

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -741,11 +741,16 @@ class ModelEMA:
             d = self.decay(self.updates)
 
             msd = unwrap_model(model).state_dict()  # model state_dict
+            ema_v, model_v = [], []
             for k, v in self.ema.state_dict().items():
                 if v.dtype.is_floating_point:  # true for FP16 and FP32
-                    v *= d
-                    v += (1 - d) * msd[k].detach()
-                    # assert v.dtype == msd[k].dtype == torch.float32, f'{k}: EMA {v.dtype},  model {msd[k].dtype}'
+                    ema_v.append(v)
+                    model_v.append(msd[k].detach())
+            if TORCH_2_4 and ema_v:  # single batched kernel launch per op instead of one per tensor
+                torch._foreach_lerp_(ema_v, model_v, 1 - d)
+            else:  # foreach ops lack MPS support before torch 2.4
+                for v, m in zip(ema_v, model_v):
+                    v.lerp_(m, 1 - d)
 
     def update_attr(self, model, include=(), exclude=("process_group", "reducer")):
         """Copy attributes from model to EMA, with options to include/exclude certain attributes.


### PR DESCRIPTION
## summary

`ModelEMA.update()` ran a Python loop with two in-place ops per state-dict tensor on every optimizer step, so for yolo26n that is 594 float tensors and ~1188 tiny kernel launches per step. The update now collects the float tensors once and applies a single batched `torch._foreach_lerp_` (the same op PyTorch's `swa_utils.get_ema_multi_avg_fn` and timm's `ModelEmaV3` use for EMA), gated on `TORCH_2_0` for op availability and on `TORCH_2_4` for MPS only, while other configurations keep the original per-tensor `mul_`/`add_` math as the fallback.

The gate was verified empirically on real installs of torch 2.0.1, 2.2.2, 2.10.0, and 2.13.0: `_foreach_lerp_` ships in torch 2.0.0 and works on CPU across all four, raises `NotImplementedError` on MPS through 2.2.2 (MPS dispatch lands in 2.4), and works on MPS on the newer builds. On torch 2.0.1 the actual `ModelEMA.update()` was run on both devices: CPU takes the batched path and matches the legacy loop to 1e-6, MPS takes the fallback and matches bit-for-bit.

Instrumented training on Apple M-series (yolo26n, coco8): EMA update 12.8 to 5.8 ms per step (2.2x); larger gains expected on CUDA where the loop is launch-bound. Deterministic seeded 2-epoch training gives identical final mAP50-95 (0.4531983722) before and after; 1000-step trajectory tests show only ulp-level rounding differences with no drift. Checkpoint layout is unchanged.

The CI `test_train_scratch` failure this PR initially hit exposed a pre-existing state leak: `BaseModel._profile_one_layer` ran `thop.profile` on live modules, and thop registers float64 `total_ops`/`total_params` buffers it never removes. Those buffers land on the class-level `Conv.default_act` activation singleton shared by every model in the process, so after any `predict(profile=True)` call every subsequently built model carries float64 buffers in its `state_dict()` (105 for yolo26n) and in its saved checkpoints. The old EMA loop silently downcast those mismatched pairs each step, while `_foreach_lerp_` is strict about dtype and surfaced the mismatch (in-training validation calls `.float()` on the EMA but the live model keeps the float64 buffers). Fixed at the source: `_profile_one_layer` now profiles a `deepcopy` of the layer, matching how `get_flops` and `profile_ops` already call thop for exactly this reason, which also keeps profiled models and their checkpoints free of thop buffers.

Deleted: the per-tensor update statements in the state-dict loop, a stale commented-out dtype assert, a redundant `.detach()` on state-dict tensors (`state_dict()` already returns detached tensors), and the live-module `thop.profile` call in `_profile_one_layer`. Net +6 lines because the version gate with its fallback branch is required for torch<2.4 MPS and torch<2.0 compatibility, which rules out a pure deletion.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

⚡ Improves model profiling reliability and speeds up Exponential Moving Average (EMA) updates during training.

### 📊 Key Changes

- 🧪 Profiles a deep copy of each model layer with `thop` to prevent profiling buffers from modifying shared modules, including the default activation function.
- 🚀 Optimizes EMA parameter updates using `torch._foreach_lerp_` when supported by the PyTorch version and device.
- 🔄 Retains a compatible fallback implementation for older PyTorch versions and MPS devices that do not support the optimized operation.

### 🎯 Purpose & Impact

- ✅ Prevents profiling from leaving unwanted `float64` buffers on model modules, improving correctness and stability.
- ⏱️ Reduces the overhead of EMA updates by processing parameters with fewer kernel launches.
- 🍎 Maintains compatibility across supported PyTorch versions and Apple MPS hardware.
- 📈 Can improve training efficiency without changing model behavior or EMA results.