### PR TITLE
Fix CoreML dynamic=True depth export bilinear upsample mapping error

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -845,8 +845,9 @@ class Depth(nn.Module):
 
         out = feats[-1]
         for i in range(self.nl - 2, -1, -1):
-            # align_corners=True is baked into the released depth weights.
-            out = F.interpolate(out, size=feats[i].shape[2:], mode="bilinear", align_corners=True)
+            # align_corners=True is baked into the released depth weights. Constant scale (consecutive pyramid
+            # levels) keeps the upsample static for dynamic-shape CoreML export; output size is identical.
+            out = F.interpolate(out, scale_factor=2, mode="bilinear", align_corners=True)
             out = out + feats[i]
             out = self.refine[i](out)
 


### PR DESCRIPTION
## Summary

Follow-up to #25347, fixing the same CoreML `dynamic=True` export failure for the depth task: `yolo export model=yolo26n-depth.pt format=coreml dynamic=True` crashed in coremltools' `torch_upsample_to_core_upsample` pass with `ValueError: Unable to map torch_upsample_bilinear to core upsample`.

## Root cause and fix

The `Depth` head's coarse-to-fine fusion loop upsampled each level with `F.interpolate(..., size=feats[i].shape[2:], mode="bilinear", align_corners=True)`. Under dynamic-shape tracing the size becomes a runtime tensor CoreML cannot map — identical mechanism to the `Proto26` fix in #25347.

Only `yolo26-depth.yaml` wires this head, at `[[16, 19, 22]]` (consecutive P3/P4/P5 octaves whose exact ×2 halving the neck Concat already enforces), and the loop steps one level at a time, so the scale is a build-time constant: `scale_factor=2`.

`align_corners=True` is unaffected: bilinear sampling geometry depends only on input/output sizes, and `scale_factor=2` yields exactly the same output size as `size=(2h, 2w)`, so results are bitwise identical — released depth weights behave identically.

Deleted: the dynamic `size=feats[i].shape[2:]` shape-dependent interpolate target in `Depth.forward` (replaced by a constant `scale_factor`, net +1 line for the constraint comment).

## Verification (local macOS, coremltools 9.0, torch 2.13)

- Repro command failed on main, exports successfully after.
- Full-model PyTorch outputs bitwise identical pre/post at imgsz 32×32, 64×96, 160×128.
- Dynamic CoreML export loads and predicts: corr ≥ 0.9999 vs PyTorch with median relative error 0.0000 at both 320 and 256.
- Static CoreML export parity is byte-for-byte identical to unmodified main (same mean/corr to 5 decimals) — the modest pre-existing static gap (corr 0.883, likely uint8 ImageType input quantization amplified by exp()) is untouched by this change.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated depth-head upsampling to use a fixed scale factor, improving compatibility with dynamic-shape CoreML exports without changing outputs.

### 📊 Key Changes

- Replaced size-based bilinear interpolation with `scale_factor=2`.
- Preserved `align_corners=True` to remain compatible with released depth-model weights.
- Kept the output resolution unchanged for consecutive feature-pyramid levels.
- Made the upsampling operation static for dynamic-shape CoreML export.

### 🎯 Purpose & Impact

- ✅ Improves CoreML export compatibility, especially for models handling dynamic input shapes.
- ✅ Maintains existing depth prediction behavior and output dimensions.
- 🚀 Reduces export-related issues without requiring changes from users.