### PR TITLE
Fix `TRACKTRACK.update` IndexError on a single torch-backed detection

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -459,9 +459,9 @@ def test_track_reid_auto_user_detections(tracker_type):
 def test_track_single_torch_detection(tracker_type):
     """A single torch-backed detection must not break the low-level tracker update.
 
-    numpy resolves a single-element torch bool mask through `__index__` (True -> 1), so a 1-row numpy
-    detection array masked by it asks for row 1 and raises IndexError; larger torch masks fall back to
-    boolean indexing and work, which is why only the single-detection case fails.
+    numpy resolves a single-element torch bool mask through `__index__` (True -> 1), so a 1-row numpy detection array
+    masked by it asks for row 1 and raises IndexError; larger torch masks fall back to boolean indexing and work, which
+    is why only the single-detection case fails.
     """
     from ultralytics.engine.results import Boxes
     from ultralytics.trackers.track import TRACKER_MAP

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -455,24 +455,6 @@ def test_track_reid_auto_user_detections(tracker_type):
     assert len(tracks) == 2, f"native-ReID tracker must keep tracking without feats:\n{tracks}"
 
 
-@pytest.mark.parametrize("tracker_type", ["bytetrack", "botsort", "tracktrack", "fasttrack", "ocsort", "deepocsort"])
-def test_track_single_torch_detection(tracker_type):
-    """A single torch-backed detection must not break the low-level tracker update.
-
-    numpy resolves a single-element torch bool mask through `__index__` (True -> 1), so a 1-row numpy detection array
-    masked by it asks for row 1 and raises IndexError; larger torch masks fall back to boolean indexing and work, which
-    is why only the single-detection case fails.
-    """
-    from ultralytics.engine.results import Boxes
-    from ultralytics.trackers.track import TRACKER_MAP
-    from ultralytics.utils import ROOT, YAML, IterableSimpleNamespace
-
-    args = IterableSimpleNamespace(**YAML.load(ROOT / f"cfg/trackers/{tracker_type}.yaml"))
-    tracker = TRACKER_MAP[tracker_type](args)
-    tracks = tracker.update(Boxes(torch.tensor([[100, 100, 200, 200, 0.9, 0]], dtype=torch.float32), (640, 640)))
-    assert len(tracks) == 1, f"single torch-backed detection lost by {tracker_type}:\n{tracks}"
-
-
 def test_reid_invalid_crops():
     """Test ReID skips out-of-bounds detection crops while preserving feature alignment."""
     from types import SimpleNamespace

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -455,6 +455,24 @@ def test_track_reid_auto_user_detections(tracker_type):
     assert len(tracks) == 2, f"native-ReID tracker must keep tracking without feats:\n{tracks}"
 
 
+@pytest.mark.parametrize("tracker_type", ["bytetrack", "botsort", "tracktrack", "fasttrack", "ocsort", "deepocsort"])
+def test_track_single_torch_detection(tracker_type):
+    """A single torch-backed detection must not break the low-level tracker update.
+
+    numpy resolves a single-element torch bool mask through `__index__` (True -> 1), so a 1-row numpy
+    detection array masked by it asks for row 1 and raises IndexError; larger torch masks fall back to
+    boolean indexing and work, which is why only the single-detection case fails.
+    """
+    from ultralytics.engine.results import Boxes
+    from ultralytics.trackers.track import TRACKER_MAP
+    from ultralytics.utils import ROOT, YAML, IterableSimpleNamespace
+
+    args = IterableSimpleNamespace(**YAML.load(ROOT / f"cfg/trackers/{tracker_type}.yaml"))
+    tracker = TRACKER_MAP[tracker_type](args)
+    tracks = tracker.update(Boxes(torch.tensor([[100, 100, 200, 200, 0.9, 0]], dtype=torch.float32), (640, 640)))
+    assert len(tracks) == 1, f"single torch-backed detection lost by {tracker_type}:\n{tracks}"
+
+
 def test_reid_invalid_crops():
     """Test ReID skips out-of-bounds detection crops while preserving feature alignment."""
     from types import SimpleNamespace

--- a/ultralytics/trackers/track_tracker.py
+++ b/ultralytics/trackers/track_tracker.py
@@ -439,7 +439,7 @@ class TRACKTRACK:
         self.frame_id += 1
         activated, refind, lost, removed = [], [], [], []
 
-        scores = results.conf
+        scores = np.asarray(results.conf)  # keep masks numpy; numpy coerces a 1-element torch bool mask via __index__
         boxes = parse_bboxes(results)
         high_mask = scores >= self.args.track_high_thresh
         low_mask = (scores > self.args.track_low_thresh) & (scores < self.args.track_high_thresh)


### PR DESCRIPTION
Feeding a single torch-backed detection to the low-level `TRACKTRACK.update()` (calling the tracker API directly, without going through `model.track()`) crashes with `IndexError: index 1 is out of bounds for axis 0 with size 1`. The other five built-in trackers handle the same input fine, so it is easy to miss.

The cause is a mask type mismatch. `TRACKTRACK.update` does:

```python
scores = results.conf                  # torch tensor when the Boxes is torch-backed
boxes = parse_bboxes(results)          # numpy array
high_mask = scores >= self.args.track_high_thresh   # torch bool tensor
...
high_boxes = boxes[high_mask]          # numpy indexed by a torch bool tensor
```

When `results` is torch-backed, `high_mask` is a torch bool tensor. With several detections numpy converts it to a boolean array and the masking works, that is why the bug did not appear before. With exactly one detection numpy resolves the single-element tensor through `__index__` instead, so `True` becomes the integer index `1`, and indexing row 1 of an array with only 1 row raises the error. The sibling `BYTETracker` is not affected because it indexes the `results` object itself (`results[remain_inds]`), which handles a torch mask, instead of masking a separate numpy array; the other trackers only `zip` over detections, no masking.

The fix makes the masks numpy from the start, so they match the numpy `boxes`:

```python
scores = np.asarray(results.conf)
```

`np.asarray` is a no-op when `results.conf` is already numpy (the `model.track()` path calls `.cpu().numpy()` before `update`), so that path does not change. `results.cls[mask]` and `feats[mask]` keep working because torch accepts a numpy bool array as a mask, verified also for the single-element case.

Validation, on the six built-in trackers called directly with a single torch-backed detection `Boxes(torch.tensor([[100, 100, 200, 200, 0.9, 0]]), (640, 640))`:

- before: only `tracktrack` raises `IndexError` at `track_tracker.py:452`, the other five return one track.
- after: all six return one track.
- the existing tracking tests still pass (21 passed, `-k "track or reid"`), including the torch-backed `Boxes` cases in `test_track_second_association_*`.

I added `test_track_single_torch_detection`, parametrized over the six trackers, asserting that a single torch-backed detection returns one track. It fails on `main` only for `tracktrack` (IndexError) and passes for all six with the fix. It follows the existing `TRACKER_MAP` regression style, so a future tracker with the same problem will be caught too.

Deleted: nothing — the fix is a one-call change (`results.conf` → `np.asarray(results.conf)`); the added lines are the parametrized regression test.

Scope: `model.track()` is not affected because it already feeds numpy-backed detections; the crash only appears when the tracker is driven directly with a torch-backed `Boxes`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes `TRACKTRACK.update` handling of a single torch-backed detection to prevent an `IndexError`.

### 📊 Key Changes
- Converts detection confidence values to a NumPy array before creating tracker masks.
- Adds regression coverage for single torch-backed detections across all supported tracker types.
- Verifies that one detection is preserved by ByteTrack, BoT-SORT, TrackTrack, FastTrack, OCSORT, and DeepOCSORT.

### 🎯 Purpose & Impact
- Prevents single-detection tracking failures caused by torch boolean mask behavior in NumPy indexing.
- Improves reliability for low-level tracker updates when detections originate from PyTorch tensors.
- Keeps existing multi-detection behavior covered while adding targeted protection for the edge case.