### PR TITLE
Collapse conv/bn fusion to broadcast form and delete input-side channels_last conversions

### DIFF
--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -423,8 +423,7 @@ class BasePredictor:
             self.args.imgsz = self.model.imgsz  # reuse imgsz from export metadata
         self.model.eval()
         # channels_last (NHWC) is CUDA-only and native-PyTorch-only: lossless and Tensor-Core friendly there, wrong
-        # on MPS, no CPU gain. Exported CUDA runtimes (TensorRT / ONNX io-binding) read im.data_ptr() against an NCHW
-        # binding, so feeding them an NHWC-strided input would be misread as NCHW and corrupt predictions.
+        # on MPS, no CPU gain, and only a native nn.Module has weights to convert.
         channels_last = self.args.channels_last and self.device.type == "cuda" and self.model.format == "pt"
         if self.args.channels_last and not channels_last:
             LOGGER.warning(

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -129,7 +129,6 @@ class BasePredictor:
         if self.args.conf is None:
             self.args.conf = 0.25  # default conf=0.25
         self.done_warmup = False
-        self.channels_last = False  # set in setup_model; NHWC memory format for native PyTorch CUDA inference
         if self.args.show:
             self.args.show = check_imshow(warn=True)
 
@@ -175,8 +174,6 @@ class BasePredictor:
         im = im.half() if self.model.fp16 else im.float()  # uint8 to fp16/32
         if not_tensor:
             im /= 255  # 0 - 255 to 0.0 - 1.0
-        if self.channels_last:
-            im = im.contiguous(memory_format=torch.channels_last)
         return im
 
     def inference(self, im: torch.Tensor, *args, **kwargs):
@@ -316,8 +313,7 @@ class BasePredictor:
                         1 if self.model.format in {"pt", "triton"} else self.dataset.bs,
                         self.model.channels,
                         *self.imgsz,
-                    ),
-                    channels_last=self.channels_last,  # match preprocess layout so compile traces it once
+                    )
                 )
                 self.done_warmup = True
 
@@ -429,13 +425,13 @@ class BasePredictor:
         # channels_last (NHWC) is CUDA-only and native-PyTorch-only: lossless and Tensor-Core friendly there, wrong
         # on MPS, no CPU gain. Exported CUDA runtimes (TensorRT / ONNX io-binding) read im.data_ptr() against an NCHW
         # binding, so feeding them an NHWC-strided input would be misread as NCHW and corrupt predictions.
-        self.channels_last = self.args.channels_last and self.device.type == "cuda" and self.model.format == "pt"
-        if self.args.channels_last and not self.channels_last:
+        channels_last = self.args.channels_last and self.device.type == "cuda" and self.model.format == "pt"
+        if self.args.channels_last and not channels_last:
             LOGGER.warning(
                 f"'channels_last=True' applies only to native PyTorch models on CUDA, ignoring for "
                 f"format='{self.model.format}' on '{self.device.type}'."
             )
-        if self.channels_last:
+        if channels_last:
             self.model.to(memory_format=torch.channels_last)
         self.model = attempt_compile(self.model, device=self.device, mode=self.args.compile)
 

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -304,7 +304,7 @@ class BaseTrainer:
         ckpt = self.setup_model()
         self.model = self.model.to(self.device)
         # channels_last (NHWC) is CUDA-only: lossless and Tensor-Core friendly there, but numerically wrong
-        # on MPS and no benefit on CPU, so restrict to CUDA and convert the input batches to match below
+        # on MPS and no benefit on CPU
         if self.args.channels_last and self.device.type == "cuda":
             self.model = self.model.to(memory_format=torch.channels_last)
         elif self.args.channels_last:

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -305,11 +305,10 @@ class BaseTrainer:
         self.model = self.model.to(self.device)
         # channels_last (NHWC) is CUDA-only: lossless and Tensor-Core friendly there, but numerically wrong
         # on MPS and no benefit on CPU, so restrict to CUDA and convert the input batches to match below
-        self.channels_last = self.args.channels_last and self.device.type == "cuda"
-        if self.args.channels_last and not self.channels_last:
-            LOGGER.warning(f"'channels_last=True' is only supported on CUDA, ignoring on '{self.device.type}'.")
-        if self.channels_last:
+        if self.args.channels_last and self.device.type == "cuda":
             self.model = self.model.to(memory_format=torch.channels_last)
+        elif self.args.channels_last:
+            LOGGER.warning(f"'channels_last=True' is only supported on CUDA, ignoring on '{self.device.type}'.")
         self.set_model_attributes()
 
         # Compile model (knowledge distillation runs the wrapped model eagerly and relies on
@@ -471,8 +470,6 @@ class BaseTrainer:
                 try:
                     with autocast(self.amp):
                         batch = self.preprocess_batch(batch)
-                        if self.channels_last:
-                            batch["img"] = batch["img"].to(memory_format=torch.channels_last)
                         if self.args.compile:
                             # Decouple inference and loss calculations for improved compile performance
                             preds = self.model(batch["img"])

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -122,7 +122,6 @@ class BaseValidator:
         self.device = None
         self.batch_i = None
         self.training = True
-        self.channels_last = False  # set in __call__; convert val batches to NHWC when the trained model is
         self.names = None
         self.seen = None
         self.stats = None
@@ -153,7 +152,6 @@ class BaseValidator:
             (dict): Dictionary containing validation statistics.
         """
         self.training = trainer is not None
-        self.channels_last = self.training and trainer.channels_last
         augment = self.args.augment and (not self.training)
         if self.training:
             self.device = trainer.device
@@ -193,13 +191,13 @@ class BaseValidator:
             stride, fmt = model.stride, model.format
             pt = fmt == "pt"
             # Same gate as predictor.setup_model: NHWC is lossless only for native PyTorch models on CUDA.
-            self.channels_last = self.args.channels_last and self.device.type == "cuda" and pt
-            if self.args.channels_last and not self.channels_last:
+            channels_last = self.args.channels_last and self.device.type == "cuda" and pt
+            if self.args.channels_last and not channels_last:
                 LOGGER.warning(
                     f"'channels_last=True' applies only to native PyTorch models on CUDA, ignoring for "
                     f"format='{fmt}' on '{self.device.type}'."
                 )
-            if self.channels_last:
+            if channels_last:
                 model.to(memory_format=torch.channels_last)
             imgsz = check_imgsz(self.args.imgsz, stride=stride)
             if fmt not in {"pt", "torchscript"} and not getattr(model, "dynamic", False):
@@ -248,8 +246,6 @@ class BaseValidator:
             # Preprocess
             with dt[0]:
                 batch = self.preprocess(batch)
-                if self.channels_last:
-                    batch["img"] = batch["img"].to(memory_format=torch.channels_last)  # match channels_last model
 
             with autocast(self.training and self.args.quantize == 16, device=self.device.type):
                 # Inference

--- a/ultralytics/models/yolo/classify/predict.py
+++ b/ultralytics/models/yolo/classify/predict.py
@@ -70,8 +70,6 @@ class ClassificationPredictor(BasePredictor):
             )
         img = (img if isinstance(img, torch.Tensor) else torch.from_numpy(img)).to(self.model.device)
         img = img.half() if self.model.fp16 else img.float()  # Convert uint8 to fp16/32
-        if self.channels_last:  # base preprocess is bypassed here (no super), so convert the layout directly
-            img = img.contiguous(memory_format=torch.channels_last)
         return img
 
     def postprocess(self, preds, img, orig_imgs):

--- a/ultralytics/models/yolo/yoloe/val.py
+++ b/ultralytics/models/yolo/yoloe/val.py
@@ -81,8 +81,6 @@ class YOLOEDetectValidator(DetectionValidator):
         pbar = TQDM(dataloader, total=len(dataloader), desc=desc)
         for batch in pbar:
             batch = self.preprocess(batch)
-            if self.channels_last:
-                batch["img"] = batch["img"].to(memory_format=torch.channels_last)  # match channels_last model
             preds = model.get_visual_pe(batch["img"], visual=batch["visuals"])  # (B, max_n, embed_dim)
 
             batch_idx = batch["batch_idx"]
@@ -156,7 +154,6 @@ class YOLOEDetectValidator(DetectionValidator):
         """
         if trainer is not None:
             self.device = trainer.device
-            self.channels_last = trainer.channels_last  # set before get_visual_pe, which runs before super().__call__
             model = trainer.ema.ema
             names = [name.split("/", 1)[0] for name in list(self.dataloader.dataset.data["names"].values())]
 

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -300,13 +300,11 @@ class AutoBackend(nn.Module):
         x = torch.tensor(x) if isinstance(x, np.ndarray) else x
         return x.to(self.device) if isinstance(x, torch.Tensor) else x
 
-    def warmup(self, imgsz: tuple[int, int, int, int] = (1, 3, 640, 640), channels_last: bool = False) -> None:
+    def warmup(self, imgsz: tuple[int, int, int, int] = (1, 3, 640, 640)) -> None:
         """Warm up the model by running forward pass(es) with a dummy input.
 
         Args:
             imgsz (tuple[int, int, int, int]): Dummy input shape in (batch, channels, height, width) format.
-            channels_last (bool): Warm up with a channels_last (NHWC) input to match a channels_last predictor, so
-                `torch.compile` traces that layout once instead of recompiling on the first real request.
         """
         from ultralytics.utils.nms import non_max_suppression
 
@@ -316,8 +314,6 @@ class AutoBackend(nn.Module):
             self.device.type != "cpu" or self.format == "triton"
         ):
             im = torch.empty(*imgsz, dtype=torch.half if self.fp16 else torch.float, device=self.device)  # input
-            if channels_last:
-                im = im.to(memory_format=torch.channels_last)
             for _ in range(2 if self.format == "torchscript" else 1):
                 self.forward(im)  # warmup model
                 warmup_boxes = torch.rand(1, 84, 16, device=self.device)  # 16 boxes works best empirically

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -327,10 +327,9 @@ def fuse_conv_and_bn(conv, bn):
         >>> bn = nn.BatchNorm2d(16)
         >>> fused_conv = fuse_conv_and_bn(conv, bn)
     """
-    # Compute fused weights
-    w_conv = conv.weight.reshape(conv.out_channels, -1)
-    w_bn = torch.diag(bn.weight.div(torch.sqrt(bn.eps + bn.running_var)))
-    conv.weight.data = torch.mm(w_bn, w_conv).view(conv.weight.shape)
+    # Compute fused weights: Conv2d weight is [out_channels, in_channels // groups, kH, kW], scale along axis 0
+    bn_scale = bn.weight.div(torch.sqrt(bn.eps + bn.running_var))
+    conv.weight.data = conv.weight * bn_scale.view(-1, 1, 1, 1)
 
     # Compute fused bias
     b_conv = (
@@ -339,7 +338,7 @@ def fuse_conv_and_bn(conv, bn):
         else conv.bias
     )
     b_bn = bn.bias - bn.weight.mul(bn.running_mean).div(torch.sqrt(bn.running_var + bn.eps))
-    fused_bias = torch.mm(w_bn, b_conv.reshape(-1, 1)).reshape(-1) + b_bn
+    fused_bias = bn_scale * b_conv + b_bn
 
     if conv.bias is None:
         conv.register_parameter("bias", nn.Parameter(fused_bias))


### PR DESCRIPTION
## What

Two consolidations, net −21 lines (+15/−36):

**1. `fuse_conv_and_bn` broadcast form.** Same shape #25364 gave `fuse_deconv_and_bn`: the per-output-channel BN scale multiplies the weight directly along axis 0, deleting the dense `torch.diag` matrix, both `torch.mm` calls, and the flatten/`view` round-trip (an O(out²) temporary per fused layer).

**2. Model-side-only `channels_last`.** A conv with channels_last weights emits channels_last activations from an NCHW input — the layout transpose happens once at the first conv whether or not the input was converted first. So the seven conversion sites from #25362 reduce to three model conversions (trainer, predictor, standalone val); the four input-side batch/preprocess conversions (trainer batch, validator batch, yoloe visual-prompt batch, classify preprocess, predictor preprocess) and the `warmup(channels_last=...)` kwarg are deleted, and the now-single-use `self.channels_last` attributes on trainer/validator/predictor become locals.

Deleted: `torch.diag`/`torch.mm` fusion machinery; 5 input-side `.to(memory_format=torch.channels_last)` conversion sites; the `AutoBackend.warmup` `channels_last` parameter; 3 `self.channels_last` attributes.

## Verification (empirical, no test additions)

- Fusion: old vs new implementations produce **bitwise-equal** fused weights/biases (groups 1/2/16, bias/no-bias, fp32/fp16, channels_last), fused-vs-unfused forward err 7e-7–5e-6, end-to-end `yolo26n.pt` `model.fuse()` err 6.5e-5.
- Layout propagation: with `model.to(channels_last)` and an **NCHW** input, deep backbone features are channels_last and outputs are **bit-identical** to NHWC-input runs (`torch.equal`), on a single conv and full yolo26n.
- CPU smoke: predict, `channels_last=True` warn path, classify predict, standalone val (mAP unchanged), and 1-epoch coco8 train incl. training-val and fused final-eval — all pass.
- torch.compile stays consistent: warmup and runtime now both trace NCHW inputs.

GPU timing parity rests on the layout-propagation proof above (the transpose cost is identical, just relocated); worth one T4 A/B run to confirm the 1.19–1.26x from #25362 holds.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Simplifies `channels_last` handling and improves Conv-BatchNorm fusion efficiency and compatibility.

### 📊 Key Changes

- Removed input-batch `channels_last` conversions from prediction, training, validation, classification, and YOLOE validation flows.
- Restricted `channels_last` model conversion to native PyTorch models running on CUDA, with clearer warnings for unsupported devices and formats.
- Simplified backend warmup by removing the `channels_last` argument and always using standard input layout.
- Replaced matrix-based Conv-BatchNorm fusion with direct per-channel scaling and bias computation.
- Updated model warmup and compilation paths to avoid tracing unnecessary memory-layout variants.

### 🎯 Purpose & Impact

- ⚡ Reduces unnecessary tensor copies and simplifies inference, training, and validation code.
- 🛡️ Prevents incorrect memory-layout handling for exported models and unsupported devices such as CPU and MPS.
- 📈 Makes Conv-BatchNorm fusion more efficient and better supports grouped convolutions.
- 🔧 Improves compatibility with compiled models and different inference backends while preserving CUDA performance benefits for native PyTorch models.