### PR TITLE
Build TAL get_box_metrics gather indices on device

### DIFF
--- a/ultralytics/utils/tal.py
+++ b/ultralytics/utils/tal.py
@@ -188,11 +188,9 @@ class TaskAlignedAssigner(nn.Module):
         overlaps = torch.zeros([self.bs, self.n_max_boxes, na], dtype=pd_bboxes.dtype, device=pd_bboxes.device)
         bbox_scores = torch.zeros([self.bs, self.n_max_boxes, na], dtype=pd_scores.dtype, device=pd_scores.device)
 
-        ind = torch.zeros([2, self.bs, self.n_max_boxes], dtype=torch.long)  # 2, b, max_num_obj
-        ind[0] = torch.arange(end=self.bs).view(-1, 1).expand(-1, self.n_max_boxes)  # b, max_num_obj
-        ind[1] = gt_labels.squeeze(-1)  # b, max_num_obj
+        batch_ind = torch.arange(self.bs, device=pd_scores.device)[:, None]  # b, 1
         # Get the scores of each grid for each gt cls
-        bbox_scores[mask_gt] = pd_scores[ind[0], :, ind[1]][mask_gt]  # b, max_num_obj, h*w
+        bbox_scores[mask_gt] = pd_scores[batch_ind, :, gt_labels.squeeze(-1).long()][mask_gt]  # b, max_num_obj, h*w
 
         # (b, max_num_obj, 1, 4), (b, 1, h*w, 4)
         pd_boxes = pd_bboxes.unsqueeze(1).expand(-1, self.n_max_boxes, -1, -1)[mask_gt]


### PR DESCRIPTION
## summary

`TaskAlignedAssigner.get_box_metrics` built its gather index as a CPU-allocated `ind` scratch tensor, so `ind[1] = gt_labels.squeeze(-1)` forced a blocking device-to-host copy on every training step (every detect/segment/pose/OBB loss call, twice for E2E models with two assigners), and the indices were then copied back to the device to index `pd_scores`. The index is now built on `pd_scores.device` and `gt_labels` indexes `pd_scores` directly with an explicit `.long()` cast, matching how `get_targets` already builds its `batch_ind`.

Outputs are bit-exact: a 22-case differential against the previous code (17 seeds plus ragged padding, no-gt, empty gt, bs=1, nc=1, float labels as in real training) is `torch.equal` identical, and a deterministic 3-epoch coco8 CPU A/B run gives mAP50-95 identical to 16 digits. On MPS the isolated gather drops 6.8 to 2.0 ms and the CPU-side block inside the call while the GPU queue is busy drops 172 to 0.3 ms; CPU timing is unchanged.

Deleted: the CPU `ind` scratch tensor and its two fill assignments in `get_box_metrics`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Simplified target-class score gathering in task-aligned assignment while improving device handling and index safety.

### 📊 Key Changes

- Replaced a manually constructed two-dimensional index tensor with a simpler `batch_ind` tensor.
- Ensured batch indices are created directly on the prediction device.
- Explicitly converted ground-truth labels to `long` before using them for indexing.
- Preserved the existing bounding-box score computation behavior.

### 🎯 Purpose & Impact

- ✅ Reduces unnecessary tensor creation and makes the indexing logic easier to read and maintain.
- ⚡ Improves compatibility across CPU and GPU execution by placing indices on the correct device.
- 🛡️ Makes class-label indexing more robust by enforcing the expected integer type.
- 📈 Supports more reliable training without changing model outputs or assignment behavior.