### PR TITLE
Compute DFL log_softmax once instead of two cross_entropy calls

### DIFF
--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -101,9 +101,10 @@ class DFLoss(nn.Module):
         tr = tl + 1  # target right
         wl = tr - target  # weight left
         wr = 1 - wl  # weight right
-        return (
-            F.cross_entropy(pred_dist, tl.view(-1), reduction="none").view(tl.shape) * wl
-            + F.cross_entropy(pred_dist, tr.view(-1), reduction="none").view(tl.shape) * wr
+        # Compute log_softmax once, then two gathers; cross_entropy(x, t) = -log_softmax(x).gather(t)
+        logp = F.log_softmax(pred_dist, dim=1)
+        return -(
+            logp.gather(1, tl.view(-1, 1)).view(tl.shape) * wl + logp.gather(1, tr.view(-1, 1)).view(tl.shape) * wr
         ).mean(-1, keepdim=True)
 
 


### PR DESCRIPTION
## summary

`DFLoss.__call__` called `F.cross_entropy` twice on the same `pred_dist`, so `log_softmax` over the `(N*4, reg_max)` distribution was computed twice every training step. This computes `log_softmax` once and gathers the two DFL targets from it, using `cross_entropy(x, t) = -log_softmax(x).gather(t)`. The `tr = tl + 1` gather is always in range because the target is clamped to `reg_max - 1 - 0.01`.

Forward is bit-exact (max abs diff 0.0 across rand / all-zero / at-ceiling targets) and the gradient differs only by fp32 rounding (<=1.49e-8); a 3-epoch coco8 detect run at seed 0 gives identical mAP50-95. Microbenchmark shows 1.5x-1.75x on the DFL term, scaling with the number of positives.

Deleted: the redundant second `log_softmax` pass (one of the two `F.cross_entropy` calls); the net +1 line is a one-line comment recording the cross_entropy/log_softmax identity so the two-call form is not restored.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Optimizes distribution focal loss by computing `log_softmax` once instead of running cross-entropy twice. ⚡

### 📊 Key Changes

- Replaced two `F.cross_entropy` calls with:
  - One `F.log_softmax` computation.
  - Two targeted `gather` operations for the left and right target bins.
- Preserved the existing weighted interpolation and output behavior.
- Added an explanatory comment documenting the equivalent computation.

### 🎯 Purpose & Impact

- Reduces redundant calculations during loss computation, potentially improving training efficiency. 🚀
- May lower computational overhead for models using distribution-based bounding-box regression.
- Keeps the loss mathematically equivalent, so model accuracy and training behavior should remain unchanged. ✅