### PR TITLE
Point remaining banner links to YOLO Vision 2026 registration

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -7,7 +7,7 @@ keywords: Ultralytics, YOLO, YOLO26, YOLO11, object detection, image segmentatio
 
 <div align="center">
 <br><br>
-<a href="https://platform.ultralytics.com/ultralytics/yolo26?utm_source=docs&utm_medium=referral&utm_campaign=platform_launch&utm_content=banner&utm_term=ultralytics_docs" target="_blank"><img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png" alt="Ultralytics YOLO banner"></a>
+<a href="https://www.ultralytics.com/events/yolovision?utm_source=docs&utm_medium=referral&utm_campaign=yolovision26&utm_content=banner" target="_blank"><img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png" alt="Ultralytics YOLO banner"></a>
 <br><br>
 </div>
 

--- a/examples/heatmaps.ipynb
+++ b/examples/heatmaps.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "<div align=\"center\">\n",
     "\n",
-    "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+    "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
     "    <img width=\"1024\", src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\"></a>\n",
     "\n",
     "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",

--- a/examples/object_counting.ipynb
+++ b/examples/object_counting.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "<div align=\"center\">\n",
     "\n",
-    "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+    "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
     "    <img width=\"1024\", src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\"></a>\n",
     "\n",
     "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",

--- a/examples/object_tracking.ipynb
+++ b/examples/object_tracking.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "<div align=\"center\">\n",
     "\n",
-    "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+    "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
     "    <img width=\"1024\", src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\"></a>\n",
     "\n",
     "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -21,7 +21,7 @@
       },
       "source": [
         "<div align=\"center\">\n",
-        "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+        "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
         "    <img width=\"1024\" src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\">\n",
         "  </a>\n",
         "\n",


### PR DESCRIPTION
Follow-up to #25377 (README banner link). The YOLO Vision 2026 "Register now" banner (image swapped in ultralytics/assets#184) is also embedded on the docs homepage and in the example notebooks, where the click still went to the Platform or a generic YOLO link. This repoints those to the YOLO Vision 2026 event page so every clickable instance of the banner matches its call to action.

- `docs/en/index.md`: banner link → events/yolovision (docs UTM: utm_source=docs, utm_medium=referral).
- `examples/heatmaps|object_counting|object_tracking|tutorial.ipynb`: banner link → events/yolovision (github UTM: utm_source=github, utm_medium=social).

Only the href wrapping the banner image is changed; all other links in these files are untouched. Banner `<img src>` is unchanged (image is swapped in-place via the assets repo).

Deleted: nothing — one-line link corrections; the previous Platform/generic URLs are replaced, nothing to relocate or remove.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates documentation and example notebook banners to promote the YOLO Vision event. 🎉

### 📊 Key Changes
- Changed the main documentation banner link from the Ultralytics Platform YOLO26 page to the [YOLO Vision event page](https://www.ultralytics.com/events/yolovision).
- Updated banners in the heatmaps, object counting, object tracking, and tutorial notebooks.
- Added campaign tracking parameters to measure traffic from documentation and GitHub examples.

### 🎯 Purpose & Impact
- 📣 Increases visibility for the YOLO Vision event across key Ultralytics resources.
- 🔗 Directs users who click prominent banners to event information rather than the previous YOLO or YOLO26 destinations.
- 📈 Enables more accurate tracking of banner engagement and referral sources.
- 🧩 No changes to model behavior, APIs, examples’ functionality, or user workflows beyond the banner destination.