### PR TITLE
Fix CoreML dynamic=True segment export upsample mapping error

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1229,12 +1229,21 @@ class Exporter:
         model = IOSDetectModel(self.model, self.im, mlprogram=not mlmodel) if self.args.nms else self.model
 
         if self.args.dynamic:
+            h, w = self.imgsz
+            lb_h = lb_w = 32
+            if getattr(self.model, "end2end", False):
+                # end2end graphs bake TopK k=max_det, so the smallest declared input must still supply >= k anchors
+                # or CoreML rejects the model at load; shrink the range proportionally from the traced default size
+                stride = int(self.model.stride.max())
+                r = self.model.model[-1].max_det / sum(int(h / s) * int(w / s) for s in self.model.stride.tolist())
+                lb_h = max(lb_h, int(np.ceil(h * r**0.5 / stride)) * stride)
+                lb_w = max(lb_w, int(np.ceil(w * r**0.5 / stride)) * stride)
             input_shape = ct.Shape(
                 shape=(
                     ct.RangeDim(lower_bound=1, upper_bound=self.args.batch, default=1),
                     self.im.shape[1],
-                    ct.RangeDim(lower_bound=32, upper_bound=self.imgsz[0] * 2, default=self.imgsz[0]),
-                    ct.RangeDim(lower_bound=32, upper_bound=self.imgsz[1] * 2, default=self.imgsz[1]),
+                    ct.RangeDim(lower_bound=lb_h, upper_bound=h * 2, default=h),
+                    ct.RangeDim(lower_bound=lb_w, upper_bound=w * 2, default=w),
                 )
             )
             inputs = [ct.TensorType("image", shape=input_shape)]

--- a/ultralytics/nn/modules/block.py
+++ b/ultralytics/nn/modules/block.py
@@ -1999,7 +1999,8 @@ class Proto26(Proto):
         feat = x[0]
         for i, f in enumerate(self.feat_refine):
             up_feat = f(x[i + 1])
-            up_feat = F.interpolate(up_feat, size=feat.shape[2:], mode="nearest")
+            # Constant scale (P4/P5 -> P3) keeps the upsample static for dynamic-shape CoreML export
+            up_feat = F.interpolate(up_feat, scale_factor=2 ** (i + 1), mode="nearest")
             feat = feat + up_feat
         p = super().forward(self.feat_fuse(feat))
         if self.training and return_semantic:


### PR DESCRIPTION
## Summary

Fixes https://github.com/ultralytics/ultralytics/issues/25327 (CoreML `dynamic=True` segment export crash), plus a second pre-existing CoreML dynamic bug found while verifying: end2end models exported at imgsz > 32 failed to load at inference time.

## Fix 1: `Proto26` dynamic-size upsample (the fuzz crash)

`yolo export segment model=yolo26n-seg.pt format=coreml dynamic=True ...` crashed in coremltools' `torch_upsample_to_core_upsample` pass with `ValueError: Unable to map torch_upsample_nearest_neighbor to core upsample`.

`Proto26.forward` upsampled P4/P5 features to P3 size with `F.interpolate(..., size=feat.shape[2:], mode="nearest")`. Under dynamic-shape tracing (`ct.RangeDim` inputs) the target size becomes a runtime tensor, producing a dynamic-size upsample CoreML cannot map. Since `Segment26`/`YOLOESegment26` always feed Proto26 consecutive pyramid levels (P3/P4/P5 — the only two YAMLs using these heads both wire `[16, 19, 22]`, and the neck Concat already enforces exact ×2 halving), the scale is a build-time constant: `scale_factor=2 ** (i + 1)`. This is also the form every neck `nn.Upsample` already exports through all formats; the size-based call was the outlier.

## Fix 2: dynamic `RangeDim` lower bound vs baked TopK

End2end graphs bake `topk(k=max_det)` with constant k (clamped to the anchor count at the traced size). `export_coreml` declared `RangeDim(lower_bound=32)`, promising input sizes whose anchor count is below k, so CoreML type inference rejected the model at load: `Provided k (300) is not within range [1, 21] for TopK` — reproducible on unmodified main with plain `yolo26n.pt` at `imgsz=320 dynamic=True`. Every end2end dynamic CoreML export at imgsz > 32 was unusable.

The declared input range now derives from the graph's actual constraint: the H/W lower bounds shrink proportionally from the traced default so the smallest declared input still supplies ≥ k anchors (e.g. imgsz=640, max_det=300 → lower bound 128). Non-end2end graphs (no TopK) keep the previous 32 floor.

Deleted: the dynamic `size=feat.shape[2:]` interpolate target in `Proto26.forward` and the hardcoded `lower_bound=32` constants in `export_coreml`. Net positive lines are the anchor-requirement computation, which cannot be expressed by deletion — it replaces wrong constants with the derived constraint.

## Verification (local macOS, coremltools 9.0, torch 2.13)

- Exact fuzz repro command failed before, exports successfully after (lower bound correctly stays 32 there since k=21).
- PyTorch outputs bitwise identical pre/post Proto26 change at imgsz 32×32, 64×96, 160×128 (integer-scale nearest is equivalent to size-based for stride-multiple inputs, which `check_imgsz` guarantees).
- `yolo26n.pt` imgsz=320 `dynamic=True`: failed at load on main; now loads and predictions match PyTorch classes exactly at 320 and 256.
- `yolo26n-seg.pt` imgsz=320 `dynamic=True`: loads, predictions match PyTorch exactly at 320 and 256, masks correct.
- Regression checks: static CoreML seg export+predict, dynamic ONNX seg export+predict (matches PyTorch exactly), 1-epoch coco8-seg train+val smoke (training shares the Proto26 path).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Improved dynamic-shape CoreML export compatibility for end-to-end models and semantic feature refinement.

### 📊 Key Changes

- Updated CoreML dynamic input sizing to calculate suitable minimum height and width for end-to-end models based on detection limits and model stride.
- Preserved the default image size while allowing inputs up to twice the configured dimensions.
- Changed feature upsampling in `block.py` from shape-based resizing to fixed scale factors.
- Added static upsampling behavior to improve compatibility with dynamic-shape CoreML export.

### 🎯 Purpose & Impact

- ✅ Prevents CoreML from rejecting exported end-to-end models when smaller input sizes cannot provide enough detection anchors.
- 📱 Improves reliability when deploying Ultralytics models with dynamic image shapes on Apple devices.
- ⚡ Makes semantic feature refinement more compatible with CoreML’s static graph requirements.
- 🔄 Maintains existing export behavior for standard models while improving support for dynamic inputs.