### PR TITLE
Fix optimizer=RMSprop silently building MuSGD

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1119,11 +1119,11 @@ class BaseTrainer:
         if not use_muon:
             g = [x.values() for x in g[:3]]  # convert to list of params
 
-        optimizers = {"Adam", "Adamax", "AdamW", "NAdam", "RAdam", "RMSProp", "SGD", "MuSGD", "auto"}
+        optimizers = {"Adam", "Adamax", "AdamW", "NAdam", "RAdam", "RMSprop", "SGD", "MuSGD", "auto"}
         name = {x.lower(): x for x in optimizers}.get(str(name).lower(), str(name))
         if name in {"Adam", "Adamax", "AdamW", "NAdam", "RAdam"}:
             optim_args = dict(lr=lr, betas=(momentum, 0.999), weight_decay=0.0)
-        elif name == "RMSProp":
+        elif name == "RMSprop":
             optim_args = dict(lr=lr, momentum=momentum)
         elif name == "SGD" or name == "MuSGD":
             optim_args = dict(lr=lr, momentum=momentum, nesterov=True)


### PR DESCRIPTION
## summary

`optimizer=RMSprop` (in any casing) silently built a `MuSGD` optimizer instead of `torch.optim.RMSprop`: the `optimizers` set and the arg branch used the literal `"RMSProp"` (capital P), but torch's class is `torch.optim.RMSprop` (lowercase p), so `getattr(optim, "RMSProp", partial(MuSGD, ...))` fell through to the MuSGD fallback with no error or warning. This corrects both literals to `"RMSprop"` so the name resolves to the real class; any input casing still works via the existing lowercase normalization, and no other optimizer name is affected.

Deleted: nothing — net-zero replace of two wrong-cased string literals in place. Nothing to remove: the RMSprop arg branch and the `getattr(..., partial(MuSGD, ...))` resolution were correct except for the literal casing (the MuSGD fallback is intended for building MuSGD, which is absent from `torch.optim`).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Corrects the optimizer name from `RMSProp` to PyTorch’s standard `RMSprop` spelling for reliable optimizer selection. 🛠️

### 📊 Key Changes

- Renamed the supported optimizer entry from `RMSProp` to `RMSprop`.
- Updated the corresponding conditional logic in `build_optimizer()`.
- Preserved case-insensitive optimizer name matching for user convenience.

### 🎯 Purpose & Impact

- ✅ Ensures the RMSprop optimizer is recognized and configured correctly.
- 🚀 Prevents failures or incorrect behavior when users select RMSprop during training.
- 🔄 Improves consistency with the optimizer naming used by PyTorch.