### PR TITLE
Validate effective final training batch

### DIFF
--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -172,7 +172,7 @@ EXPECTED_MODULES = (
     "ultralytics/data/utils.py",
     "ultralytics/data/augment.py:classify_augmentations",
     "ultralytics/data/loaders.py:__init__",  # source loaders ARE the source-validation layer; their raises are clean
-    "ultralytics/engine/trainer.py:_setup_train",  # trainer validation of batch/imgsz interplay before training
+    "ultralytics/engine/trainer.py:_build_train_pipeline",  # actual train batch/imgsz validation before optimizer setup
     "ultralytics/engine/exporter.py:validate_args",  # exporter's intentional per-format argument validation
     "ultralytics/engine/exporter.py:__call__",  # intentional compat asserts; per-format bugs raise in deeper frames
 )

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -267,6 +267,12 @@ class BaseTrainer:
         self.train_loader = self.get_dataloader(
             self.data["train"], batch_size=batch_size, rank=LOCAL_RANK, mode="train"
         )
+        final_batch_size = len(self.train_loader.sampler) % self.train_loader.batch_size or self.train_loader.batch_size
+        if self.args.imgsz < 2 * self.stride and not self.train_loader.drop_last and final_batch_size == 1:
+            raise ValueError(
+                f"final batch=1 training at imgsz={self.args.imgsz} gives BatchNorm a single value per channel; "
+                f"change batch or use imgsz >= {2 * self.stride}"
+            )
         # Note: When training DOTA dataset, double batch size could get OOM on images with >2000 objects.
         self.test_loader = self.get_dataloader(
             self.data.get("val") or self.data.get("test"),
@@ -365,12 +371,6 @@ class BaseTrainer:
         # Batch size
         if self.batch_size < 1 and RANK == -1:  # single-GPU only, estimate best batch size
             self.args.batch = self.batch_size = self.auto_batch()
-        if self.batch_size // max(self.world_size, 1) == 1 and self.args.imgsz < 2 * gs:
-            raise ValueError(
-                f"batch=1 training at imgsz={self.args.imgsz} gives BatchNorm a single value per channel; "
-                f"increase batch or use imgsz >= {2 * gs}"
-            )
-
         self._build_train_pipeline()
         self.validator = self.get_validator()
         if self.args.distill_model is not None and "dis_loss" not in self.loss_names:


### PR DESCRIPTION
## Summary

- validate the effective final training batch after dataset fractioning and sampler construction
- keep validation before validation-loader and optimizer setup
- update the fuzz oracle to the relocated owner

Deleted: the configured-batch guard from `BaseTrainer._setup_train`.

The replacement is line-neutral: the effective final batch only exists after the train loader is constructed.

## Validation

- exact #25308 fuzz replay: expected 2/2
- Ruff format and lint
- adversarial Core Principles review: LGTM

Fixes #25308

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛠️ Moves batch-size and image-size validation to the actual training pipeline, improving detection of BatchNorm-incompatible final batches.

### 📊 Key Changes

- Replaces the earlier `_setup_train` check with validation inside `_build_train_pipeline`.
- Checks the **actual final batch size** produced by the training sampler, including cases where the last batch contains only one sample.
- Raises a clear error when a single-sample final batch combined with a small image size could cause BatchNorm failures.
- Updates the fuzzing configuration to target `_build_train_pipeline` for this validation.

### 🎯 Purpose & Impact

- ✅ Prevents training crashes caused by BatchNorm receiving only one value per channel.
- 🎯 Provides more accurate validation for datasets whose size is not evenly divisible by the batch size.
- 🌍 Improves distributed and variable-batch training behavior by validating the real loader output rather than only the configured batch size.
- 💬 Gives users actionable guidance: increase the batch size or use a larger image size.