### PR TITLE
Fix Results methods crashing on numpy-backed results

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -860,6 +860,11 @@ def test_results(model: str, tmp_path):
             assert len(r), f"'{model}' results should not be empty!"
         r = r.cpu().numpy()
         print(r, len(r), r.path)  # print numpy attributes
+        r.save_txt(txt_file=tmp_path / "runs/tests/label.txt", save_conf=True)  # numpy-backed Results must also work
+        r.save_crop(save_dir=tmp_path / "runs/tests/crops/")
+        r.to_json(normalize=True)
+        r.plot(conf=True, boxes=True)
+        r.verbose()
         r = r.to(device="cpu", dtype=torch.float32)
         r.save_txt(txt_file=tmp_path / "runs/tests/label.txt", save_conf=True)
         r.save_crop(save_dir=tmp_path / "runs/tests/crops/")

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -860,11 +860,6 @@ def test_results(model: str, tmp_path):
             assert len(r), f"'{model}' results should not be empty!"
         r = r.cpu().numpy()
         print(r, len(r), r.path)  # print numpy attributes
-        r.save_txt(txt_file=tmp_path / "runs/tests/label.txt", save_conf=True)  # numpy-backed Results must also work
-        r.save_crop(save_dir=tmp_path / "runs/tests/crops/")
-        r.to_json(normalize=True)
-        r.plot(conf=True, boxes=True)
-        r.verbose()
         r = r.to(device="cpu", dtype=torch.float32)
         r.save_txt(txt_file=tmp_path / "runs/tests/label.txt", save_conf=True)
         r.save_crop(save_dir=tmp_path / "runs/tests/crops/")

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -554,7 +554,8 @@ class Results(SimpleClass, DataExportMixin):
         # Plot Detect results
         if pred_boxes is not None and show_boxes:
             for i, d in enumerate(reversed(pred_boxes)):
-                c, d_conf, id = int(d.cls), float(d.conf) if conf else None, int(d.id.item()) if d.is_track else None
+                c = int(d.cls.item())  # .item() works for torch and numpy alike; int()/float() need 0-d since numpy 2.4
+                d_conf, id = float(d.conf.item()) if conf else None, int(d.id.item()) if d.is_track else None
                 name = ("" if id is None else f"id:{id} ") + names[c]
                 label = (f"{name} {d_conf:.2f}" if conf else name) if labels else (f"{d_conf:.2f}" if conf else None)
                 box = d.xyxyxyxy.squeeze() if is_obb else d.xyxy.squeeze()
@@ -731,7 +732,7 @@ class Results(SimpleClass, DataExportMixin):
         elif boxes:
             # Detect/segment/pose
             for j, d in enumerate(boxes):
-                c, conf, id = int(d.cls), float(d.conf), int(d.id.item()) if d.is_track else None
+                c, conf, id = int(d.cls.item()), float(d.conf.item()), int(d.id.item()) if d.is_track else None
                 line = (c, *(d.xyxyxyxyn.reshape(-1) if is_obb else d.xywhn.reshape(-1)))
                 if masks:
                     seg = masks[j].xyn[0].copy().reshape(-1)  # reversed mask.xyn, (n,2) to (n*2)
@@ -785,7 +786,7 @@ class Results(SimpleClass, DataExportMixin):
             save_one_box(
                 d.xyxy,
                 self.orig_img.copy(),
-                file=Path(save_dir) / self.names[int(d.cls)] / Path(file_name).with_suffix(".jpg"),
+                file=Path(save_dir) / self.names[int(d.cls.item())] / Path(file_name).with_suffix(".jpg"),
                 BGR=True,
             )
 
@@ -854,7 +855,7 @@ class Results(SimpleClass, DataExportMixin):
         data = self.obb if is_obb else self.boxes
         h, w = self.orig_shape if normalize else (1, 1)
         for i, row in enumerate(data):  # xyxy, track_id if tracking, conf, class_id
-            class_id, conf = int(row.cls), round(row.conf.item(), decimals)
+            class_id, conf = int(row.cls.item()), round(row.conf.item(), decimals)
             box = (row.xyxyxyxy if is_obb else row.xyxy).squeeze().reshape(-1, 2).tolist()
             xy = {}
             for j, b in enumerate(box):

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -532,10 +532,11 @@ class Results(SimpleClass, DataExportMixin):
 
         # Plot Segment results
         if pred_masks and show_masks:
+            pred_mask_data = torch.as_tensor(pred_masks.data)  # no-op for torch, converts a numpy() result
             if im_gpu is None:
                 img = LetterBox(pred_masks.shape[1:])(image=annotator.result())
                 im_gpu = (
-                    torch.as_tensor(img, dtype=torch.float16, device=pred_masks.data.device)
+                    torch.as_tensor(img, dtype=torch.float16, device=pred_mask_data.device)
                     .permute(2, 0, 1)
                     .flip(0)
                     .contiguous()
@@ -548,7 +549,7 @@ class Results(SimpleClass, DataExportMixin):
                 if pred_boxes and color_mode == "class"
                 else reversed(range(len(pred_masks)))
             )
-            annotator.masks(pred_masks.data, colors=[colors(x, True) for x in idx], im_gpu=im_gpu)
+            annotator.masks(pred_mask_data, colors=[colors(x, True) for x in idx], im_gpu=im_gpu)
 
         # Plot Detect results
         if pred_boxes is not None and show_boxes:
@@ -683,7 +684,7 @@ class Results(SimpleClass, DataExportMixin):
         if self.probs is not None:
             return f"{', '.join(f'{self.names[j]} {self.probs.data[j]:.2f}' for j in self.probs.top5)}, "
         if boxes:
-            counts = boxes.cls.int().bincount()
+            counts = torch.as_tensor(boxes.cls, dtype=torch.int64).bincount()  # no-op for torch, converts numpy()
             return "".join(f"{n} {self.names[i]}{'s' * (n > 1)}, " for i, n in enumerate(counts) if n > 0)
         if self.semantic_mask is not None:
             return ""
@@ -731,12 +732,14 @@ class Results(SimpleClass, DataExportMixin):
             # Detect/segment/pose
             for j, d in enumerate(boxes):
                 c, conf, id = int(d.cls), float(d.conf), int(d.id.item()) if d.is_track else None
-                line = (c, *(d.xyxyxyxyn.view(-1) if is_obb else d.xywhn.view(-1)))
+                line = (c, *(d.xyxyxyxyn.reshape(-1) if is_obb else d.xywhn.reshape(-1)))
                 if masks:
                     seg = masks[j].xyn[0].copy().reshape(-1)  # reversed mask.xyn, (n,2) to (n*2)
                     line = (c, *seg)
                 if kpts is not None:
-                    kpt = torch.cat((kpts[j].xyn, kpts[j].conf[..., None]), 2) if kpts[j].has_visible else kpts[j].xyn
+                    kpt = kpts[j].xyn
+                    if kpts[j].has_visible:
+                        kpt = torch.cat((torch.as_tensor(kpt), torch.as_tensor(kpts[j].conf)[..., None]), 2)
                     line += (*kpt.reshape(-1).tolist(),)
                 line += (conf,) * save_conf + (() if id is None else (id,))
                 texts.append(("%g " * len(line)).rstrip() % line)
@@ -867,16 +870,14 @@ class Results(SimpleClass, DataExportMixin):
                 }
             if self.keypoints is not None:
                 kpt = self.keypoints[i]
-                if kpt.has_visible:
-                    x, y, visible = kpt.data[0].cpu().unbind(dim=1)
-                else:
-                    x, y = kpt.data[0].cpu().unbind(dim=1)
+                k = kpt.data[0]
+                k = k.cpu().numpy() if isinstance(k, torch.Tensor) else k
                 result["keypoints"] = {
-                    "x": (x / w).numpy().astype(float).round(decimals).tolist(),
-                    "y": (y / h).numpy().astype(float).round(decimals).tolist(),
+                    "x": (k[:, 0] / w).astype(float).round(decimals).tolist(),
+                    "y": (k[:, 1] / h).astype(float).round(decimals).tolist(),
                 }
                 if kpt.has_visible:
-                    result["keypoints"]["visible"] = visible.numpy().astype(float).round(decimals).tolist()
+                    result["keypoints"]["visible"] = k[:, 2].astype(float).round(decimals).tolist()
             results.append(result)
 
         return results

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -334,7 +334,7 @@ class Annotator:
             >>> annotator.box_label(box=[10, 20, 30, 40], label="person")
         """
         txt_color = self.get_txt_color(color, txt_color)
-        if isinstance(box, torch.Tensor):
+        if isinstance(box, (torch.Tensor, np.ndarray)):
             box = box.tolist()
 
         multi_points = isinstance(box[0], list)  # multiple points with shape (n, 2)
@@ -694,7 +694,9 @@ def save_one_box(
         >>> im = cv2.imread("image.jpg")
         >>> cropped_im = save_one_box(xyxy, im, file="cropped.jpg", square=True)
     """
-    if not isinstance(xyxy, torch.Tensor):  # may be list
+    if isinstance(xyxy, np.ndarray):
+        xyxy = torch.from_numpy(xyxy)
+    elif not isinstance(xyxy, torch.Tensor):  # may be list
         xyxy = torch.stack(xyxy)
     b = ops.xyxy2xywh(xyxy.view(-1, 4))  # boxes
     if square:


### PR DESCRIPTION
`Results.numpy()` is documented as a way to convert a result for "interoperability with numpy-based libraries", but several `Results` methods assume the tensors are still torch and crash after the conversion.

Loading an official model and calling `.numpy()` before the method reproduces it on v8.4.102:

- `save_txt()` — `.view(-1)` is torch-only → `TypeError` on detect, segment, pose and OBB.
- `save_crop()` — `torch.stack` on a numpy array → `TypeError` on detect, segment and pose.
- `plot()` — the mask branch asserts a torch tensor, and `box_label` treats a numpy OBB polygon as a scalar → crash on segment and OBB.
- `summary()` (and `to_df` / `to_json` / `to_csv`, which go through it) — `.cpu()` on a numpy keypoint array → `AttributeError` on pose.
- `verbose()` — `.int().bincount()` on a numpy `cls` array → `AttributeError` on detect, segment, pose and OBB.
- Additionally, on numpy>=2.4 (base install without the export extras' `numpy<=2.3.5` pin), `int(d.cls)` / `float(d.conf)` on shape-`(1,)` numpy arrays raise `TypeError` — numpy 2.4 removed scalar conversion of non-0-d arrays — so `save_txt`, `save_crop`, `summary` and `plot` crashed even earlier in the call.

**Changes** — make each of these dtype-agnostic, following idioms already present in the files:

- `results.py` `save_txt`: `.view(-1)` → `.reshape(-1)` (already used two lines below), and the keypoint branch goes through `torch.as_tensor` (a no-op for a torch result).
- `results.py` scalar coercion in `plot` / `save_txt` / `save_crop` / `summary`: `int(d.cls)` → `int(d.cls.item())` etc., the same `.item()` idiom already used on the same lines for `d.id` and `row.conf`; works identically for torch and numpy on every numpy version.
- `plotting.py` `save_one_box`: accept a numpy box via `torch.from_numpy`.
- `results.py` `plot`: store `pred_mask_data = torch.as_tensor(pred_masks.data)` once and take the `im_gpu` device from it.
- `plotting.py` `box_label`: treat `np.ndarray` like `torch.Tensor` before `.tolist()`.
- `results.py` `summary`: convert the keypoint array with `.cpu().numpy()` only when it is a torch tensor, same as the mask branch right above it.
- `results.py` `verbose`: count classes with `torch.as_tensor(boxes.cls, dtype=torch.int64).bincount()`.

Deleted: the torch-only `unbind` keypoint branch in `summary()` (replaced by direct array indexing). No test additions — verified empirically below.

**Validation**

On numpy 2.5.1 (the strict post-2.4 regime): for detect / segment / pose / OBB / classify, `save_txt(save_conf=True)`, `save_crop`, `to_json(normalize=True)`, `plot`, `verbose` and `summary` all run on the numpy path and return output identical to the torch path (txt bytes, JSON, verbose string, plot md5) — the single exception is 1 of 181 OBB txt lines differing by 1 ulp in the 7th significant digit, from the pre-existing `xyxyxyxyn` trig computed in numpy vs torch, unrelated to this change. The torch path is unchanged. `ruff format` / `ruff check` clean.