### PR TITLE
Validate CoreML combinations before export

### DIFF
--- a/docs/en/guides/ros-quickstart.md
+++ b/docs/en/guides/ros-quickstart.md
@@ -90,6 +90,7 @@ class UltralyticsNode(Node):
     """Run YOLO detection on ROS2 image messages."""
 
     def __init__(self):
+        """Initialize the ROS2 node, model, and image interfaces."""
         super().__init__("ultralytics")
         self.bridge = cv_bridge.CvBridge()
         self.model = YOLO("yolo26m.pt")

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -729,6 +729,18 @@ class Exporter:
                 raise ValueError("Alibaba MNN export does not support combining 'dynamic=True' with 'nms=True'.")
             if model.task not in {"detect", "pose"}:
                 raise ValueError("Alibaba MNN export with 'nms=True' only supports detect and pose models.")
+        if fmt == "coreml":
+            if self.args.batch > 1:
+                assert self.args.dynamic, (
+                    "batch sizes > 1 are not supported without 'dynamic=True' for CoreML export. Please retry at 'dynamic=True'."
+                )
+            if self.args.dynamic:
+                assert not self.args.nms, (
+                    "'nms=True' cannot be used together with 'dynamic=True' for CoreML export. Please disable one of them."
+                )
+                assert model.task != "classify" and not isinstance(model.model[-1], RTDETRDecoder), (
+                    "'dynamic=True' is not supported for CoreML classification or RT-DETR models."
+                )
         if (fmt in {"engine", "coreml"} or self.args.nms) and self.args.dynamic and self.args.batch == 1:
             LOGGER.warning(
                 f"'dynamic=True' model with '{'nms=True' if self.args.nms else f'format={self.args.format}'}' requires max batch size, i.e. 'batch=16'"
@@ -1204,15 +1216,6 @@ class Exporter:
 
         assert not WINDOWS, "CoreML export is not supported on Windows, please run on macOS or Linux."
         assert TORCH_1_11, "CoreML export requires torch>=1.11"
-        if self.args.batch > 1:
-            assert self.args.dynamic, (
-                "batch sizes > 1 are not supported without 'dynamic=True' for CoreML export. Please retry at 'dynamic=True'."
-            )
-        if self.args.dynamic:
-            assert not self.args.nms, (
-                "'nms=True' cannot be used together with 'dynamic=True' for CoreML export. Please disable one of them."
-            )
-            assert self.model.task != "classify", "'dynamic=True' is not supported for CoreML classification models."
         f = self.file.with_suffix(".mlmodel" if mlmodel else ".mlpackage")
         if f.is_dir():
             shutil.rmtree(f)


### PR DESCRIPTION
## Summary

- relocate existing CoreML compatibility checks to the common pre-export validation owner
- reject unsupported dynamic RT-DETR and classification exports before model conversion
- document the ROS2 node constructor in the source snippet that generates the linted Python block

Deleted: the CoreML batch, dynamic, NMS, and classification compatibility block from `export_coreml()`.

The net-added RT-DETR condition is required because no existing CoreML contract represented that unsupported model family; the other checks were relocated and deleted from the backend.

## Validation

- exact #25309 fuzz replay: expected 2/2
- exact #25310 fuzz replay: expected 2/2
- Ruff format and lint
- pinned Prettier check for the ROS guide
- adversarial Core Principles review: LGTM

Fixes #25309
Fixes #25310

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improved CoreML export validation by centralizing compatibility checks and extending them to RT-DETR models, with a minor ROS2 documentation enhancement. 🚀

### 📊 Key Changes

- Moved CoreML batch and dynamic export validation from `export_coreml()` into the main exporter validation flow.
- Added a restriction preventing `dynamic=True` for RT-DETR models, alongside classification models.
- Preserved checks that:
  - Batch sizes above 1 require `dynamic=True`.
  - `dynamic=True` cannot be combined with `nms=True`.
- Added a descriptive docstring to the ROS2 quickstart example’s node initializer.
- Updated the ROS2 example to use the recommended YOLO26 model reference. 🤖

### 🎯 Purpose & Impact

- Provides earlier, more consistent error messages for invalid CoreML export configurations.
- Prevents unsupported dynamic CoreML exports for classification and RT-DETR models.
- Reduces duplicated validation logic and makes exporter behavior easier to maintain.
- Improves ROS2 example readability for users learning to integrate Ultralytics models. 📚