### PR TITLE
Fix safe_download tar extraction crash with delete=True

### DIFF
--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -417,10 +417,10 @@ def safe_download(
                         target.mkdir(parents=True, exist_ok=True)
                     elif source := tar.extractfile(m):
                         target.parent.mkdir(parents=True, exist_ok=True)
-                        with source, open(target, "wb") as f:
-                            shutil.copyfileobj(source, f)
+                        with source, open(target, "wb") as out:  # 'f' is the archive path, deleted below
+                            shutil.copyfileobj(source, out)
         if delete:
-            f.unlink()  # remove zip
+            f.unlink()  # remove archive
         return unzip_dir
     return f
 


### PR DESCRIPTION
## Bug

`safe_download(url, unzip=True, delete=True)` crashes with `AttributeError: '_io.BufferedWriter' object has no attribute 'unlink'` for any tar archive (`.tar.gz`/`.tar`), and the archive is left on disk. The tar-extraction loop rebinds `f` — the downloaded archive `Path` — to each extracted member's output file object (`open(target, "wb") as f`), so the later `f.unlink()` calls `unlink()` on a closed file object instead of the archive path.

Reproduced on main with a local HTTP server serving a small `.tar.gz`:

```
AttributeError - '_io.BufferedWriter' object has no attribute 'unlink'
archive still exists: True
```

## Fix

Rename the inner file handle to `out` so `f` keeps meaning the archive path. After the fix the same repro extracts all members and deletes the archive. Zip archives were never affected (the zip branch doesn't rebind `f`), which is why CI never caught this — dataset zips dominate; tarballs with `delete=True` are the broken path.

Verified: repro passes post-fix (archive deleted, members extracted), `pytest tests/test_python.py -k download` passes, ruff clean.

Deleted: nothing — the fix is a two-line variable rename inside the tar branch; the crash comes from name shadowing, not from removable logic, so there is nothing to delete or relocate.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🐛 Fixed archive extraction cleanup so downloaded archives are deleted reliably after unpacking.

### 📊 Key Changes
- Renamed the extracted file output handle from `f` to `out` in `safe_download()`.
- Preserved `f` as the archive path for the subsequent cleanup step.
- Updated comments to clarify that the archive—not an extracted file—is removed.

### 🎯 Purpose & Impact
- ✅ Prevents variable shadowing that could cause incorrect archive deletion.
- 🧹 Ensures temporary ZIP or TAR archives are cleaned up after extraction when `delete=True`.
- 📦 Improves reliability of model, dataset, and other asset downloads without changing the public API.