### PR TITLE
Fix Path values in exported model metadata

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -67,7 +67,7 @@ def test_export_onnx(end2end, isolated_model):
 @pytest.mark.parametrize("precision", [{"int8": True}, {"quantize": 8}])
 def test_export_onnx_int8(isolated_model, precision):
     """Test INT8 ONNX export via both the legacy int8 alias and the unified quantize arg."""
-    file = YOLO(isolated_model).export(format="onnx", data="coco8.yaml", fraction=0.25, imgsz=32, **precision)
+    file = YOLO(isolated_model).export(format="onnx", data=Path("coco8.yaml"), fraction=0.25, imgsz=32, **precision)
     assert Path(file).name.endswith("_int8.onnx")
     YOLO(file)(SOURCE, imgsz=32)  # exported model inference
     Path(file).unlink()  # cleanup

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -873,7 +873,7 @@ class Exporter:
             "batch": self.args.batch,
             "imgsz": self.imgsz,
             "names": model.names,
-            "args": {k: v for k, v in self.args if k in fmt_keys},
+            "args": {k: str(v) if isinstance(v, Path) else v for k, v in self.args if k in fmt_keys},
             "channels": model.yaml.get("channels", 3),
             "end2end": getattr(model, "end2end", False),
         }  # model metadata


### PR DESCRIPTION
## Summary

Fix Sentry ULTRALYTICS-276D by converting Path-valued export arguments to strings when the exporter constructs portable model metadata. ONNX metadata previously contained PosixPath(...) inside the args dictionary, which BaseBackend could not parse with ast.literal_eval when loading the exported model.

The existing INT8 ONNX export test now passes a Path dataset and reloads the artifact, covering the exact failure for both precision aliases.

Deleted: the non-literal Path representation from exported metadata. No function or file deletion was possible because this is a single existing serialization expression; the change is net-zero at 2 insertions and 2 deletions and reuses an existing test.

## Validation

- pytest --slow tests/test_exports.py::test_export_onnx_int8 --export-env base -q (2 passed)
- ruff check ultralytics/engine/exporter.py tests/test_exports.py
- ruff format --check ultralytics/engine/exporter.py tests/test_exports.py
- git diff --check
- Claude Code exact-head cold review: LGTM, no findings
- Codex CLI exact-head cold review: LGTM, no findings

Sentry: https://ultralytics.sentry.io/issues/7623302073/

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improved export metadata serialization so `Path` arguments are stored as strings, with updated INT8 ONNX export coverage. 🛠️

### 📊 Key Changes
- Converts `Path` values to strings when saving model export metadata in `ultralytics/engine/exporter.py`.
- Updates the INT8 ONNX export test to pass the dataset configuration as a `Path` object.
- Continues validating both legacy `int8` and unified `quantize` export options.

### 🎯 Purpose & Impact
- Prevents filesystem `Path` objects from causing serialization or compatibility issues in exported model metadata. ✅
- Makes exports more robust when users provide file paths as `Path` objects instead of plain strings.
- Improves test coverage for real-world path handling without changing the exported model’s core behavior. 🚀