### PR TITLE
Fix nullable YouTube stream resolution

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -4,11 +4,13 @@ import contextlib
 import csv
 import os
 import shutil
+import sys
 import tarfile
 import urllib
 import zipfile
 from copy import copy
 from pathlib import Path
+from types import ModuleType, SimpleNamespace
 
 import cv2
 import numpy as np
@@ -17,6 +19,7 @@ import torch
 from PIL import Image
 
 import ultralytics.data.build as data_build
+import ultralytics.data.loaders as data_loaders
 from tests import CFG, MODEL, MODELS, SOURCE, SOURCES_LIST, TASK_MODEL_DATA
 from ultralytics import RTDETR, YOLO
 from ultralytics.cfg import get_cfg
@@ -402,6 +405,47 @@ def test_youtube():
     # Handle internet connection errors and 'urllib.error.HTTPError: HTTP Error 429: Too Many Requests'
     except (urllib.error.HTTPError, ConnectionError) as e:
         LOGGER.error(f"YouTube Test Error: {e}")
+
+
+def test_youtube_ignores_streams_without_resolution(monkeypatch):
+    """Test YouTube stream selection delegates nullable-safe resolution ordering to pytubefix."""
+
+    class StreamQuery:
+        def __init__(self, streams):
+            self.streams = streams
+
+        def filter(self, **kwargs):
+            return self
+
+        def order_by(self, attribute):
+            self.streams = sorted(
+                (stream for stream in self.streams if getattr(stream, attribute) is not None),
+                key=lambda stream: int(getattr(stream, attribute)[:-1]),
+            )
+            return self
+
+        def desc(self):
+            self.streams.reverse()
+            return self
+
+        def first(self):
+            return self.streams[0] if self.streams else None
+
+    pytubefix = ModuleType("pytubefix")
+    pytubefix.YouTube = lambda _: SimpleNamespace(
+        streams=StreamQuery(
+            [
+                SimpleNamespace(resolution=None, url="none"),
+                SimpleNamespace(resolution="720p", url="720"),
+                SimpleNamespace(resolution="1080p", url="1080"),
+                SimpleNamespace(resolution="2160p", url="2160"),
+            ]
+        )
+    )
+    monkeypatch.setitem(sys.modules, "pytubefix", pytubefix)
+    monkeypatch.setattr(data_loaders, "check_requirements", lambda *_: None)
+
+    assert data_loaders.get_best_youtube_url("https://youtu.be/example") == "2160"
 
 
 def test_track_second_association_indices():

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -684,11 +684,11 @@ def get_best_youtube_url(url: str, method: str = "pytube") -> str | None:
         check_requirements("pytubefix>=6.5.2")
         from pytubefix import YouTube
 
-        streams = YouTube(url).streams.filter(file_extension="mp4", only_video=True)
-        streams = sorted(streams, key=lambda s: s.resolution, reverse=True)  # sort streams by resolution
-        for stream in streams:
-            if stream.resolution and int(stream.resolution[:-1]) >= 1080:  # check if resolution is at least 1080p
-                return stream.url
+        stream = (
+            YouTube(url).streams.filter(file_extension="mp4", only_video=True).order_by("resolution").desc().first()
+        )
+        if stream and int(stream.resolution[:-1]) >= 1080:  # check if resolution is at least 1080p
+            return stream.url
 
     elif method == "pafy":
         check_requirements(("pafy", "youtube_dl==2020.12.2"))


### PR DESCRIPTION
## Summary

Fixes [ULTRALYTICS-1Y63](https://ultralytics.sentry.io/issues/6222931210/), observed once in the required 24-hour Sentry production sweep.

`get_best_youtube_url()` manually sorted pytubefix resolution values, but pytubefix legitimately returns `None` for some video streams. Mixed `None` and string resolutions raised `TypeError` before selection. The function now delegates filtering and numeric resolution ordering to pytubefix's existing `StreamQuery.order_by("resolution")` owner, selects the highest stream, and preserves the existing 1080p threshold.

The issue occurred at `2026-07-22T07:29:03Z` in release `8.4.104`, within the same 24-hour lookback used for Portal. Sentry was swept across `production` and `runpod`; no runpod events were active. ULTRALYTICS-1Y63 was marked resolved in Sentry for the next release.

## Verification

- Reproduced the original `TypeError: '<' not supported between instances of 'NoneType' and 'str'`
- Verified pytubefix `6.5.2` owns nullable filtering and numeric ordering in `StreamQuery.order_by`
- `pytest -q tests/test_python.py -k youtube_ignores_streams_without_resolution` — 1 passed
- `ruff format --check ultralytics/data/loaders.py tests/test_python.py`
- `ruff check ultralytics/data/loaders.py tests/test_python.py`
- Python compilation passed

## Review

- Claude Fable, medium: LGTM for the complete diff; no Core Principles findings.
- Codex CLI adversarial review: initially required upstream-owner delegation and deterministic coverage; after both changes, LGTM.
- Independent reviewer agent: LGTM on correctness and the nullable ordering behavior.

Nothing further can be deleted without removing the resolution-selection behavior. The remaining empty-result check is the required boundary after pytubefix filters resolution-less streams; it does not suppress the original symptom.

Net-additive justification: deterministic regression coverage is required because the existing YouTube test is network-dependent and does not guarantee a nullable-resolution stream; the production change replaces and shortens the custom selection path.

Deleted: the custom nullable-unsafe resolution sort and its manual iteration loop.

Companion Platform fix: https://github.com/ultralytics/portal/pull/3047

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves YouTube stream selection by safely handling videos with streams that have no resolution metadata. 🛠️

### 📊 Key Changes
- Replaced manual stream sorting with pytubefix’s nullable-safe `.order_by("resolution").desc().first()` selection.
- Added a guard to ensure a stream exists before checking its resolution.
- Added a regression test covering streams with `None` resolution values.

### 🎯 Purpose & Impact
- Prevents YouTube loading errors caused by attempting to sort streams with missing resolution data. ✅
- Continues selecting the highest available video stream at 1080p or above.
- Improves reliability for YouTube inference and data-loading workflows without changing the existing resolution requirements. 📺