### PR TITLE
Preserve falsey activation arguments

### DIFF
--- a/ultralytics/nn/modules/block.py
+++ b/ultralytics/nn/modules/block.py
@@ -168,7 +168,7 @@ class HGBlock(nn.Module):
             act (nn.Module): Activation function.
         """
         super().__init__()
-        act = act or nn.ReLU()
+        act = nn.ReLU() if act is None else act
         block = LightConv if lightconv else Conv
         self.m = nn.ModuleList(block(c1 if i == 0 else cm, cm, k=k, act=act) for i in range(n))
         self.sc = Conv(c1 + n * cm, c2 // 2, 1, 1, act=act)  # squeeze conv

--- a/ultralytics/nn/modules/conv.py
+++ b/ultralytics/nn/modules/conv.py
@@ -167,7 +167,7 @@ class LightConv(nn.Module):
             act (nn.Module): Activation function.
         """
         super().__init__()
-        act = act or nn.ReLU()
+        act = nn.ReLU() if act is None else act
         self.conv1 = Conv(c1, c2, 1, act=False)
         self.conv2 = DWConv(c2, c2, k, act=act)
 

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -1585,7 +1585,7 @@ class RTDETRDecoder(nn.Module):
             learnt_init_query (bool): Whether to learn initial query embeddings.
         """
         super().__init__()
-        act = act or nn.ReLU()
+        act = nn.ReLU() if act is None else act
         self.hidden_dim = hd
         self.nhead = nh
         self.nl = len(ch)  # num level

--- a/ultralytics/nn/modules/transformer.py
+++ b/ultralytics/nn/modules/transformer.py
@@ -85,7 +85,7 @@ class TransformerEncoderLayer(nn.Module):
         self.dropout1 = nn.Dropout(dropout)
         self.dropout2 = nn.Dropout(dropout)
 
-        self.act = act or nn.GELU()
+        self.act = nn.GELU() if act is None else act
         self.normalize_before = normalize_before
 
     @staticmethod
@@ -645,7 +645,7 @@ class DeformableTransformerDecoderLayer(nn.Module):
 
         # FFN
         self.linear1 = nn.Linear(d_model, d_ffn)
-        self.act = act or nn.ReLU()
+        self.act = nn.ReLU() if act is None else act
         self.dropout3 = nn.Dropout(dropout)
         self.linear2 = nn.Linear(d_ffn, d_model)
         self.dropout4 = nn.Dropout(dropout)


### PR DESCRIPTION
## Summary
- preserve explicit falsey activation modules while retaining the new safe default construction
- use the existing `None` sentinel contract in all five affected activation owners

Deleted: five truthiness fallbacks that replaced valid falsey activation arguments.

## Validation
- Ruff 0.16.0 check with the shared Actions Python 3.8 settings
- Ruff 0.16.0 format check
- focused construction smoke for `False` and empty `nn.Sequential()` activations
- `git diff --check`

No test files are added; the existing activation paths are validated directly.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Preserves explicitly provided activation modules instead of replacing them with defaults. ✅

### 📊 Key Changes

- Updated activation handling across convolutional, block, head, and transformer modules.
- Replaced truthiness checks such as `act or nn.ReLU()` with explicit `None` checks.
- Retains any user-supplied activation, including activation objects that evaluate as false.
- Keeps the existing default activations unchanged when `act` is not provided:
  - `ReLU` for most modules.
  - `GELU` for the transformer encoder layer.

### 🎯 Purpose & Impact

- Improves correctness and predictability when customizing model activations. 🛠️
- Prevents valid activation modules from being unintentionally replaced by defaults.
- Maintains backward-compatible behavior for standard model configurations.
- Benefits developers building custom YOLO architectures and experimenting with alternative activation functions.