### PR TITLE
Update DFL label for L1 regression heads

### DIFF
--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -203,9 +203,22 @@ class DetectionTrainer(BaseTrainer):
             model.load(weights)
         return model
 
+    @property
+    def detect_head(self):
+        """Return the active detection head module, resolving DDP and distillation wrappers."""
+        model = unwrap_model(self.model)
+        if hasattr(model, "student_model"):
+            model = model.student_model  # copy_attr does not copy nn.Module attributes like .model
+        return model.model[-1]
+
+    @property
+    def bbox_dist_loss_name(self):
+        """Return 'dfl_loss' when the detection head uses DFL (reg_max > 1), otherwise 'l1_loss'."""
+        return "dfl_loss" if self.detect_head.reg_max > 1 else "l1_loss"
+
     def get_validator(self):
         """Return a DetectionValidator for YOLO model validation."""
-        self.loss_names = "box_loss", "cls_loss", "dfl_loss"
+        self.loss_names = "box_loss", "cls_loss", self.bbox_dist_loss_name
         return yolo.detect.DetectionValidator(
             self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
         )

--- a/ultralytics/models/yolo/obb/train.py
+++ b/ultralytics/models/yolo/obb/train.py
@@ -74,7 +74,7 @@ class OBBTrainer(yolo.detect.DetectionTrainer):
 
     def get_validator(self):
         """Return an instance of OBBValidator for validation of YOLO model."""
-        self.loss_names = "box_loss", "cls_loss", "dfl_loss", "angle_loss"
+        self.loss_names = "box_loss", "cls_loss", self.bbox_dist_loss_name, "angle_loss"
         return yolo.obb.OBBValidator(
             self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
         )

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -9,7 +9,6 @@ from typing import Any
 from ultralytics.models import yolo
 from ultralytics.nn.tasks import PoseModel
 from ultralytics.utils import DEFAULT_CFG, RANK
-from ultralytics.utils.torch_utils import unwrap_model
 
 
 class PoseTrainer(yolo.detect.DetectionTrainer):
@@ -97,11 +96,8 @@ class PoseTrainer(yolo.detect.DetectionTrainer):
 
     def get_validator(self):
         """Return an instance of the PoseValidator class for validation."""
-        self.loss_names = "box_loss", "pose_loss", "kobj_loss", "cls_loss", "dfl_loss"
-        model = unwrap_model(self.model)
-        if hasattr(model, "student_model"):
-            model = model.student_model  # copy_attr does not copy nn.Module attributes like .model
-        if getattr(model.model[-1], "flow_model", None) is not None:
+        self.loss_names = "box_loss", "pose_loss", "kobj_loss", "cls_loss", self.bbox_dist_loss_name
+        if getattr(self.detect_head, "flow_model", None) is not None:
             self.loss_names += ("rle_loss",)
         return yolo.pose.PoseValidator(
             self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks

--- a/ultralytics/models/yolo/segment/train.py
+++ b/ultralytics/models/yolo/segment/train.py
@@ -65,7 +65,7 @@ class SegmentationTrainer(yolo.detect.DetectionTrainer):
 
     def get_validator(self):
         """Return an instance of SegmentationValidator for validation of YOLO model."""
-        self.loss_names = "box_loss", "seg_loss", "cls_loss", "dfl_loss", "sem_loss"
+        self.loss_names = "box_loss", "seg_loss", "cls_loss", self.bbox_dist_loss_name, "sem_loss"
         return yolo.segment.SegmentationValidator(
             self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
         )


### PR DESCRIPTION

Deleted: unwrap_model` import in `pose/train.py`; pose's inline 3-line `unwrap_model`/`student_model` head-resolution block (relocated into shared `DetectionTrainer.detect_head`).

```
ultralytics/models/yolo/detect/train.py  | 15 ++++++++++++++-
 ultralytics/models/yolo/obb/train.py     |  2 +-
 ultralytics/models/yolo/pose/train.py    |  8 ++------
 ultralytics/models/yolo/segment/train.py |  2 +-
 4 files changed, 18 insertions(+), 9 deletions(-)
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛠️ Updated YOLO training and validation to correctly report bounding-box loss names for both DFL-based and L1-based detection heads.

### 📊 Key Changes

- Added shared `detect_head` logic to identify the active detection head, including DDP and distillation-wrapped models.
- Added `bbox_dist_loss_name` to select:
  - `dfl_loss` for heads using Distribution Focal Loss.
  - `l1_loss` for heads using L1 box regression.
- Updated detection, OBB, pose, and segmentation trainers to use the dynamic loss name.
- Simplified pose training by reusing the shared detection-head utilities.
- Preserved pose-specific `rle_loss` handling when a flow model is present.

### 🎯 Purpose & Impact

- ✅ Ensures training logs and validation metrics accurately reflect the model’s actual bounding-box loss.
- 🔄 Improves compatibility with models that use L1 regression instead of DFL.
- 🧩 Supports wrapped models used in distributed training and knowledge distillation.
- 📈 Provides more reliable loss reporting across detection, oriented bounding box, pose, and segmentation workflows.