### PR TITLE
Honor validation confidence in confusion matrices

### DIFF
--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -423,7 +423,6 @@ class ConfusionMatrix(DataExportMixin):
             for i in range(gt_cls.shape[0]):
                 self._append_matches("GT", batch, i)  # store GT
         is_obb = gt_bboxes.shape[1] == 5  # check if boxes contains angle for OBB
-        conf = 0.25 if conf in {None, 0.01 if is_obb else 0.001} else conf  # apply 0.25 if default val conf is passed
         no_pred = detections["cls"].shape[0] == 0
         if gt_cls.shape[0] == 0:  # Check if labels is empty
             if not no_pred:


### PR DESCRIPTION
## Summary
- honor the confidence threshold passed by validators when accumulating confusion matrices
- prevent low-confidence but valid detections from being relabeled as background by an implicit 0.25 override

Deleted: the hidden branch that replaced default detection/OBB validation confidence with 0.25.

## Reproduction
A matching detection at confidence 0.02 with `conf=0.001` produced `[[0, 0], [1, 0]]` (false negative/background) before this change and `[[1, 0], [0, 0]]` after it. Portal model `exp-40` peaks at confidence 0.02 but had a 100% background confusion matrix because its F1 at 0.25 is zero.

## Validation
- focused synthetic `ConfusionMatrix.process_batch(..., conf=0.001)` regression probe
- `uv run --active --no-sync pytest "tests/test_python.py::test_val[detect-weight1-coco8.yaml]" -q`
- `uv run --active --no-sync ruff check ultralytics/utils/metrics.py`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Removes an internal confidence-threshold override from batch metric processing to preserve the caller-provided configuration.

### 📊 Key Changes

- Deleted the automatic replacement of default confidence values with `0.25` in `ultralytics/utils/metrics.py`.
- Metric processing now uses the confidence threshold supplied by the caller without silently modifying it.
- Applies to standard bounding boxes and oriented bounding boxes (OBB).

### 🎯 Purpose & Impact

- ✅ Makes evaluation behavior more predictable and consistent with user settings.
- 📈 Prevents unintended filtering of detections that could affect reported metrics.
- 🧪 Improves reliability for validation, benchmarking, and custom evaluation workflows.