### PR TITLE
Document depth predict bits parameter and model-resolution maps

### DIFF
--- a/docs/en/platform/api/index.md
+++ b/docs/en/platform/api/index.md
@@ -1024,7 +1024,7 @@ Provide either `file` or `source`. Maximum upload size is 100 MB.
 
 **Response:**
 
-Responses contain per-image `shape`, `speed`, `results`, and optional dense pixel-map data (a semantic class map, or a 16-bit depth map where `depth = pixel × max / 65535`), plus `metadata` with image count, function timing, task, and service versions. Internal model paths are never returned.
+Responses contain per-image `shape`, `speed`, `results`, and optional dense pixel-map data (a semantic class map, or a depth map where `depth = pixel × max / divisor` — divisor 255 for the default 8-bit map, 65535 with `bits=12|16`), plus `metadata` with image count, function timing, task, and service versions. Internal model paths are never returned.
 
 ```json
 {

--- a/docs/en/platform/deploy/inference.md
+++ b/docs/en/platform/deploy/inference.md
@@ -328,14 +328,15 @@ Response format varies by task:
       "depth": {
         "shape": [480, 640],
         "encoding": "png",
-        "data": "<base64 16-bit grayscale PNG>",
+        "data": "<base64 grayscale PNG>",
         "min": 0.31,
-        "max": 79.9
+        "max": 79.9,
+        "bits": 8
       }
     }
     ```
 
-    [Depth estimation](../../tasks/depth.md) returns a dense per-pixel map instead of per-object results: a base64-encoded 16-bit grayscale PNG where `depth = pixel × max / 65535` and a pixel value of `0` means no depth. Decode it with any image library:
+    [Depth estimation](../../tasks/depth.md) returns a dense per-pixel map instead of per-object results: a base64-encoded grayscale PNG where `depth = pixel × max / divisor` and a pixel value of `0` means no depth. The optional `bits` request parameter selects the quantization — `8` (default, uint8 PNG, divisor 255), `12`, or `16` (uint16 PNG, divisor 65535). The map is returned at model inference resolution (`imgsz`), so resize it to the image dimensions if you need per-pixel alignment. Decode it with any image library:
 
     ```python
     import base64
@@ -346,7 +347,7 @@ Response format varies by task:
 
     depth = response["images"][0]["depth"]
     pixels = np.asarray(Image.open(io.BytesIO(base64.b64decode(depth["data"]))))
-    meters = pixels * depth["max"] / 65535.0  # 0 = no depth
+    meters = pixels * depth["max"] / (255.0 if depth["bits"] == 8 else 65535.0)  # 0 = no depth
     ```
 
 === "Pose"


### PR DESCRIPTION
Follows ultralytics/portal#3022: the Platform depth predict response now defaults to an 8-bit grayscale PNG (divisor 255) with optional `bits=12|16` for uint16 maps (divisor 65535), returned at model inference resolution. Updates the inference response tab (example, formula, decode snippet now bits-aware) and the API reference prose.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📐 Updates depth estimation API documentation to support configurable 8-, 12-, and 16-bit output maps.

### 📊 Key Changes

- Clarifies that depth maps use an 8-bit grayscale PNG by default, with optional `bits=12` or `bits=16` precision.
- Documents the correct scaling divisor:
  - `255` for 8-bit output
  - `65535` for 12- or 16-bit output
- Adds a `bits` field to depth responses so clients can identify the output precision.
- Notes that depth maps are returned at the model inference resolution (`imgsz`) and may need resizing for image alignment.
- Updates the Python decoding example to handle both 8-bit and higher-precision depth maps.

### 🎯 Purpose & Impact

- ✅ Prevents incorrect depth-value conversion caused by assuming all maps are 16-bit.
- 🎚️ Gives users a choice between smaller, faster 8-bit maps and higher-precision 12- or 16-bit maps.
- 🧩 Makes API responses easier to interpret and integrate into downstream computer vision workflows.
- ⚠️ Users consuming depth outputs should read the new `bits` field and resize maps when pixel-perfect alignment with the original image is required.