### PR TITLE
Document YOLO26-Depth task in Platform docs and API reference

### DIFF
--- a/docs/en/platform/api/index.md
+++ b/docs/en/platform/api/index.md
@@ -911,12 +911,12 @@ POST /api/models
 
 **JSON Body:**
 
-| Field         | Type   | Required | Description                                                |
-| ------------- | ------ | -------- | ---------------------------------------------------------- |
-| `projectId`   | string | Yes      | Target project ID                                          |
-| `slug`        | string | No       | URL slug (lowercase alphanumeric/hyphens)                  |
-| `name`        | string | No       | Display name (max 100 chars)                               |
-| `description` | string | No       | Model description (max 1000 chars)                         |
+| Field         | Type   | Required | Description                                                       |
+| ------------- | ------ | -------- | ----------------------------------------------------------------- |
+| `projectId`   | string | Yes      | Target project ID                                                 |
+| `slug`        | string | No       | URL slug (lowercase alphanumeric/hyphens)                         |
+| `name`        | string | No       | Display name (max 100 chars)                                      |
+| `description` | string | No       | Model description (max 1000 chars)                                |
 | `task`        | string | No       | Task type (detect, segment, semantic, depth, pose, obb, classify) |
 
 !!! note "Model File Upload"

--- a/docs/en/platform/api/index.md
+++ b/docs/en/platform/api/index.md
@@ -293,7 +293,7 @@ POST /api/datasets
 
 !!! note "Supported Tasks"
 
-    Valid `task` values: `detect`, `segment`, `semantic`, `classify`, `pose`, `obb`.
+    Valid `task` values: `detect`, `segment`, `semantic`, `classify`, `pose`, `obb`. Depth datasets are coming soon.
 
 **Response:**
 
@@ -917,7 +917,7 @@ POST /api/models
 | `slug`        | string | No       | URL slug (lowercase alphanumeric/hyphens)                  |
 | `name`        | string | No       | Display name (max 100 chars)                               |
 | `description` | string | No       | Model description (max 1000 chars)                         |
-| `task`        | string | No       | Task type (detect, segment, semantic, pose, obb, classify) |
+| `task`        | string | No       | Task type (detect, segment, semantic, depth, pose, obb, classify) |
 
 !!! note "Model File Upload"
 
@@ -1024,7 +1024,7 @@ Provide either `file` or `source`. Maximum upload size is 100 MB.
 
 **Response:**
 
-Responses contain per-image `shape`, `speed`, `results`, and optional semantic mask data, plus `metadata` with image count, function timing, task, and service versions. Internal model paths are never returned.
+Responses contain per-image `shape`, `speed`, `results`, and optional dense pixel-map data (a semantic class map, or a 16-bit depth map where `depth = pixel × max / 65535`), plus `metadata` with image count, function timing, task, and service versions. Internal model paths are never returned.
 
 ```json
 {

--- a/docs/en/platform/data/index.md
+++ b/docs/en/platform/data/index.md
@@ -55,7 +55,7 @@ graph LR
 
 ## Supported Tasks
 
-Ultralytics Platform supports all 6 YOLO task types:
+Ultralytics Platform datasets support 6 of the 7 YOLO task types — [depth](../../tasks/depth.md) datasets are coming soon (depth models and prediction are already supported):
 
 | Task                                             | Description                                                     | Annotation Tool   |
 | ------------------------------------------------ | --------------------------------------------------------------- | ----------------- |

--- a/docs/en/platform/deploy/inference.md
+++ b/docs/en/platform/deploy/inference.md
@@ -320,6 +320,35 @@ Response format varies by task:
 
     Semantic segmentation returns per-class pixel coverage (`pixel_ratio`, the fraction of image pixels assigned to each class) instead of per-object boxes.
 
+=== "Depth"
+
+    ```json
+    {
+      "results": [],
+      "depth": {
+        "shape": [480, 640],
+        "encoding": "png",
+        "data": "<base64 16-bit grayscale PNG>",
+        "min": 0.31,
+        "max": 79.9
+      }
+    }
+    ```
+
+    [Depth estimation](../../tasks/depth.md) returns a dense per-pixel map instead of per-object results: a base64-encoded 16-bit grayscale PNG where `depth = pixel × max / 65535` and a pixel value of `0` means no depth. Decode it with any image library:
+
+    ```python
+    import base64
+    import io
+
+    import numpy as np
+    from PIL import Image
+
+    depth = response["images"][0]["depth"]
+    pixels = np.asarray(Image.open(io.BytesIO(base64.b64decode(depth["data"]))))
+    meters = pixels * depth["max"] / 65535.0  # 0 = no depth
+    ```
+
 === "Pose"
 
     ```json

--- a/docs/en/platform/explore.md
+++ b/docs/en/platform/explore.md
@@ -199,7 +199,7 @@ Official `@ultralytics` content is pinned to the top of the Explore page. This i
 
 | Project                           | Description                 | Models                        | Tasks                                          |
 | --------------------------------- | --------------------------- | ----------------------------- | ---------------------------------------------- |
-| **[YOLO26](../models/yolo26.md)** | Latest January 2026 release | 30 models (5 sizes × 6 tasks) | detect, segment, semantic, pose, OBB, classify |
+| **[YOLO26](../models/yolo26.md)** | Latest January 2026 release | 35 models (5 sizes × 7 tasks) | detect, segment, semantic, depth, pose, OBB, classify |
 | **[YOLO11](../models/yolo11.md)** | Current stable release      | 25 models (5 sizes × 5 tasks) | detect, segment, pose, OBB, classify           |
 | **YOLOv8**                        | Previous generation         | 25 models (5 sizes × 5 tasks) | detect, segment, pose, OBB, classify           |
 | **YOLOv5**                        | Legacy, widely adopted      | 15+ models                    | detect, segment, classify                      |

--- a/docs/en/platform/explore.md
+++ b/docs/en/platform/explore.md
@@ -197,12 +197,12 @@ See [Projects](train/projects.md) for organizing models in your project.
 
 Official `@ultralytics` content is pinned to the top of the Explore page. This includes:
 
-| Project                           | Description                 | Models                        | Tasks                                          |
-| --------------------------------- | --------------------------- | ----------------------------- | ---------------------------------------------- |
+| Project                           | Description                 | Models                        | Tasks                                                 |
+| --------------------------------- | --------------------------- | ----------------------------- | ----------------------------------------------------- |
 | **[YOLO26](../models/yolo26.md)** | Latest January 2026 release | 35 models (5 sizes × 7 tasks) | detect, segment, semantic, depth, pose, OBB, classify |
-| **[YOLO11](../models/yolo11.md)** | Current stable release      | 25 models (5 sizes × 5 tasks) | detect, segment, pose, OBB, classify           |
-| **YOLOv8**                        | Previous generation         | 25 models (5 sizes × 5 tasks) | detect, segment, pose, OBB, classify           |
-| **YOLOv5**                        | Legacy, widely adopted      | 15+ models                    | detect, segment, classify                      |
+| **[YOLO11](../models/yolo11.md)** | Current stable release      | 25 models (5 sizes × 5 tasks) | detect, segment, pose, OBB, classify                  |
+| **YOLOv8**                        | Previous generation         | 25 models (5 sizes × 5 tasks) | detect, segment, pose, OBB, classify                  |
+| **YOLOv5**                        | Legacy, widely adopted      | 15+ models                    | detect, segment, classify                             |
 
 Official datasets include benchmark datasets like [coco8](../datasets/detect/coco8.md) (8-image COCO subset), [VOC](../datasets/detect/voc.md), [african-wildlife](../datasets/detect/african-wildlife.md), [dota8](../datasets/obb/dota8.md), and other commonly used computer vision datasets.
 

--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -294,7 +294,7 @@ For a detailed guide, see the [Quickstart](quickstart.md) page.
 - **No-Code Training**: Train advanced YOLO models without writing code
 - **Real-Time Metrics**: Stream training progress and monitor deployments
 - **42 Deploy Regions**: Deploy models close to your users worldwide
-- **6 Task Types**: Support for detection, instance segmentation, semantic segmentation, pose, OBB, and classification (see [task docs](../tasks/index.md))
+- **7 Task Types**: Support for detection, instance segmentation, semantic segmentation, depth estimation (models and prediction today; depth datasets coming soon), pose, OBB, and classification (see [task docs](../tasks/index.md))
 - **AI-Assisted Annotation**: [Smart annotation](data/annotation.md#smart-annotation) with SAM and YOLO models to speed up data preparation
 
 ### What GPU options are available for cloud training?

--- a/docs/en/platform/train/models.md
+++ b/docs/en/platform/train/models.md
@@ -32,7 +32,7 @@ Supported model formats:
 
 After upload, the platform parses model metadata:
 
-- Task type ([detect](../../tasks/detect.md), [segment](../../tasks/segment.md), [semantic](../../tasks/semantic.md), [pose](../../tasks/pose.md), [OBB](../../tasks/obb.md), [classify](../../tasks/classify.md))
+- Task type ([detect](../../tasks/detect.md), [segment](../../tasks/segment.md), [semantic](../../tasks/semantic.md), [depth](../../tasks/depth.md), [pose](../../tasks/pose.md), [OBB](../../tasks/obb.md), [classify](../../tasks/classify.md))
 - Architecture (YOLO26n, YOLO26s, etc.)
 - Class names and count
 - Input size and parameters
@@ -143,7 +143,7 @@ Run interactive inference directly in the browser:
 - Upload an image, use example images, or use webcam
 - Results display with bounding boxes, masks, semantic class maps, or keypoints
 - Auto-inference when an image is provided
-- Supports all task types ([detect](../../tasks/detect.md), [segment](../../tasks/segment.md), [semantic](../../tasks/semantic.md), [pose](../../tasks/pose.md), [OBB](../../tasks/obb.md), [classify](../../tasks/classify.md))
+- Supports all task types ([detect](../../tasks/detect.md), [segment](../../tasks/segment.md), [semantic](../../tasks/semantic.md), [depth](../../tasks/depth.md), [pose](../../tasks/pose.md), [OBB](../../tasks/obb.md), [classify](../../tasks/classify.md))
 
 !!! tip "Quick Testing"
 
@@ -387,7 +387,7 @@ Ultralytics Platform fully supports all YOLO architectures with dedicated projec
 - [**YOLOv8**](../../models/yolov8.md): n, s, m, l, x variants — [platform.ultralytics.com/ultralytics/yolov8](https://platform.ultralytics.com/ultralytics/yolov8)
 - [**YOLOv5**](../../models/yolov5.md): n, s, m, l, x variants — [platform.ultralytics.com/ultralytics/yolov5](https://platform.ultralytics.com/ultralytics/yolov5)
 
-YOLO26 supports 6 task types: [detect](../../tasks/detect.md), [segment](../../tasks/segment.md), [semantic](../../tasks/semantic.md), [pose](../../tasks/pose.md), [OBB](../../tasks/obb.md), and [classify](../../tasks/classify.md). YOLO11 and YOLOv8 support the same set except semantic segmentation, while YOLOv5 supports detect, segment, and classify.
+YOLO26 supports 7 task types: [detect](../../tasks/detect.md), [segment](../../tasks/segment.md), [semantic](../../tasks/semantic.md), [depth](../../tasks/depth.md), [pose](../../tasks/pose.md), [OBB](../../tasks/obb.md), and [classify](../../tasks/classify.md). YOLO11 and YOLOv8 support the same set except semantic segmentation and depth, while YOLOv5 supports detect, segment, and classify.
 
 ### Can I download my trained model?
 


### PR DESCRIPTION
## Summary

Updates Platform docs for the YOLO26-Depth task now live on [Ultralytics Platform](https://platform.ultralytics.com) (ultralytics/portal#3019) — model upload/cloning and prediction are supported today; depth datasets are documented as coming soon.

- **deploy/inference.md**: new Depth tab in Task-Specific Responses documenting the API contract — a base64 16-bit grayscale PNG where `depth = pixel × max / 65535` and `0` = no depth — with a 5-line Python decode example
- **train/models.md**: depth added to the upload/clone task lists; YOLO26 task matrix updated to 7 tasks
- **explore.md**: YOLO26 catalog row updated to 35 models (5 sizes × 7 tasks)
- **platform/index.md**: 7 task types, with depth scoped to models/prediction (datasets coming soon); annotation-editor claims intentionally remain 6 tasks
- **data/index.md**: supported-tasks framing updated truthfully (6 of 7; depth datasets coming soon)
- **api/index.md**: depth in model `task` values, dataset task note, and predict-response prose

Depth model weights (`yolo26{n,s,m,l,x}-depth.pt`) are being published to the Platform ultralytics account alongside this change.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📚 Updated Ultralytics Platform documentation to reflect YOLO26 depth estimation support, including inference responses, model tasks, and the upcoming availability of depth datasets.

### 📊 Key Changes

- Added **depth estimation** as a supported YOLO26 model and prediction task across Platform documentation.
- Documented depth inference responses with:
  - Base64-encoded 16-bit grayscale PNG output.
  - Per-pixel depth values and image dimensions.
  - Minimum and maximum depth metadata.
  - A Python decoding example using Pillow and NumPy.
- Clarified that **depth datasets are coming soon**, while depth models and prediction are already supported.
- Updated API documentation to include `depth` as a valid model task and describe dense depth-map outputs.
- Updated YOLO26 listings from **30 models across 6 tasks** to **35 models across 7 tasks**.
- Added depth support to model upload metadata, browser inference, and Platform feature descriptions.

### 🎯 Purpose & Impact

- 🚀 Gives users clear guidance for using YOLO26 depth estimation through the Ultralytics Platform.
- 🧭 Makes depth prediction output easier to understand and decode programmatically.
- ✅ Keeps API and Platform documentation aligned with current YOLO26 capabilities.
- 🗂️ Sets accurate expectations that depth model inference is available now, while depth dataset workflows are still forthcoming.