### PR TITLE
Fix depth training with single-class mode

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1229,7 +1229,7 @@ def test_depth_trainer_records_portable_calibration_split(tmp_path, monkeypatch,
 
 
 def test_depth_dataset_ignores_unreadable_targets(tmp_path):
-    """Drop images with missing or corrupt depth maps during the cached dataset scan."""
+    """Drop unreadable depth maps and accept single-class mode with empty class labels."""
     from ultralytics.data.dataset import DepthDataset
 
     images, depth = tmp_path / "images" / "train", tmp_path / "depth" / "train"
@@ -1241,7 +1241,7 @@ def test_depth_dataset_ignores_unreadable_targets(tmp_path):
     (depth / "corrupt.npy").write_text("not an npy file")
 
     data = {"names": {0: "depth"}, "nc": 1, "channels": 3}
-    ds = DepthDataset(img_path=str(images), imgsz=32, data=data, augment=False, batch_size=1)
+    ds = DepthDataset(img_path=str(images), imgsz=32, data=data, augment=False, single_cls=True, batch_size=1)
     assert [Path(f).stem for f in ds.im_files] == ["valid"]
     assert (depth.parent / "train.cache").exists()  # scan results cached next to the depth maps
 

--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -205,7 +205,7 @@ class BaseDataset(Dataset):
                 if keypoints is not None:
                     self.labels[i]["keypoints"] = keypoints[j]
             if self.single_cls:
-                self.labels[i]["cls"][:, 0] = 0
+                self.labels[i]["cls"][:] = 0
 
     def load_image(
         self, i: int, rect_mode: bool = True, resize_short: bool = False


### PR DESCRIPTION
## Summary
- normalize all class-label array shapes in single-class mode
- cover depth datasets whose class arrays are empty and one-dimensional
- resolve #25361

## Validation
- python -m pytest tests/test_python.py::test_depth_dataset_ignores_unreadable_targets -q
- python -m pytest tests/test_engine.py -k depth -q
- ruff check ultralytics/data/base.py tests/test_python.py
- ruff format --check ultralytics/data/base.py tests/test_python.py
- reproduced the reported one-epoch command before the fix; completed training, validation, and calibration after the fix

Deleted: the two-dimensional class-column indexing assumption in BaseDataset.update_labels.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves single-class label handling so datasets with empty class labels are processed safely, including depth datasets. ✅

### 📊 Key Changes

- Updated `BaseDataset.update_labels()` to reset all class-label values using `self.labels[i]["cls"][:] = 0` when `single_cls=True`.
- Expanded the depth dataset test to verify single-class mode with empty class labels.
- Continued validating that missing or corrupt depth maps are excluded and scan results are cached.

### 🎯 Purpose & Impact

- Prevents errors when converting datasets to single-class mode, particularly when label arrays contain no entries.
- Improves robustness for depth-estimation and other datasets with incomplete or empty annotations.
- Maintains existing behavior for filtering unreadable depth targets and caching valid scan results.