### PR TITLE
Update fuzz coverage for depth task

### DIFF
--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -340,8 +340,9 @@ def sample_trial(rng, uni, corpus, personality):
     def mutate_combos(max_groups=4):
         """Combine compatible mode-specific argument groups without repeating keys."""
         options = [c.split() for m, c in COMBO_POOL if m == mode]
-        options.extend(c.split() for m, task, c in TASK_COMBO_POOL if m == mode and task == base["task"])
         rng.shuffle(options)
+        task_options = [c.split() for m, task, c in TASK_COMBO_POOL if m == mode and task == base["task"]]
+        options = task_options + options
         used, target = set(), rng.randint(1, max_groups)
         for combo in options:
             keys = {a.partition("=")[0] for a in combo}

--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -163,6 +163,9 @@ COMBO_POOL = [
     ("export", "quantize=fp16"),
     ("export", "end2end=True max_det=10"),
 ]
+TASK_COMBO_POOL = [
+    ("train", "depth", "dlog=0.5 dgrad=1.0 dlam=0.0"),
+]
 
 # Oracle: expected clean errors are these types raised from the validation layers (modules or exact frames)
 EXPECTED_TYPES = {"SyntaxError", "ValueError", "TypeError", "AssertionError", "FileNotFoundError"}
@@ -283,7 +286,7 @@ def build_corpus(uni):
         # Bare weight names keep issue repro commands portable; they resolve against the precached weights_dir
         model, data = uni["task2model"][task], uni["task2data"][task]
         for mode in MODES:
-            if mode == "track" and task in {"classify", "semantic"}:
+            if mode == "track" and task not in {"detect", "segment", "pose", "obb"}:
                 continue
             argv = [mode, task, f"model={model}", *strip_defaults(CLAMPS[mode].split(), uni["defaults"])]
             if mode in {"train", "val"}:
@@ -337,6 +340,7 @@ def sample_trial(rng, uni, corpus, personality):
     def mutate_combos(max_groups=4):
         """Combine compatible mode-specific argument groups without repeating keys."""
         options = [c.split() for m, c in COMBO_POOL if m == mode]
+        options.extend(c.split() for m, task, c in TASK_COMBO_POOL if m == mode and task == base["task"])
         rng.shuffle(options)
         used, target = set(), rng.randint(1, max_groups)
         for combo in options:


### PR DESCRIPTION
## Summary

- restrict tracking canaries to tasks that produce trackable boxes
- exercise the YOLO-Depth `dlog`, `dgrad`, and `dlam` loss controls together in valid-combination trials

Deleted: the denylist assumption that every task except classification and semantic segmentation supports tracking.

The targeted combination is additive because the shared typed mutation pool cannot guarantee that depth-only loss controls are exercised together on a depth trial.

## Tests

- `ruff format --check .github/scripts/fuzz.py`
- `ruff check .github/scripts/fuzz.py`
- corpus assertion: depth includes train/val/predict/export and excludes track
- one-epoch depth fuzz trial with `dlog=0.5 dgrad=1.0 dlam=0.0`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧪 Expands fuzz testing to cover task-specific training parameters and more accurately validate tracking support across YOLO tasks.

### 📊 Key Changes

- Added a task-specific fuzzing combination for **depth training**, including `dlog`, `dgrad`, and `dlam` parameters.
- Updated tracking test generation to allow only supported tasks: **detect, segment, pose, and OBB**.
- Integrated task-specific argument combinations into the fuzzing mutation process for relevant modes and tasks.

### 🎯 Purpose & Impact

- ✅ Improves automated testing coverage for depth-estimation training options.
- 🛡️ Reduces invalid tracking test cases for unsupported tasks such as classification and semantic segmentation.
- 🔍 Helps uncover task-specific validation and compatibility issues earlier, improving overall reliability of Ultralytics workflows.