### PR TITLE
s3d: network-level diagnostics toolkit (oracle ladder, bootstrap CIs, probes, gradient conflict)

### DIFF
--- a/docs/en/reference/data/scripts/diagnose_s3d.md
+++ b/docs/en/reference/data/scripts/diagnose_s3d.md
@@ -1,0 +1,61 @@
+---
+title: data.scripts.diagnose_s3d API Reference
+description: Reference for `ultralytics.data.scripts.diagnose_s3d` in the Ultralytics package.
+keywords: Ultralytics, ultralytics.data.scripts.diagnose_s3d, API reference, YOLO, Python
+---
+
+# Reference for `ultralytics/data/scripts/diagnose_s3d.py`
+
+!!! success "Improvements"
+
+    This page is sourced from [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/scripts/diagnose_s3d.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/scripts/diagnose_s3d.py). Have an improvement or example to add? Open a [Pull Request](https://docs.ultralytics.com/help/contributing) — thank you! 🙏
+
+<br>
+
+## ::: ultralytics.data.scripts.diagnose_s3d.rank_levers
+
+<br><br><hr><br>
+
+## ::: ultralytics.data.scripts.diagnose_s3d.render_report
+
+<br><br><hr><br>
+
+## ::: ultralytics.data.scripts.diagnose_s3d._md_table
+
+<br><br><hr><br>
+
+## ::: ultralytics.data.scripts.diagnose_s3d._error_profile_section
+
+<br><br><hr><br>
+
+## ::: ultralytics.data.scripts.diagnose_s3d._oracle_section
+
+<br><br><hr><br>
+
+## ::: ultralytics.data.scripts.diagnose_s3d._bootstrap_section
+
+<br><br><hr><br>
+
+## ::: ultralytics.data.scripts.diagnose_s3d._probe_hooks
+
+<br><br><hr><br>
+
+## ::: ultralytics.data.scripts.diagnose_s3d._gt_probe_rows
+
+<br><br><hr><br>
+
+## ::: ultralytics.data.scripts.diagnose_s3d._shift_probe
+
+<br><br><hr><br>
+
+## ::: ultralytics.data.scripts.diagnose_s3d._decode_forward
+
+<br><br><hr><br>
+
+## ::: ultralytics.data.scripts.diagnose_s3d._grad_section
+
+<br><br><hr><br>
+
+## ::: ultralytics.data.scripts.diagnose_s3d.main
+
+<br><br>

--- a/docs/en/reference/models/yolo/s3d/diagnose.md
+++ b/docs/en/reference/models/yolo/s3d/diagnose.md
@@ -1,0 +1,73 @@
+---
+title: models.yolo.s3d.diagnose API Reference
+description: Reference for `ultralytics.models.yolo.s3d.diagnose` in the Ultralytics package.
+keywords: Ultralytics, ultralytics.models.yolo.s3d.diagnose, API reference, YOLO, Python
+---
+
+# Reference for `ultralytics/models/yolo/s3d/diagnose.py`
+
+!!! success "Improvements"
+
+    This page is sourced from [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/s3d/diagnose.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/s3d/diagnose.py). Have an improvement or example to add? Open a [Pull Request](https://docs.ultralytics.com/help/contributing) — thank you! 🙏
+
+<br>
+
+## ::: ultralytics.models.yolo.s3d.diagnose.match_stats
+
+<br><br><hr><br>
+
+## ::: ultralytics.models.yolo.s3d.diagnose.error_records
+
+<br><br><hr><br>
+
+## ::: ultralytics.models.yolo.s3d.diagnose.summarize_errors
+
+<br><br><hr><br>
+
+## ::: ultralytics.models.yolo.s3d.diagnose.oracle_swap
+
+<br><br><hr><br>
+
+## ::: ultralytics.models.yolo.s3d.diagnose.run_metrics
+
+<br><br><hr><br>
+
+## ::: ultralytics.models.yolo.s3d.diagnose.oracle_ladder
+
+<br><br><hr><br>
+
+## ::: ultralytics.models.yolo.s3d.diagnose.bootstrap_ap
+
+<br><br><hr><br>
+
+## ::: ultralytics.models.yolo.s3d.diagnose.dist_stats
+
+<br><br><hr><br>
+
+## ::: ultralytics.models.yolo.s3d.diagnose.expected_dz
+
+<br><br><hr><br>
+
+## ::: ultralytics.models.yolo.s3d.diagnose.stereo_sensitivity
+
+<br><br><hr><br>
+
+## ::: ultralytics.models.yolo.s3d.diagnose.shared_params
+
+<br><br><hr><br>
+
+## ::: ultralytics.models.yolo.s3d.diagnose.per_branch_gradients
+
+<br><br><hr><br>
+
+## ::: ultralytics.models.yolo.s3d.diagnose.grad_diag_step
+
+<br><br><hr><br>
+
+## ::: ultralytics.models.yolo.s3d.diagnose.grad_diag_callback
+
+<br><br><hr><br>
+
+## ::: ultralytics.models.yolo.s3d.diagnose.depth_bias_fit
+
+<br><br>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -686,6 +686,7 @@ nav:
           - scripts:
               - benchmark_s3d: reference/data/scripts/benchmark_s3d.md
               - convert_kitti_3d: reference/data/scripts/convert_kitti_3d.md
+              - diagnose_s3d: reference/data/scripts/diagnose_s3d.md
           - split: reference/data/split.md
           - split_dota: reference/data/split_dota.md
           - stereo:
@@ -775,6 +776,7 @@ nav:
                   - auto_label: reference/models/yolo/s3d/auto_label.md
                   - dataset: reference/models/yolo/s3d/dataset.md
                   - dense_align_optimized: reference/models/yolo/s3d/dense_align_optimized.md
+                  - diagnose: reference/models/yolo/s3d/diagnose.md
                   - geometric: reference/models/yolo/s3d/geometric.md
                   - head: reference/models/yolo/s3d/head.md
                   - loss: reference/models/yolo/s3d/loss.md

--- a/tests/test_s3d_diagnose.py
+++ b/tests/test_s3d_diagnose.py
@@ -207,6 +207,50 @@ def test_stereo_sensitivity_scales():
     assert stereo_sensitivity(base, none, base, dpx, fx, b) == pytest.approx(0.0, abs=1e-6)
 
 
+def test_per_branch_gradients_conflict_detected():
+    """loss_b = -loss_a on shared weights → cosine exactly -1, equal norms."""
+    import torch
+    import torch.nn as nn
+
+    from ultralytics.models.yolo.s3d.diagnose import per_branch_gradients
+
+    torch.manual_seed(0)
+    shared = nn.Linear(4, 4, bias=False)
+    x = torch.randn(8, 4)
+    y = shared(x)
+    losses = {"a": y.sum(), "b": -y.sum(), "zero": (y * 0.0).sum()}
+    out = per_branch_gradients(losses, list(shared.parameters()))
+    assert out["cosine"][("a", "b")] == pytest.approx(-1.0, abs=1e-6)
+    assert out["norms"]["a"] == pytest.approx(out["norms"]["b"])
+    assert out["norms"]["zero"] == pytest.approx(0.0)
+    assert np.isnan(out["cosine"][("a", "zero")])
+
+
+def test_loss_component_names_match_trainer():
+    """Component order must match Stereo3DDetTrainer.loss_names (train.py)."""
+    from ultralytics.models.yolo.s3d.diagnose import LOSS_COMPONENT_NAMES
+
+    assert LOSS_COMPONENT_NAMES == ("box", "cls", "lr_dist", "depth", "dims", "orient", "proj_center")
+
+
+def test_shared_params_excludes_head():
+    """Toy model with .model list: last element is 'the head' and must be excluded."""
+    import torch.nn as nn
+
+    from ultralytics.models.yolo.s3d.diagnose import shared_params
+
+    class Toy(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = nn.ModuleList([nn.Linear(2, 2), nn.Linear(2, 2), nn.Linear(2, 3)])
+
+    toy = Toy()
+    sp = shared_params(toy)
+    head_ids = {id(p) for p in toy.model[-1].parameters()}
+    assert sp and all(id(p) not in head_ids for p in sp)
+    assert len(sp) == len(list(toy.model[0].parameters())) + len(list(toy.model[1].parameters()))
+
+
 def test_depth_bias_fit_recovers_slope():
     """dz = 0.05*z + 0.1 exactly → fit recovers (0.05, 0.1, ~0)."""
     rng = np.random.default_rng(0)

--- a/tests/test_s3d_diagnose.py
+++ b/tests/test_s3d_diagnose.py
@@ -169,6 +169,44 @@ def test_bootstrap_ap_tightens_with_perfect_preds():
     assert lo == pytest.approx(hi)
 
 
+def test_dist_stats_peaky_vs_flat():
+    """Peaky logits → near-zero entropy, top1≈1; flat logits → entropy 1, top1=1/n_bins."""
+    import torch
+
+    from ultralytics.models.yolo.s3d.diagnose import dist_stats
+
+    peaky = torch.zeros(1, 16)
+    peaky[0, 7] = 20.0
+    flat = torch.zeros(1, 16)
+    sp, sf = dist_stats(peaky), dist_stats(flat)
+    assert sp["entropy"][0] < 0.05 and sf["entropy"][0] == pytest.approx(1.0, abs=1e-5)
+    assert sp["top1"][0] > 0.99 and sp["argmax"][0] == 7
+    assert sf["top1"][0] == pytest.approx(1 / 16, abs=1e-5)
+
+
+def test_expected_dz_geometry():
+    """KITTI-ish: fx=721.5, b=0.54, z=20 → d=19.48 px; disparity change moves depth the right way."""
+    from ultralytics.models.yolo.s3d.diagnose import expected_dz
+
+    fx, b, z = 721.5377, 0.54, 20.0
+    d = fx * b / z
+    assert expected_dz(z, -1.0, fx, b) == pytest.approx(fx * b / (d + 1.0) - z)
+    assert expected_dz(z, -1.0, fx, b) < 0  # more disparity → nearer
+    assert expected_dz(z, 1.0, fx, b) > 0  # less disparity → farther
+
+
+def test_stereo_sensitivity_scales():
+    """Sensitivity is 1.0 for a fully stereo-driven shift and 0.0 when depth ignores the shift."""
+    from ultralytics.models.yolo.s3d.diagnose import expected_dz, stereo_sensitivity
+
+    fx, b, dpx = 721.5377, 0.54, 1.0
+    base = np.array([10.0, 20.0, 30.0])
+    full = base + np.array([expected_dz(z, dpx, fx, b) for z in base])
+    none = base.copy()
+    assert stereo_sensitivity(base, full, base, dpx, fx, b) == pytest.approx(1.0, abs=1e-6)
+    assert stereo_sensitivity(base, none, base, dpx, fx, b) == pytest.approx(0.0, abs=1e-6)
+
+
 def test_depth_bias_fit_recovers_slope():
     """dz = 0.05*z + 0.1 exactly → fit recovers (0.05, 0.1, ~0)."""
     rng = np.random.default_rng(0)

--- a/tests/test_s3d_diagnose.py
+++ b/tests/test_s3d_diagnose.py
@@ -81,6 +81,59 @@ def test_summarize_errors():
     assert s["frac_iou3d_ge_50"] == pytest.approx(0.5)
 
 
+def test_oracle_swap_z_restores_iou():
+    """A pred that only errs in depth becomes a perfect box under the z oracle."""
+    from ultralytics.models.yolo.s3d.diagnose import oracle_swap
+
+    # y=0 keeps the box on the optical axis so the ray-preserving rescale is identity in x,y
+    gt = [_box(y=0.0, z=20.0)]
+    pred = [_box(y=0.0, z=21.5)]
+    swapped = oracle_swap([_stat(pred, gt)], "z")
+    sb = swapped[0]["pred_boxes"][0]
+    assert sb.center_3d[2] == pytest.approx(20.0)
+    assert swapped[0]["iou_matrix"][0, 0] == pytest.approx(1.0, abs=1e-3)
+    # original stats untouched
+    assert _stat(pred, gt)["pred_boxes"][0].center_3d[2] == pytest.approx(21.5)
+
+
+def test_oracle_swap_z_rescales_xy():
+    """Depth oracle preserves the camera ray: x scales by z_gt/z_pred."""
+    from ultralytics.models.yolo.s3d.diagnose import oracle_swap
+
+    gt = [_box(x=2.0, z=20.0)]
+    pred = [_box(x=2.2, z=22.0)]
+    sb = oracle_swap([_stat(pred, gt)], "z")[0]["pred_boxes"][0]
+    assert sb.center_3d[2] == pytest.approx(20.0)
+    assert sb.center_3d[0] == pytest.approx(2.2 * 20.0 / 22.0)
+
+
+def test_oracle_score_reranks():
+    """Ranking oracle sets confidence to achieved 3D IoU."""
+    from ultralytics.models.yolo.s3d.diagnose import oracle_swap
+
+    gt = [_box(z=20.0)]
+    pred = [_box(z=20.1, conf=0.3), _box(x=15.0, z=50.0, conf=0.95)]  # good box low conf, bad box high conf
+    swapped = oracle_swap([_stat(pred, gt)], "score")
+    confs = [b.confidence for b in swapped[0]["pred_boxes"]]
+    assert confs[0] > confs[1]
+
+
+def test_oracle_ladder_orders_headroom():
+    """With depth as the only error source, the z oracle recovers more AP than the dims oracle."""
+    from ultralytics.models.yolo.s3d.diagnose import oracle_ladder
+
+    stats = []
+    rng = np.random.default_rng(1)
+    for _ in range(12):
+        gt = [_box(z=float(rng.uniform(10, 40)))]
+        # depth off by ~8%, dims off by 2% → depth is the binding error
+        pred = [_box(z=gt[0].center_3d[2] * 1.08, dims=(4.08, 1.836, 1.53))]
+        stats.append(_stat(pred, gt))
+    ladder = oracle_ladder(stats, {0: "Car"}, components=("z", "dims"))
+    assert ladder["z"]["ap3d_70"] >= ladder["dims"]["ap3d_70"]
+    assert ladder["z"]["ap3d_70"] >= ladder["baseline"]["ap3d_70"]
+
+
 def test_depth_bias_fit_recovers_slope():
     """dz = 0.05*z + 0.1 exactly → fit recovers (0.05, 0.1, ~0)."""
     rng = np.random.default_rng(0)

--- a/tests/test_s3d_diagnose.py
+++ b/tests/test_s3d_diagnose.py
@@ -251,6 +251,45 @@ def test_shared_params_excludes_head():
     assert len(sp) == len(list(toy.model[0].parameters())) + len(list(toy.model[1].parameters()))
 
 
+def test_component_losses_matches_loss_vector():
+    """Refactored Stereo3DDetLoss.component_losses must reproduce loss() exactly (CPU, tiny model)."""
+    import math
+
+    import torch
+
+    from ultralytics import YOLO
+    from ultralytics.models.yolo.s3d.diagnose import LOSS_COMPONENT_NAMES
+    from ultralytics.models.yolo.s3d.orientation import ORIENT_CHANNELS
+
+    from ultralytics.cfg import get_cfg
+
+    model = YOLO("yolo26n-s3d.yaml")  # build from YAML, no weights download
+    core = model.model
+    core.args = get_cfg()  # loss reads hyp gains (box/cls) from a namespace
+    criterion = core.init_criterion()
+    imgsz = 64
+    batch = {
+        "img": torch.zeros(1, 6, imgsz, imgsz),
+        "batch_idx": torch.zeros(1),
+        "cls": torch.zeros(1, 1),
+        "bboxes": torch.tensor([[0.5, 0.5, 0.2, 0.2]]),
+        "aux_targets": {
+            "lr_distance": torch.full((1, 1, 1), 2.0),
+            "depth": torch.full((1, 1, 1), math.log(20.0)),
+            "dimensions": torch.zeros(1, 1, 3),
+            "orientation": torch.zeros(1, 1, ORIENT_CHANNELS),
+            "proj_offset": torch.zeros(1, 1, 2),
+        },
+    }
+    core.train()
+    preds = core(batch["img"])
+    comp = criterion.component_losses(preds, batch)
+    total, items = criterion.loss(preds, batch)
+    for i, name in enumerate(LOSS_COMPONENT_NAMES):
+        assert float(comp[name]) == pytest.approx(float(items[i]), abs=1e-5)
+    assert comp["depth"].requires_grad  # live graph, not detached
+
+
 def test_depth_bias_fit_recovers_slope():
     """dz = 0.05*z + 0.1 exactly → fit recovers (0.05, 0.1, ~0)."""
     rng = np.random.default_rng(0)

--- a/tests/test_s3d_diagnose.py
+++ b/tests/test_s3d_diagnose.py
@@ -1,0 +1,91 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+"""Tests for the s3d network diagnostics toolkit (ultralytics/models/yolo/s3d/diagnose.py)."""
+
+import numpy as np
+import pytest
+
+from ultralytics.data.stereo.box3d import Box3D
+from ultralytics.models.yolo.s3d.diagnose import (
+    depth_bias_fit,
+    error_records,
+    match_stats,
+    summarize_errors,
+)
+from ultralytics.models.yolo.s3d.val import compute_3d_iou_batch, compute_bev_iou_batch
+
+
+def _box(x=0.0, y=1.0, z=20.0, dims=(4.0, 1.8, 1.5), ry=0.0, cls_id=0, conf=0.9):
+    """Build a synthetic Box3D with car-like defaults."""
+    return Box3D(
+        center_3d=(x, y, z),
+        dimensions=dims,
+        orientation=ry,
+        class_label="Car",
+        class_id=cls_id,
+        confidence=conf,
+        truncated=0.0,
+        occluded=0,
+    )
+
+
+def _stat(pred_boxes, gt_boxes):
+    """Build a stats dict exactly like val.py update_metrics does."""
+    return {
+        "pred_boxes": pred_boxes,
+        "gt_boxes": gt_boxes,
+        "iou_matrix": compute_3d_iou_batch(pred_boxes, gt_boxes),
+        "bev_iou_matrix": compute_bev_iou_batch(pred_boxes, gt_boxes),
+        "gt_difficulties": np.zeros(len(gt_boxes), dtype=int),  # all Easy
+        "pred_heights_2d": np.full(len(pred_boxes), 50.0, dtype=np.float32),
+    }
+
+
+def test_match_stats_greedy_bev():
+    """Two preds, two GTs: each pred matches its overlapping GT, not the other."""
+    gt = [_box(z=20.0), _box(x=10.0, z=40.0)]
+    pred = [_box(z=20.3, conf=0.9), _box(x=10.1, z=40.5, conf=0.8)]
+    matches = match_stats([_stat(pred, gt)])
+    assert matches[0] == [0, 1]
+
+
+def test_match_stats_center_fallback():
+    """A pred with zero IoU everywhere matches the nearest same-class GT under the cap."""
+    gt = [_box(z=20.0)]
+    pred = [_box(z=23.0)]  # 3 m off: zero 3D IoU but within 4 m fallback
+    matches = match_stats([_stat(pred, gt)])
+    assert matches[0] == [0]
+    far = [_box(z=30.0)]  # 10 m off: beyond cap → unmatched
+    assert match_stats([_stat(far, gt)])[0] == [-1]
+
+
+def test_error_records_signed():
+    """Errors are signed pred − GT."""
+    gt = [_box(z=20.0)]
+    pred = [_box(z=21.0, x=0.5)]
+    recs = error_records([_stat(pred, gt)])
+    assert len(recs) == 1
+    assert recs[0]["dz"] == pytest.approx(1.0, abs=1e-6)
+    assert recs[0]["dx"] == pytest.approx(0.5, abs=1e-6)
+    assert recs[0]["z_gt"] == pytest.approx(20.0)
+
+
+def test_summarize_errors():
+    """Summary aggregates MAE and IoU-threshold fractions."""
+    recs = [
+        {"dx": 0.5, "dy": 0.0, "dz": 1.0, "dtheta": 0.0, "iou3d": 0.6, "ioubev": 0.7},
+        {"dx": -0.5, "dy": 0.0, "dz": -2.0, "dtheta": 0.1, "iou3d": 0.4, "ioubev": 0.5},
+    ]
+    s = summarize_errors(recs)
+    assert s["n"] == 2
+    assert s["mae_z"] == pytest.approx(1.5)
+    assert s["frac_iou3d_ge_50"] == pytest.approx(0.5)
+
+
+def test_depth_bias_fit_recovers_slope():
+    """dz = 0.05*z + 0.1 exactly → fit recovers (0.05, 0.1, ~0)."""
+    rng = np.random.default_rng(0)
+    recs = [{"z_gt": z, "dz": 0.05 * z + 0.1} for z in rng.uniform(5, 60, 50)]
+    a, b, resid = depth_bias_fit(recs)
+    assert a == pytest.approx(0.05, abs=1e-6)
+    assert b == pytest.approx(0.1, abs=1e-6)
+    assert resid == pytest.approx(0.0, abs=1e-6)

--- a/tests/test_s3d_diagnose.py
+++ b/tests/test_s3d_diagnose.py
@@ -290,6 +290,21 @@ def test_component_losses_matches_loss_vector():
     assert comp["depth"].requires_grad  # live graph, not detached
 
 
+def test_render_report_and_rank():
+    """rank_levers sorts by ΔAP over baseline; render_report assembles titled sections."""
+    from ultralytics.data.scripts.diagnose_s3d import rank_levers, render_report
+
+    ladder = {
+        "baseline": {"ap3d_50": 0.30, "ap3d_70": 0.05},
+        "z": {"ap3d_50": 0.55, "ap3d_70": 0.30},
+        "dims": {"ap3d_50": 0.31, "ap3d_70": 0.06},
+    }
+    levers = rank_levers(ladder, key="ap3d_70")
+    assert levers[0][0] == "z" and levers[0][1] == pytest.approx(0.25)
+    report = render_report({"Oracle ladder": "| a | b |\n|---|---|\n| 1 | 2 |"})
+    assert "# s3d network diagnostics" in report and "Oracle ladder" in report
+
+
 def test_depth_bias_fit_recovers_slope():
     """dz = 0.05*z + 0.1 exactly → fit recovers (0.05, 0.1, ~0)."""
     rng = np.random.default_rng(0)

--- a/tests/test_s3d_diagnose.py
+++ b/tests/test_s3d_diagnose.py
@@ -134,6 +134,41 @@ def test_oracle_ladder_orders_headroom():
     assert ladder["z"]["ap3d_70"] >= ladder["baseline"]["ap3d_70"]
 
 
+def _mixed_stats(n_img=20, seed=0):
+    """Images with ~5% depth-noised single-object predictions."""
+    rng = np.random.default_rng(seed)
+    stats = []
+    for _ in range(n_img):
+        z = float(rng.uniform(10, 40))
+        gt = [_box(z=z)]
+        pred = [_box(z=z * float(rng.normal(1.0, 0.05)))]
+        stats.append(_stat(pred, gt))
+    return stats
+
+
+def test_bootstrap_ap_deterministic_and_ordered():
+    """Seeded bootstrap is reproducible and returns ordered (lo, med, hi) in [0, 1]."""
+    from ultralytics.models.yolo.s3d.diagnose import bootstrap_ap
+
+    stats = _mixed_stats()
+    ci1 = bootstrap_ap(stats, {0: "Car"}, n=25, seed=7)
+    ci2 = bootstrap_ap(stats, {0: "Car"}, n=25, seed=7)
+    assert ci1 == ci2  # seeded → reproducible
+    lo, med, hi = ci1["ap3d_50"]
+    assert lo <= med <= hi
+    assert 0.0 <= lo and hi <= 1.0
+
+
+def test_bootstrap_ap_tightens_with_perfect_preds():
+    """All-perfect predictions → zero-width CI at AP=1 regardless of resample."""
+    from ultralytics.models.yolo.s3d.diagnose import bootstrap_ap
+
+    stats = [_stat([_box(z=z)], [_box(z=z)]) for z in (10.0, 20.0, 30.0, 40.0)]
+    ci = bootstrap_ap(stats, {0: "Car"}, n=10, seed=0)
+    lo, med, hi = ci["ap3d_50"]
+    assert lo == pytest.approx(hi)
+
+
 def test_depth_bias_fit_recovers_slope():
     """dz = 0.05*z + 0.1 exactly → fit recovers (0.05, 0.1, ~0)."""
     rng = np.random.default_rng(0)

--- a/tests/test_s3d_diagnose.py
+++ b/tests/test_s3d_diagnose.py
@@ -165,7 +165,7 @@ def test_bootstrap_ap_tightens_with_perfect_preds():
 
     stats = [_stat([_box(z=z)], [_box(z=z)]) for z in (10.0, 20.0, 30.0, 40.0)]
     ci = bootstrap_ap(stats, {0: "Car"}, n=10, seed=0)
-    lo, med, hi = ci["ap3d_50"]
+    lo, _med, hi = ci["ap3d_50"]
     assert lo == pytest.approx(hi)
 
 
@@ -258,10 +258,9 @@ def test_component_losses_matches_loss_vector():
     import torch
 
     from ultralytics import YOLO
+    from ultralytics.cfg import get_cfg
     from ultralytics.models.yolo.s3d.diagnose import LOSS_COMPONENT_NAMES
     from ultralytics.models.yolo.s3d.orientation import ORIENT_CHANNELS
-
-    from ultralytics.cfg import get_cfg
 
     model = YOLO("yolo26n-s3d.yaml")  # build from YAML, no weights download
     core = model.model
@@ -284,7 +283,7 @@ def test_component_losses_matches_loss_vector():
     core.train()
     preds = core(batch["img"])
     comp = criterion.component_losses(preds, batch)
-    total, items = criterion.loss(preds, batch)
+    _total, items = criterion.loss(preds, batch)
     for i, name in enumerate(LOSS_COMPONENT_NAMES):
         assert float(comp[name]) == pytest.approx(float(items[i]), abs=1e-5)
     assert comp["depth"].requires_grad  # live graph, not detached
@@ -306,7 +305,7 @@ def test_render_report_and_rank():
 
 
 def test_depth_bias_fit_recovers_slope():
-    """dz = 0.05*z + 0.1 exactly → fit recovers (0.05, 0.1, ~0)."""
+    """Dz = 0.05*z + 0.1 exactly → fit recovers (0.05, 0.1, ~0)."""
     rng = np.random.default_rng(0)
     recs = [{"z_gt": z, "dz": 0.05 * z + 0.1} for z in rng.uniform(5, 60, 50)]
     a, b, resid = depth_bias_fit(recs)

--- a/ultralytics/data/scripts/diagnose_s3d.py
+++ b/ultralytics/data/scripts/diagnose_s3d.py
@@ -188,7 +188,6 @@ def _gt_probe_rows(validator, captured: dict) -> list[dict]:
 
 def _shift_probe(core, validator, shift_px: int) -> list[tuple[float, float]]:
     """Counterfactual right-image shift on the current batch: (base_z, shifted_z) per matched det pair."""
-
     batch = validator._current_batch
     decode_kw = dict(
         batch=batch,

--- a/ultralytics/data/scripts/diagnose_s3d.py
+++ b/ultralytics/data/scripts/diagnose_s3d.py
@@ -1,0 +1,406 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+"""Network-level diagnostics for s3d checkpoints.
+
+Runs the val split once, then computes: a MonoDLE/TIDE3D oracle-swap ladder (per-component AP headroom incl. a
+score-ranking oracle), the per-component error profile with a depth bias/variance split, bootstrap AP confidence
+intervals (the metric-noise floor for small val sets), DepthDFL and cost-volume distribution probes at GT centers,
+a counterfactual right-image-shift stereo probe (is depth stereo-driven or a monocular shortcut?), and an optional
+per-branch gradient-conflict probe. Outputs <out-dir>/report.md plus CSVs.
+
+Example:
+    python -m ultralytics.data.scripts.diagnose_s3d --weights best.pt --data cube-s3d.yaml \
+        --imgsz 768 1216 --device 0 --out-dir diagnosis/cube_best
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from ultralytics import YOLO
+from ultralytics.models.yolo.s3d.diagnose import (
+    ORACLE_COMPONENTS,
+    bootstrap_ap,
+    depth_bias_fit,
+    dist_stats,
+    error_records,
+    grad_diag_step,
+    oracle_ladder,
+    stereo_sensitivity,
+    summarize_errors,
+)
+from ultralytics.utils import LOGGER
+
+LADDER_KEYS = ("ap3d_50", "ap3d_70", "apbev_50", "apbev_70")
+
+
+def rank_levers(ladder: dict[str, dict[str, float]], key: str = "ap3d_70") -> list[tuple[str, float]]:
+    """Sort oracle components by ΔAP over baseline (descending) — the ranked lever list."""
+    base = ladder.get("baseline", {}).get(key, 0.0)
+    return sorted(((c, v.get(key, 0.0) - base) for c, v in ladder.items() if c != "baseline"), key=lambda t: -t[1])
+
+
+def render_report(sections: dict[str, str]) -> str:
+    """Assemble named markdown sections into the final report."""
+    out = ["# s3d network diagnostics\n"]
+    for title, body in sections.items():
+        out += [f"## {title}\n", body, ""]
+    return "\n".join(out)
+
+
+def _md_table(headers: list[str], rows: list[list[str]]) -> str:
+    """Render a simple markdown table."""
+    lines = ["| " + " | ".join(headers) + " |", "|" + "---|" * len(headers)]
+    lines += ["| " + " | ".join(r) + " |" for r in rows]
+    return "\n".join(lines)
+
+
+def _error_profile_section(stats, out_dir: Path) -> str:
+    """Per-component error profile + depth bias/variance split + error-vs-distance buckets."""
+    recs = error_records(stats)
+    if not recs:
+        return "_No matched predictions — nothing to profile._"
+    with open(out_dir / "error_records.csv", "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(recs[0]))
+        w.writeheader()
+        w.writerows(recs)
+    s = summarize_errors(recs)
+    a, b, resid = depth_bias_fit(recs)
+    rows = [
+        ["matched objects", str(s["n"])],
+        ["MAE x / y / z (m)", f"{s['mae_x']:.3f} / {s['mae_y']:.3f} / {s['mae_z']:.3f}"],
+        ["MAE orientation (rad)", f"{s['mae_theta']:.3f}"],
+        ["mean IoU3D / IoU_BEV", f"{s['mean_iou3d']:.3f} / {s['mean_ioubev']:.3f}"],
+        ["frac IoU3D ≥ 0.5 / ≥ 0.7", f"{s['frac_iou3d_ge_50']:.3f} / {s['frac_iou3d_ge_70']:.3f}"],
+        ["depth bias fit dz = a·z + b", f"a={a:.4f}, b={b:.3f} m, residual σ={resid:.3f} m"],
+    ]
+    # Error vs distance (MonoDLE): MAE_z per z_gt quartile
+    z = np.array([r["z_gt"] for r in recs])
+    dz = np.abs([r["dz"] for r in recs])
+    qs = np.quantile(z, [0.25, 0.5, 0.75])
+    buckets = ["z<q1", "q1-q2", "q2-q3", "z>q3"]
+    edges = [-np.inf, *qs, np.inf]
+    for name, lo, hi in zip(buckets, edges[:-1], edges[1:]):
+        m = (z >= lo) & (z < hi)
+        if m.any():
+            rows.append(
+                [f"MAE z, {name} (z∈[{max(lo, z.min()):.1f},{min(hi, z.max()):.1f}] m)", f"{dz[m].mean():.3f} m"]
+            )
+    note = (
+        "\nInterpretation: a significant slope `a` is a systematic depth **scale bias** (calibration/fusion bug "
+        "signature); near-zero slope with large residual σ is a **resolution/matching limit**."
+    )
+    return _md_table(["quantity", "value"], rows) + note
+
+
+def _oracle_section(stats, names) -> tuple[str, dict]:
+    """One-at-a-time GT-substitution ladder + ranked levers."""
+    ladder = oracle_ladder(stats, names, components=ORACLE_COMPONENTS, keys=LADDER_KEYS)
+    base = ladder["baseline"]
+    rows = [["baseline"] + [f"{base[k]:.4f}" for k in LADDER_KEYS] + ["—"]]
+    for comp in ORACLE_COMPONENTS:
+        v = ladder[comp]
+        rows.append([comp] + [f"{v[k]:.4f}" for k in LADDER_KEYS] + [f"{v['ap3d_70'] - base['ap3d_70']:+.4f}"])
+    table = _md_table(["oracle", *LADDER_KEYS, "ΔAP3D@.7"], rows)
+    levers = rank_levers(ladder)
+    ranked = "\n".join(f"{i + 1}. **{c}**: ΔAP3D@0.7 = {d:+.4f}" for i, (c, d) in enumerate(levers))
+    return table + "\n\n### Ranked levers (headroom at strict IoU)\n\n" + ranked, ladder
+
+
+def _bootstrap_section(stats, names, n: int) -> str:
+    """Bootstrap CI section."""
+    ci = bootstrap_ap(stats, names, n=n)
+    rows = [[k, f"{med:.4f}", f"[{lo:.4f}, {hi:.4f}]", f"{hi - lo:.4f}"] for k, (lo, med, hi) in ci.items()]
+    return (
+        _md_table(["metric", "median", "95% CI", "width"], rows)
+        + "\n\nA/B deltas smaller than the CI width are metric noise, not model differences."
+    )
+
+
+def _probe_hooks(core: torch.nn.Module) -> tuple[dict, list]:
+    """Register forward hooks capturing DepthDFL input logits and the raw cost volume."""
+    from ultralytics.models.yolo.s3d.head import Stereo3DDetHead
+    from ultralytics.nn.modules.block import StereoCostVolume
+
+    captured: dict[str, torch.Tensor] = {}
+    hooks = []
+    head = next((m for m in core.modules() if isinstance(m, Stereo3DDetHead)), None)
+    if head is not None:
+        hooks.append(
+            head.depth_dfl.register_forward_pre_hook(lambda m, inp: captured.update(depth_logits=inp[0].detach()))
+        )
+    costvol = next((m for m in core.modules() if isinstance(m, StereoCostVolume)), None)
+    if costvol is not None:
+        hooks.append(costvol.refine.register_forward_pre_hook(lambda m, inp: captured.update(cost_vol=inp[0].detach())))
+    return captured, hooks
+
+
+def _gt_probe_rows(validator, captured: dict) -> list[dict]:
+    """Per-GT distribution-shape stats at the GT's P3 cell (DepthDFL) and cost-volume cell."""
+    from ultralytics.data.stereo.box3d import Box3D
+    from ultralytics.models.yolo.s3d.preprocess import compute_letterbox_params
+    from ultralytics.models.yolo.s3d.val import _reverse_letterbox_calib
+
+    batch = validator._current_batch
+    imgsz = validator.args.imgsz
+    in_h, in_w = (imgsz, imgsz) if isinstance(imgsz, int) else (int(imgsz[0]), int(imgsz[1]))
+    p3_hw = (in_h // 8) * (in_w // 8)
+    rows = []
+    depth_logits = captured.get("depth_logits")  # [B, n_bins, HW_total]
+    cost_vol = captured.get("cost_vol")  # [B, n_disp_bins, Hc, Wc]
+    for si, labels in enumerate(batch.get("labels", [])):
+        calib_lb = batch["calib"][si] if si < len(batch.get("calib", [])) else None
+        ori = batch["ori_shape"][si] if si < len(batch.get("ori_shape", [])) else None
+        if not isinstance(calib_lb, dict) or ori is None:
+            continue
+        scale, pad_left, pad_top = compute_letterbox_params(int(ori[0]), int(ori[1]), imgsz)
+        calib = _reverse_letterbox_calib(calib_lb, scale, pad_left, pad_top, int(ori[1]), int(ori[0]))
+        gt_boxes = [b for lab in labels if (b := Box3D.from_label(lab, calib, class_names=validator.names)) is not None]
+        for gb in gt_boxes:
+            x, y, z = gb.center_3d
+            if z <= 0:
+                continue
+            u = (calib["fx"] * x / z + calib["cx"]) * scale + pad_left
+            v = (calib["fy"] * y / z + calib["cy"]) * scale + pad_top
+            row: dict[str, float] = {"z_gt": float(z), "img_key": f"{validator.batch_i}_{si}"}
+            if depth_logits is not None:
+                flat = int(v // 8) * (in_w // 8) + int(u // 8)
+                if 0 <= flat < min(p3_hw, depth_logits.shape[2]):
+                    ds = dist_stats(depth_logits[si, :, flat][None])
+                    row.update(dfl_entropy=float(ds["entropy"][0]), dfl_top2=float(ds["top2_mass"][0]))
+            if cost_vol is not None:
+                stride_cv = in_h / cost_vol.shape[2]
+                cu, cv_ = int(u / stride_cv), int(v / stride_cv)
+                if 0 <= cv_ < cost_vol.shape[2] and 0 <= cu < cost_vol.shape[3]:
+                    ds = dist_stats(cost_vol[si, :, cv_, cu][None])
+                    gt_disp_bins = (calib["fx"] * scale) * calib["baseline"] / z / stride_cv
+                    row.update(
+                        cv_entropy=float(ds["entropy"][0]),
+                        cv_peak_err_bins=float(abs(float(ds["argmax"][0]) - gt_disp_bins)),
+                    )
+            rows.append(row)
+    return rows
+
+
+def _shift_probe(core, validator, shift_px: int) -> list[tuple[float, float]]:
+    """Counterfactual right-image shift on the current batch: (base_z, shifted_z) per matched det pair."""
+
+    batch = validator._current_batch
+    decode_kw = dict(
+        batch=batch,
+        args=validator.args,
+        use_geometric=False,
+        use_dense_alignment=False,
+        conf_threshold=0.25,
+        top_k=100,
+        iou_thres=getattr(validator.args, "iou", 0.45),
+        imgsz=validator.args.imgsz,
+        mean_dims=getattr(validator, "mean_dims", None),
+        std_dims=getattr(validator, "std_dims", None),
+        class_names=getattr(validator, "names", None),
+        score_k=getattr(validator.args, "score_k", 0.5),
+    )
+    with torch.no_grad():
+        base = _decode_forward(core, batch["img"], decode_kw)
+        img2 = batch["img"].clone()
+        # Roll right-image channels rightward: content at u moves to u+k → measured disparity u_L−u_R
+        # DECREASES by k → dpx = −shift_px in expected_dz.
+        img2[:, 3:6] = torch.roll(img2[:, 3:6], shifts=shift_px, dims=3)
+        shifted = _decode_forward(core, img2, decode_kw)
+    pairs = []
+    for boxes_a, boxes_b in zip(base, shifted):
+        for ba in boxes_a:
+            if not boxes_b:
+                continue
+            bb = min(boxes_b, key=lambda o: np.linalg.norm(np.array(o.center_3d) - np.array(ba.center_3d)))
+            if np.linalg.norm(np.array(bb.center_3d) - np.array(ba.center_3d)) < max(1.0, 0.25 * ba.center_3d[2]):
+                pairs.append((float(ba.center_3d[2]), float(bb.center_3d[2])))
+    return pairs
+
+
+def _decode_forward(core, img, decode_kw):
+    """Forward the raw module and decode to Box3D lists."""
+    from ultralytics.models.yolo.s3d.preprocess import decode_and_refine_predictions
+
+    out = core(img)
+    if isinstance(out, (tuple, list)) and len(out) == 2 and isinstance(out[1], dict):
+        preds = {**out[1], "det": out[0]}
+    else:
+        preds = out
+    return decode_and_refine_predictions(preds=preds, **decode_kw)
+
+
+def _grad_section(weights: str, validator, n_batches: int, device: str) -> str:
+    """Offline gradient probe: per-branch norms + pairwise cosine conflict averaged over N val batches."""
+    from ultralytics.cfg import get_cfg
+
+    fresh = YOLO(weights)  # unfused copy — val fuses Conv+BN, which would distort training-time gradients
+    core = fresh.model.to(validator.device)
+    if not hasattr(core, "args") or isinstance(getattr(core, "args", None), dict):
+        core.args = get_cfg()
+    if getattr(core, "criterion", None) is None:
+        core.criterion = core.init_criterion()
+    norms_acc: dict[str, list[float]] = {}
+    cos_acc: dict[tuple[str, str], list[float]] = {}
+    for bi, batch in enumerate(validator.dataloader):
+        if bi >= n_batches:
+            break
+        batch = validator.preprocess(batch)
+        out = grad_diag_step(core, batch)
+        for k, v in out["norms"].items():
+            norms_acc.setdefault(k, []).append(v)
+        for k, v in out["cosine"].items():
+            if not np.isnan(v):
+                cos_acc.setdefault(k, []).append(v)
+    if not norms_acc:
+        return "_No gradient data collected._"
+    mean_norms = {k: float(np.mean(v)) for k, v in norms_acc.items()}
+    gbar = np.mean(list(mean_norms.values())) or 1.0
+    rows = [[k, f"{v:.4g}", f"{v / gbar:.2f}"] for k, v in sorted(mean_norms.items(), key=lambda t: -t[1])]
+    table = _md_table(["branch", "‖g‖ on shared neck", "ratio vs mean"], rows)
+    crows = [
+        [f"{a} ↔ {b}", f"{np.mean(v):+.3f}", "**CONFLICT**" if np.mean(v) < 0 else ""]
+        for (a, b), v in sorted(cos_acc.items(), key=lambda t: np.mean(t[1]))
+    ]
+    ctable = _md_table(["branch pair", "mean cos(g_i, g_j)", ""], crows)
+    return (
+        table
+        + "\n\nGradNorm ratio ≫ 1 = branch dominates shared features; ≪ 1 = starved.\n\n"
+        + ctable
+        + "\n\nPCGrad: persistent cos < 0 means the pair fights on shared parameters — evidence for "
+        "uncertainty weighting or gradient surgery over hand-tuned loss weights."
+    )
+
+
+def main() -> None:
+    """Parse args, run the val pass with probes attached, compute analyses, write report.md."""
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--weights", required=True, help="Checkpoint path or resolvable name.")
+    p.add_argument("--data", default="kitti-stereo.yaml", help="Dataset YAML.")
+    p.add_argument("--imgsz", nargs=2, type=int, default=[384, 1248], help="Validation image size [H, W].")
+    p.add_argument("--batch", type=int, default=8, help="Validation batch size.")
+    p.add_argument("--device", default="0", help="CUDA device, e.g. '0' or 'cpu'.")
+    p.add_argument("--out-dir", default="diagnosis", help="Output directory.")
+    p.add_argument("--bootstrap", type=int, default=200, help="Bootstrap resamples (0 = skip).")
+    p.add_argument("--no-oracle", action="store_true", help="Skip the oracle-swap ladder.")
+    p.add_argument("--no-probes", action="store_true", help="Skip DFL/cost-volume/shift probes.")
+    p.add_argument("--shift-px", type=int, default=2, help="Right-image shift in px for the stereo probe.")
+    p.add_argument("--shift-batches", type=int, default=4, help="Batches to run the shift probe on.")
+    p.add_argument("--grad-batches", type=int, default=0, help="Batches for the gradient probe (0 = skip).")
+    args = p.parse_args()
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    model = YOLO(args.weights)
+
+    # Build and drive the validator directly (mirrors Model.val) so we keep a handle on it for
+    # the dataloader, hooks, and per-batch probe callback — everything happens in ONE val pass.
+    v_args = {
+        **model.overrides,
+        "rect": True,
+        "data": args.data,
+        "imgsz": args.imgsz,
+        "batch": args.batch,
+        "device": args.device,
+        "plots": False,
+        "verbose": False,
+        "mode": "val",
+    }
+    validator = model._smart_load("validator")(args=v_args, _callbacks=model.callbacks)
+
+    probe_rows: list[dict] = []
+    shift_pairs: list[tuple[float, float]] = []
+    fx0, b0 = [None], [None]
+    captured, hooks = ({}, [])
+    if not args.no_probes:
+        captured, hooks = _probe_hooks(model.model)
+
+        def _probe_cb(v):
+            try:
+                probe_rows.extend(_gt_probe_rows(v, captured))
+                if v.batch_i < args.shift_batches:
+                    shift_pairs.extend(_shift_probe(model.model, v, args.shift_px))
+                    if fx0[0] is None and v._current_batch.get("calib"):
+                        c0 = v._current_batch["calib"][0]
+                        ori0 = v._current_batch["ori_shape"][0]
+                        from ultralytics.models.yolo.s3d.preprocess import compute_letterbox_params
+
+                        s0, _, _ = compute_letterbox_params(int(ori0[0]), int(ori0[1]), v.args.imgsz)
+                        fx0[0] = float(c0["fx"]) / s0  # original-image fx
+                        b0[0] = float(c0.get("baseline", 0.54))
+            except Exception as e:  # probes must never break the val pass
+                LOGGER.warning("s3d diagnose probe failed on batch %s: %s", v.batch_i, e)
+            finally:
+                captured.clear()
+
+        validator.add_callback("on_val_batch_end", _probe_cb)
+
+    try:
+        validator(model=model.model)
+    finally:
+        for h in hooks:
+            h.remove()
+
+    stats, names = validator.metrics.stats, validator.metrics.names
+    if not stats:
+        raise SystemExit("No validation stats collected — check --data/--weights/--imgsz.")
+
+    sections: dict[str, str] = {}
+    sections["Error profile (stable per-component eval)"] = _error_profile_section(stats, out_dir)
+
+    ladder = None
+    if not args.no_oracle:
+        sections["Oracle-swap ladder (GT substitution, MonoDLE/TIDE3D)"], ladder = _oracle_section(stats, names)
+    if args.bootstrap > 0:
+        sections[f"Bootstrap AP CIs ({args.bootstrap} resamples)"] = _bootstrap_section(stats, names, args.bootstrap)
+
+    if probe_rows:
+        with open(out_dir / "probe_records.csv", "w", newline="") as f:
+            keys = sorted({k for r in probe_rows for k in r})
+            w = csv.DictWriter(f, fieldnames=keys)
+            w.writeheader()
+            w.writerows(probe_rows)
+        lines = [f"GT objects probed: {len(probe_rows)}"]
+        for col, label in (("dfl_entropy", "DepthDFL entropy"), ("cv_entropy", "cost-volume entropy")):
+            vals = [r[col] for r in probe_rows if col in r]
+            if vals:
+                lines.append(f"- mean {label}: {np.mean(vals):.3f} (0 = one-hot, 1 = uniform)")
+        errs = [r["cv_peak_err_bins"] for r in probe_rows if "cv_peak_err_bins" in r]
+        if errs:
+            lines.append(f"- cost-volume peak vs GT disparity: median |err| = {np.median(errs):.2f} bins")
+        lines.append("Per-object records in probe_records.csv — correlate entropy vs |dz| (GFLv2/AcfNet).")
+        sections["Representation probes (GT-anchored)"] = "\n".join(lines)
+
+    if shift_pairs and fx0[0]:
+        base_z = np.array([a for a, _ in shift_pairs])
+        shifted_z = np.array([b for _, b in shift_pairs])
+        sens = stereo_sensitivity(base_z, shifted_z, base_z, dpx=-args.shift_px, fx=fx0[0], baseline=b0[0])
+        sections["Counterfactual stereo probe"] = (
+            f"Right image rolled by +{args.shift_px} px on {len(shift_pairs)} matched detections → "
+            f"**stereo sensitivity = {sens:.2f}**.\n\n"
+            "1.0 = depth fully stereo-driven; 0.0 = stereo ignored (monocular shortcut, e.g. apparent-size cue "
+            "on constant-dimension objects); intermediate = fused."
+        )
+
+    if args.grad_batches > 0:
+        try:
+            sections["Gradient diagnostics (per-branch, shared neck)"] = _grad_section(
+                args.weights, validator, args.grad_batches, args.device
+            )
+        except Exception as e:
+            LOGGER.warning("s3d diagnose gradient probe failed: %s", e)
+
+    report = render_report(sections)
+    (out_dir / "report.md").write_text(report)
+    print(report)
+    if ladder:
+        print("\nRanked levers (ΔAP3D@0.7):", rank_levers(ladder))
+    print(f"\nSaved to {out_dir / 'report.md'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ultralytics/models/yolo/s3d/diagnose.py
+++ b/ultralytics/models/yolo/s3d/diagnose.py
@@ -228,6 +228,38 @@ def oracle_ladder(
     return ladder
 
 
+def bootstrap_ap(
+    stats: list[dict[str, Any]],
+    names: dict[int, str],
+    n: int = 200,
+    seed: int = 0,
+    keys: tuple[str, ...] = ("ap3d_50", "ap3d_70"),
+) -> dict[str, tuple[float, float, float]]:
+    """Bootstrap-resample images to a (2.5%, 50%, 97.5%) confidence interval per metric key.
+
+    Separates "training is unstable" from "AP on a small val set is a coin flip": any A/B delta smaller than
+    the CI width is noise. n=200 keeps runtime tolerable (metrics.process() is O(images) per resample).
+
+    Args:
+        stats (list[dict]): Per-image stat dicts.
+        names (dict[int, str]): Class id → name mapping.
+        n (int): Number of bootstrap resamples.
+        seed (int): RNG seed for reproducibility.
+        keys (tuple[str, ...]): results_dict keys to report.
+
+    Returns:
+        (dict[str, tuple[float, float, float]]): {key: (p2.5, median, p97.5)}.
+    """
+    rng = np.random.default_rng(seed)
+    samples: dict[str, list[float]] = {k: [] for k in keys}
+    for _ in range(n):
+        idx = rng.integers(0, len(stats), size=len(stats))
+        rd = run_metrics([stats[i] for i in idx], names)
+        for k in keys:
+            samples[k].append(float(rd.get(k, 0.0)))
+    return {k: tuple(float(np.percentile(v, p)) for p in (2.5, 50, 97.5)) for k, v in samples.items()}
+
+
 def depth_bias_fit(records: list[dict[str, float]]) -> tuple[float, float, float]:
     """Fit dz = a·z_gt + b over matched predictions.
 

--- a/ultralytics/models/yolo/s3d/diagnose.py
+++ b/ultralytics/models/yolo/s3d/diagnose.py
@@ -1,0 +1,144 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+"""Network-level diagnostics for the s3d task.
+
+Pure analysis functions over Stereo3DDetMetrics.stats (see val.py update_metrics for the stat schema), plus tensor
+probes and a gradient-conflict callback. Literature basis: MonoDLE (CVPR 2021) oracle substitution, TIDE3D
+(arXiv:2310.05447) ranking oracle, GradNorm (ICML 2018) / PCGrad (NeurIPS 2020) gradient diagnostics, GFLv2 (CVPR
+2021) distribution-shape quality, van Dijk & de Croon (ICCV 2019) counterfactual probes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def match_stats(stats: list[dict[str, Any]], max_center_dist: float = 4.0) -> list[list[int]]:
+    """Match predictions to GT per image for diagnostics (not for AP).
+
+    Greedy on descending BEV IoU; a pred with zero IoU against every GT falls back to the nearest unmatched
+    same-class GT by 3D center distance, capped at ``max_center_dist`` meters.
+
+    Args:
+        stats (list[dict]): Per-image stat dicts (Stereo3DDetMetrics.stats schema).
+        max_center_dist (float): Fallback matching radius in meters.
+
+    Returns:
+        (list[list[int]]): Per image, matched GT indices aligned with pred_boxes (-1 = unmatched).
+    """
+    all_matches = []
+    for stat in stats:
+        preds, gts = stat["pred_boxes"], stat["gt_boxes"]
+        bev = stat.get("bev_iou_matrix", np.zeros((len(preds), len(gts))))
+        match = [-1] * len(preds)
+        taken: set[int] = set()
+        # Pass 1: greedy by BEV IoU
+        if bev.size:
+            order = np.dstack(np.unravel_index(np.argsort(-bev, axis=None), bev.shape))[0]
+            for pi, gi in order:
+                if bev[pi, gi] <= 0:
+                    break
+                if match[pi] == -1 and int(gi) not in taken:
+                    match[pi] = int(gi)
+                    taken.add(int(gi))
+        # Pass 2: center-distance fallback for still-unmatched preds
+        for pi, pb in enumerate(preds):
+            if match[pi] != -1:
+                continue
+            best, best_d = -1, max_center_dist
+            for gi, gb in enumerate(gts):
+                if gi in taken or gb.class_id != pb.class_id:
+                    continue
+                d = float(np.linalg.norm(np.array(pb.center_3d) - np.array(gb.center_3d)))
+                if d < best_d:
+                    best, best_d = gi, d
+            if best >= 0:
+                match[pi] = best
+                taken.add(best)
+        all_matches.append(match)
+    return all_matches
+
+
+def error_records(
+    stats: list[dict[str, Any]], matches: list[list[int]] | None = None, max_center_dist: float = 4.0
+) -> list[dict[str, float]]:
+    """Compute per-matched-prediction signed component errors (pred − GT).
+
+    Args:
+        stats (list[dict]): Per-image stat dicts.
+        matches (list[list[int]], optional): Precomputed match_stats output; computed when None.
+        max_center_dist (float): Fallback matching radius passed to match_stats.
+
+    Returns:
+        (list[dict]): One record per matched pred with keys img, cls, conf, z_gt, dx, dy, dz, dl, dw, dh,
+            dtheta (wrapped to [-π, π]), iou3d, ioubev.
+    """
+    if matches is None:
+        matches = match_stats(stats, max_center_dist)
+    records = []
+    for img_i, (stat, match) in enumerate(zip(stats, matches)):
+        for pi, gi in enumerate(match):
+            if gi < 0:
+                continue
+            pb, gb = stat["pred_boxes"][pi], stat["gt_boxes"][gi]
+            dtheta = float(np.arctan2(np.sin(pb.orientation - gb.orientation), np.cos(pb.orientation - gb.orientation)))
+            iou = stat["iou_matrix"]
+            bev = stat["bev_iou_matrix"]
+            records.append(
+                {
+                    "img": img_i,
+                    "cls": int(pb.class_id),
+                    "conf": float(pb.confidence),
+                    "z_gt": float(gb.center_3d[2]),
+                    "dx": float(pb.center_3d[0] - gb.center_3d[0]),
+                    "dy": float(pb.center_3d[1] - gb.center_3d[1]),
+                    "dz": float(pb.center_3d[2] - gb.center_3d[2]),
+                    "dl": float(pb.dimensions[0] - gb.dimensions[0]),
+                    "dw": float(pb.dimensions[1] - gb.dimensions[1]),
+                    "dh": float(pb.dimensions[2] - gb.dimensions[2]),
+                    "dtheta": dtheta,
+                    "iou3d": float(iou[pi, gi]) if iou.size else 0.0,
+                    "ioubev": float(bev[pi, gi]) if bev.size else 0.0,
+                }
+            )
+    return records
+
+
+def summarize_errors(records: list[dict[str, float]]) -> dict[str, float]:
+    """Aggregate error records into the stable per-component profile (the anti-spiky-AP eval)."""
+    if not records:
+        return {"n": 0}
+    arr = {k: np.array([r[k] for r in records]) for k in ("dx", "dy", "dz", "dtheta", "iou3d", "ioubev")}
+    return {
+        "n": len(records),
+        "mae_x": float(np.abs(arr["dx"]).mean()),
+        "mae_y": float(np.abs(arr["dy"]).mean()),
+        "mae_z": float(np.abs(arr["dz"]).mean()),
+        "mae_theta": float(np.abs(arr["dtheta"]).mean()),
+        "mean_iou3d": float(arr["iou3d"].mean()),
+        "mean_ioubev": float(arr["ioubev"].mean()),
+        "frac_iou3d_ge_50": float((arr["iou3d"] >= 0.5).mean()),
+        "frac_iou3d_ge_70": float((arr["iou3d"] >= 0.7).mean()),
+    }
+
+
+def depth_bias_fit(records: list[dict[str, float]]) -> tuple[float, float, float]:
+    """Fit dz = a·z_gt + b over matched predictions.
+
+    A significant slope ``a`` is a systematic depth scale bias (calibration/fusion bug signature); a near-zero
+    slope with large residual std is a resolution/matching limit.
+
+    Args:
+        records (list[dict]): error_records output.
+
+    Returns:
+        (tuple[float, float, float]): Slope a, intercept b, residual standard deviation.
+    """
+    if len(records) < 3:
+        return 0.0, 0.0, 0.0
+    z = np.array([r["z_gt"] for r in records])
+    dz = np.array([r["dz"] for r in records])
+    a, b = np.polyfit(z, dz, 1)
+    resid = dz - (a * z + b)
+    return float(a), float(b), float(resid.std())

--- a/ultralytics/models/yolo/s3d/diagnose.py
+++ b/ultralytics/models/yolo/s3d/diagnose.py
@@ -9,9 +9,12 @@ probes and a gradient-conflict callback. Literature basis: MonoDLE (CVPR 2021) o
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 import numpy as np
+
+ORACLE_COMPONENTS = ("z", "y", "xy", "location", "dims", "orientation", "score")
 
 
 def match_stats(stats: list[dict[str, Any]], max_center_dist: float = 4.0) -> list[list[int]]:
@@ -121,6 +124,108 @@ def summarize_errors(records: list[dict[str, float]]) -> dict[str, float]:
         "frac_iou3d_ge_50": float((arr["iou3d"] >= 0.5).mean()),
         "frac_iou3d_ge_70": float((arr["iou3d"] >= 0.7).mean()),
     }
+
+
+def oracle_swap(
+    stats: list[dict[str, Any]], component: str, matches: list[list[int]] | None = None
+) -> list[dict[str, Any]]:
+    """Return a copy of stats with one predicted component replaced by GT (MonoDLE-style oracle).
+
+    Matched preds get the GT value for ``component``; IoU matrices are recomputed — except for the "score"
+    ranking oracle, which only re-scores confidence by achieved 3D IoU (TIDE3D style). Component semantics:
+    "z" replaces depth AND rescales x,y by z_gt/z_pred (preserves the camera ray, i.e. the image-plane center);
+    "y" replaces the vertical center only (height/Y hypothesis); "xy" replaces the lateral/vertical center
+    keeping depth; "location" replaces the full 3D center; "dims"/"orientation" replace those fields.
+
+    Args:
+        stats (list[dict]): Per-image stat dicts.
+        component (str): One of ORACLE_COMPONENTS.
+        matches (list[list[int]], optional): Precomputed match_stats output.
+
+    Returns:
+        (list[dict]): New stat dicts; input stats and Box3D objects are not mutated.
+    """
+    from ultralytics.models.yolo.s3d.val import compute_3d_iou_batch, compute_bev_iou_batch
+
+    if component not in ORACLE_COMPONENTS:
+        raise ValueError(f"Unknown oracle component {component!r}; expected one of {ORACLE_COMPONENTS}")
+    if matches is None:
+        matches = match_stats(stats)
+
+    out = []
+    for stat, match in zip(stats, matches):
+        preds, gts = stat["pred_boxes"], stat["gt_boxes"]
+        new_preds = []
+        for pi, pb in enumerate(preds):
+            gi = match[pi]
+            if component == "score":
+                iou = stat["iou_matrix"]
+                q = float(iou[pi].max()) if iou.size else 0.0
+                new_preds.append(replace(pb, confidence=min(max(q, 0.0), 1.0)))
+                continue
+            if gi < 0:
+                new_preds.append(pb)
+                continue
+            gb = gts[gi]
+            x, y, z = pb.center_3d
+            if component == "z":
+                zg = gb.center_3d[2]
+                s = zg / z if z > 0 else 1.0
+                new_preds.append(replace(pb, center_3d=(x * s, y * s, zg)))
+            elif component == "y":
+                new_preds.append(replace(pb, center_3d=(x, gb.center_3d[1], z)))
+            elif component == "xy":
+                new_preds.append(replace(pb, center_3d=(gb.center_3d[0], gb.center_3d[1], z)))
+            elif component == "location":
+                new_preds.append(replace(pb, center_3d=gb.center_3d))
+            elif component == "dims":
+                new_preds.append(replace(pb, dimensions=gb.dimensions))
+            elif component == "orientation":
+                new_preds.append(replace(pb, orientation=gb.orientation))
+        new_stat = dict(stat)
+        new_stat["pred_boxes"] = new_preds
+        if component != "score":
+            new_stat["iou_matrix"] = compute_3d_iou_batch(new_preds, gts)
+            new_stat["bev_iou_matrix"] = compute_bev_iou_batch(new_preds, gts)
+        out.append(new_stat)
+    return out
+
+
+def run_metrics(stats: list[dict[str, Any]], names: dict[int, str]) -> dict[str, Any]:
+    """Run Stereo3DDetMetrics over a stats list and return its results_dict."""
+    from ultralytics.models.yolo.s3d.metrics import Stereo3DDetMetrics
+
+    m = Stereo3DDetMetrics(names=names)
+    for stat in stats:
+        m.update_stats(stat)
+    m.process()
+    return m.results_dict
+
+
+def oracle_ladder(
+    stats: list[dict[str, Any]],
+    names: dict[int, str],
+    components: tuple[str, ...] = ORACLE_COMPONENTS,
+    keys: tuple[str, ...] = ("ap3d_50", "ap3d_70", "apbev_50", "apbev_70"),
+) -> dict[str, dict[str, float]]:
+    """Compute the one-at-a-time GT-substitution ladder: ΔAP per component quantifies its headroom.
+
+    Args:
+        stats (list[dict]): Per-image stat dicts from a completed validation run.
+        names (dict[int, str]): Class id → name mapping for the metrics.
+        components (tuple[str, ...]): Oracle components to evaluate.
+        keys (tuple[str, ...]): results_dict keys to report per rung.
+
+    Returns:
+        (dict[str, dict[str, float]]): {"baseline": {key: val}, "<component>": {key: val}, ...}.
+    """
+    matches = match_stats(stats)
+    baseline_rd = run_metrics(stats, names)
+    ladder = {"baseline": {k: float(baseline_rd.get(k, 0.0)) for k in keys}}
+    for comp in components:
+        rd = run_metrics(oracle_swap(stats, comp, matches), names)
+        ladder[comp] = {k: float(rd.get(k, 0.0)) for k in keys}
+    return ladder
 
 
 def depth_bias_fit(records: list[dict[str, float]]) -> tuple[float, float, float]:

--- a/ultralytics/models/yolo/s3d/diagnose.py
+++ b/ultralytics/models/yolo/s3d/diagnose.py
@@ -367,6 +367,59 @@ def per_branch_gradients(losses: dict[str, torch.Tensor], params: list[torch.Ten
     return {"norms": norms, "cosine": cosine}
 
 
+def grad_diag_step(model: torch.nn.Module, batch: dict[str, Any]) -> dict[str, Any]:
+    """Run one gradient-diagnostics probe: fresh forward + per-component grads on shared params.
+
+    Args:
+        model (torch.nn.Module): Unwrapped Stereo3DDetModel with .criterion initialized.
+        batch (dict): A preprocessed training batch (img float on device, targets on device).
+
+    Returns:
+        (dict): {"norms": {...}, "cosine": {...}} from per_branch_gradients.
+    """
+    was_training = model.training
+    model.train()
+    try:
+        preds = model(batch["img"])
+        comp = model.criterion.component_losses(preds, batch)
+        live = {k: v for k, v in comp.items() if v.requires_grad}
+        return per_branch_gradients(live, shared_params(model))
+    finally:
+        model.train(was_training)
+
+
+def grad_diag_callback(trainer) -> None:
+    """Append a grad_diag.csv row every `diag_grad_every` batches (on_train_batch_end callback).
+
+    Enabled by `training: {diag_grad_every: N}` in the model YAML (see Stereo3DDetTrainer). Uses
+    autograd.grad internally, so it never touches .grad or interferes with the optimizer step.
+    """
+    from ultralytics.utils.torch_utils import unwrap_model
+
+    every = getattr(trainer, "_diag_grad_every", 0)
+    ib = getattr(trainer, "_diag_batch_i", 0)
+    trainer._diag_batch_i = ib + 1
+    if not every or ib % every:
+        return
+    model = unwrap_model(trainer.model)
+    if getattr(model, "criterion", None) is None or not hasattr(trainer, "batch"):
+        return
+    out = grad_diag_step(model, trainer.batch)
+    path = trainer.save_dir / "grad_diag.csv"
+    names = sorted(out["norms"])
+    pairs = sorted(out["cosine"])
+    if not path.exists():
+        header = ["epoch", "batch"] + [f"norm_{n}" for n in names] + [f"cos_{a}__{b}" for a, b in pairs]
+        path.write_text(",".join(header) + "\n")
+    row = (
+        [str(trainer.epoch), str(ib)]
+        + [f"{out['norms'][n]:.6g}" for n in names]
+        + [f"{out['cosine'][p]:.4f}" for p in pairs]
+    )
+    with open(path, "a") as f:
+        f.write(",".join(row) + "\n")
+
+
 def depth_bias_fit(records: list[dict[str, float]]) -> tuple[float, float, float]:
     """Fit dz = a·z_gt + b over matched predictions.
 

--- a/ultralytics/models/yolo/s3d/diagnose.py
+++ b/ultralytics/models/yolo/s3d/diagnose.py
@@ -17,6 +17,7 @@ import numpy as np
 import torch
 
 ORACLE_COMPONENTS = ("z", "y", "xy", "location", "dims", "orientation", "score")
+LOSS_COMPONENT_NAMES = ("box", "cls", "lr_dist", "depth", "dims", "orient", "proj_center")
 
 
 def match_stats(stats: list[dict[str, Any]], max_center_dist: float = 4.0) -> list[list[int]]:
@@ -324,6 +325,46 @@ def stereo_sensitivity(
     if not valid.any():
         return float("nan")
     return float(np.median((shifted_z[valid] - base_z[valid]) / expected[valid]))
+
+
+def shared_params(model: torch.nn.Module) -> list[torch.Tensor]:
+    """Return trainable parameters shared by all loss branches: everything except the head (model.model[-1]).
+
+    The s3d head attaches its branches directly to neck P3/P4/P5 features, so cross-branch gradient interaction
+    happens in the backbone+neck (including the StereoCostVolume neck layer).
+    """
+    head = model.model[-1]
+    head_ids = {id(p) for p in head.parameters()}
+    return [p for p in model.parameters() if p.requires_grad and id(p) not in head_ids]
+
+
+def per_branch_gradients(losses: dict[str, torch.Tensor], params: list[torch.Tensor]) -> dict[str, Any]:
+    """Compute per-loss gradient norms and pairwise cosine similarity on shared params.
+
+    GradNorm-style magnitude ratios + PCGrad-style conflict (cos < 0). Uses autograd.grad with retain_graph so
+    it never pollutes .grad — safe to call mid-training from a callback.
+
+    Args:
+        losses (dict[str, torch.Tensor]): Named scalar losses sharing one autograd graph.
+        params (list[torch.Tensor]): Shared parameters to differentiate against.
+
+    Returns:
+        (dict): {"norms": {name: float}, "cosine": {(a, b): float}} — cosine is nan for all-zero gradients.
+    """
+    flats: dict[str, torch.Tensor] = {}
+    for name, loss in losses.items():
+        grads = torch.autograd.grad(loss, params, retain_graph=True, allow_unused=True)
+        flats[name] = torch.cat(
+            [(g if g is not None else torch.zeros_like(p)).flatten() for g, p in zip(grads, params)]
+        )
+    norms = {name: float(g.norm()) for name, g in flats.items()}
+    cosine: dict[tuple[str, str], float] = {}
+    names = list(losses)
+    for i, a in enumerate(names):
+        for b in names[i + 1 :]:
+            na, nb = norms[a], norms[b]
+            cosine[(a, b)] = float("nan") if na == 0 or nb == 0 else float(torch.dot(flats[a], flats[b]) / (na * nb))
+    return {"norms": norms, "cosine": cosine}
 
 
 def depth_bias_fit(records: list[dict[str, float]]) -> tuple[float, float, float]:

--- a/ultralytics/models/yolo/s3d/diagnose.py
+++ b/ultralytics/models/yolo/s3d/diagnose.py
@@ -9,10 +9,12 @@ probes and a gradient-conflict callback. Literature basis: MonoDLE (CVPR 2021) o
 
 from __future__ import annotations
 
+import math
 from dataclasses import replace
 from typing import Any
 
 import numpy as np
+import torch
 
 ORACLE_COMPONENTS = ("z", "y", "xy", "location", "dims", "orientation", "score")
 
@@ -258,6 +260,70 @@ def bootstrap_ap(
         for k in keys:
             samples[k].append(float(rd.get(k, 0.0)))
     return {k: tuple(float(np.percentile(v, p)) for p in (2.5, 50, 97.5)) for k, v in samples.items()}
+
+
+def dist_stats(logits: torch.Tensor) -> dict[str, torch.Tensor]:
+    """Softmax distribution-shape stats for [N, n_bins] logits (GFLv2: shape predicts localization quality).
+
+    Entropy is normalized by log(n_bins) so 1.0 = uniform (uninformative) and 0.0 = one-hot. Applies to both
+    DepthDFL depth-bin logits and cost-volume disparity slices.
+
+    Args:
+        logits (torch.Tensor): [..., n_bins] raw logits.
+
+    Returns:
+        (dict[str, torch.Tensor]): entropy, top1 (peak mass), top2_mass, argmax — each [...].
+    """
+    p = logits.float().softmax(dim=-1)
+    n_bins = p.shape[-1]
+    entropy = -(p * (p + 1e-12).log()).sum(-1) / math.log(n_bins)
+    top2 = p.topk(min(2, n_bins), dim=-1).values
+    return {"entropy": entropy, "top1": top2[..., 0], "top2_mass": top2.sum(-1), "argmax": p.argmax(-1)}
+
+
+def expected_dz(z: float, dpx: float, fx: float, baseline: float) -> float:
+    """Exact depth change when the measured disparity changes by dpx pixels (d = fx·b/z).
+
+    Args:
+        z (float): Base depth in meters.
+        dpx (float): Disparity reduction in pixels: the perturbed disparity is d − dpx, so positive dpx
+            (less disparity) yields z' > z.
+        fx (float): Focal length in pixels (original-image space).
+        baseline (float): Stereo baseline in meters.
+
+    Returns:
+        (float): z' − z; inf when the perturbed disparity is non-positive.
+    """
+    d = fx * baseline / z
+    if d - dpx <= 0:
+        return float("inf")
+    return fx * baseline / (d - dpx) - z
+
+
+def stereo_sensitivity(
+    base_z: np.ndarray, shifted_z: np.ndarray, z_gt: np.ndarray, dpx: float, fx: float, baseline: float
+) -> float:
+    """Median ratio of observed to geometrically-expected depth shift under a right-image shift.
+
+    1.0 → depth is fully stereo-driven; 0.0 → the network ignores stereo (monocular shortcut, e.g. the
+    apparent-size cue on constant-dimension objects). van Dijk & de Croon (ICCV 2019)-style probe.
+
+    Args:
+        base_z (np.ndarray): Predicted depths on the unmodified batch.
+        shifted_z (np.ndarray): Predicted depths on the right-image-shifted batch (matched objects).
+        z_gt (np.ndarray): GT depths (unused in the ratio; kept for per-range breakdowns by callers).
+        dpx (float): Disparity change implied by the shift (right image rolled +k px → dpx = −k).
+        fx (float): Focal length in pixels.
+        baseline (float): Stereo baseline in meters.
+
+    Returns:
+        (float): Median sensitivity ratio, or nan when no valid objects.
+    """
+    expected = np.array([expected_dz(float(z), dpx, fx, baseline) for z in base_z])
+    valid = np.isfinite(expected) & (np.abs(expected) > 1e-9)
+    if not valid.any():
+        return float("nan")
+    return float(np.median((shifted_z[valid] - base_z[valid]) / expected[valid]))
 
 
 def depth_bias_fit(records: list[dict[str, float]]) -> tuple[float, float, float]:

--- a/ultralytics/models/yolo/s3d/loss.py
+++ b/ultralytics/models/yolo/s3d/loss.py
@@ -330,8 +330,13 @@ class Stereo3DDetLoss(v8DetectionLoss):
             return (raw * aux_weights).sum() / aux_weights.sum().clamp(min=1.0)
         return raw.mean()
 
-    def loss(self, preds: dict[str, torch.Tensor], batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
-        """Calculate stereo 3D detection loss: det losses + aux 3D losses.
+    def component_losses(
+        self, preds: dict[str, torch.Tensor], batch: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        """Compute live (non-detached) per-component losses keyed in trainer loss_names order.
+
+        Keys: box, cls, lr_dist, depth, dims, orient, proj_center. Used by loss() and by the gradient
+        diagnostics probe (diagnose.py), which needs each component's own autograd graph.
 
         Args:
             preds: Dict with boxes, scores, feats, lr_distance, depth, dimensions, orientation.
@@ -341,23 +346,38 @@ class Stereo3DDetLoss(v8DetectionLoss):
         aux_keys = {"lr_distance", "lr_logvar", "depth", "depth_bins", "dimensions", "orientation", "proj_offset"}
         aux_preds = {k: v for k, v in preds.items() if k in aux_keys}
 
-        loss = torch.zeros(7, device=self.device)  # box, cls, lr_dist, depth, dims, orient, proj_center
-
         # Get detection losses + TAL assignment results
         (fg_mask, target_gt_idx, _, _, _), det_loss, _ = self.get_assigned_targets_and_loss(preds, batch)
-
-        if self.use_bbox_loss:
-            loss[0] = det_loss[0]  # box (already scaled by hyp.box)
-        loss[1] = det_loss[1]  # cls (already scaled by hyp.cls)
         # det_loss[2] is dfl, which is 0 since reg_max=1
 
-        # Aux losses
+        zero = preds["boxes"].sum() * 0.0  # graph-connected zero for absent components
+        comp = {
+            "box": det_loss[0] if self.use_bbox_loss else zero,  # already scaled by hyp.box
+            "cls": det_loss[1],  # already scaled by hyp.cls
+        }
         aux_losses = self._compute_aux_losses(aux_preds, batch, target_gt_idx, fg_mask)
-        for i, k in enumerate(["lr_distance", "depth", "dimensions", "orientation"], 2):
-            if k in aux_losses:
-                loss[i] = aux_losses[k] * float(self.aux_w.get(k, 1.0))
-        if "proj_center" in aux_losses:
-            loss[6] = aux_losses["proj_center"] * float(self.aux_w.get("proj_center", 1.0))
+        for name, k in (
+            ("lr_dist", "lr_distance"),
+            ("depth", "depth"),
+            ("dims", "dimensions"),
+            ("orient", "orientation"),
+        ):
+            comp[name] = aux_losses[k] * float(self.aux_w.get(k, 1.0)) if k in aux_losses else zero
+        comp["proj_center"] = (
+            aux_losses["proj_center"] * float(self.aux_w.get("proj_center", 1.0))
+            if "proj_center" in aux_losses
+            else zero
+        )
+        return comp
 
+    def loss(self, preds: dict[str, torch.Tensor], batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
+        """Calculate stereo 3D detection loss: det losses + aux 3D losses.
+
+        Args:
+            preds: Dict with boxes, scores, feats, lr_distance, depth, dimensions, orientation.
+            batch: Batch dict with img, batch_idx, cls, bboxes, aux_targets.
+        """
+        comp = self.component_losses(preds, batch)
+        loss = torch.stack([comp[k] for k in ("box", "cls", "lr_dist", "depth", "dims", "orient", "proj_center")])
         batch_size = preds["boxes"].shape[0]
         return loss * batch_size, loss.detach()

--- a/ultralytics/models/yolo/s3d/train.py
+++ b/ultralytics/models/yolo/s3d/train.py
@@ -30,6 +30,7 @@ class Stereo3DDetTrainer(yolo.detect.DetectionTrainer):
         overrides["task"] = "s3d"
         super().__init__(cfg, overrides, _callbacks)
         self.add_callback("on_train_epoch_start", Stereo3DDetTrainer._set_loss_epoch_frac)
+        self.add_callback("on_train_start", Stereo3DDetTrainer._maybe_enable_grad_diag)
 
     @staticmethod
     def _set_loss_epoch_frac(trainer):
@@ -37,6 +38,18 @@ class Stereo3DDetTrainer(yolo.detect.DetectionTrainer):
         criterion = getattr(unwrap_model(trainer.model), "criterion", None)
         if criterion is not None:
             criterion.epoch_frac = trainer.epoch / max(trainer.epochs, 1)
+
+    @staticmethod
+    def _maybe_enable_grad_diag(trainer):
+        """Enable gradient diagnostics when the model YAML sets training.diag_grad_every > 0."""
+        yaml_cfg = getattr(unwrap_model(trainer.model), "yaml", {}) or {}
+        every = int((yaml_cfg.get("training") or {}).get("diag_grad_every", 0))
+        if every > 0:
+            from ultralytics.models.yolo.s3d.diagnose import grad_diag_callback
+
+            trainer._diag_grad_every = every
+            trainer._diag_batch_i = 0
+            trainer.add_callback("on_train_batch_end", grad_diag_callback)
 
     def get_validator(self):
         """Return a Stereo3DDetValidator, currently extending DetectionValidator."""


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-07-21-s3d-network-diagnostics-design.md` — a repeatable analysis method that, given any s3d checkpoint + dataset, attributes AP3D loss to network components and ranks the next levers with quantified headroom.

## What's included

- **`ultralytics/models/yolo/s3d/diagnose.py`**: pred/GT matching, per-component signed error records, depth bias/variance fit (`dz = a·z + b`), MonoDLE/TIDE3D **oracle-swap ladder** (z / y / xy / location / dims / orientation / **score-ranking** oracles) with recomputed rotated IoU, **bootstrap AP CIs** (metric-noise floor for small val sets), distribution-shape probes (softmax entropy/top-2 for DepthDFL bins and cost-volume disparity slices), **counterfactual stereo-shift math** (is depth stereo-driven or a monocular shortcut?), and a **per-branch gradient probe** (GradNorm norms + PCGrad cosine conflict on the shared neck).
- **`ultralytics/data/scripts/diagnose_s3d.py`**: one-pass CLI (pattern: `benchmark_s3d.py`) that drives the standard validator with probe hooks attached and emits `report.md` + CSVs with a ranked lever list.
- **`Stereo3DDetLoss.loss()` construction relocated into `component_losses()`** — single loss-construction path; `loss()` is now a thin stack-and-scale wrapper. Exact-equality test guards the refactor.
- **Opt-in gradient callback**: model YAML `training.diag_grad_every: N` appends per-branch gradient norms + pairwise cosines to `grad_diag.csv` every N batches via `torch.autograd.grad` (never touches `.grad`). Zero behavior change when unset.

## Testing

- 19 new CPU unit tests in `tests/test_s3d_diagnose.py` (synthetic Box3D stats, toy-model gradient conflict, loss-refactor equality); full non-network s3d suite passes (43 tests).
- End-to-end GPU validation on the client cube_s3d dataset (RTX PRO 6000): val pass reproduces the known cv48 checkpoint metrics; all report sections (oracle ladder, bootstrap CIs, DFL/cost-volume probes, stereo-shift, gradient conflict matrix) produce data.

Deleted: nothing removed in-repo beyond the `loss()` body relocation (net-negative in loss.py); consolidates and supersedes the off-repo profiling scripts (diag8.py / profile_arm.py / profile_ema.py / farm_s3d_collect.py per-component sections) — reuses `Stereo3DDetMetrics`, `compute_3d_iou_batch`, `decode_and_refine_predictions` rather than adding parallel implementations. Rule-2 justification: error attribution/probing is net-new capability, not expressible as deletion.

Known follow-up (documented in spec): a decode-space depth oracle (overwriting `outputs["depth"]` pre-decode) to separate representation error from fusion error; the box-space `z` oracle here answers the headroom question.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧭 Adds a comprehensive S3D network diagnostics toolkit for identifying stereo 3D detection errors, performance bottlenecks, and training issues.

### 📊 Key Changes
- Added `diagnose_s3d` analysis utilities for:
  - Per-object error records and depth-bias profiling.
  - Oracle component swaps to estimate AP headroom for depth, location, dimensions, orientation, and confidence ranking.
  - Bootstrap AP confidence intervals.
  - DepthDFL and stereo cost-volume distribution analysis.
  - Counterfactual stereo sensitivity testing.
  - Per-branch gradient magnitude and conflict diagnostics.
- Added a command-line diagnostic script that runs validation once and generates:
  - A Markdown `report.md`.
  - CSV files containing error and probe records.
  - Ranked recommendations for the model components with the greatest potential impact.
- Refactored S3D loss computation with `component_losses()` so individual loss terms remain connected to the autograd graph for gradient analysis.
- Added optional training-time gradient diagnostics through the `training.diag_grad_every` configuration.
- Added extensive unit tests covering matching, error summaries, oracle swaps, bootstrap metrics, stereo geometry, distribution statistics, gradients, and report generation.
- Added API reference pages and navigation entries for the new diagnostic modules.

### 🎯 Purpose & Impact
- 🛠️ Helps developers quickly determine whether accuracy issues come from depth estimation, stereo fusion, localization, dimensions, orientation, ranking, or optimization conflicts.
- 📈 Provides more reliable evaluation context by exposing metric uncertainty on small validation sets instead of relying on AP alone.
- 🔍 Makes stereo-specific failure modes easier to detect, including monocular shortcuts, depth scale bias, poor cost-volume quality, and conflicting loss branches.
- 🚀 Produces actionable reports and ranked improvement opportunities, potentially reducing S3D model debugging and iteration time.
- ✅ The core training and validation behavior remains consistent, while diagnostics are opt-in through the new script and configuration setting.