### PR TITLE
Threshold SAM3 semantic masks at the model logit threshold

### DIFF
--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -2328,7 +2328,7 @@ class SAM3SemanticPredictor(SAM3Predictor):
             if masks.shape[0] == 0:
                 masks, boxes = None, torch.zeros((0, 6), device=pred_masks.device)
             else:
-                masks = F.interpolate(masks.float()[None], orig_img.shape[:2], mode="bilinear")[0] > 0.5
+                masks = F.interpolate(masks.float()[None], orig_img.shape[:2], mode="bilinear")[0].sigmoid() > 0.5
                 boxes[..., [0, 2]] *= orig_img.shape[1]
                 boxes[..., [1, 3]] *= orig_img.shape[0]
             results.append(Results(orig_img, path=img_path, names=names, masks=masks, boxes=boxes))
@@ -2398,7 +2398,7 @@ class SAM3SemanticPredictor(SAM3Predictor):
         if pred_masks.shape[0] == 0:
             pred_masks, pred_boxes = None, torch.zeros((0, 6), device=pred_masks.device)
         else:
-            pred_masks = F.interpolate(pred_masks.float()[None], src_shape[:2], mode="bilinear")[0] > 0.5
+            pred_masks = F.interpolate(pred_masks.float()[None], src_shape[:2], mode="bilinear")[0].sigmoid() > 0.5
             pred_boxes[..., 0] *= src_shape[1]
             pred_boxes[..., 1] *= src_shape[0]
             pred_boxes[..., 2] *= src_shape[1]

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -2328,7 +2328,7 @@ class SAM3SemanticPredictor(SAM3Predictor):
             if masks.shape[0] == 0:
                 masks, boxes = None, torch.zeros((0, 6), device=pred_masks.device)
             else:
-                masks = F.interpolate(masks.float()[None], orig_img.shape[:2], mode="bilinear")[0].sigmoid() > 0.5
+                masks = F.interpolate(masks.float()[None], orig_img.shape[:2], mode="bilinear")[0] > self.model.mask_threshold
                 boxes[..., [0, 2]] *= orig_img.shape[1]
                 boxes[..., [1, 3]] *= orig_img.shape[0]
             results.append(Results(orig_img, path=img_path, names=names, masks=masks, boxes=boxes))
@@ -2398,7 +2398,7 @@ class SAM3SemanticPredictor(SAM3Predictor):
         if pred_masks.shape[0] == 0:
             pred_masks, pred_boxes = None, torch.zeros((0, 6), device=pred_masks.device)
         else:
-            pred_masks = F.interpolate(pred_masks.float()[None], src_shape[:2], mode="bilinear")[0].sigmoid() > 0.5
+            pred_masks = F.interpolate(pred_masks.float()[None], src_shape[:2], mode="bilinear")[0] > self.model.mask_threshold
             pred_boxes[..., 0] *= src_shape[1]
             pred_boxes[..., 1] *= src_shape[0]
             pred_boxes[..., 2] *= src_shape[1]

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -2328,7 +2328,10 @@ class SAM3SemanticPredictor(SAM3Predictor):
             if masks.shape[0] == 0:
                 masks, boxes = None, torch.zeros((0, 6), device=pred_masks.device)
             else:
-                masks = F.interpolate(masks.float()[None], orig_img.shape[:2], mode="bilinear")[0] > self.model.mask_threshold
+                masks = (
+                    F.interpolate(masks.float()[None], orig_img.shape[:2], mode="bilinear")[0]
+                    > self.model.mask_threshold
+                )
                 boxes[..., [0, 2]] *= orig_img.shape[1]
                 boxes[..., [1, 3]] *= orig_img.shape[0]
             results.append(Results(orig_img, path=img_path, names=names, masks=masks, boxes=boxes))
@@ -2398,7 +2401,9 @@ class SAM3SemanticPredictor(SAM3Predictor):
         if pred_masks.shape[0] == 0:
             pred_masks, pred_boxes = None, torch.zeros((0, 6), device=pred_masks.device)
         else:
-            pred_masks = F.interpolate(pred_masks.float()[None], src_shape[:2], mode="bilinear")[0] > self.model.mask_threshold
+            pred_masks = (
+                F.interpolate(pred_masks.float()[None], src_shape[:2], mode="bilinear")[0] > self.model.mask_threshold
+            )
             pred_boxes[..., 0] *= src_shape[1]
             pred_boxes[..., 1] *= src_shape[0]
             pred_boxes[..., 2] *= src_shape[1]


### PR DESCRIPTION
Fixes #25378.

## Summary

`SAM3SemanticPredictor` was thresholding raw mask logits at `0.5`, which is an effective probability cutoff of about `0.622` and erodes mask boundaries. Both semantic output paths now use the model's existing `mask_threshold` (`0.0`), matching the other SAM owners and remaining equivalent to `sigmoid(logits) > 0.5` without adding a sigmoid kernel.

Deleted: the two incorrect hard-coded `0.5` logit thresholds; no helper, branch, or test code was added.

## Validation

- `ruff check ultralytics/models/sam/predict.py`
- Verified `logits > 0.0` is exactly equal to `logits.sigmoid() > 0.5` across representative logits.
- Full CI is green on the exact head.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ SAM mask postprocessing now uses the model’s configurable `mask_threshold` instead of a fixed `0.5` threshold.

### 📊 Key Changes
- Replaced hardcoded mask binarization thresholds in both standard prediction and feature-based inference.
- Applied `self.model.mask_threshold` when converting interpolated mask probabilities into binary masks.
- Kept existing mask resizing and bounding-box scaling behavior unchanged.

### 🎯 Purpose & Impact
- 🎯 Allows SAM models to control mask sensitivity through a configurable threshold.
- ✅ Improves consistency between model configuration and inference results.
- 🔧 Enables users to adjust segmentation precision and recall without modifying source code.
- 🚀 Affects generated masks directly, potentially changing object boundaries and the number of pixels classified as foreground.