### PR TITLE
Point README banner link to YOLO Vision 2026 registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <p>
-    <a href="https://platform.ultralytics.com/?utm_source=github&utm_medium=referral&utm_campaign=platform_launch&utm_content=banner&utm_term=ultralytics_github" target="_blank">
+    <a href="https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner" target="_blank">
       <img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png" alt="Ultralytics YOLO banner"></a>
   </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 <div align="center">
   <p>
-    <a href="https://platform.ultralytics.com/?utm_source=github&utm_medium=referral&utm_campaign=platform_launch&utm_content=banner&utm_term=ultralytics_github" target="_blank">
+    <a href="https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner" target="_blank">
       <img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png" alt="Ultralytics YOLO banner"></a>
   </p>
 


### PR DESCRIPTION
The top README banner now shows the YOLO Vision 2026 Shenzhen artwork with a "Register now" call to action (banner image updated in ultralytics/assets#184), but its link still pointed to the Platform. This repoints the banner link to the YOLO Vision 2026 event/registration page so the click destination matches the artwork.

- `README.md` and `README.zh-CN.md`: banner `<a href>` → https://www.ultralytics.com/events/yolovision (verified to resolve to the YOLO Vision 2026 Shenzhen page, September 13, 2026).

The banner `<img src>` is unchanged — the image itself is swapped in-place via the assets repo.

Deleted: nothing — a bugfix-style one-line link correction; the previous Platform URL is replaced, there is nothing to relocate or remove.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🎉 Updated the README banner link to promote the YOLO Vision event.

### 📊 Key Changes

- Replaced the Ultralytics Platform banner destination with the [YOLO Vision event page](https://www.ultralytics.com/events/yolovision) in:
  - `README.md`
  - `README.zh-CN.md`
- Updated the campaign tracking parameters from Platform launch tracking to YOLO Vision 26 promotion.

### 🎯 Purpose & Impact

- 📣 Directs GitHub visitors to information about the YOLO Vision event.
- 🌍 Keeps the English and Simplified Chinese README files aligned.
- 📈 Enables campaign performance tracking through updated URL parameters.
- 🛠️ No changes to code, models, or runtime behavior.