### PR TITLE
Fix yolo26-seg semantic target labelling empty images as class 0 when `overlap_mask=False`

### DIFF
--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -539,7 +539,7 @@ class v8SegmentationLoss(v8DetectionLoss):
                     present = masks != 0  # NxHxW
                 else:
                     batch_idx = batch["batch_idx"].view(-1)  # [total_instances]
-                    present = torch.ones(batch_size, *masks.shape[-2:], dtype=torch.bool, device=self.device)
+                    present = torch.zeros(batch_size, *masks.shape[-2:], dtype=torch.bool, device=self.device)
                     for i in range(batch_size):
                         instance_mask_i = masks[batch_idx == i]  # [num_instances_i, H, W]
                         if len(instance_mask_i):


### PR DESCRIPTION
When you train a yolo26-seg model with `overlap_mask=False` and your dataset has background images (frames with no instances, which is a common and recommended practice), the auxiliary semantic head is taught that the whole background frame is class `0`. It does not crash, training just runs with wrong targets on those images.

The target is built in `v8SegmentationLoss.loss`. The `overlap_mask=True` branch (the default) gets it right with `present = masks != 0`, so an empty image ends up all-zero, i.e. background, no class active. The `overlap_mask=False` branch starts from `torch.ones(...)` and only overwrites the images that have instances inside the loop:

```python
# before
present = torch.ones(batch_size, *masks.shape[-2:], dtype=torch.bool, device=self.device)
for i in range(batch_size):
    instance_mask_i = masks[batch_idx == i]
    if len(instance_mask_i):
        present[i] = instance_mask_i.sum(dim=0) != 0
```

A background image has no instances, so `masks[batch_idx == i]` is empty, the `if` never runs, and its `present` row stays all-True. The `scatter_` a few lines below then writes class `0` over every pixel of that image, while the correct target is all-zero. This also contradicts the branch's own comment right above it (`One-hot targets zeroed at uncovered pixels`) and the dataset side, which already emits an all-zero `sem_masks` for empty images in both overlap modes (`Format.apply_instances`, with the `consistent with mask_overlap=True` note).

The fix is to start `present` from zeros so an untouched (empty) image keeps a zeroed target, matching the overlap branch:

```python
# after
present = torch.zeros(batch_size, *masks.shape[-2:], dtype=torch.bool, device=self.device)
```

Images that do have instances are unchanged, because their `present[i]` row is fully overwritten in the loop regardless of the init. So the init is only ever visible for images with no instances at all, and for those zeros is the correct value.

Validation, on a real training step of `yolo26n-seg` (built from YAML, CPU) with a 2-image batch, one image with an instance and one empty background image, capturing the exact `sem_masks` target that reaches `bcedice_loss`:

- `overlap_mask=True`: the empty image gets 0% of its pixels labelled with any class (background, correct).
- `overlap_mask=False` on `main`: the empty image gets 100% of its pixels labelled as class 0 (the bug).
- `overlap_mask=False` with this change: back to 0%, same as the overlap branch.
- The image that has an instance is byte-identical across both branches and before/after the fix, so only the empty-image row moves.

The semantic term is `loss[4]`, scaled by `hyp.box`, so these wrong gradients reach the shared backbone and are not negligible.

Deleted: nothing — this is a one-word initializer change (`torch.ones` → `torch.zeros`), no lines added or removed.

Scope: the default `overlap_mask=True` is not affected, it already runs the correct branch. The bug needs `overlap_mask=False` together with a batch that mixes at least one background image with at least one image that has instances (so the semantic block runs at all). I did not add a test since it is a one-word fix and the property is symmetric with the overlap branch that already covers it, but I'm happy to fold a small assertion into the segmentation-loss test if you prefer.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes semantic target labeling for empty images in YOLO26 segmentation when `overlap_mask=False`.

### 📊 Key Changes
- Initializes the `present` mask tensor with zeros instead of ones.
- Preserves per-image instance-mask updates for images containing objects.
- Prevents empty images from being incorrectly labeled as class 0.

### 🎯 Purpose & Impact
- Corrects segmentation loss targets for batches containing empty images.
- Improves YOLO26-seg training behavior and avoids false foreground labels.
- Limits the change to the relevant target-generation logic in `ultralytics/utils/loss.py`.