### PR TITLE
Harden macos-26 CI parallelism and Streamlit Inference model list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,13 +188,13 @@ jobs:
         run: python tests/cache_test_assets.py
       - name: Pytest tests
         shell: bash # for Windows compatibility
+        # GitHub-hosted ARM runners have disconnected under xdist auto-parallelism: ubuntu-24.04-arm runs
+        # single-process, and the 3-vCPU/7GB macos-26 runners cap at 2 workers to avoid memory starvation.
         run: |
-          if [[ "${{ matrix.os }}" == "ubuntu-24.04-arm" ]]; then
-            # GitHub-hosted ARM runners have disconnected under xdist auto-parallelism.
-            pytest --cov=ultralytics/ --cov-report=xml tests/ --export-env base
-          else
-            pytest -n auto --dist=loadfile --cov=ultralytics/ --cov-report=xml tests/ --export-env base
-          fi
+          xdist="-n auto --dist=loadfile"
+          [[ "${{ matrix.os }}" == "macos-26" ]] && xdist="-n 2 --dist=loadfile"
+          [[ "${{ matrix.os }}" == "ubuntu-24.04-arm" ]] && xdist=""
+          pytest $xdist --cov=ultralytics/ --cov-report=xml tests/ --export-env base
         env:
           YOLO_AUTOINSTALL: "false"
       - name: Upload Coverage Reports to CodeCov

--- a/ultralytics/solutions/streamlit_inference.py
+++ b/ultralytics/solutions/streamlit_inference.py
@@ -150,26 +150,13 @@ class Inference:
 
     def configure(self) -> None:
         """Configure the model and load selected classes for inference."""
-        # Add dropdown menu for model selection
-        M_ORD, T_ORD = (
-            ["yolo26n", "yolo26s", "yolo26m", "yolo26l", "yolo26x"],
-            [
-                "",
-                "-seg",
-                "-sem",
-                "-pose",
-                "-obb",
-                "-cls",
-            ],
-        )
-        available_models = sorted(
-            [
-                x.replace("yolo", "YOLO")
-                for x in GITHUB_ASSETS_STEMS
-                if any(x.startswith(b) for b in M_ORD) and "grayscale" not in x
-            ],
-            key=lambda x: (M_ORD.index(x[:7].lower()), T_ORD.index(x[7:].lower() or "")),
-        )
+        # Add dropdown menu for model selection, offering the standard size/task grid in order
+        available_models = [
+            f"{size}{task}".replace("yolo", "YOLO")
+            for size in ("yolo26n", "yolo26s", "yolo26m", "yolo26l", "yolo26x")
+            for task in ("", "-seg", "-sem", "-pose", "-obb", "-cls")
+            if f"{size}{task}" in GITHUB_ASSETS_STEMS
+        ]
         if self.model_path:  # Insert user provided custom model in available_models
             available_models.insert(0, self.model_path)
         selected_model = self.st.sidebar.selectbox("Model", available_models)


### PR DESCRIPTION
Two robustness fixes for recent CI failures:

**1. macos-26 runner deaths under \`-n auto\`**

[Run 29791812827](https://github.com/ultralytics/ultralytics/actions/runs/29791812827/job/88515032437) died at 59 min (normal: 13–22 min) with "The hosted runner lost communication with the server" and never uploaded logs. The macos-26 runner is a 3-vCPU/7 GB Apple M1 VM; \`pytest -n auto\` spawns 3 torch-loaded workers there, and memory starvation kills the runner agent — the same GitHub-hosted-ARM disconnect already documented for ubuntu-24.04-arm in this workflow, and the same reason SlowTests already caps shared runners at \`-n 2\`. The Tests job now caps macos-26 at 2 workers and consolidates the duplicated pytest invocation into one command with a per-runner xdist flag.

**2. Streamlit Inference crashes on non-task asset stems**

\`test_solutions\` failed on the Objects365 docs PR ([run 29821937823](https://github.com/ultralytics/ultralytics/actions/runs/29821937823)) with \`ValueError: '-objv1-150' is not in list\`: the model dropdown filtered \`GITHUB_ASSETS_STEMS\` by \`yolo26*\` prefix, then crashed in its sort key on any suffix outside the known task list — with a \`grayscale\` denylist already patching one prior instance (now dead code, since \`yolo11n-grayscale\` never passes the yolo26 prefix filter). The dropdown is now built as an allowlist from the size×task grid, so future asset additions can't break it. Verified the produced list is byte-identical to the old one on current assets, and unchanged when the \`-objv1-150\` stems are added.

Deleted: the duplicated pytest invocation branch in ci.yml; in streamlit_inference.py the \`M_ORD\`/\`T_ORD\` locals, the \`sorted()\` call with its index-based lambda key, the \`startswith\` prefix filter, and the dead \`"grayscale" not in x\` guard.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves CI reliability across ARM and macOS runners while simplifying YOLO26 model selection in the Streamlit inference app. 🚀

### 📊 Key Changes
- 🧪 Updated GitHub Actions test parallelism:
  - ARM Ubuntu runners now run tests in a single process.
  - macOS 26 runners use a maximum of two workers.
  - Other runners continue using automatic parallelism.
- 🎛️ Simplified Streamlit model discovery by generating the standard YOLO26 size-and-task grid directly.
- 🤖 Preserved support for YOLO26 detection, segmentation, semantic segmentation, pose, OBB, and classification models.
- 📦 Custom user-provided models are still added at the top of the model selector.

### 🎯 Purpose & Impact
- ✅ Reduces CI disconnections and memory-related failures on constrained ARM and macOS runners.
- ⚡ Maintains faster parallel test execution on capable environments.
- 🧭 Makes the Streamlit model selector more predictable and easier to maintain.
- 👥 Gives users a consistent way to select available YOLO26 models or load a custom model.