### PR TITLE
Refactor dataset label caching into shared template with per-class hooks

### DIFF
--- a/docs/en/reference/data/dataset.md
+++ b/docs/en/reference/data/dataset.md
@@ -42,4 +42,8 @@ keywords: Ultralytics, YOLODataset, object detection, segmentation, dataset load
 
 ## ::: ultralytics.data.dataset.ClassificationDataset
 
+<br><br><hr><br>
+
+## ::: ultralytics.data.dataset._text_augment_transform
+
 <br><br>

--- a/docs/en/reference/data/dataset.md
+++ b/docs/en/reference/data/dataset.md
@@ -42,8 +42,4 @@ keywords: Ultralytics, YOLODataset, object detection, segmentation, dataset load
 
 ## ::: ultralytics.data.dataset.ClassificationDataset
 
-<br><br><hr><br>
-
-## ::: ultralytics.data.dataset._text_augment_transform
-
 <br><br>

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -51,28 +51,6 @@ from .utils import (
 DATASET_CACHE_VERSION = "1.0.4"
 
 
-def _text_augment_transform(category_freq: dict, max_samples: int) -> RandomLoadText:
-    """Build the RandomLoadText augmentation shared by multi-modal and grounding datasets.
-
-    Args:
-        category_freq (dict): Frequency of each category in the dataset.
-        max_samples (int): Maximum number of text samples before clamping to 80.
-
-    Returns:
-        (RandomLoadText): Text augmentation transform, padding negative texts from the most frequent categories.
-    """
-    # NOTE: hard-coded the args for now.
-    # NOTE: this implementation is different from official yoloe,
-    # the strategy of selecting negative is restricted in one dataset,
-    # while official pre-saved neg embeddings from all datasets at once.
-    threshold = min(max(category_freq.values()), 100)
-    return RandomLoadText(
-        max_samples=min(max_samples, 80),
-        padding=True,
-        padding_value=[k for k, v in category_freq.items() if v >= threshold],
-    )
-
-
 class YOLODataset(BaseDataset):
     """Dataset class for loading object detection and/or segmentation labels in YOLO format.
 
@@ -578,7 +556,16 @@ class YOLOMultiModalDataset(YOLODataset):
         """
         transforms = super().build_transforms(hyp)
         if self.augment:
-            transforms.insert(-1, _text_augment_transform(self.category_freq, self.data["nc"]))
+            # NOTE: hard-coded the args for now.
+            # NOTE: this implementation is different from official yoloe,
+            # the strategy of selecting negative is restricted in one dataset,
+            # while official pre-saved neg embeddings from all datasets at once.
+            transform = RandomLoadText(
+                max_samples=min(self.data["nc"], 80),
+                padding=True,
+                padding_value=self._get_neg_texts(self.category_freq),
+            )
+            transforms.insert(-1, transform)
         return transforms
 
     @property
@@ -603,6 +590,12 @@ class YOLOMultiModalDataset(YOLODataset):
                     t = t.strip()
                     category_freq[t] += 1
         return category_freq
+
+    @staticmethod
+    def _get_neg_texts(category_freq: dict, threshold: int = 100) -> list[str]:
+        """Get negative text samples based on frequency threshold."""
+        threshold = min(max(category_freq.values()), 100)
+        return [k for k, v in category_freq.items() if v >= threshold]
 
 
 class GroundingDataset(YOLODataset):
@@ -800,7 +793,16 @@ class GroundingDataset(YOLODataset):
         """
         transforms = super().build_transforms(hyp)
         if self.augment:
-            transforms.insert(-1, _text_augment_transform(self.category_freq, self.max_samples))
+            # NOTE: hard-coded the args for now.
+            # NOTE: this implementation is different from official yoloe,
+            # the strategy of selecting negative is restricted in one dataset,
+            # while official pre-saved neg embeddings from all datasets at once.
+            transform = RandomLoadText(
+                max_samples=min(self.max_samples, 80),
+                padding=True,
+                padding_value=self._get_neg_texts(self.category_freq),
+            )
+            transforms.insert(-1, transform)
         return transforms
 
     @property
@@ -818,6 +820,12 @@ class GroundingDataset(YOLODataset):
                     t = t.strip()
                     category_freq[t] += 1
         return category_freq
+
+    @staticmethod
+    def _get_neg_texts(category_freq: dict, threshold: int = 100) -> list[str]:
+        """Get negative text samples based on frequency threshold."""
+        threshold = min(max(category_freq.values()), 100)
+        return [k for k, v in category_freq.items() if v >= threshold]
 
 
 class YOLOConcatDataset(ConcatDataset):

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -1093,18 +1093,16 @@ class PolygonSemanticDataset(SemanticDataset, YOLODataset):
         self.bg_class_idx = data.get("bg_class_idx", max(int(nc) - 1, 0))
         super().__init__(*args, data=data, **kwargs)
 
-    # Rebind the scanning hooks to YOLODataset's polygon .txt label implementations; the MRO
-    # (SemanticDataset, YOLODataset) would otherwise resolve SemanticDataset's PNG-mask hooks.
+    # Rebind label scanning to YOLODataset's polygon .txt implementations; the MRO (SemanticDataset, YOLODataset)
+    # would otherwise resolve SemanticDataset's PNG-mask hooks and its get_labels, which syncs mask_files from
+    # label dicts that polygon labels do not have.
+    get_labels = YOLODataset.get_labels
     get_label_files = YOLODataset.get_label_files
     get_cache_hash = YOLODataset.get_cache_hash
     scan_summary = YOLODataset.scan_summary
     verify_args = YOLODataset.verify_args
     result_to_label = YOLODataset.result_to_label
     verify_labels = YOLODataset.verify_labels
-
-    def get_labels(self) -> list[dict]:
-        """Parse YOLO polygon .txt labels via YOLODataset's template, skipping SemanticDataset's mask-file sync."""
-        return YOLODataset.get_labels(self)
 
     def load_mask(self, index: int, image_shape: tuple[int, int] | None = None) -> np.ndarray:
         """Rasterize this image's polygons into a (H, W) uint8 semantic mask, bg = self.bg_class_idx."""

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -328,6 +328,35 @@ class YOLODataset(BaseDataset):
         )
         return transforms
 
+    def build_text_transforms(self, transforms: Compose, max_samples: int) -> Compose:
+        """Insert text augmentation for text-based subclasses providing `category_freq`.
+
+        Args:
+            transforms (Compose): Transforms composed by build_transforms.
+            max_samples (int): Maximum number of text samples per image.
+
+        Returns:
+            (Compose): Transforms with RandomLoadText inserted before Format when augmenting.
+        """
+        if self.augment:
+            # NOTE: hard-coded the args for now.
+            # NOTE: this implementation is different from official yoloe,
+            # the strategy of selecting negative is restricted in one dataset,
+            # while official pre-saved neg embeddings from all datasets at once.
+            transform = RandomLoadText(
+                max_samples=min(max_samples, 80),
+                padding=True,
+                padding_value=self._get_neg_texts(self.category_freq),
+            )
+            transforms.insert(-1, transform)
+        return transforms
+
+    @staticmethod
+    def _get_neg_texts(category_freq: dict) -> list[str]:
+        """Get negative text samples with frequency above the dataset threshold."""
+        threshold = min(max(category_freq.values()), 100)
+        return [k for k, v in category_freq.items() if v >= threshold]
+
     def close_mosaic(self, hyp: dict) -> None:
         """Disable mosaic, copy_paste, mixup and cutmix augmentations by setting their probabilities to 0.0.
 
@@ -546,7 +575,7 @@ class YOLOMultiModalDataset(YOLODataset):
         return labels
 
     def build_transforms(self, hyp: dict | None = None) -> Compose:
-        """Enhance data transformations with optional text augmentation for multi-modal training.
+        """Enhance data transformations with text augmentation for multi-modal training.
 
         Args:
             hyp (dict, optional): Hyperparameters for transforms.
@@ -554,19 +583,7 @@ class YOLOMultiModalDataset(YOLODataset):
         Returns:
             (Compose): Composed transforms including text augmentation if applicable.
         """
-        transforms = super().build_transforms(hyp)
-        if self.augment:
-            # NOTE: hard-coded the args for now.
-            # NOTE: this implementation is different from official yoloe,
-            # the strategy of selecting negative is restricted in one dataset,
-            # while official pre-saved neg embeddings from all datasets at once.
-            transform = RandomLoadText(
-                max_samples=min(self.data["nc"], 80),
-                padding=True,
-                padding_value=self._get_neg_texts(self.category_freq),
-            )
-            transforms.insert(-1, transform)
-        return transforms
+        return self.build_text_transforms(super().build_transforms(hyp), self.data["nc"])
 
     @property
     def category_names(self):
@@ -590,12 +607,6 @@ class YOLOMultiModalDataset(YOLODataset):
                     t = t.strip()
                     category_freq[t] += 1
         return category_freq
-
-    @staticmethod
-    def _get_neg_texts(category_freq: dict, threshold: int = 100) -> list[str]:
-        """Get negative text samples based on frequency threshold."""
-        threshold = min(max(category_freq.values()), 100)
-        return [k for k, v in category_freq.items() if v >= threshold]
 
 
 class GroundingDataset(YOLODataset):
@@ -643,7 +654,7 @@ class GroundingDataset(YOLODataset):
         """
         return []
 
-    def verify_labels(self, labels: list[dict[str, Any]]) -> None:
+    def _verify_instance_counts(self, labels: list[dict[str, Any]]) -> None:
         """Verify the number of instances in the dataset matches expected counts.
 
         This method checks if the total number of bounding box instances in the provided labels matches the expected
@@ -776,7 +787,7 @@ class GroundingDataset(YOLODataset):
         cache, _ = self._load_or_scan_cache(cache_path, get_hash(self.json_file))
         [cache.pop(k) for k in ("hash", "version")]  # remove items
         labels = cache["labels"]
-        self.verify_labels(labels)
+        self._verify_instance_counts(labels)
         self.im_files = [str(label["im_file"]) for label in labels]
         if LOCAL_RANK in {-1, 0}:
             LOGGER.info(f"Load {self.json_file} from cache file {cache_path}")
@@ -791,19 +802,7 @@ class GroundingDataset(YOLODataset):
         Returns:
             (Compose): Composed transforms including text augmentation if applicable.
         """
-        transforms = super().build_transforms(hyp)
-        if self.augment:
-            # NOTE: hard-coded the args for now.
-            # NOTE: this implementation is different from official yoloe,
-            # the strategy of selecting negative is restricted in one dataset,
-            # while official pre-saved neg embeddings from all datasets at once.
-            transform = RandomLoadText(
-                max_samples=min(self.max_samples, 80),
-                padding=True,
-                padding_value=self._get_neg_texts(self.category_freq),
-            )
-            transforms.insert(-1, transform)
-        return transforms
+        return self.build_text_transforms(super().build_transforms(hyp), self.max_samples)
 
     @property
     def category_names(self):
@@ -820,12 +819,6 @@ class GroundingDataset(YOLODataset):
                     t = t.strip()
                     category_freq[t] += 1
         return category_freq
-
-    @staticmethod
-    def _get_neg_texts(category_freq: dict, threshold: int = 100) -> list[str]:
-        """Get negative text samples based on frequency threshold."""
-        threshold = min(max(category_freq.values()), 100)
-        return [k for k, v in category_freq.items() if v >= threshold]
 
 
 class YOLOConcatDataset(ConcatDataset):

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -197,11 +197,11 @@ class YOLODataset(BaseDataset):
             repeat(self.single_cls),
         )
 
-    def result_to_label(self, result) -> tuple[dict | None, int, int, int, int, str]:
+    def result_to_label(self, result: list) -> tuple[dict | None, int, int, int, int, str]:
         """Convert one verification result into a label dict and scan counter increments.
 
         Args:
-            result: One result from the verification function returned by `verify_args`.
+            result (list): One result from the verification function returned by `verify_args`.
 
         Returns:
             (tuple): (label dict or None, missing, found, empty, corrupt, message).
@@ -472,7 +472,7 @@ class DepthDataset(YOLODataset):
         """Return the depth verification function and its argument iterable."""
         return verify_image_depth, zip(self.im_files, self.depth_files, repeat(self.prefix))
 
-    def result_to_label(self, result) -> tuple[dict | None, int, int, int, int, str]:
+    def result_to_label(self, result: tuple) -> tuple[dict | None, int, int, int, int, str]:
         """Convert one verify_image_depth result into a label dict and scan counter increments."""
         im_file, shape, nf_f, nm_f, nc_f, msg = result
         label = (
@@ -962,7 +962,7 @@ class SemanticDataset(YOLODataset):
             repeat(int(self.data.get("nc", 0)) == 1),
         )
 
-    def result_to_label(self, result) -> tuple[dict | None, int, int, int, int, str]:
+    def result_to_label(self, result: tuple) -> tuple[dict | None, int, int, int, int, str]:
         """Convert one verify_image_mask result into a label dict and scan counter increments."""
         im_file, mask_file, shape, is_1bit, nm_f, nf_f, nc_f, msg = result
         label = (

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -51,6 +51,28 @@ from .utils import (
 DATASET_CACHE_VERSION = "1.0.4"
 
 
+def _text_augment_transform(category_freq: dict, max_samples: int) -> RandomLoadText:
+    """Build the RandomLoadText augmentation shared by multi-modal and grounding datasets.
+
+    Args:
+        category_freq (dict): Frequency of each category in the dataset.
+        max_samples (int): Maximum number of text samples before clamping to 80.
+
+    Returns:
+        (RandomLoadText): Text augmentation transform, padding negative texts from the most frequent categories.
+    """
+    # NOTE: hard-coded the args for now.
+    # NOTE: this implementation is different from official yoloe,
+    # the strategy of selecting negative is restricted in one dataset,
+    # while official pre-saved neg embeddings from all datasets at once.
+    threshold = min(max(category_freq.values()), 100)
+    return RandomLoadText(
+        max_samples=min(max_samples, 80),
+        padding=True,
+        padding_value=[k for k, v in category_freq.items() if v >= threshold],
+    )
+
+
 class YOLODataset(BaseDataset):
     """Dataset class for loading object detection and/or segmentation labels in YOLO format.
 
@@ -296,31 +318,6 @@ class YOLODataset(BaseDataset):
         self.im_files = [lb["im_file"] for lb in labels]  # update im_files
         self.verify_labels(labels, cache_path)
         return labels
-
-    @staticmethod
-    def _get_neg_texts(category_freq: dict, threshold: int = 100) -> list[str]:
-        """Get negative text samples based on frequency threshold."""
-        threshold = min(max(category_freq.values()), 100)
-        return [k for k, v in category_freq.items() if v >= threshold]
-
-    def _text_augment_transform(self, max_samples: int) -> RandomLoadText:
-        """Build the RandomLoadText augmentation shared by multi-modal and grounding datasets.
-
-        Args:
-            max_samples (int): Maximum number of text samples before clamping to 80.
-
-        Returns:
-            (RandomLoadText): Text augmentation transform. Requires a `category_freq` property on the subclass.
-        """
-        # NOTE: hard-coded the args for now.
-        # NOTE: this implementation is different from official yoloe,
-        # the strategy of selecting negative is restricted in one dataset,
-        # while official pre-saved neg embeddings from all datasets at once.
-        return RandomLoadText(
-            max_samples=min(max_samples, 80),
-            padding=True,
-            padding_value=self._get_neg_texts(self.category_freq),
-        )
 
     def build_transforms(self, hyp: dict | None = None) -> Compose:
         """Build and append transforms to the list.
@@ -581,7 +578,7 @@ class YOLOMultiModalDataset(YOLODataset):
         """
         transforms = super().build_transforms(hyp)
         if self.augment:
-            transforms.insert(-1, self._text_augment_transform(self.data["nc"]))
+            transforms.insert(-1, _text_augment_transform(self.category_freq, self.data["nc"]))
         return transforms
 
     @property
@@ -803,7 +800,7 @@ class GroundingDataset(YOLODataset):
         """
         transforms = super().build_transforms(hyp)
         if self.augment:
-            transforms.insert(-1, self._text_augment_transform(self.max_samples))
+            transforms.insert(-1, _text_augment_transform(self.category_freq, self.max_samples))
         return transforms
 
     @property

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -48,7 +48,7 @@ from .utils import (
 )
 
 # Ultralytics dataset *.cache version, >= 1.0.0 for Ultralytics YOLO models
-DATASET_CACHE_VERSION = "1.0.3"
+DATASET_CACHE_VERSION = "1.0.4"
 
 
 class YOLODataset(BaseDataset):
@@ -66,6 +66,10 @@ class YOLODataset(BaseDataset):
     Methods:
         cache_labels: Cache dataset labels, check images and read shapes.
         get_labels: Return list of label dictionaries for YOLO training.
+        get_label_files: Return companion label files for the dataset's images.
+        verify_args: Return the per-image verification function and its arguments.
+        result_to_label: Convert one verification result into a label dict.
+        verify_labels: Check box/segment consistency of the loaded labels.
         build_transforms: Build and append transforms to the list.
         close_mosaic: Disable mosaic, copy_paste, mixup and cutmix augmentations and build transformations.
         update_labels_info: Update label format for different tasks.
@@ -95,6 +99,10 @@ class YOLODataset(BaseDataset):
     def cache_labels(self, path: Path = Path("./labels.cache")) -> dict:
         """Cache dataset labels, check images and read shapes.
 
+        This is the shared scanning skeleton for file-based datasets; subclasses customize it through the
+        `get_label_files`, `get_cache_hash`, `verify_args`, `result_to_label` and `scan_summary` hooks instead of
+        duplicating this method.
+
         Args:
             path (Path): Path where to save the cache file.
 
@@ -105,48 +113,21 @@ class YOLODataset(BaseDataset):
         nm, nf, ne, nc, msgs = 0, 0, 0, 0, []  # number missing, found, empty, corrupt, messages
         desc = f"{self.prefix}Scanning {path.parent / path.stem}..."
         total = len(self.im_files)
-        nkpt, ndim = self.data.get("kpt_shape", (0, 0))
-        if self.use_keypoints and (nkpt <= 0 or ndim not in {2, 3}):
-            raise ValueError(
-                "'kpt_shape' in data.yaml missing or incorrect. Should be a list with [number of "
-                "keypoints, number of dims (2 for x,y or 3 for x,y,visible)], i.e. 'kpt_shape: [17, 3]'"
-            )
         with ThreadPool(NUM_THREADS) as pool:
-            results = pool.imap(
-                func=verify_image_label,
-                iterable=zip(
-                    self.im_files,
-                    self.label_files,
-                    repeat(self.prefix),
-                    repeat(self.use_keypoints),
-                    repeat(len(self.data["names"])),
-                    repeat(nkpt),
-                    repeat(ndim),
-                    repeat(self.single_cls),
-                ),
-            )
+            func, iterable = self.verify_args()
+            results = pool.imap(func=func, iterable=iterable)
             pbar = TQDM(results, desc=desc, total=total)
-            for im_file, lb, shape, segments, keypoint, nm_f, nf_f, ne_f, nc_f, msg in pbar:
+            for result in pbar:
+                label, nm_f, nf_f, ne_f, nc_f, msg = self.result_to_label(result)
                 nm += nm_f
                 nf += nf_f
                 ne += ne_f
                 nc += nc_f
-                if im_file:
-                    x["labels"].append(
-                        {
-                            "im_file": im_file,
-                            "shape": shape,
-                            "cls": lb[:, 0:1],  # n, 1
-                            "bboxes": lb[:, 1:],  # n, 4
-                            "segments": segments,
-                            "keypoints": keypoint,
-                            "normalized": True,
-                            "bbox_format": "xywh",
-                        }
-                    )
+                if label is not None:
+                    x["labels"].append(label)
                 if msg:
                     msgs.append(msg)
-                pbar.desc = f"{desc} {nf} images, {nm + ne} backgrounds, {nc} corrupt"
+                pbar.desc = f"{desc} {self.scan_summary(nf, nm, ne, nc)}"
             pbar.close()
 
         if msgs:
@@ -155,46 +136,100 @@ class YOLODataset(BaseDataset):
             if self.augment:  # training requires labels; unlabeled val splits (e.g. COCO test-dev) only warn
                 raise ValueError(f"{self.prefix}No labels found in {path}. {HELP_URL}")
             LOGGER.warning(f"{self.prefix}No labels found in {path}. {HELP_URL}")
-        x["hash"] = get_hash(self.label_files + self.im_files)
-        x["results"] = nf, nm, ne, nc, len(self.im_files)
+        x["hash"] = self.get_cache_hash()
+        x["results"] = nf, nm, ne, nc, total
         x["msgs"] = msgs  # warnings
         if x["labels"]:
             save_dataset_cache_file(self.prefix, path, x, DATASET_CACHE_VERSION)
         return x
 
-    def get_labels(self) -> list[dict]:
-        """Return list of label dictionaries for YOLO training.
-
-        This method loads labels from disk or cache, verifies their integrity, and prepares them for training.
+    def get_label_files(self) -> list[str]:
+        """Return the companion label files for the dataset's images, storing them on the instance.
 
         Returns:
-            (list[dict]): List of label dictionaries, each containing information about an image and its annotations.
+            (list[str]): List of label file paths.
         """
         self.label_files = img2label_paths(self.im_files)
-        cache_path = Path(self.label_files[0]).parent.with_suffix(".cache")
-        try:
-            cache, exists = load_dataset_cache_file(cache_path), True  # attempt to load a *.cache file
-            assert cache["version"] == DATASET_CACHE_VERSION  # matches current version
-            assert cache["hash"] == get_hash(self.label_files + self.im_files)  # identical hash
-        except (FileNotFoundError, AssertionError, AttributeError, ModuleNotFoundError):
-            cache, exists = self.cache_labels(cache_path), False  # run cache ops
+        return self.label_files
 
-        # Display cache
-        nf, nm, ne, nc, n = cache.pop("results")  # found, missing, empty, corrupt, total
-        if exists and LOCAL_RANK in {-1, 0}:
-            d = f"Scanning {cache_path}... {nf} images, {nm + ne} backgrounds, {nc} corrupt"
-            TQDM(None, desc=self.prefix + d, total=n, initial=n)  # display results
-            if cache["msgs"]:
-                LOGGER.info("\n".join(cache["msgs"]))  # display warnings
+    def get_cache_hash(self) -> str:
+        """Return the hash used to validate a label cache against the current dataset files.
 
-        # Read cache
-        labels = cache["labels"]
-        if not labels:
-            issues = "\n  ".join(sorted(set(cache["msgs"]))) or "no error details"
-            raise RuntimeError(f"No valid images found in {cache_path}.\n  {issues}\n{HELP_URL}")
-        [cache.pop(k) for k in ("hash", "version", "msgs")]  # remove items
-        self.im_files = [lb["im_file"] for lb in labels]  # update im_files
+        Returns:
+            (str): Dataset cache hash.
+        """
+        return get_hash(self.label_files + self.im_files)
 
+    def scan_summary(self, nf: int, nm: int, ne: int, nc: int) -> str:
+        """Return a one-line summary of scan counters for progress bars and cache logs.
+
+        Args:
+            nf (int): Number of found images.
+            nm (int): Number of missing labels.
+            ne (int): Number of empty labels.
+            nc (int): Number of corrupt images.
+
+        Returns:
+            (str): Scan summary message.
+        """
+        return f"{nf} images, {nm + ne} backgrounds, {nc} corrupt"
+
+    def verify_args(self) -> tuple:
+        """Return the per-image verification function and its argument iterable used by `cache_labels`.
+
+        Returns:
+            (tuple): (verify function, zipped argument iterable) for ThreadPool.imap.
+        """
+        nkpt, ndim = self.data.get("kpt_shape", (0, 0))
+        if self.use_keypoints and (nkpt <= 0 or ndim not in {2, 3}):
+            raise ValueError(
+                "'kpt_shape' in data.yaml missing or incorrect. Should be a list with [number of "
+                "keypoints, number of dims (2 for x,y or 3 for x,y,visible)], i.e. 'kpt_shape: [17, 3]'"
+            )
+        return verify_image_label, zip(
+            self.im_files,
+            self.label_files,
+            repeat(self.prefix),
+            repeat(self.use_keypoints),
+            repeat(len(self.data["names"])),
+            repeat(nkpt),
+            repeat(ndim),
+            repeat(self.single_cls),
+        )
+
+    def result_to_label(self, result) -> tuple[dict | None, int, int, int, int, str]:
+        """Convert one verification result into a label dict and scan counter increments.
+
+        Args:
+            result: One result from the verification function returned by `verify_args`.
+
+        Returns:
+            (tuple): (label dict or None, missing, found, empty, corrupt, message).
+        """
+        im_file, lb, shape, segments, keypoint, nm_f, nf_f, ne_f, nc_f, msg = result
+        label = (
+            {
+                "im_file": im_file,
+                "shape": shape,
+                "cls": lb[:, 0:1],  # n, 1
+                "bboxes": lb[:, 1:],  # n, 4
+                "segments": segments,
+                "keypoints": keypoint,
+                "normalized": True,
+                "bbox_format": "xywh",
+            }
+            if im_file
+            else None
+        )
+        return label, nm_f, nf_f, ne_f, nc_f, msg
+
+    def verify_labels(self, labels: list[dict], cache_path: Path) -> None:
+        """Check that the dataset is all boxes or all segments, removing mixed segments if necessary.
+
+        Args:
+            labels (list[dict]): List of label dictionaries.
+            cache_path (Path): Path of the dataset cache file, used in warning messages.
+        """
         # Check if the dataset is all boxes or all segments
         lengths = ((len(lb["cls"]), len(lb["bboxes"]), len(lb["segments"])) for lb in labels)
         len_cls, len_boxes, len_segments = (sum(x) for x in zip(*lengths))
@@ -213,7 +248,79 @@ class YOLODataset(BaseDataset):
                 lb["segments"] = []
         if len_cls == 0:
             LOGGER.warning(f"Labels are missing or empty in {cache_path}, training may not work correctly. {HELP_URL}")
+
+    def _load_or_scan_cache(self, cache_path: Path, cache_hash: str) -> tuple[dict, bool]:
+        """Load a dataset cache file if it matches the current version and hash, otherwise rescan and rebuild it.
+
+        Args:
+            cache_path (Path): Path of the cache file.
+            cache_hash (str): Expected hash of the dataset files.
+
+        Returns:
+            (tuple): (cache dict, True if a valid existing cache file was loaded).
+        """
+        try:
+            cache, exists = load_dataset_cache_file(cache_path), True  # attempt to load a *.cache file
+            assert cache["version"] == DATASET_CACHE_VERSION  # matches current version
+            assert cache["hash"] == cache_hash  # identical hash
+        except (FileNotFoundError, AssertionError, AttributeError, ModuleNotFoundError):
+            cache, exists = self.cache_labels(cache_path), False  # run cache ops
+        return cache, exists
+
+    def get_labels(self) -> list[dict]:
+        """Return list of label dictionaries for YOLO training.
+
+        This method loads labels from disk or cache, verifies their integrity, and prepares them for training.
+
+        Returns:
+            (list[dict]): List of label dictionaries, each containing information about an image and its annotations.
+        """
+        label_files = self.get_label_files()
+        cache_path = Path(label_files[0]).parent.with_suffix(".cache")
+        cache, exists = self._load_or_scan_cache(cache_path, self.get_cache_hash())
+
+        # Display cache
+        nf, nm, ne, nc, n = cache.pop("results")  # found, missing, empty, corrupt, total
+        if exists and LOCAL_RANK in {-1, 0}:
+            d = f"Scanning {cache_path}... {self.scan_summary(nf, nm, ne, nc)}"
+            TQDM(None, desc=self.prefix + d, total=n, initial=n)  # display results
+            if cache["msgs"]:
+                LOGGER.info("\n".join(cache["msgs"]))  # display warnings
+
+        # Read cache
+        labels = cache["labels"]
+        if not labels:
+            issues = "\n  ".join(sorted(set(cache["msgs"]))) or "no error details"
+            raise RuntimeError(f"No valid images found in {cache_path}.\n  {issues}\n{HELP_URL}")
+        [cache.pop(k) for k in ("hash", "version", "msgs")]  # remove items
+        self.im_files = [lb["im_file"] for lb in labels]  # update im_files
+        self.verify_labels(labels, cache_path)
         return labels
+
+    @staticmethod
+    def _get_neg_texts(category_freq: dict, threshold: int = 100) -> list[str]:
+        """Get negative text samples based on frequency threshold."""
+        threshold = min(max(category_freq.values()), 100)
+        return [k for k, v in category_freq.items() if v >= threshold]
+
+    def _text_augment_transform(self, max_samples: int) -> RandomLoadText:
+        """Build the RandomLoadText augmentation shared by multi-modal and grounding datasets.
+
+        Args:
+            max_samples (int): Maximum number of text samples before clamping to 80.
+
+        Returns:
+            (RandomLoadText): Text augmentation transform. Requires a `category_freq` property on the subclass.
+        """
+        # NOTE: hard-coded the args for now.
+        # NOTE: this implementation is different from official yoloe,
+        # the strategy of selecting negative is restricted in one dataset,
+        # while official pre-saved neg embeddings from all datasets at once.
+        return RandomLoadText(
+            max_samples=min(max_samples, 80),
+            padding=True,
+            padding_value=self._get_neg_texts(self.category_freq),
+        )
 
     def build_transforms(self, hyp: dict | None = None) -> Compose:
         """Build and append transforms to the list.
@@ -340,85 +447,51 @@ class DepthDataset(YOLODataset):
                 break
         return str(Path(*parts).with_suffix(".npy"))
 
-    def cache_labels(self, path: Path = Path("./labels.cache")) -> dict[str, Any]:
-        """Cache image-depth pairing metadata, verifying images and depth maps in one pass.
-
-        Args:
-            path (Path): Path where to save the cache file.
+    def get_label_files(self) -> list[str]:
+        """Return the depth .npy paths paired with the dataset's images.
 
         Returns:
-            (dict[str, Any]): Cached depth metadata.
-        """
-        x = {"labels": []}
-        nf, nm, nc, msgs = 0, 0, 0, []  # found, missing, corrupt, messages
-        desc = f"{self.prefix}Scanning {path.parent / path.stem}..."
-        total = len(self.im_files)
-        with ThreadPool(NUM_THREADS) as pool:
-            results = pool.imap(
-                func=verify_image_depth,
-                iterable=zip(self.im_files, self.depth_files, repeat(self.prefix)),
-            )
-            pbar = TQDM(results, desc=desc, total=total)
-            for im_file, shape, nf_f, nm_f, nc_f, msg in pbar:
-                nf += nf_f
-                nm += nm_f
-                nc += nc_f
-                if im_file:
-                    x["labels"].append(
-                        {
-                            "im_file": im_file,
-                            "shape": shape,
-                            "cls": np.array([], dtype=np.float32),
-                            "bboxes": np.zeros((0, 4), dtype=np.float32),
-                            "segments": [],
-                            "normalized": True,
-                            "bbox_format": "xywh",
-                        }
-                    )
-                if msg:
-                    msgs.append(msg)
-                pbar.desc = f"{desc} {nf} images, {nm} missing depth, {nc} corrupt"
-            pbar.close()
-        if msgs:
-            LOGGER.info("\n".join(msgs))
-        x["hash"] = get_hash(self.depth_files + self.im_files)
-        x["results"] = nf, nm, nc, total
-        x["msgs"] = msgs
-        if x["labels"]:
-            save_dataset_cache_file(self.prefix, path, x, DATASET_CACHE_VERSION)
-        return x
-
-    def get_labels(self) -> list[dict]:
-        """Load image-depth pairs from cache or scan, dropping images with missing or corrupt depth maps.
-
-        Returns:
-            (list[dict]): List of label dictionaries with image shapes; depth maps load lazily per index.
+            (list[str]): List of depth file paths.
         """
         self.depth_files = [self._depth_path_for(f) for f in self.im_files]
-        cache_path = Path(self.depth_files[0]).parent.with_suffix(".cache")
-        try:
-            cache, exists = load_dataset_cache_file(cache_path), True
-            assert cache["version"] == DATASET_CACHE_VERSION
-            assert cache["hash"] == get_hash(self.depth_files + self.im_files)
-        except (FileNotFoundError, AssertionError, AttributeError, ModuleNotFoundError):
-            cache, exists = self.cache_labels(cache_path), False
+        return self.depth_files
 
-        nf, nm, nc, n = cache.pop("results")
-        if exists and LOCAL_RANK in {-1, 0}:
-            d = f"Scanning {cache_path}... {nf} images, {nm} missing depth, {nc} corrupt"
-            TQDM(None, desc=self.prefix + d, total=n, initial=n)
-            if cache["msgs"]:
-                LOGGER.info("\n".join(cache["msgs"]))
+    def get_cache_hash(self) -> str:
+        """Return a hash over the paired depth and image files.
 
-        [cache.pop(k) for k in ("hash", "version", "msgs")]
-        labels = cache["labels"]
-        if not labels:
-            raise FileNotFoundError(
-                f"{self.prefix}No valid image-depth pairs found in {cache_path}. Expected readable 2D .npy files in a "
-                f"'depth/' tree parallel to 'images/' (images/train/x.jpg → depth/train/x.npy). {HELP_URL}"
-            )
-        self.im_files = [lb["im_file"] for lb in labels]
-        return labels
+        Returns:
+            (str): Dataset cache hash.
+        """
+        return get_hash(self.depth_files + self.im_files)
+
+    def scan_summary(self, nf: int, nm: int, ne: int, nc: int) -> str:
+        """Return a one-line summary of image-depth scan counters."""
+        return f"{nf} images, {nm} missing depth, {nc} corrupt"
+
+    def verify_args(self) -> tuple:
+        """Return the depth verification function and its argument iterable."""
+        return verify_image_depth, zip(self.im_files, self.depth_files, repeat(self.prefix))
+
+    def result_to_label(self, result) -> tuple[dict | None, int, int, int, int, str]:
+        """Convert one verify_image_depth result into a label dict and scan counter increments."""
+        im_file, shape, nf_f, nm_f, nc_f, msg = result
+        label = (
+            {
+                "im_file": im_file,
+                "shape": shape,
+                "cls": np.array([], dtype=np.float32),
+                "bboxes": np.zeros((0, 4), dtype=np.float32),
+                "segments": [],
+                "normalized": True,
+                "bbox_format": "xywh",
+            }
+            if im_file
+            else None
+        )
+        return label, nm_f, nf_f, 0, nc_f, msg
+
+    def verify_labels(self, labels: list[dict], cache_path: Path) -> None:
+        """Skip box and segment checks; depth datasets carry no box or segment annotations."""
 
     def _load_depth(self, index):
         """Return the native-resolution depth map for an image, with non-finite values mapped to 0 (invalid)."""
@@ -508,16 +581,7 @@ class YOLOMultiModalDataset(YOLODataset):
         """
         transforms = super().build_transforms(hyp)
         if self.augment:
-            # NOTE: hard-coded the args for now.
-            # NOTE: this implementation is different from official yoloe,
-            # the strategy of selecting negative is restricted in one dataset,
-            # while official pre-saved neg embeddings from all datasets at once.
-            transform = RandomLoadText(
-                max_samples=min(self.data["nc"], 80),
-                padding=True,
-                padding_value=self._get_neg_texts(self.category_freq),
-            )
-            transforms.insert(-1, transform)
+            transforms.insert(-1, self._text_augment_transform(self.data["nc"]))
         return transforms
 
     @property
@@ -542,12 +606,6 @@ class YOLOMultiModalDataset(YOLODataset):
                     t = t.strip()
                     category_freq[t] += 1
         return category_freq
-
-    @staticmethod
-    def _get_neg_texts(category_freq: dict, threshold: int = 100) -> list[str]:
-        """Get negative text samples based on frequency threshold."""
-        threshold = min(max(category_freq.values()), 100)
-        return [k for k, v in category_freq.items() if v >= threshold]
 
 
 class GroundingDataset(YOLODataset):
@@ -725,12 +783,7 @@ class GroundingDataset(YOLODataset):
             (list[dict]): List of label dictionaries, each containing information about an image and its annotations.
         """
         cache_path = Path(self.json_file).with_suffix(".cache")
-        try:
-            cache, _ = load_dataset_cache_file(cache_path), True  # attempt to load a *.cache file
-            assert cache["version"] == DATASET_CACHE_VERSION  # matches current version
-            assert cache["hash"] == get_hash(self.json_file)  # identical hash
-        except (FileNotFoundError, AssertionError, AttributeError, ModuleNotFoundError):
-            cache, _ = self.cache_labels(cache_path), False  # run cache ops
+        cache, _ = self._load_or_scan_cache(cache_path, get_hash(self.json_file))
         [cache.pop(k) for k in ("hash", "version")]  # remove items
         labels = cache["labels"]
         self.verify_labels(labels)
@@ -750,16 +803,7 @@ class GroundingDataset(YOLODataset):
         """
         transforms = super().build_transforms(hyp)
         if self.augment:
-            # NOTE: hard-coded the args for now.
-            # NOTE: this implementation is different from official yoloe,
-            # the strategy of selecting negative is restricted in one dataset,
-            # while official pre-saved neg embeddings from all datasets at once.
-            transform = RandomLoadText(
-                max_samples=min(self.max_samples, 80),
-                padding=True,
-                padding_value=self._get_neg_texts(self.category_freq),
-            )
-            transforms.insert(-1, transform)
+            transforms.insert(-1, self._text_augment_transform(self.max_samples))
         return transforms
 
     @property
@@ -777,12 +821,6 @@ class GroundingDataset(YOLODataset):
                     t = t.strip()
                     category_freq[t] += 1
         return category_freq
-
-    @staticmethod
-    def _get_neg_texts(category_freq: dict, threshold: int = 100) -> list[str]:
-        """Get negative text samples based on frequency threshold."""
-        threshold = min(max(category_freq.values()), 100)
-        return [k for k, v in category_freq.items() if v >= threshold]
 
 
 class YOLOConcatDataset(ConcatDataset):
@@ -893,93 +931,67 @@ class SemanticDataset(YOLODataset):
             normalized[src] = dst
         return normalized
 
-    def _semantic_cache_hash(self, mask_files: list[str]) -> str:
-        """Return a hash for semantic cache validation that also includes label_mapping changes."""
-        mapping = json.dumps(self.label_mapping, sort_keys=True, separators=(",", ":"))
-        return get_hash(self.im_files + mask_files + [f"label_mapping:{mapping}", "mask_bit_depth"])
-
-    def cache_labels(self, path: Path = Path("./labels.cache")) -> dict[str, Any]:
-        """Cache semantic labels and image-mask pairing metadata.
-
-        Args:
-            path (Path): Path where to save the cache file.
+    def get_label_files(self) -> list[str]:
+        """Return the mask PNG paths paired with the dataset's images.
 
         Returns:
-            (dict[str, Any]): Cached semantic metadata.
+            (list[str]): List of mask file paths.
         """
-        x = {"labels": []}
-        nm, nf, nc, msgs = 0, 0, 0, []  # missing, found, corrupt, messages
-        desc = f"{self.prefix}Scanning {path.parent / path.stem}..."
-        total = len(self.im_files)
+        self.mask_files = img2label_paths(self.im_files, label_dir=self.data.get("masks_dir", "masks"), suffix=".png")
+        return self.mask_files
 
-        with ThreadPool(NUM_THREADS) as pool:
-            results = pool.imap(
-                func=verify_image_mask,
-                iterable=zip(
-                    self.im_files,
-                    self.mask_files,
-                    repeat(self.prefix),
-                    repeat(int(self.data.get("nc", 0)) == 1),
-                ),
-            )
-            pbar = TQDM(results, desc=desc, total=total)
-            for im_file, mask_file, shape, is_1bit, nm_f, nf_f, nc_f, msg in pbar:
-                nm += nm_f
-                nf += nf_f
-                nc += nc_f
-                if im_file:
-                    x["labels"].append(
-                        {
-                            "im_file": im_file,
-                            "mask_file": mask_file,
-                            "shape": shape,
-                            "is_1bit": is_1bit,
-                            "cls": np.array([], dtype=np.float32),
-                            "bboxes": np.zeros((0, 4), dtype=np.float32),
-                            "segments": [],
-                            "normalized": True,
-                            "bbox_format": "xywh",
-                        }
-                    )
-                if msg:
-                    msgs.append(msg)
-                pbar.desc = f"{desc} {nf} images, {nm} missing masks, {nc} corrupt"
-            pbar.close()
-        x["hash"] = self._semantic_cache_hash(self.mask_files)
-        x["results"] = nf, nm, nc, total
-        x["msgs"] = msgs
-        if x["labels"]:
-            save_dataset_cache_file(self.prefix, path, x, DATASET_CACHE_VERSION)
-        return x
+    def get_cache_hash(self) -> str:
+        """Return a hash for semantic cache validation that also includes label_mapping changes.
 
-    def get_labels(self):
+        Returns:
+            (str): Dataset cache hash.
+        """
+        mapping = json.dumps(self.label_mapping, sort_keys=True, separators=(",", ":"))
+        return get_hash(self.im_files + self.mask_files + [f"label_mapping:{mapping}", "mask_bit_depth"])
+
+    def scan_summary(self, nf: int, nm: int, ne: int, nc: int) -> str:
+        """Return a one-line summary of image-mask scan counters."""
+        return f"{nf} images, {nm} missing masks, {nc} corrupt"
+
+    def verify_args(self) -> tuple:
+        """Return the mask verification function and its argument iterable."""
+        return verify_image_mask, zip(
+            self.im_files,
+            self.mask_files,
+            repeat(self.prefix),
+            repeat(int(self.data.get("nc", 0)) == 1),
+        )
+
+    def result_to_label(self, result) -> tuple[dict | None, int, int, int, int, str]:
+        """Convert one verify_image_mask result into a label dict and scan counter increments."""
+        im_file, mask_file, shape, is_1bit, nm_f, nf_f, nc_f, msg = result
+        label = (
+            {
+                "im_file": im_file,
+                "mask_file": mask_file,
+                "shape": shape,
+                "is_1bit": is_1bit,
+                "cls": np.array([], dtype=np.float32),
+                "bboxes": np.zeros((0, 4), dtype=np.float32),
+                "segments": [],
+                "normalized": True,
+                "bbox_format": "xywh",
+            }
+            if im_file
+            else None
+        )
+        return label, nm_f, nf_f, 0, nc_f, msg
+
+    def verify_labels(self, labels: list[dict], cache_path: Path) -> None:
+        """Skip box and segment checks; semantic masks carry no box or segment annotations."""
+
+    def get_labels(self) -> list[dict]:
         """Load semantic labels from cache or scan image-mask paths.
 
         Returns:
             (list[dict]): List of label dictionaries with mask file paths and image shapes.
         """
-        self.mask_files = img2label_paths(self.im_files, label_dir=self.data.get("masks_dir", "masks"), suffix=".png")
-        cache_path = Path(self.mask_files[0]).parent.with_suffix(".cache")
-
-        try:
-            cache, exists = load_dataset_cache_file(cache_path), True
-            assert cache["version"] == DATASET_CACHE_VERSION
-            assert cache["hash"] == self._semantic_cache_hash(self.mask_files)
-        except (FileNotFoundError, AssertionError, AttributeError, ModuleNotFoundError):
-            cache, exists = self.cache_labels(cache_path), False
-
-        nf, nm, nc, n = cache.pop("results")
-        if exists and LOCAL_RANK in {-1, 0}:
-            d = f"Scanning {cache_path}... {nf} masks, {nm} missing, {nc} corrupt"
-            TQDM(None, desc=self.prefix + d, total=n, initial=n)
-            if cache["msgs"]:
-                LOGGER.info("\n".join(cache["msgs"]))
-
-        [cache.pop(k) for k in ("hash", "version", "msgs")]
-        labels = cache["labels"]
-        if not labels:
-            raise RuntimeError(f"No valid images found in {cache_path}. {HELP_URL}")
-        self.im_files = [lb["im_file"] for lb in labels]
+        labels = super().get_labels()
         self.mask_files = [lb["mask_file"] for lb in labels]
         return labels
 
@@ -1076,13 +1088,18 @@ class PolygonSemanticDataset(SemanticDataset, YOLODataset):
         self.bg_class_idx = data.get("bg_class_idx", max(int(nc) - 1, 0))
         super().__init__(*args, data=data, **kwargs)
 
-    def get_labels(self):
-        """Parse YOLO polygon .txt labels."""
-        return YOLODataset.get_labels(self)
+    # Rebind the scanning hooks to YOLODataset's polygon .txt label implementations; the MRO
+    # (SemanticDataset, YOLODataset) would otherwise resolve SemanticDataset's PNG-mask hooks.
+    get_label_files = YOLODataset.get_label_files
+    get_cache_hash = YOLODataset.get_cache_hash
+    scan_summary = YOLODataset.scan_summary
+    verify_args = YOLODataset.verify_args
+    result_to_label = YOLODataset.result_to_label
+    verify_labels = YOLODataset.verify_labels
 
-    def cache_labels(self, path: Path = Path("./labels.cache")) -> dict[str, Any]:
-        """Cache polygon labels via YOLODataset to keep the 5-tuple `results` format expected by get_labels."""
-        return YOLODataset.cache_labels(self, path)
+    def get_labels(self) -> list[dict]:
+        """Parse YOLO polygon .txt labels via YOLODataset's template, skipping SemanticDataset's mask-file sync."""
+        return YOLODataset.get_labels(self)
 
     def load_mask(self, index: int, image_shape: tuple[int, int] | None = None) -> np.ndarray:
         """Rasterize this image's polygons into a (H, W) uint8 semantic mask, bg = self.bg_class_idx."""


### PR DESCRIPTION
Consolidates the triplicated `cache_labels`/`get_labels` skeletons (`YOLODataset`, `DepthDataset`, `SemanticDataset`) into a single template on `YOLODataset` driven by small per-class hooks: `get_label_files`, `get_cache_hash`, `scan_summary`, `verify_args`, `result_to_label`, `verify_labels`, plus a shared `_load_or_scan_cache`.

- The box/segment consistency checks move into `YOLODataset.verify_labels` — subclasses without box/segment annotations (depth, semantic) override a one-line no-op instead of rewriting the full scan.
- `GroundingDataset` reuses `_load_or_scan_cache`; `_get_neg_texts` and the `RandomLoadText` insertion are now single shared copies used by `YOLOMultiModalDataset` and `GroundingDataset`.
- `PolygonSemanticDataset` rebinds the hooks to YOLO's implementations instead of bypassing the MRO with duplicate overrides.
- `DATASET_CACHE_VERSION` bumped to `1.0.4` (the cache `results` tuple is now uniformly 5 fields); stale caches rescan once.

Deleted: `DepthDataset.cache_labels`/`get_labels`, `SemanticDataset.cache_labels`/`get_labels`/`_semantic_cache_hash`, `PolygonSemanticDataset.cache_labels`/`get_labels` MRO-bypass overrides, the duplicate `_get_neg_texts`, and one `RandomLoadText` block (~170 duplicated lines).

Verified: 35 targeted tests pass (depth/semantic/polygon dataset scans, train/val across tasks, cache paths); `ruff` clean; codex review LGTM. `test_train_scratch` fails identically on `main` (AutoBatch picks batch=11 for 12 images in this env) — pre-existing, unrelated.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Refactors dataset label and cache scanning into reusable hooks, improving consistency across detection, depth, semantic, grounding, and multimodal datasets. 🧩

### 📊 Key Changes
- Bumped the dataset cache version to `1.0.4` to invalidate incompatible existing caches.
- Added shared dataset-scanning hooks for:
  - Finding companion label files
  - Building cache hashes
  - Verifying files in parallel
  - Converting verification results into labels
  - Formatting scan summaries
  - Validating loaded labels
- Reworked depth and semantic-mask datasets to use the common caching and scanning framework instead of duplicating logic.
- Added shared text augmentation support, including negative text sample selection for multimodal datasets. 📝
- Updated grounding and polygon-based semantic datasets to use the appropriate label-scanning implementations despite their multiple-inheritance structure.
- Preserved specialized cache validation, including semantic label-mapping changes and depth/image pairing checks.

### 🎯 Purpose & Impact
- Reduces duplicated dataset code, making future dataset types easier to maintain and extend. 🛠️
- Provides more consistent cache loading, validation, progress reporting, and error handling across tasks.
- Automatically rebuilds stale caches after the version change or when dataset files and configuration mappings change.
- Improves multimodal training support by centralizing text augmentation behavior.
- Existing users may experience one-time dataset rescans because older cache files are no longer considered valid.