### PR TITLE
Fix Mask/Pose curves and raw confusion matrix dropped from experiment trackers

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -510,6 +510,8 @@ def test_val(task: str, weight: str, data: str) -> None:
     if IS_RASPBERRYPI and task == "semantic":
         skip_rpi_semantic()
     model = YOLO(weight)
+    plot_names = set()
+    model.add_callback("on_val_end", lambda validator: plot_names.update(f.name for f in validator.plots))
     for plots in {True, False}:  # Test both cases i.e. plots=True and plots=False
         metrics = model.val(data=data, imgsz=32, plots=plots)
         metrics.to_df()
@@ -523,6 +525,8 @@ def test_val(task: str, weight: str, data: str) -> None:
         expected = cm.nc if task in {"classify", "semantic"} else cm.nc + 1  # detection-style tasks include background
         assert cm.matrix.shape == (expected, expected), f"{task} confusion matrix is {cm.matrix.shape}"
         assert len(cm.tp_fp()[0]) == cm.nc  # per-class TP/FP never include background
+    if task == "segment":  # plots sharing a type must all register, i.e. Mask curves next to Box curves
+        assert {"MaskPR_curve.png", "confusion_matrix.png", "confusion_matrix_normalized.png"} <= plot_names
 
 
 def test_val_save_txt_pose(tmp_path):

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -510,8 +510,6 @@ def test_val(task: str, weight: str, data: str) -> None:
     if IS_RASPBERRYPI and task == "semantic":
         skip_rpi_semantic()
     model = YOLO(weight)
-    plot_names = set()
-    model.add_callback("on_val_end", lambda validator: plot_names.update(f.name for f in validator.plots))
     for plots in {True, False}:  # Test both cases i.e. plots=True and plots=False
         metrics = model.val(data=data, imgsz=32, plots=plots)
         metrics.to_df()
@@ -525,8 +523,6 @@ def test_val(task: str, weight: str, data: str) -> None:
         expected = cm.nc if task in {"classify", "semantic"} else cm.nc + 1  # detection-style tasks include background
         assert cm.matrix.shape == (expected, expected), f"{task} confusion matrix is {cm.matrix.shape}"
         assert len(cm.tp_fp()[0]) == cm.nc  # per-class TP/FP never include background
-    if task == "segment":  # plots sharing a type must all register, i.e. Mask curves next to Box curves
-        assert {"MaskPR_curve.png", "confusion_matrix.png", "confusion_matrix_normalized.png"} <= plot_names
 
 
 def test_val_save_txt_pose(tmp_path):

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -391,10 +391,7 @@ class BaseValidator:
         return []
 
     def on_plot(self, name, data=None):
-        """Register plots for visualization, deduplicating by type."""
-        plot_type = data.get("type") if data else None
-        if plot_type and any((v.get("data") or {}).get("type") == plot_type for v in self.plots.values()):
-            return  # Skip duplicate plot types
+        """Register a plot by its unique path for visualization and logging."""
         self.plots[Path(name)] = {"data": data, "timestamp": time.time()}
 
     def plot_val_samples(self, batch, ni):


### PR DESCRIPTION
While training a segmentation model with `plots=True` and Weights & Biases enabled, I noticed the Mask PR/F1/P/R curves never reached the dashboard, even though the PNGs were written in the run folder.

The cause is in `BaseValidator.on_plot`. It deduplicates by the plot `type` string. The Box head registers `pr_curve`, `f1_curve`, `precision_curve` and `recall_curve` first, so when the Mask head produces the same four types (with different filenames: `MaskPR_curve.png`, `MaskF1_curve.png`, ...) the guard sees the type as already present and returns early. The four curves are written to disk but never added to `validator.plots`. The same thing drops the raw `confusion_matrix.png` on every task, because `confusion_matrix_normalized.png` registers the `confusion_matrix` type first and the raw one is skipped.

This is silent: the file-based trackers (W&B, ClearML, Neptune, DVC) upload by iterating `validator.plots` keys, which are unique paths, so a plot that is never registered is never uploaded and there is no warning.

The guard was added in #23105 together with the Platform-side dedup in `on_train_end`, which merges trainer + validator plots into a one-per-type set before uploading. That consumer-side dedup stays untouched, and it is the part that keeps the Platform payload small. So the validator-side guard is redundant for that purpose, its only remaining effect is dropping plots from the trackers that need every path. `self.plots` is already keyed by the unique `Path(name)`, so distinct plots never collide by key, and the sibling `BaseTrainer.on_plot` already registers by path without this guard. This change makes the validator consistent with both.

**Changes**
- `BaseValidator.on_plot`: drop the type-based dedup and register every plot by its unique path.
- No test additions — verified empirically: on `main`, `validator.plots` for a `yolo11n-seg` val contains only the Box curves and the normalized matrix; with the fix it also contains the four `Mask*` curves and the raw `confusion_matrix.png` (confirmed for pose likewise).

Deleted: the type-based dedup guard in `BaseValidator.on_plot` (3 lines).

**Validation**
On `yolo11n-seg` + `coco8-seg` with `plots=True`, `validator.plots` now contains the four `Mask*` curves and the raw `confusion_matrix.png` next to the Box curves, instead of only the Box curves and the normalised matrix. There is no double logging: the trackers key by path (all unique, and disjoint from `trainer.plots`), and the Platform callback keeps its own one-per-type dedup (`dict.setdefault` keeps the first-registered plot per type, the same one the old guard kept), so its payload does not change. `ruff check` is clean.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes validation plot registration so Mask/Pose curves and raw confusion matrices are retained and uploaded by experiment trackers. 🛠️

### 📊 Key Changes
- Removes type-based deduplication from `Validator.on_plot`, registering plots by their unique file paths instead.
- Adds validation coverage for segmentation plots, including `MaskPR_curve.png` and both raw and normalized confusion matrices.
- Verifies plots are collected across validation runs with `plots=True` and `plots=False`. ✅

### 🎯 Purpose & Impact
- Prevents plots that share a data type from being silently dropped.
- Ensures experiment trackers receive complete Mask/Pose visualization outputs and raw confusion matrices.
- Improves validation observability without changing metric calculations or confusion matrix behavior. 📈
