### PR TITLE
Return loss items as name-keyed dicts from criteria

### DIFF
--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -116,24 +116,6 @@ def test_export_engine_matrix(task, dynamic, quantize, batch):
 
 
 @pytest.mark.skipif(not DEVICES, reason="No CUDA devices available")
-@pytest.mark.parametrize("nc", [1, 3])
-def test_semantic_loss_all_ignore_amp(nc):
-    """All-ignore guard must stay finite with large fp16 logits, where sum() overflows to inf (AMP is a GPU path)."""
-    from ultralytics.cfg import get_cfg
-    from ultralytics.nn.tasks import SemanticSegmentationModel
-    from ultralytics.utils.loss import SemanticSegmentationLoss
-
-    model = SemanticSegmentationModel(cfg="yolo26-sem.yaml", nc=nc, verbose=False)
-    model.args = get_cfg()
-    loss_fn = SemanticSegmentationLoss(model)
-    preds = (torch.randn(1, nc, 64, 64, device=f"cuda:{DEVICES[0]}") + 50).half().requires_grad_()
-    loss, items = loss_fn(preds, {"semantic_mask": torch.full((1, 64, 64), 255, dtype=torch.long)})
-    assert torch.isfinite(loss).all() and torch.isfinite(torch.stack(list(items.values()))).all()
-    loss.backward()
-    assert preds.grad is not None
-
-
-@pytest.mark.skipif(not DEVICES, reason="No CUDA devices available")
 @pytest.mark.skipif(IS_JETSON, reason="Edge devices not intended for training")
 def test_train():
     """Test model training on a minimal dataset using available CUDA devices."""

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -116,6 +116,24 @@ def test_export_engine_matrix(task, dynamic, quantize, batch):
 
 
 @pytest.mark.skipif(not DEVICES, reason="No CUDA devices available")
+@pytest.mark.parametrize("nc", [1, 3])
+def test_semantic_loss_all_ignore_amp(nc):
+    """All-ignore guard must stay finite with large fp16 logits, where sum() overflows to inf (AMP is a GPU path)."""
+    from ultralytics.cfg import get_cfg
+    from ultralytics.nn.tasks import SemanticSegmentationModel
+    from ultralytics.utils.loss import SemanticSegmentationLoss
+
+    model = SemanticSegmentationModel(cfg="yolo26-sem.yaml", nc=nc, verbose=False)
+    model.args = get_cfg()
+    loss_fn = SemanticSegmentationLoss(model)
+    preds = (torch.randn(1, nc, 64, 64, device=f"cuda:{DEVICES[0]}") + 50).half().requires_grad_()
+    loss, items = loss_fn(preds, {"semantic_mask": torch.full((1, 64, 64), 255, dtype=torch.long)})
+    assert torch.isfinite(loss).all() and all(torch.isfinite(x).all() for x in items.values())
+    loss.backward()
+    assert preds.grad is not None
+
+
+@pytest.mark.skipif(not DEVICES, reason="No CUDA devices available")
 @pytest.mark.skipif(IS_JETSON, reason="Edge devices not intended for training")
 def test_train():
     """Test model training on a minimal dataset using available CUDA devices."""

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -128,7 +128,7 @@ def test_semantic_loss_all_ignore_amp(nc):
     loss_fn = SemanticSegmentationLoss(model)
     preds = (torch.randn(1, nc, 64, 64, device=f"cuda:{DEVICES[0]}") + 50).half().requires_grad_()
     loss, items = loss_fn(preds, {"semantic_mask": torch.full((1, 64, 64), 255, dtype=torch.long)})
-    assert torch.isfinite(loss).all() and torch.isfinite(torch.stack(items.values())).all()
+    assert torch.isfinite(loss).all() and torch.isfinite(torch.stack(list(items.values()))).all()
     loss.backward()
     assert preds.grad is not None
 

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -128,7 +128,7 @@ def test_semantic_loss_all_ignore_amp(nc):
     loss_fn = SemanticSegmentationLoss(model)
     preds = (torch.randn(1, nc, 64, 64, device=f"cuda:{DEVICES[0]}") + 50).half().requires_grad_()
     loss, items = loss_fn(preds, {"semantic_mask": torch.full((1, 64, 64), 255, dtype=torch.long)})
-    assert torch.isfinite(loss).all() and torch.isfinite(items).all()
+    assert torch.isfinite(loss).all() and torch.isfinite(items.values()).all()
     loss.backward()
     assert preds.grad is not None
 

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -128,7 +128,7 @@ def test_semantic_loss_all_ignore_amp(nc):
     loss_fn = SemanticSegmentationLoss(model)
     preds = (torch.randn(1, nc, 64, 64, device=f"cuda:{DEVICES[0]}") + 50).half().requires_grad_()
     loss, items = loss_fn(preds, {"semantic_mask": torch.full((1, 64, 64), 255, dtype=torch.long)})
-    assert torch.isfinite(loss).all() and torch.isfinite(items.values()).all()
+    assert torch.isfinite(loss).all() and torch.isfinite(torch.stack(items.values())).all()
     loss.backward()
     assert preds.grad is not None
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -238,7 +238,7 @@ def test_nan_recovery():
     def inject_nan(trainer):
         """Inject NaN into loss during batch processing to test recovery mechanism."""
         if trainer.epoch == 1 and trainer.tloss is not None and not nan_injected[0]:
-            trainer.tloss *= torch.tensor(float("nan"))
+            trainer.tloss[next(iter(trainer.tloss))] *= float("nan")
             nan_injected[0] = True
 
     overrides = {"data": "coco8.yaml", "model": "yolo26n.yaml", "imgsz": 32, "epochs": 3}

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1168,24 +1168,6 @@ def test_utils_torchutils():
     time_sync()
 
 
-@pytest.mark.parametrize("nc", [1, 3])
-def test_semantic_loss_all_ignore(nc):
-    """SemanticSegmentationLoss must stay finite when the whole batch is ignore (255), e.g. unlabeled/void frames."""
-    from ultralytics.cfg import get_cfg
-    from ultralytics.nn.tasks import SemanticSegmentationModel
-    from ultralytics.utils.loss import SemanticSegmentationLoss
-
-    model = SemanticSegmentationModel(cfg="yolo26-sem.yaml", nc=nc, verbose=False)
-    model.args = get_cfg()
-    loss_fn = SemanticSegmentationLoss(model)
-    preds = torch.randn(1, nc, 64, 64, requires_grad=True)
-    aux = torch.randn(1, nc, 32, 32, requires_grad=True)
-    loss, items = loss_fn((preds, aux), {"semantic_mask": torch.full((1, 64, 64), 255, dtype=torch.long)})
-    assert torch.isfinite(loss).all() and torch.isfinite(items).all()
-    loss.backward()
-    assert preds.grad is not None and aux.grad is not None
-
-
 def test_utils_ops():
     """Test utility operations for coordinate transformations and normalizations."""
     from ultralytics.utils.ops import (

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1168,6 +1168,24 @@ def test_utils_torchutils():
     time_sync()
 
 
+@pytest.mark.parametrize("nc", [1, 3])
+def test_semantic_loss_all_ignore(nc):
+    """SemanticSegmentationLoss must stay finite when the whole batch is ignore (255), e.g. unlabeled/void frames."""
+    from ultralytics.cfg import get_cfg
+    from ultralytics.nn.tasks import SemanticSegmentationModel
+    from ultralytics.utils.loss import SemanticSegmentationLoss
+
+    model = SemanticSegmentationModel(cfg="yolo26-sem.yaml", nc=nc, verbose=False)
+    model.args = get_cfg()
+    loss_fn = SemanticSegmentationLoss(model)
+    preds = torch.randn(1, nc, 64, 64, requires_grad=True)
+    aux = torch.randn(1, nc, 32, 32, requires_grad=True)
+    loss, items = loss_fn((preds, aux), {"semantic_mask": torch.full((1, 64, 64), 255, dtype=torch.long)})
+    assert torch.isfinite(loss).all() and all(torch.isfinite(x).all() for x in items.values())
+    loss.backward()
+    assert preds.grad is not None and aux.grad is not None
+
+
 def test_utils_ops():
     """Test utility operations for coordinate transformations and normalizations."""
     from ultralytics.utils.ops import (

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -97,7 +97,8 @@ class BaseTrainer:
         fitness (float): Current fitness value.
         loss (torch.Tensor): Current loss value.
         tloss (dict): Running mean of loss items.
-        loss_names (tuple): Names of loss items, derived from the loss dict returned by the criterion on the first batch.
+        loss_names (tuple): Names of loss items, derived from the loss dict returned by the criterion on the first
+            batch.
         csv (Path): Path to results CSV file.
         metrics (dict): Dictionary of metrics.
         plots (dict): Dictionary of plots.

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -96,8 +96,8 @@ class BaseTrainer:
         best_fitness (float): The best fitness value achieved.
         fitness (float): Current fitness value.
         loss (torch.Tensor): Current loss value.
-        tloss (torch.Tensor): Running mean of loss items.
-        loss_names (list): List of loss names.
+        tloss (dict): Running mean of loss items.
+        loss_names (tuple): Names of loss items, derived from the loss dict returned by the criterion on the first batch.
         csv (Path): Path to results CSV file.
         metrics (dict): Dictionary of metrics.
         plots (dict): Dictionary of plots.
@@ -191,7 +191,7 @@ class BaseTrainer:
         self.fitness = None
         self.loss = None
         self.tloss = None
-        self.loss_names = ["Loss"]
+        self.loss_names = ()
         self.csv = self.save_dir / "results.csv"
         if self.csv.exists() and not self.args.resume:
             self.csv.unlink()
@@ -378,8 +378,6 @@ class BaseTrainer:
             self.args.batch = self.batch_size = self.auto_batch()
         self._build_train_pipeline()
         self.validator = self.get_validator()
-        if self.args.distill_model is not None and "dis_loss" not in self.loss_names:
-            self.loss_names += ("dis_loss",)
         self.ema = ModelEMA(self.model)
         self.set_class_weights()  # compute class weights after dataloader is ready
         if RANK in {-1, 0}:
@@ -435,7 +433,8 @@ class BaseTrainer:
                 self.train_loader.reset()
 
             if RANK in {-1, 0}:
-                LOGGER.info(self.progress_string())
+                if self.loss_names:
+                    LOGGER.info(self.progress_string())
                 pbar = TQDM(enumerate(self.train_loader), total=nb)
             self.tloss = None
             for i, batch in pbar:
@@ -473,8 +472,15 @@ class BaseTrainer:
                         self.loss = loss.sum()
                         if RANK != -1:
                             self.loss *= self.world_size
+                        if not self.loss_names:  # derive loss names from the criterion's loss dict on first batch
+                            self.loss_names = tuple(self.loss_items)
+                            if RANK in {-1, 0}:
+                                LOGGER.info(self.progress_string())
+                                self.metrics.update(dict.fromkeys(self.label_loss_items(prefix="val"), 0.0))
                         self.tloss = (
-                            self.loss_items if self.tloss is None else (self.tloss * i + self.loss_items) / (i + 1)
+                            self.loss_items
+                            if self.tloss is None
+                            else {k: (self.tloss[k] * i + v) / (i + 1) for k, v in self.loss_items.items()}
                         )
 
                     # Backward
@@ -525,13 +531,13 @@ class BaseTrainer:
 
                 # Log
                 if RANK in {-1, 0}:
-                    loss_length = self.tloss.shape[0] if len(self.tloss.shape) else 1
+                    loss_length = len(self.tloss)
                     pbar.set_description(
                         ("%11s" * 2 + "%11.4g" * (2 + loss_length))
                         % (
                             f"{epoch + 1}/{self.epochs}",
                             f"{self._get_memory():.3g}G",  # (GB) GPU memory util
-                            *(self.tloss if loss_length > 1 else torch.unsqueeze(self.tloss, 0)),  # losses
+                            *self.tloss.values(),  # losses
                             batch.get("cls", batch["img"]).shape[0],  # no. of instances
                             batch["img"].shape[-1],  # imgsz, i.e 640
                         )
@@ -853,12 +859,10 @@ class BaseTrainer:
         raise NotImplementedError("build_dataset function not implemented in trainer")
 
     def label_loss_items(self, loss_items=None, prefix="train"):
-        """Return a loss dict with labeled training loss items, or a list of loss names if loss_items is None.
-
-        Notes:
-            This is not needed for classification but necessary for segmentation & detection.
-        """
-        return {"loss": loss_items} if loss_items is not None else ["loss"]
+        """Return a loss dict with labeled training loss items, or a list of loss names if loss_items is None."""
+        if loss_items is None:
+            return [f"{prefix}/{x}" for x in self.loss_names]
+        return {f"{prefix}/{k}": round(float(v), 5) for k, v in loss_items.items()}
 
     def set_model_attributes(self):
         """Set or update model parameters before training."""

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -80,7 +80,7 @@ class BaseValidator:
         plots (dict): Dictionary to store plots for visualization.
         callbacks (dict): Dictionary to store various callback functions.
         stride (int): Model stride for padding calculations.
-        loss (torch.Tensor): Accumulated loss during training validation.
+        loss (dict): Accumulated loss items during training validation.
 
     Methods:
         __call__: Execute validation process, running inference on dataloader and computing performance metrics.
@@ -162,7 +162,7 @@ class BaseValidator:
             if trainer.args.compile and hasattr(model, "_orig_mod"):
                 model = model._orig_mod  # validate non-compiled original model to avoid issues
             model = model.float()
-            self.loss = torch.zeros_like(trainer.loss_items, device=trainer.device)
+            self.loss = {k: torch.zeros_like(v) for k, v in trainer.loss_items.items()}
             self.args.plots &= trainer.stopper.possible_stop or (trainer.epoch == trainer.epochs - 1)
             model.eval()
         else:
@@ -245,7 +245,8 @@ class BaseValidator:
                 # Loss
                 with dt[2]:
                     if self.training:
-                        self.loss += model.loss(batch, preds)[1]
+                        for k, v in model.loss(batch, preds)[1].items():
+                            self.loss[k] += v
 
             # Postprocess
             with dt[3]:
@@ -269,12 +270,14 @@ class BaseValidator:
 
         if self.training:
             # Reduce loss across all GPUs
-            loss = self.loss.clone().detach()
+            loss = {k: v.clone().detach() for k, v in self.loss.items()}
             if trainer.world_size > 1:
-                dist.reduce(loss, dst=0, op=dist.ReduceOp.AVG)
+                for v in loss.values():
+                    dist.reduce(v, dst=0, op=dist.ReduceOp.AVG)
             if RANK > 0:
                 return
-            results = {**stats, **trainer.label_loss_items(loss.cpu() / len(self.dataloader), prefix="val")}
+            loss = {k: v.cpu() / len(self.dataloader) for k, v in loss.items()}
+            results = {**stats, **trainer.label_loss_items(loss, prefix="val")}
             return {k: round(float(v), 5) for k, v in results.items()}  # return results as 5 decimal place floats
         else:
             if RANK > 0:

--- a/ultralytics/models/rtdetr/train.py
+++ b/ultralytics/models/rtdetr/train.py
@@ -19,7 +19,7 @@ class RTDETRTrainer(DetectionTrainer):
     inference speed.
 
     Attributes:
-        loss_names (tuple): Names of the loss components used for training.
+        loss_names (tuple): Names of the loss components, derived from the loss dict returned by the criterion.
         data (dict): Dataset configuration containing class count and other parameters.
         args (dict): Training arguments and hyperparameters.
         save_dir (Path): Directory to save training results.
@@ -85,5 +85,4 @@ class RTDETRTrainer(DetectionTrainer):
 
     def get_validator(self):
         """Return an RTDETRValidator suitable for RT-DETR model validation."""
-        self.loss_names = "giou_loss", "cls_loss", "l1_loss"
         return RTDETRValidator(self.test_loader, save_dir=self.save_dir, args=copy(self.args))

--- a/ultralytics/models/yolo/classify/train.py
+++ b/ultralytics/models/yolo/classify/train.py
@@ -25,7 +25,7 @@ class ClassificationTrainer(BaseTrainer):
     Attributes:
         model (ClassificationModel): The classification model to be trained.
         data (dict[str, Any]): Dictionary containing dataset information including class names and number of classes.
-        loss_names (list[str]): Names of the loss functions used during training.
+        loss_names (tuple): Names of the loss items, derived from the loss dict returned by the criterion.
         validator (ClassificationValidator): Validator instance for model evaluation.
 
     Methods:
@@ -37,7 +37,6 @@ class ClassificationTrainer(BaseTrainer):
         preprocess_batch: Preprocess a batch of images and classes.
         progress_string: Return a formatted string showing training progress.
         get_validator: Return an instance of ClassificationValidator.
-        label_loss_items: Return a loss dict with labeled training loss items.
         final_eval: Evaluate trained model and save validation results.
         plot_training_samples: Plot training samples with their annotations.
 
@@ -188,26 +187,9 @@ class ClassificationTrainer(BaseTrainer):
 
     def get_validator(self):
         """Return an instance of ClassificationValidator for validation."""
-        self.loss_names = ["loss"]
         return yolo.classify.ClassificationValidator(
             self.test_loader, self.save_dir, args=copy(self.args), _callbacks=self.callbacks
         )
-
-    def label_loss_items(self, loss_items: torch.Tensor | None = None, prefix: str = "train"):
-        """Return a loss dict with labeled training loss items tensor.
-
-        Args:
-            loss_items (torch.Tensor, optional): Loss tensor items.
-            prefix (str, optional): Prefix to prepend to loss names.
-
-        Returns:
-            (dict | list): Dictionary of labeled loss items if loss_items is provided, otherwise list of keys.
-        """
-        keys = [f"{prefix}/{x}" for x in self.loss_names]
-        if loss_items is None:
-            return keys
-        loss_items = [round(float(loss_items), 5)]
-        return dict(zip(keys, loss_items))
 
     def plot_training_samples(self, batch: dict[str, torch.Tensor], ni: int):
         """Plot training samples with their annotations.

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -30,7 +30,7 @@ class DetectionTrainer(BaseTrainer):
     Attributes:
         model (DetectionModel): The YOLO detection model being trained.
         data (dict): Dictionary containing dataset information including class names and number of classes.
-        loss_names (tuple): Names of the loss components used in training (box_loss, cls_loss, dfl_loss).
+        loss_names (tuple): Names of the loss components, derived from the loss dict returned by the criterion.
 
     Methods:
         build_dataset: Build YOLO dataset for training or validation.
@@ -39,7 +39,6 @@ class DetectionTrainer(BaseTrainer):
         set_model_attributes: Set model attributes based on dataset information.
         get_model: Return a YOLO detection model.
         get_validator: Return a validator for model evaluation.
-        label_loss_items: Return a loss dictionary with labeled training loss items.
         progress_string: Return a formatted string of training progress.
         plot_training_samples: Plot training samples with their annotations.
         plot_training_labels: Create a labeled training plot of the YOLO model.
@@ -205,27 +204,9 @@ class DetectionTrainer(BaseTrainer):
 
     def get_validator(self):
         """Return a DetectionValidator for YOLO model validation."""
-        self.loss_names = "box_loss", "cls_loss", "dfl_loss"
         return yolo.detect.DetectionValidator(
             self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
         )
-
-    def label_loss_items(self, loss_items: list[float] | None = None, prefix: str = "train"):
-        """Return a loss dict with labeled training loss items tensor.
-
-        Args:
-            loss_items (list[float], optional): List of loss values.
-            prefix (str): Prefix for keys in the returned dictionary.
-
-        Returns:
-            (dict | list): Dictionary of labeled loss items if loss_items is provided, otherwise list of keys.
-        """
-        keys = [f"{prefix}/{x}" for x in self.loss_names]
-        if loss_items is not None:
-            loss_items = [round(float(x), 5) for x in loss_items]  # convert tensors to 5 decimal place floats
-            return dict(zip(keys, loss_items))
-        else:
-            return keys
 
     def progress_string(self):
         """Return a formatted string of training progress with epoch, GPU memory, loss, instances and size."""

--- a/ultralytics/models/yolo/obb/train.py
+++ b/ultralytics/models/yolo/obb/train.py
@@ -17,8 +17,7 @@ class OBBTrainer(yolo.detect.DetectionTrainer):
     objects at arbitrary angles rather than just axis-aligned rectangles.
 
     Attributes:
-        loss_names (tuple): Names of the loss components used during training including box_loss, cls_loss, dfl_loss,
-            and angle_loss.
+        loss_names (tuple): Names of the loss components, derived from the loss dict returned by the criterion.
 
     Methods:
         get_model: Return OBBModel initialized with specified config and weights.
@@ -74,7 +73,6 @@ class OBBTrainer(yolo.detect.DetectionTrainer):
 
     def get_validator(self):
         """Return an instance of OBBValidator for validation of YOLO model."""
-        self.loss_names = "box_loss", "cls_loss", "dfl_loss", "angle_loss"
         return yolo.obb.OBBValidator(
             self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
         )

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -9,7 +9,6 @@ from typing import Any
 from ultralytics.models import yolo
 from ultralytics.nn.tasks import PoseModel
 from ultralytics.utils import DEFAULT_CFG, RANK
-from ultralytics.utils.torch_utils import unwrap_model
 
 
 class PoseTrainer(yolo.detect.DetectionTrainer):
@@ -22,7 +21,7 @@ class PoseTrainer(yolo.detect.DetectionTrainer):
         args (dict): Configuration arguments for training.
         model (PoseModel): The pose estimation model being trained.
         data (dict): Dataset configuration including keypoint shape information.
-        loss_names (tuple): Names of the loss components used in training.
+        loss_names (tuple): Names of the loss components, derived from the loss dict returned by the criterion.
 
     Methods:
         get_model: Retrieve a pose estimation model with specified configuration.
@@ -97,12 +96,6 @@ class PoseTrainer(yolo.detect.DetectionTrainer):
 
     def get_validator(self):
         """Return an instance of the PoseValidator class for validation."""
-        self.loss_names = "box_loss", "pose_loss", "kobj_loss", "cls_loss", "dfl_loss"
-        model = unwrap_model(self.model)
-        if hasattr(model, "student_model"):
-            model = model.student_model  # copy_attr does not copy nn.Module attributes like .model
-        if getattr(model.model[-1], "flow_model", None) is not None:
-            self.loss_names += ("rle_loss",)
         return yolo.pose.PoseValidator(
             self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
         )

--- a/ultralytics/models/yolo/segment/train.py
+++ b/ultralytics/models/yolo/segment/train.py
@@ -17,7 +17,7 @@ class SegmentationTrainer(yolo.detect.DetectionTrainer):
     functionality including model initialization, validation, and visualization.
 
     Attributes:
-        loss_names (tuple[str]): Names of the loss components used during training.
+        loss_names (tuple[str]): Names of the loss components, derived from the loss dict returned by the criterion.
 
     Examples:
         >>> from ultralytics.models.yolo.segment import SegmentationTrainer
@@ -65,7 +65,6 @@ class SegmentationTrainer(yolo.detect.DetectionTrainer):
 
     def get_validator(self):
         """Return an instance of SegmentationValidator for validation of YOLO model."""
-        self.loss_names = "box_loss", "seg_loss", "cls_loss", "dfl_loss", "sem_loss"
         return yolo.segment.SegmentationValidator(
             self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
         )

--- a/ultralytics/models/yolo/semantic/train.py
+++ b/ultralytics/models/yolo/semantic/train.py
@@ -67,7 +67,6 @@ class SemanticSegmentationTrainer(DetectionTrainer):
 
     def get_validator(self):
         """Return a SemanticSegmentationValidator for model evaluation."""
-        self.loss_names = "ce_loss", "dice_loss", "aux_loss"
         return yolo.semantic.SemanticSegmentationValidator(
             self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
         )

--- a/ultralytics/models/yolo/yoloe/train.py
+++ b/ultralytics/models/yolo/yoloe/train.py
@@ -25,7 +25,7 @@ class YOLOETrainer(DetectionTrainer):
     model initialization, validation, and dataset building with multi-modal support.
 
     Attributes:
-        loss_names (tuple): Names of loss components used during training.
+        loss_names (tuple): Names of loss components, derived from the loss dict returned by the criterion.
 
     Methods:
         get_model: Initialize and return a YOLOEModel with specified configuration.
@@ -79,7 +79,6 @@ class YOLOETrainer(DetectionTrainer):
 
     def get_validator(self):
         """Return a YOLOEDetectValidator for YOLOE model validation."""
-        self.loss_names = "box", "cls", "dfl"
         return YOLOEDetectValidator(
             self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
         )
@@ -222,7 +221,6 @@ class YOLOEPEFreeTrainer(YOLOEPETrainer, YOLOETrainerFromScratch):
 
     def get_validator(self):
         """Return a DetectionValidator for YOLO model validation."""
-        self.loss_names = "box", "cls", "dfl"
         return DetectionValidator(
             self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
         )

--- a/ultralytics/models/yolo/yoloe/train_seg.py
+++ b/ultralytics/models/yolo/yoloe/train_seg.py
@@ -52,7 +52,6 @@ class YOLOESegTrainer(YOLOETrainer, SegmentationTrainer):
         Returns:
             (YOLOESegValidator): Validator for YOLOE segmentation models.
         """
-        self.loss_names = "box", "seg", "cls", "dfl"
         return YOLOESegValidator(
             self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
         )

--- a/ultralytics/nn/distill_model.py
+++ b/ultralytics/nn/distill_model.py
@@ -209,8 +209,9 @@ class DistillationModel(nn.Module):
         if not self.training:  # for loss calculation during validation while training
             if preds is None:
                 preds = self.student_model(batch["img"])
-            regular_loss, regular_loss_detach = self.student_model.loss(batch, preds)
-            return torch.cat([regular_loss, loss_distill]), torch.cat([regular_loss_detach, loss_distill])
+            regular_loss, loss_items = self.student_model.loss(batch, preds)
+            loss_items["dis_loss"] = loss_distill.detach()
+            return torch.cat([regular_loss, loss_distill]), loss_items
 
         # Clear feature dicts before forward passes
         self._teacher_feats.clear()
@@ -220,7 +221,7 @@ class DistillationModel(nn.Module):
             self.teacher_model(batch["img"])  # hooks capture teacher features
         preds = self.student_model(batch["img"])  # hooks capture student features
 
-        regular_loss, regular_loss_detach = self.student_model.loss(batch, preds)
+        regular_loss, loss_items = self.student_model.loss(batch, preds)
         teacher_head_feat = self._teacher_feats[self.feats_idx[-1]]
         teacher_scores = (
             self.decouple_outputs(teacher_head_feat, branch="one2many")["scores"]
@@ -237,9 +238,9 @@ class DistillationModel(nn.Module):
                 self.loss_sl2(student_feat, teacher_feat, feat_idx=i, teacher_scores=teacher_scores) * self.dis
             )
 
-        distill_loss_detach = loss_distill.detach()
+        loss_items["dis_loss"] = loss_distill.detach()
         loss_distill = loss_distill * batch["img"].shape[0]
-        return torch.cat([regular_loss, loss_distill]), torch.cat([regular_loss_detach, distill_loss_detach])
+        return torch.cat([regular_loss, loss_distill]), loss_items
 
     def loss_sl2(
         self, student_feat: torch.Tensor, teacher_feat: torch.Tensor, feat_idx: int, teacher_scores: tuple

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -931,7 +931,7 @@ class RTDETRDetectionModel(DetectionModel):
 
         Returns:
             (torch.Tensor): Total loss value.
-            (torch.Tensor): Main three losses in a tensor.
+            (dict): Main three losses in a dict.
         """
         if not hasattr(self, "criterion"):
             self.criterion = self.init_criterion()
@@ -964,9 +964,11 @@ class RTDETRDetectionModel(DetectionModel):
             (dec_bboxes, dec_scores), targets, dn_bboxes=dn_bboxes, dn_scores=dn_scores, dn_meta=dn_meta
         )
         # NOTE: There are like 12 losses in RTDETR, backward with all losses but only show the main three losses.
-        return sum(loss.values()), torch.as_tensor(
-            [loss[k].detach() for k in ["loss_giou", "loss_class", "loss_bbox"]], device=img.device
-        )
+        return sum(loss.values()), {
+            "giou_loss": loss["loss_giou"].detach(),
+            "cls_loss": loss["loss_class"].detach(),
+            "l1_loss": loss["loss_bbox"].detach(),
+        }
 
     def predict(self, x, profile=False, visualize=False, batch=None, augment=False, embed=None):
         """Perform a forward pass through the model.

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -353,6 +353,7 @@ class v8DetectionLoss:
         self.device = device
 
         self.use_dfl = m.reg_max > 1
+        self.loss_names = "box_loss", "cls_loss", "dfl_loss" if self.use_dfl else "l1_loss"
 
         # Class weights for handling imbalanced datasets
         self.class_weights = getattr(model, "class_weights", None)
@@ -455,15 +456,10 @@ class v8DetectionLoss:
         loss[0] *= self.hyp.box  # box gain
         loss[1] *= self.hyp.cls  # cls gain
         loss[2] *= self.hyp.dfl  # dfl gain
-        detached = loss.detach()
         return (
             (fg_mask, target_gt_idx, target_bboxes, anchor_points, stride_tensor),
             loss,
-            {
-                "box_loss": detached[0],
-                "cls_loss": detached[1],
-                "dfl_loss" if self.reg_max > 1 else "l1_loss": detached[2],
-            },
+            dict(zip(self.loss_names, loss.detach())),
         )  # loss(box, cls, dfl)
 
     def parse_output(
@@ -497,6 +493,7 @@ class v8SegmentationLoss(v8DetectionLoss):
     ):  # model must be de-paralleled
         """Initialize the v8SegmentationLoss class with model parameters and mask overlap setting."""
         super().__init__(model, tal_topk, tal_topk2)
+        self.loss_names = ("box_loss", "seg_loss", *self.loss_names[1:], "sem_loss")
         self.overlap = model.args.overlap_mask
         self.bcedice_loss = BCEDiceLoss(weight_bce=0.5, weight_dice=0.5)
 
@@ -560,14 +557,7 @@ class v8SegmentationLoss(v8DetectionLoss):
                 loss[4] += (pred_semantic * 0).sum()
 
         loss[1] *= self.hyp.box  # seg gain
-        detached = loss.detach()
-        return loss * batch_size, {
-            "box_loss": detached[0],
-            "seg_loss": detached[1],
-            "cls_loss": detached[2],
-            "dfl_loss" if self.reg_max > 1 else "l1_loss": detached[3],
-            "sem_loss": detached[4],
-        }  # loss(box, seg, cls, dfl, semantic)
+        return loss * batch_size, dict(zip(self.loss_names, loss.detach()))  # loss(box, seg, cls, dfl, semantic)
 
     @staticmethod
     def single_mask_loss(
@@ -663,6 +653,7 @@ class v8PoseLoss(v8DetectionLoss):
     def __init__(self, model: torch.nn.Module, tal_topk: int = 10, tal_topk2: int = 10):  # model must be de-paralleled
         """Initialize v8PoseLoss with model parameters and keypoint-specific loss functions."""
         super().__init__(model, tal_topk, tal_topk2)
+        self.loss_names = ("box_loss", "pose_loss", "kobj_loss", *self.loss_names[1:])
         self.kpt_shape = model.model[-1].kpt_shape
         self.bce_pose = nn.BCEWithLogitsLoss()
         is_pose = self.kpt_shape == [17, 3]
@@ -707,14 +698,7 @@ class v8PoseLoss(v8DetectionLoss):
         loss[1] *= self.hyp.pose  # pose gain
         loss[2] *= self.hyp.kobj  # kobj gain
 
-        detached = loss.detach()
-        return loss * batch_size, {
-            "box_loss": detached[0],
-            "pose_loss": detached[1],
-            "kobj_loss": detached[2],
-            "cls_loss": detached[3],
-            "dfl_loss" if self.reg_max > 1 else "l1_loss": detached[4],
-        }  # loss(box, pose, kobj, cls, dfl)
+        return loss * batch_size, dict(zip(self.loss_names, loss.detach()))  # loss(box, pose, kobj, cls, dfl)
 
     @staticmethod
     def kpts_decode(anchor_points: torch.Tensor, pred_kpts: torch.Tensor) -> torch.Tensor:
@@ -838,6 +822,7 @@ class PoseLoss26(v8PoseLoss):
         self.flow_model = model.model[-1].flow_model if hasattr(model.model[-1], "flow_model") else None
         if self.flow_model is not None:
             self.rle_loss = RLELoss(use_target_weight=True).to(self.device)
+            self.loss_names += ("rle_loss",)
             self.target_weights = (
                 torch.from_numpy(RLE_WEIGHT).to(self.device) if is_pose else torch.ones(nkpt, device=self.device)
             )
@@ -893,17 +878,8 @@ class PoseLoss26(v8PoseLoss):
         if self.rle_loss is not None:
             loss[5] *= self.hyp.rle  # rle gain
 
-        detached = loss.detach()
-        loss_items = {
-            "box_loss": detached[0],
-            "pose_loss": detached[1],
-            "kobj_loss": detached[2],
-            "cls_loss": detached[3],
-            "dfl_loss" if self.reg_max > 1 else "l1_loss": detached[4],
-        }  # loss(box, kpt_location, kpt_visibility, cls, dfl[, rle])
-        if self.rle_loss is not None:
-            loss_items["rle_loss"] = detached[5]
-        return loss * batch_size, loss_items
+        # loss(box, kpt_location, kpt_visibility, cls, dfl[, rle])
+        return loss * batch_size, dict(zip(self.loss_names, loss.detach()))
 
     @staticmethod
     def kpts_decode(anchor_points: torch.Tensor, pred_kpts: torch.Tensor) -> torch.Tensor:
@@ -1028,6 +1004,7 @@ class v8OBBLoss(v8DetectionLoss):
     def __init__(self, model: torch.nn.Module, tal_topk=10, tal_topk2: int | None = None):
         """Initialize v8OBBLoss with model, assigner, and rotated bbox loss; model must be de-paralleled."""
         super().__init__(model, tal_topk=tal_topk)
+        self.loss_names = (*self.loss_names, "angle_loss")
         self.assigner = RotatedTaskAlignedAssigner(
             topk=tal_topk,
             num_classes=self.nc,
@@ -1140,13 +1117,7 @@ class v8OBBLoss(v8DetectionLoss):
         loss[2] *= self.hyp.dfl  # dfl gain
         loss[3] *= self.hyp.angle  # angle gain
 
-        detached = loss.detach()
-        return loss * batch_size, {
-            "box_loss": detached[0],
-            "cls_loss": detached[1],
-            "dfl_loss" if self.reg_max > 1 else "l1_loss": detached[2],
-            "angle_loss": detached[3],
-        }  # loss(box, cls, dfl, angle)
+        return loss * batch_size, dict(zip(self.loss_names, loss.detach()))  # loss(box, cls, dfl, angle)
 
     def bbox_decode(
         self, anchor_points: torch.Tensor, pred_dist: torch.Tensor, pred_angle: torch.Tensor
@@ -1259,6 +1230,7 @@ class TVPDetectLoss:
     def __init__(self, model: torch.nn.Module, tal_topk=10, tal_topk2: int | None = None):
         """Initialize TVPDetectLoss with task-prompt and visual-prompt criteria using the provided model."""
         self.vp_criterion = v8DetectionLoss(model, tal_topk, tal_topk2)
+        self.loss_names = tuple(k[:-5] for k in self.vp_criterion.loss_names)  # strip "_loss" suffix
         # NOTE: store following info as it's changeable in __call__
         self.hyp = self.vp_criterion.hyp
         self.ori_nc = self.vp_criterion.nc
@@ -1279,11 +1251,11 @@ class TVPDetectLoss:
         """Calculate the loss for text-visual prompt detection."""
         if self.ori_nc == preds["scores"].shape[1]:
             loss = torch.zeros(3, device=self.vp_criterion.device, requires_grad=True)
-            return loss, {"box": loss[0].detach(), "cls": loss[1].detach(), "dfl": loss[2].detach()}
+            return loss, dict(zip(self.loss_names, loss.detach()))
 
         preds["scores"] = self._get_vp_features(preds)
         vp_loss = self.vp_criterion(preds, batch)
-        return vp_loss[0][1], {k[:-5]: v for k, v in vp_loss[1].items()}  # strip "_loss" suffix from keys
+        return vp_loss[0][1], dict(zip(self.loss_names, vp_loss[1].values()))
 
     def _get_vp_features(self, preds: dict[str, torch.Tensor]) -> list[torch.Tensor]:
         """Extract visual-prompt features from the model output."""
@@ -1303,6 +1275,7 @@ class TVPSegmentLoss(TVPDetectLoss):
         """Initialize TVPSegmentLoss with task-prompt and visual-prompt criteria using the provided model."""
         super().__init__(model)
         self.vp_criterion = v8SegmentationLoss(model, tal_topk, tal_topk2)
+        self.loss_names = tuple(k[:-5] for k in self.vp_criterion.loss_names if k != "sem_loss")  # strip "_loss"
         self.hyp = self.vp_criterion.hyp
 
     def __call__(self, preds: Any, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
@@ -1313,14 +1286,13 @@ class TVPSegmentLoss(TVPDetectLoss):
         """Calculate the loss for text-visual prompt segmentation."""
         if self.ori_nc == preds["scores"].shape[1]:
             loss = torch.zeros(4, device=self.vp_criterion.device, requires_grad=True)
-            detached = loss.detach()
-            return loss, {"box": detached[0], "seg": detached[1], "cls": detached[2], "dfl": detached[3]}
+            return loss, dict(zip(self.loss_names, loss.detach()))
 
         preds["scores"] = self._get_vp_features(preds)
         vp_loss = self.vp_criterion(preds, batch)
         cls_loss = vp_loss[0][2]
-        # strip "_loss" suffix from keys, drop "sem_loss" to match the logged columns
-        return cls_loss, {k[:-5]: v for k, v in vp_loss[1].items() if k != "sem_loss"}
+        # zip drops the trailing "sem_loss" item to match the logged columns
+        return cls_loss, dict(zip(self.loss_names, vp_loss[1].values()))
 
 
 class SemanticSegmentationLoss(nn.Module):

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -455,10 +455,15 @@ class v8DetectionLoss:
         loss[0] *= self.hyp.box  # box gain
         loss[1] *= self.hyp.cls  # cls gain
         loss[2] *= self.hyp.dfl  # dfl gain
+        detached = loss.detach()
         return (
             (fg_mask, target_gt_idx, target_bboxes, anchor_points, stride_tensor),
             loss,
-            loss.detach(),
+            {
+                "box_loss": detached[0],
+                "cls_loss": detached[1],
+                "dfl_loss" if self.reg_max > 1 else "l1_loss": detached[2],
+            },
         )  # loss(box, cls, dfl)
 
     def parse_output(
@@ -471,11 +476,13 @@ class v8DetectionLoss:
         self,
         preds: dict[str, torch.Tensor] | tuple[torch.Tensor, dict[str, torch.Tensor]],
         batch: dict[str, torch.Tensor],
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         """Calculate the sum of the loss for box, cls and dfl multiplied by batch size."""
         return self.loss(self.parse_output(preds), batch)
 
-    def loss(self, preds: dict[str, torch.Tensor], batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
+    def loss(
+        self, preds: dict[str, torch.Tensor], batch: dict[str, torch.Tensor]
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         """Calculate detection loss using assigned targets."""
         batch_size = preds["boxes"].shape[0]
         loss, loss_detach = self.get_assigned_targets_and_loss(preds, batch)[1:]
@@ -493,7 +500,9 @@ class v8SegmentationLoss(v8DetectionLoss):
         self.overlap = model.args.overlap_mask
         self.bcedice_loss = BCEDiceLoss(weight_bce=0.5, weight_dice=0.5)
 
-    def loss(self, preds: dict[str, torch.Tensor], batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
+    def loss(
+        self, preds: dict[str, torch.Tensor], batch: dict[str, torch.Tensor]
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         """Calculate and return the combined loss for detection and segmentation."""
         pred_masks, proto = preds["mask_coefficient"].permute(0, 2, 1).contiguous(), preds["proto"]
         loss = torch.zeros(5, device=self.device)  # box, seg, cls, dfl, semantic
@@ -551,7 +560,14 @@ class v8SegmentationLoss(v8DetectionLoss):
                 loss[4] += (pred_semantic * 0).sum()
 
         loss[1] *= self.hyp.box  # seg gain
-        return loss * batch_size, loss.detach()  # loss(box, seg, cls, dfl, semantic)
+        detached = loss.detach()
+        return loss * batch_size, {
+            "box_loss": detached[0],
+            "seg_loss": detached[1],
+            "cls_loss": detached[2],
+            "dfl_loss" if self.reg_max > 1 else "l1_loss": detached[3],
+            "sem_loss": detached[4],
+        }  # loss(box, seg, cls, dfl, semantic)
 
     @staticmethod
     def single_mask_loss(
@@ -654,7 +670,9 @@ class v8PoseLoss(v8DetectionLoss):
         sigmas = torch.from_numpy(OKS_SIGMA).to(self.device) if is_pose else torch.ones(nkpt, device=self.device) / nkpt
         self.keypoint_loss = KeypointLoss(sigmas=sigmas)
 
-    def loss(self, preds: dict[str, torch.Tensor], batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
+    def loss(
+        self, preds: dict[str, torch.Tensor], batch: dict[str, torch.Tensor]
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         """Calculate the total loss and detach it for pose estimation."""
         pred_kpts = preds["kpts"].permute(0, 2, 1).contiguous()
         loss = torch.zeros(5, device=self.device)  # box, kpt_location, kpt_visibility, cls, dfl
@@ -689,7 +707,14 @@ class v8PoseLoss(v8DetectionLoss):
         loss[1] *= self.hyp.pose  # pose gain
         loss[2] *= self.hyp.kobj  # kobj gain
 
-        return loss * batch_size, loss.detach()  # loss(box, pose, kobj, cls, dfl)
+        detached = loss.detach()
+        return loss * batch_size, {
+            "box_loss": detached[0],
+            "pose_loss": detached[1],
+            "kobj_loss": detached[2],
+            "cls_loss": detached[3],
+            "dfl_loss" if self.reg_max > 1 else "l1_loss": detached[4],
+        }  # loss(box, pose, kobj, cls, dfl)
 
     @staticmethod
     def kpts_decode(anchor_points: torch.Tensor, pred_kpts: torch.Tensor) -> torch.Tensor:
@@ -817,7 +842,9 @@ class PoseLoss26(v8PoseLoss):
                 torch.from_numpy(RLE_WEIGHT).to(self.device) if is_pose else torch.ones(nkpt, device=self.device)
             )
 
-    def loss(self, preds: dict[str, torch.Tensor], batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
+    def loss(
+        self, preds: dict[str, torch.Tensor], batch: dict[str, torch.Tensor]
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         """Calculate the total loss and detach it for pose estimation."""
         pred_kpts = preds["kpts"].permute(0, 2, 1).contiguous()
         loss = torch.zeros(
@@ -866,7 +893,17 @@ class PoseLoss26(v8PoseLoss):
         if self.rle_loss is not None:
             loss[5] *= self.hyp.rle  # rle gain
 
-        return loss * batch_size, loss.detach()  # loss(box, kpt_location, kpt_visibility, cls, dfl[, rle])
+        detached = loss.detach()
+        loss_items = {
+            "box_loss": detached[0],
+            "pose_loss": detached[1],
+            "kobj_loss": detached[2],
+            "cls_loss": detached[3],
+            "dfl_loss" if self.reg_max > 1 else "l1_loss": detached[4],
+        }  # loss(box, kpt_location, kpt_visibility, cls, dfl[, rle])
+        if self.rle_loss is not None:
+            loss_items["rle_loss"] = detached[5]
+        return loss * batch_size, loss_items
 
     @staticmethod
     def kpts_decode(anchor_points: torch.Tensor, pred_kpts: torch.Tensor) -> torch.Tensor:
@@ -978,11 +1015,11 @@ class PoseLoss26(v8PoseLoss):
 class v8ClassificationLoss:
     """Criterion class for computing training losses for classification."""
 
-    def __call__(self, preds: Any, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
+    def __call__(self, preds: Any, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         """Compute the classification loss between predictions and true labels."""
         preds = preds[1] if isinstance(preds, (list, tuple)) else preds
         loss = F.cross_entropy(preds, batch["cls"], reduction="mean")
-        return loss, loss.detach()
+        return loss, {"loss": loss.detach()}
 
 
 class v8OBBLoss(v8DetectionLoss):
@@ -1019,7 +1056,9 @@ class v8OBBLoss(v8DetectionLoss):
             out[batch_idx, within_idx] = packed_targets
         return out
 
-    def loss(self, preds: dict[str, torch.Tensor], batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
+    def loss(
+        self, preds: dict[str, torch.Tensor], batch: dict[str, torch.Tensor]
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         """Calculate and return the loss for oriented bounding box detection."""
         loss = torch.zeros(4, device=self.device)  # box, cls, dfl, angle
         pred_distri, pred_scores, pred_angle = (
@@ -1101,7 +1140,13 @@ class v8OBBLoss(v8DetectionLoss):
         loss[2] *= self.hyp.dfl  # dfl gain
         loss[3] *= self.hyp.angle  # angle gain
 
-        return loss * batch_size, loss.detach()  # loss(box, cls, dfl, angle)
+        detached = loss.detach()
+        return loss * batch_size, {
+            "box_loss": detached[0],
+            "cls_loss": detached[1],
+            "dfl_loss" if self.reg_max > 1 else "l1_loss": detached[2],
+            "angle_loss": detached[3],
+        }  # loss(box, cls, dfl, angle)
 
     def bbox_decode(
         self, anchor_points: torch.Tensor, pred_dist: torch.Tensor, pred_angle: torch.Tensor
@@ -1161,14 +1206,16 @@ class E2EDetectLoss:
         self.one2many = v8DetectionLoss(model, tal_topk=10)
         self.one2one = v8DetectionLoss(model, tal_topk=1)
 
-    def __call__(self, preds: Any, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
+    def __call__(self, preds: Any, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         """Calculate the sum of the loss for box, cls and dfl multiplied by batch size."""
         preds = preds[1] if isinstance(preds, tuple) else preds
         one2many = preds["one2many"]
         loss_one2many = self.one2many(one2many, batch)
         one2one = preds["one2one"]
         loss_one2one = self.one2one(one2one, batch)
-        return loss_one2many[0] + loss_one2one[0], loss_one2many[1] + loss_one2one[1]
+        return loss_one2many[0] + loss_one2one[0], {
+            k: loss_one2many[1][k] + loss_one2one[1][k] for k in loss_one2many[1]
+        }
 
 
 class E2ELoss:
@@ -1187,7 +1234,7 @@ class E2ELoss:
         # final gain
         self.final_o2m = 0.1
 
-    def __call__(self, preds: Any, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
+    def __call__(self, preds: Any, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         """Calculate the sum of the loss for box, cls and dfl multiplied by batch size."""
         preds = self.one2many.parse_output(preds)
         one2many, one2one = preds["one2many"], preds["one2one"]
@@ -1222,19 +1269,21 @@ class TVPDetectLoss:
         """Parse model predictions to extract features."""
         return self.vp_criterion.parse_output(preds)
 
-    def __call__(self, preds: Any, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
+    def __call__(self, preds: Any, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         """Calculate the loss for text-visual prompt detection."""
         return self.loss(self.parse_output(preds), batch)
 
-    def loss(self, preds: dict[str, torch.Tensor], batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
+    def loss(
+        self, preds: dict[str, torch.Tensor], batch: dict[str, torch.Tensor]
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         """Calculate the loss for text-visual prompt detection."""
         if self.ori_nc == preds["scores"].shape[1]:
             loss = torch.zeros(3, device=self.vp_criterion.device, requires_grad=True)
-            return loss, loss.detach()
+            return loss, {"box": loss[0].detach(), "cls": loss[1].detach(), "dfl": loss[2].detach()}
 
         preds["scores"] = self._get_vp_features(preds)
         vp_loss = self.vp_criterion(preds, batch)
-        return vp_loss[0][1], vp_loss[1]
+        return vp_loss[0][1], {k[:-5]: v for k, v in vp_loss[1].items()}  # strip "_loss" suffix from keys
 
     def _get_vp_features(self, preds: dict[str, torch.Tensor]) -> list[torch.Tensor]:
         """Extract visual-prompt features from the model output."""
@@ -1256,20 +1305,22 @@ class TVPSegmentLoss(TVPDetectLoss):
         self.vp_criterion = v8SegmentationLoss(model, tal_topk, tal_topk2)
         self.hyp = self.vp_criterion.hyp
 
-    def __call__(self, preds: Any, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
+    def __call__(self, preds: Any, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         """Calculate the loss for text-visual prompt segmentation."""
         return self.loss(self.parse_output(preds), batch)
 
-    def loss(self, preds: Any, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
+    def loss(self, preds: Any, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         """Calculate the loss for text-visual prompt segmentation."""
         if self.ori_nc == preds["scores"].shape[1]:
             loss = torch.zeros(4, device=self.vp_criterion.device, requires_grad=True)
-            return loss, loss.detach()
+            detached = loss.detach()
+            return loss, {"box": detached[0], "seg": detached[1], "cls": detached[2], "dfl": detached[3]}
 
         preds["scores"] = self._get_vp_features(preds)
         vp_loss = self.vp_criterion(preds, batch)
         cls_loss = vp_loss[0][2]
-        return cls_loss, vp_loss[1]
+        # strip "_loss" suffix from keys, drop "sem_loss" to match the logged columns
+        return cls_loss, {k[:-5]: v for k, v in vp_loss[1].items() if k != "sem_loss"}
 
 
 class SemanticSegmentationLoss(nn.Module):
@@ -1361,7 +1412,8 @@ class SemanticSegmentationLoss(nn.Module):
             batch (dict): Batch dict with 'semantic_mask' [B, H, W] containing class IDs (255=ignore).
 
         Returns:
-            (tuple[torch.Tensor, torch.Tensor]): (total_loss * batch_size, detached loss items [ce, dice, aux]).
+            (tuple[torch.Tensor, dict[str, torch.Tensor]]): Total loss * batch_size and a dict of detached loss items
+                (ce_loss, dice_loss, aux_loss).
         """
         # Unpack auxiliary logits when present.
         aux_logits = None
@@ -1378,7 +1430,7 @@ class SemanticSegmentationLoss(nn.Module):
         dice_loss = self._dice_loss(preds, masks, valid)
         total = ce_loss + dice_loss
 
-        # Auxiliary cross-entropy loss. Match ce_loss dtype so torch.stack below succeeds under AMP.
+        # Auxiliary cross-entropy loss. Match ce_loss dtype so adding to total succeeds under AMP.
         aux_loss = torch.tensor(0.0, device=preds.device, dtype=ce_loss.dtype)
         if aux_logits is not None:
             if aux_logits.shape[2:] != masks.shape[1:]:
@@ -1386,5 +1438,5 @@ class SemanticSegmentationLoss(nn.Module):
             aux_loss = self._ce_loss(aux_logits, masks, valid) * 0.4
             total += aux_loss
 
-        loss_items = torch.stack([ce_loss, dice_loss, aux_loss]).detach()
+        loss_items = {"ce_loss": ce_loss.detach(), "dice_loss": dice_loss.detach(), "aux_loss": aux_loss.detach()}
         return total * preds.shape[0], loss_items


### PR DESCRIPTION
Loss criteria now return detached loss items as a `dict[str, Tensor]` (name → value) instead of a positional tensor; trainer/validator derive loss names from the dict directly, following the pattern RT-DETR already used internally.

Fixes the third detection loss being logged as `dfl_loss` when `reg_max == 1` — no DFL there, `BboxLoss` uses L1 — so logs and `results.csv` now show `l1_loss`.

**Deleted:** `self.loss_names` assignments in all 10 trainers' `get_validator()` (incl. pose's conditional `rle_loss` append), the `dis_loss` guard in `BaseTrainer._setup_train` (distillation now adds its own dict key), `label_loss_items` overrides in detect/classify, and RT-DETR's positional `torch.as_tensor` flattening.

Verified: `yolo26n` logs `l1_loss`, `yolo11n` still logs `dfl_loss`, segment/classify smokes OK, `pytest tests/test_engine.py` 31 passed, ruff clean.

Note: names are known only after the first forward, so the epoch-0 header prints after the first batch; later epochs are unchanged.

Zero-regression follow-up: restored the CPU and CUDA all-ignore semantic-loss tests, adapted to validate every value in the new loss-item dict; targeted CPU coverage passes for nc=1 and nc=3.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Refactors training and validation loss handling to use named dictionaries, improving flexibility, logging, and support for task-specific loss components. 🧩

### 📊 Key Changes

- Changed loss-item outputs across detection, segmentation, pose, classification, OBB, RT-DETR, YOLOE, distillation, and semantic segmentation from tensors to named dictionaries.
- Automatically derives `loss_names` from the criterion’s first batch instead of hardcoding them in individual trainers.
- Updated training and validation to:
  - Track running mean losses by name.
  - Log loss values from dictionary entries.
  - Aggregate and reduce validation losses correctly across multiple GPUs.
  - Generate consistently prefixed `train/` and `val/` metrics.
- Added dynamic support for optional loss terms such as distillation, RLE, semantic, angle, and auxiliary losses.
- Updated CUDA and Python tests to validate every named loss item for finite values.
- Improved NaN recovery testing by injecting invalid values into an individual loss component. 🧪

### 🎯 Purpose & Impact

- Makes the training framework more extensible by allowing each model or criterion to define its own loss components.
- Reduces duplicated trainer code and prevents mismatches between displayed loss names and actual loss outputs.
- Improves metric visibility in logs and result files, especially for models with optional or custom losses.
- Strengthens distributed validation and mixed-precision stability checks.
- May affect custom integrations that expect `loss_items` or `tloss` to be tensors; these should now handle dictionaries keyed by loss name instead.