### PR TITLE
docs: clarify YOLOE export workflow for C++ ONNX Runtime inference

### DIFF
--- a/examples/cpp/ONNXRuntime/README.md
+++ b/examples/cpp/ONNXRuntime/README.md
@@ -55,6 +55,20 @@ model = onnx.load("yolo26n.onnx")
 onnx.save(convert_float_to_float16(model, keep_io_types=False), "yolo26n_fp16.onnx")
 ```
 
+### YOLOE Models
+
+When exporting a YOLOE model for C++ inference, call `set_classes()` before `export()`. This embeds the selected class vocabulary into the exported model, allowing the exported ONNX model to run without requiring text prompts or a text encoder at inference time.
+
+```python
+from ultralytics import YOLOE
+
+model = YOLOE("yoloe-26s-seg.pt")
+model.set_classes(["person", "bus"])
+model.export(format="onnx")
+```
+
+For additional information about `set_classes()` and YOLOE workflows, see the [YOLOE documentation](../../../docs/en/models/yoloe.md).
+
 ## 🛠️ Build
 
 ```bash

--- a/examples/cpp/ONNXRuntime/README.md
+++ b/examples/cpp/ONNXRuntime/README.md
@@ -57,7 +57,7 @@ onnx.save(convert_float_to_float16(model, keep_io_types=False), "yolo26n_fp16.on
 
 ### YOLOE Models
 
-When exporting a YOLOE model for C++ inference, call `set_classes()` before `export()`. This embeds the selected class vocabulary into the exported model, allowing the exported ONNX model to run without requiring text prompts or a text encoder at inference time.
+To export a YOLOE model with a custom text vocabulary for C++ inference, call `set_classes()` before `export()`. This embeds the selected class vocabulary into the exported model, allowing the exported ONNX model to run without requiring text prompts or a text encoder at inference time.
 
 ```python
 from ultralytics import YOLOE

--- a/examples/cpp/ONNXRuntime/README.md
+++ b/examples/cpp/ONNXRuntime/README.md
@@ -39,6 +39,8 @@ yolo export model=yolo26n-sem.pt format=onnx opset=12  # semantic
 
 See the [Export documentation](https://docs.ultralytics.com/modes/export) for more options.
 
+[YOLOE](https://docs.ultralytics.com/models/yoloe) models must have their vocabulary baked in with `set_classes()` before export — see [YOLOE Export Usage](https://docs.ultralytics.com/models/yoloe#export-usage).
+
 To run a half-precision model, export with `quantize=16` **on a GPU** (on CPU, `quantize=16` is ignored and the export stays FP32). The example detects the FP16 input type and runs it automatically:
 
 ```bash
@@ -54,20 +56,6 @@ from onnxruntime.transformers.float16 import convert_float_to_float16
 model = onnx.load("yolo26n.onnx")
 onnx.save(convert_float_to_float16(model, keep_io_types=False), "yolo26n_fp16.onnx")
 ```
-
-### YOLOE Models
-
-To export a YOLOE model with a custom text vocabulary for C++ inference, call `set_classes()` before `export()`. This embeds the selected class vocabulary into the exported model, allowing the exported ONNX model to run without requiring text prompts or a text encoder at inference time.
-
-```python
-from ultralytics import YOLOE
-
-model = YOLOE("yoloe-26s-seg.pt")
-model.set_classes(["person", "bus"])
-model.export(format="onnx")
-```
-
-For additional information about `set_classes()` and YOLOE workflows, see the [YOLOE documentation](../../../docs/en/models/yoloe.md).
 
 ## 🛠️ Build
 


### PR DESCRIPTION
## Summary

This PR adds a short documentation note explaining the required `set_classes()` step before exporting YOLOE models for C++ inference using ONNX Runtime.

## Motivation

Issue #25236 highlighted that users attempting C++ inference with YOLOE may miss the required `set_classes()` call before export. Without this step, the exported model will not contain the embedded class vocabulary needed for inference.

## Changes

- Added a **YOLOE Models** note to the ONNX Runtime C++ README.
- Included a minimal Python export example using `set_classes()`.
- Referenced the existing YOLOE documentation for additional details.

Closes #25236

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Clarifies the YOLOE export workflow for C++ ONNX Runtime inference by documenting the required `set_classes()` step before ONNX export.

### 📊 Key Changes
- Adds a dedicated YOLOE Models section to the C++ ONNX Runtime README.
- Provides a Python example using `YOLOE`, `set_classes()`, and `export(format="onnx")`.
- Explains that selected class names are embedded in the exported model, removing the need for text prompts or a text encoder during inference.
- Links to the existing YOLOE documentation for additional guidance.

### 🎯 Purpose & Impact
- Helps users successfully export YOLOE models for C++ ONNX Runtime deployment.
- Reduces inference-time configuration requirements for exported models.
- Improves documentation clarity without changing package behavior or adding runtime code.