### PR TITLE
Stride-align AutoBatch probe size to true multi-scale maximum

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -628,7 +628,8 @@ class BaseTrainer:
 
     def auto_batch(self, max_num_obj=0, dataset_size=0):
         """Calculate optimal batch size based on model and device memory constraints."""
-        max_imgsz = int(self.args.imgsz * (1 + self.args.multi_scale))  # need not be stride-aligned
+        # Stride-aligned to match the true multi-scale max size; pyramid heads require stride-multiple inputs
+        max_imgsz = math.ceil(self.args.imgsz * (1 + self.args.multi_scale) / self.stride) * self.stride
         return check_train_batch_size(
             model=self.model,
             imgsz=max_imgsz,


### PR DESCRIPTION
## Summary

Follow-up to #25347/#25350. `BaseTrainer.auto_batch` probed memory at `int(imgsz * (1 + multi_scale))` with a comment claiming the size "need not be stride-aligned". That claim is now stale, and the probe size was wrong in both directions:

1. **It crashes the profile on pyramid heads.** YOLO26 seg (`Proto26`) and depth (`Depth`) heads require exact ×2 pyramid halving, so a non-stride-multiple probe (e.g. imgsz=640, multi_scale=0.33 → 851) raises `RuntimeError: Sizes of tensors must match` inside `profile_ops` — verified empirically (851 crashes, 864 passes). The exception is caught per-batch-size and AutoBatch silently falls back to the default batch, defeating `batch=-1`.
2. **It underestimates the true multi-scale maximum.** Multi-scale training draws from `randrange(..., int(imgsz*(1+ms) + stride))` floored to a stride multiple (`models/yolo/detect/train.py:123-127`), so the largest real training size can exceed the old probe: imgsz=640, multi_scale=0.33 trains up to 864 but probed at 851.

`math.ceil(imgsz * (1 + multi_scale) / stride) * stride` equals the true multi-scale maximum (864 in the example) — the probe no longer crashes and measures the size training will actually hit. With `multi_scale=0` (default) the value is unchanged (`check_imgsz` already stride-aligns `imgsz`), so default behavior is identical. `self.stride` is set at `_setup_train` line 361, before `auto_batch()` runs at line 379.

Deleted: the stale "need not be stride-aligned" comment and the unaligned `int(...)` probe expression.

## Verification (local)

- `yolo26n-seg` forward at 851 raises the concat `RuntimeError`; at 864 passes.
- True multi-scale max for imgsz=640, ms=0.33, stride=32 computed as 864; old probe 851; new probe 864 (exact match).
- Real `batch=-1` train setup logs `AutoBatch: Computing optimal batch size for imgsz=864` and the non-CUDA fallback path is unchanged.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📏 Aligns automatic batch-size estimation with the model stride when multi-scale training is enabled.

### 📊 Key Changes
- Updates `auto_batch()` to round the maximum multi-scale image size up to the nearest stride multiple.
- Ensures batch-size checks use the same stride-aligned dimensions required by pyramid heads.
- Replaces the previous unaligned image-size calculation with a safer, model-compatible value.

### 🎯 Purpose & Impact
- ✅ Prevents shape and compatibility issues caused by non-stride-aligned multi-scale inputs.
- 📦 Improves the reliability of automatic batch-size selection across different models and devices.
- 🚀 Helps training run more consistently without requiring users to manually adjust image sizes.