### PR TITLE
Batch TaskAlignedAssigner select_topk_candidates into a single scatter_add_

### DIFF
--- a/ultralytics/utils/tal.py
+++ b/ultralytics/utils/tal.py
@@ -234,12 +234,9 @@ class TaskAlignedAssigner(nn.Module):
         # (b, max_num_obj, topk)
         topk_idxs.masked_fill_(~topk_mask, 0)
 
-        # (b, max_num_obj, topk, h*w) -> (b, max_num_obj, h*w)
+        # Count how many of the topk lists select each anchor; scatter_add_ accumulates duplicate indices in one pass
         count_tensor = torch.zeros(metrics.shape, dtype=torch.int8, device=topk_idxs.device)
-        ones = torch.ones_like(topk_idxs[:, :, :1], dtype=torch.int8, device=topk_idxs.device)
-        for k in range(self.topk):
-            # Expand topk_idxs for each value of k and add 1 at the specified positions
-            count_tensor.scatter_add_(-1, topk_idxs[:, :, k : k + 1], ones)
+        count_tensor.scatter_add_(-1, topk_idxs, torch.ones_like(topk_idxs, dtype=torch.int8))
         # Filter invalid bboxes
         count_tensor.masked_fill_(count_tensor > 1, 0)
 


### PR DESCRIPTION
## summary

`TaskAlignedAssigner.select_topk_candidates` looped over `topk` (default 13) calling `scatter_add_` once per index slice into `count_tensor`. `scatter_add_` already accumulates duplicate indices within one call, so the loop and its scratch `ones` tensor collapse into a single `scatter_add_` over the full `(b, max_num_obj, topk)` index tensor — one kernel launch instead of `topk`, on the per-step assigner path used by detect/segment/pose/OBB (`RotatedTaskAlignedAssigner` inherits the method).

The result is bit-exact: integer int8 counts, order-independent accumulation. Verified with a 17-seed real-symbol differential (`torch.equal` true, including the auto-mask and fully-masked pile-up branches) and a 3-epoch coco8 A/B where mAP50-95 is identical to 17 digits (0.43036693899782136). CPU microbenchmark of the count build shows ~1.30x/1.16x on dispatch-bound sizes and ~1.0x at large sizes; the win scales with kernel-launch overhead on GPU.

Deleted: the `for k in range(self.topk)` loop and the `ones` scratch tensor in `select_topk_candidates`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

⚡ Optimized top-k candidate selection by replacing a Python loop with a single vectorized PyTorch operation.

### 📊 Key Changes

- Updated `select_topk_candidates()` in `ultralytics/utils/tal.py`.
- Replaced the per-top-k iteration with one `scatter_add_` call.
- Preserved duplicate-index handling by filtering anchors selected more than once.
- Simplified the implementation while maintaining the existing output behavior.

### 🎯 Purpose & Impact

- 🚀 Improves candidate-selection efficiency by reducing Python-level loop overhead.
- 🧠 Makes the code shorter, clearer, and more aligned with vectorized PyTorch execution.
- ✅ Should provide faster training or inference with no intended change to model results.