### PR TITLE
Build Docker runner before export image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,9 +51,6 @@ on:
         type: boolean
         description: Publish to DockerHub and ghcr.io
 
-concurrency:
-  group: ${{ github.workflow }}
-
 jobs:
   docker:
     if: github.repository == 'ultralytics/ultralytics'
@@ -212,10 +209,8 @@ jobs:
         with:
           timeout_minutes: 120
           retry_delay_seconds: 60
-          retries: 2
+          retries: 3
           run: |
-            docker builder prune -af
-
             derivatives='${{ matrix.derivatives }}'
             if [[ -n "$derivatives" ]]; then
               IFS=',' read -ra derivative_array <<< "$derivatives"
@@ -236,7 +231,6 @@ jobs:
                   -t "ghcr.io/ultralytics/ultralytics:$derivative_tag" \
                   -t "ghcr.io/ultralytics/ultralytics:$derivative_version_tag" \
                   .
-                docker builder prune -af
               done
             fi
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -209,7 +209,7 @@ jobs:
         with:
           timeout_minutes: 120
           retry_delay_seconds: 60
-          retries: 3
+          retries: 2
           run: |
             derivatives='${{ matrix.derivatives }}'
             if [[ -n "$derivatives" ]]; then

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,7 +65,7 @@ jobs:
             tags: "latest"
             platforms: "linux/amd64"
             runs_on: "ubuntu-latest"
-            derivatives: "Dockerfile-export,Dockerfile-runner"
+            derivatives: "Dockerfile-runner,Dockerfile-export"
           - dockerfile: "Dockerfile-python"
             tags: "latest-python"
             platforms: "linux/amd64"
@@ -211,6 +211,8 @@ jobs:
           retry_delay_seconds: 60
           retries: 2
           run: |
+            docker builder prune -af
+
             derivatives='${{ matrix.derivatives }}'
             if [[ -n "$derivatives" ]]; then
               IFS=',' read -ra derivative_array <<< "$derivatives"
@@ -231,6 +233,7 @@ jobs:
                   -t "ghcr.io/ultralytics/ultralytics:$derivative_tag" \
                   -t "ghcr.io/ultralytics/ultralytics:$derivative_version_tag" \
                   .
+                docker builder prune -af
               done
             fi
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,6 +51,9 @@ on:
         type: boolean
         description: Publish to DockerHub and ghcr.io
 
+concurrency:
+  group: ${{ github.workflow }}
+
 jobs:
   docker:
     if: github.repository == 'ultralytics/ultralytics'


### PR DESCRIPTION
## Summary

- build the GPU runner derivative before the export derivative
- keep the intentionally parallel Docker matrix, cache cleanup, and two retries unchanged

## Motivation

The first attempts of runs 29930657930, 29933673153, and 29934106257 all received 72 GB runners with only 24 GB free after cleanup. Each built `Dockerfile-export` first, retained its tagged image, then exhausted disk while installing TensorRT into `Dockerfile-runner`; the retry loop rebuilt export before every runner attempt. Building the larger runner derivative first gives it the maximum available disk and prevents repeated export builds on runner failures. The export image still builds before environment checks, tests, and publishing.

## Validation

- `npx prettier@3.6.2 --check .github/workflows/docker.yml`
- `actionlint .github/workflows/docker.yml`
- `git diff --check`

Deleted: export-first derivative ordering that consumed constrained runner disk before every runner build attempt.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 Reorders Docker image derivative builds in the GitHub Actions workflow.

### 📊 Key Changes
- Changed the derivative build order from `Dockerfile-export,Dockerfile-runner` to `Dockerfile-runner,Dockerfile-export`.
- No Dockerfiles, image tags, platforms, or runtime configurations were modified.

### 🎯 Purpose & Impact
- ✅ Ensures the Docker runner image is processed before the export image.
- 🚀 May improve build sequencing or dependency handling in the CI pipeline.
- 👤 No expected changes for end users or Ultralytics model usage.