### PR TITLE
Use INTER_AREA for downscaling to reduce aliasing

### DIFF
--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1814,8 +1814,10 @@ class LetterBox(BaseTransform):
         new_unpad = params["new_unpad"]
 
         if shape[::-1] != new_unpad:  # resize
-            interp = cv2.INTER_AREA if new_unpad[0] * new_unpad[1] < shape[0] * shape[1] else self.interpolation
-            img = cv2.resize(img, new_unpad, interpolation=interp)
+            # INTER_AREA anti-aliases when downscaling but only supports <= 4 channels and the default linear mode
+            downscale = new_unpad[0] * new_unpad[1] < shape[0] * shape[1]
+            area = self.interpolation == cv2.INTER_LINEAR and downscale and (img.ndim == 2 or img.shape[2] <= 4)
+            img = cv2.resize(img, new_unpad, interpolation=cv2.INTER_AREA if area else self.interpolation)
             if img.ndim == 2:
                 img = img[..., None]
 

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1814,7 +1814,8 @@ class LetterBox(BaseTransform):
         new_unpad = params["new_unpad"]
 
         if shape[::-1] != new_unpad:  # resize
-            img = cv2.resize(img, new_unpad, interpolation=self.interpolation)
+            interp = cv2.INTER_AREA if new_unpad[0] * new_unpad[1] < shape[0] * shape[1] else self.interpolation
+            img = cv2.resize(img, new_unpad, interpolation=interp)
             if img.ndim == 2:
                 img = img[..., None]
 

--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -248,19 +248,21 @@ class BaseDataset(Dataset):
                 raise FileNotFoundError(f"Image Not Found {f}")
 
             h0, w0 = im.shape[:2]  # orig hw
+            # INTER_AREA anti-aliases when shrinking but only supports <= 4 channels
+            shrink = cv2.INTER_AREA if im.ndim == 2 or im.shape[2] <= 4 else cv2.INTER_LINEAR
             if rect_mode:  # resize long side to imgsz while maintaining aspect ratio
                 if resize_short:  # resize short side to imgsz while maintaining aspect ratio
                     r = self.imgsz / min(h0, w0)  # ratio
                     if r != 1:  # if sizes are not equal
                         w, h = (math.ceil(w0 * r), self.imgsz) if h0 < w0 else (self.imgsz, math.ceil(h0 * r))
-                        im = cv2.resize(im, (w, h), interpolation=cv2.INTER_AREA if r < 1 else cv2.INTER_LINEAR)
+                        im = cv2.resize(im, (w, h), interpolation=shrink if r < 1 else cv2.INTER_LINEAR)
                 else:
                     r = self.imgsz / max(h0, w0)  # ratio
                     if r != 1:  # if sizes are not equal
                         w, h = (min(math.ceil(w0 * r), self.imgsz), min(math.ceil(h0 * r), self.imgsz))
-                        im = cv2.resize(im, (w, h), interpolation=cv2.INTER_AREA if r < 1 else cv2.INTER_LINEAR)
+                        im = cv2.resize(im, (w, h), interpolation=shrink if r < 1 else cv2.INTER_LINEAR)
             elif not (h0 == w0 == self.imgsz):  # resize by stretching image to square imgsz
-                interp = cv2.INTER_AREA if self.imgsz < max(h0, w0) else cv2.INTER_LINEAR
+                interp = shrink if self.imgsz < max(h0, w0) else cv2.INTER_LINEAR
                 im = cv2.resize(im, (self.imgsz, self.imgsz), interpolation=interp)
             if im.ndim == 2:
                 im = im[..., None]

--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -253,14 +253,15 @@ class BaseDataset(Dataset):
                     r = self.imgsz / min(h0, w0)  # ratio
                     if r != 1:  # if sizes are not equal
                         w, h = (math.ceil(w0 * r), self.imgsz) if h0 < w0 else (self.imgsz, math.ceil(h0 * r))
-                        im = cv2.resize(im, (w, h), interpolation=cv2.INTER_LINEAR)
+                        im = cv2.resize(im, (w, h), interpolation=cv2.INTER_AREA if r < 1 else cv2.INTER_LINEAR)
                 else:
                     r = self.imgsz / max(h0, w0)  # ratio
                     if r != 1:  # if sizes are not equal
                         w, h = (min(math.ceil(w0 * r), self.imgsz), min(math.ceil(h0 * r), self.imgsz))
-                        im = cv2.resize(im, (w, h), interpolation=cv2.INTER_LINEAR)
+                        im = cv2.resize(im, (w, h), interpolation=cv2.INTER_AREA if r < 1 else cv2.INTER_LINEAR)
             elif not (h0 == w0 == self.imgsz):  # resize by stretching image to square imgsz
-                im = cv2.resize(im, (self.imgsz, self.imgsz), interpolation=cv2.INTER_LINEAR)
+                interp = cv2.INTER_AREA if self.imgsz < max(h0, w0) else cv2.INTER_LINEAR
+                im = cv2.resize(im, (self.imgsz, self.imgsz), interpolation=interp)
             if im.ndim == 2:
                 im = im[..., None]
 


### PR DESCRIPTION
Motivation: There have been 3 independent reports of local and API inference performing worse than Platform's predictions tab.
#24595
#24227
[Discord report](https://discord.com/channels/1089800235347353640/1098248998629933146/1528687692114821171)

I provided a [workaround inference code](https://github.com/ultralytics/ultralytics/issues/24595#issuecomment-4730062660) that seems to fix the issue for them by mimicking Platform preprocessing.

On further debugging, the issue appears to be downscaling strategy.

`load_image` and `LetterBox` always downscale with `cv2.INTER_LINEAR`, which samples only a 2x2 neighborhood and does not anti-alias. On large downscales (high-resolution inputs shrunk to `imgsz`) this aliases away thin and small structures, hurting detection. OpenCV recommends `cv2.INTER_AREA` for shrinking, which averages over the full source region. This matches how the Ultralytics Platform preprocesses images (PIL `BILINEAR` resize, which anti-aliases on downscale), and explains reports where local prediction quality was worse than the Platform on high-resolution images.

Two changes:

1. `ultralytics/data/base.py` `load_image`: pick `cv2.INTER_AREA` when the resize shrinks the image, else keep `cv2.INTER_LINEAR`.
2. `ultralytics/data/augment.py` `LetterBox`: same choice, comparing target area against source area.

Upscaling and equal-size paths are unchanged, so `INTER_LINEAR` still applies there.

### COCO val (`coco.yaml`, `yolo11n.pt`)

No change at `imgsz=640` because COCO val images are already <=640 px, so nothing downscales. The gain appears once a real downscale happens and grows with the factor:

| imgsz | downscale | mAP50-95 before | mAP50-95 after | mAP50 before | mAP50 after |
|-------|-----------|-----------------|----------------|--------------|-------------|
| 640   | 1x        | 0.38892         | 0.38892        | 0.54594      | 0.54594     |
| 320   | 2x        | 0.28795         | 0.28818        | 0.41837      | 0.41823     |
| 256   | 2.5x      | 0.24267         | 0.24558        | 0.36003      | 0.36308     |
| 160   | 4x        | 0.14349         | 0.14915        | 0.22042      | 0.22807     |

`yolo26m.pt` shows the same pattern: identical at 640, +0.003 mAP50-95 at 160.

The standard `imgsz=640` benchmark is unchanged, so there is no regression to reported numbers. The benefit is on real high-resolution inference, which is the reported case.

Deleted: nothing. The fix relocates the interpolation choice into the resize call sites that own downscaling rather than adding a guard elsewhere. It is net +2 lines because each site handles both up and down scaling in one `cv2.resize` call, so the filter must be selected per call, not removed

Fixes #24595
Fixes #24227

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves image resizing quality by using anti-aliased interpolation when shrinking compatible images. 🖼️

### 📊 Key Changes
- Added automatic selection of `cv2.INTER_AREA` for downscaling images with up to four channels.
- Retains `cv2.INTER_LINEAR` for upscaling and images with more than four channels, which OpenCV does not support with area interpolation.
- Applied the improved interpolation logic to both dataset image loading and augmentation resizing.
- Preserved grayscale image handling by restoring the channel dimension after resizing.

### 🎯 Purpose & Impact
- Reduces aliasing and improves visual quality when images are resized to smaller dimensions. ✨
- May provide cleaner input data for training and inference, potentially improving model consistency.
- Maintains compatibility with multi-channel images and existing resize behavior where `INTER_AREA` is unsuitable.
- No user-facing API changes are required.