### PR TITLE
Queue publish runs and retry PyPI upload failures

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,6 @@ on:
         type: boolean
         description: Publish to PyPI
 
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
-
 jobs:
   check:
     if: github.repository == 'ultralytics/ultralytics' && github.actor == 'glenn-jocher' && github.ref == 'refs/heads/main'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,10 @@ on:
         type: boolean
         description: Publish to PyPI
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   check:
     if: github.repository == 'ultralytics/ultralytics' && github.actor == 'glenn-jocher' && github.ref == 'refs/heads/main'
@@ -122,8 +126,20 @@ jobs:
           name: dist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
+        id: publish
+        continue-on-error: true
         with:
           skip-existing: true # tolerate recovery re-runs after partial failures
+      - name: Clean partial attestations # leftover *.publish.attestation files make the retry fail pre-existence checks
+        if: steps.publish.outcome == 'failure'
+        run: |
+          rm -f dist/*.publish.attestation
+          sleep 30
+      - name: Retry publish # transient sigstore/Rekor or PyPI network failures
+        if: steps.publish.outcome == 'failure'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
 
   sbom:
     needs: [check, build, publish]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: false
+  queue: max
 
 jobs:
   check:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,10 @@ on:
         type: boolean
         description: Publish to PyPI
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   check:
     if: github.repository == 'ultralytics/ultralytics' && github.actor == 'glenn-jocher' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Motivation

Two external/race failure modes have affected `publish.yml`:

- [Run 29795428480](https://github.com/ultralytics/ultralytics/actions/runs/29795428480/job/88525906492) failed before upload when `pypa/gh-action-pypi-publish` hit a transient `ConnectionResetError(104)` while creating Sigstore/Rekor attestations. Another push retriggered the workflow 46 seconds later and recovered the release.
- [Run 27335253857](https://github.com/ultralytics/ultralytics/actions/runs/27335253857) hit a tag-push race between publish runs triggered by back-to-back main pushes.

## Changes

- Serialize publish workflows with `queue: max`, preserving up to 100 pending releases rather than cancelling in-progress or pending runs.
- Retry the PyPI publish action once after a failure. Before retrying, remove partial `*.publish.attestation` files left by the first attempt and wait 30 seconds; otherwise the action rejects those pre-existing files. `skip-existing: true` keeps recovery safe if an earlier attempt uploaded only some distributions. If both attempts fail, the publish job still fails and the existing Slack notification remains unchanged.

The shared `ultralytics/actions/retry` action only wraps shell commands and cannot wrap this Docker action, so the retry requires a second conditional action invocation.

Deleted: nothing — both changes add resilience at external ownership boundaries: GitHub schedules workflow runs, and the publisher action exposes no retry input while retaining partial attestation files after failure.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves PyPI publishing reliability by serializing release workflows and automatically retrying transient upload failures. 🚀

### 📊 Key Changes
- Added workflow concurrency controls to queue publishing runs and prevent overlapping releases.
- Updated the PyPI publish step to tolerate an initial failure and retry automatically.
- Added cleanup for partial attestation files before retrying publication.
- Preserved `skip-existing` behavior to support recovery from partially completed uploads.

### 🎯 Purpose & Impact
- Reduces failed releases caused by temporary Sigstore/Rekor or PyPI network issues. ✅
- Makes interrupted or partially successful publishing runs easier to recover without manual intervention.
- Prevents concurrent publish workflows from interfering with each other.
- Improves release automation reliability while leaving successful publishing behavior unchanged.