### PR TITLE
Make threaded plot threads non-daemon so interpreter shutdown joins them

### DIFF
--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -1166,7 +1166,8 @@ def threaded(func):
         func (callable): The function to be potentially executed in a separate thread.
 
     Returns:
-        (callable): A wrapper function that either returns a daemon thread or the direct function result.
+        (callable): A wrapper function that either returns a thread or the direct function result. The thread is
+            non-daemon so interpreter shutdown joins it before module teardown, avoiding teardown races.
 
     Examples:
         >>> @threaded
@@ -1180,7 +1181,9 @@ def threaded(func):
     def wrapper(*args, **kwargs):
         """Multi-thread a given function based on 'threaded' kwarg and return the thread or function result."""
         if kwargs.pop("threaded", True):  # run in thread
-            thread = threading.Thread(target=func, args=args, kwargs=kwargs, daemon=True)
+            # Non-daemon so interpreter shutdown joins the thread before module teardown; a daemon thread still
+            # running at exit can be killed mid-C-call, aborting the process (e.g. 'FATAL: exception not rethrown').
+            thread = threading.Thread(target=func, args=args, kwargs=kwargs, daemon=False)
             thread.start()
             return thread
         else:

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -345,10 +345,17 @@ def safe_download(
                 try:
                     if (curl or i > 0) and curl_installed:  # curl download with retry, continue
                         s = "sS" * (not progress)  # silent
-                        r = subprocess.run(["curl", "-#", f"-{s}L", url, "-o", f, "--retry", "3", "-C", "-"]).returncode
+                        # Stall bounds (not a total-transfer cap): abort if <1 B/s for 300 s so a dead connection
+                        # cannot block interpreter shutdown while a non-daemon plot thread waits on a font download
+                        args = ["--connect-timeout", "30", "--speed-limit", "1", "--speed-time", "300"]
+                        r = subprocess.run(
+                            ["curl", "-#", f"-{s}L", url, "-o", f, "--retry", "3", "-C", "-", *args]
+                        ).returncode
                         assert r == 0, f"Curl return value {r}"
-                    else:  # requests download
-                        with requests.get(url, stream=True, headers={"Accept-Encoding": "identity"}) as response:
+                    else:  # requests download; timeout bounds connect and per-chunk read gaps, not total transfer
+                        with requests.get(
+                            url, stream=True, headers={"Accept-Encoding": "identity"}, timeout=(30, 300)
+                        ) as response:
                             response.raise_for_status()
                             expected_size = int(response.headers.get("Content-Length", 0))
                             if i == 0 and expected_size > 1048576:


### PR DESCRIPTION
## Problem

`@threaded` (sole consumer: `plot_images`) spawns daemon threads. A daemon thread still running at interpreter exit is killed abruptly, which has two consequences:

1. **Silently lost/corrupt plots.** Measured on macOS with the real `plot_images` path — fire the plot thread, then exit immediately (exactly what the end of a short training run or CI smoke does): with `daemon=True`, **0/15** runs produced a valid plot file (thread killed mid-write); with `daemon=False`, **15/15** produced complete valid JPEGs, with total process exit taking 0.63 s.
2. **Shutdown aborts.** A daemon thread killed mid-C-call during interpreter teardown can abort the whole process (`FATAL: exception not rethrown` from glibc's pthread machinery on Linux). This is timing-dependent and was observed in depth-branch CI smokes; it is not reproducible deterministically on macOS, so this PR claims the mechanism plus the measured plot-loss above, not a local abort repro.

## Fix

Flip the thread to `daemon=False` at the trigger — thread creation — so normal interpreter shutdown joins outstanding plot threads before module teardown. No join-tracking scaffolding anywhere: CPython's shutdown already joins non-daemon threads natively.

## Trade-off considered — and closed

Adversarial review confirmed the flip is behaviorally safe at every call site (all plot threads are rank-0, main-process, short, CPU/disk-bound; DDP non-zero ranks and dataloader workers spawn none; the genuinely-infinite threads — stream readers, telemetry, hub session — are separate and stay daemon). The one residual risk was that `safe_download`'s GET had no timeout, so a stalled first-run font download inside a now non-daemon plot thread could block interpreter shutdown indefinitely. This PR closes that at the source: the requests path gets `timeout=(30, 300)` (connect + per-chunk read gap — not a total-transfer cap, so multi-GB dataset downloads are unaffected) and the curl path gets `--connect-timeout 30 --speed-limit 1 --speed-time 300`. Both paths verified against the live assets host.

## Original trade-off analysis

A non-daemon thread that never finishes would block interpreter exit instead of being reaped. The realistic hang window is narrow: `plot_images`'s only network touch is `check_font`'s one-time font download inside `Annotator` init, which is preceded by a `requests.head(..., timeout=3)` reachability check and cached in `USER_CONFIG_DIR` afterward, leaving only a mid-transfer stall on an established connection during first-ever font fetch. Plot threads are otherwise bounded CPU/disk work of a few hundred ms.

Verified: plot-completeness measurement above (15 runs per configuration), `pytest tests/test_python.py -k plot` passes, ruff clean.

Deleted: nothing — the fix flips one existing argument at the point that owns thread creation; any alternative (explicit join bookkeeping at trainer teardown) would add synchronization code for state the interpreter already tracks, which is exactly what Core Principles rule 2 forbids.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧵 Improves threaded shutdown reliability and prevents downloads from hanging indefinitely.

### 📊 Key Changes

- Changed `@threaded` worker threads from daemon to non-daemon threads.
- Added shutdown behavior that allows active threads to finish before interpreter teardown.
- Added connection and stalled-transfer timeouts to `curl` downloads.
- Added connect and read-gap timeouts to `requests` downloads.
- Preserved download retries and resume support while bounding stalled connections.

### 🎯 Purpose & Impact

- ✅ Prevents crashes and teardown races caused by daemon threads being terminated during native or C-level operations.
- ⏱️ Ensures stalled downloads eventually stop instead of blocking application shutdown.
- 📈 Improves reliability for background tasks such as plot generation and font downloads.
- ⚠️ Non-daemon threads may keep the process alive until they complete, but the new download timeouts limit how long they can block shutdown.