### PR TITLE
Vectorize GMC point filter loops with boolean masks

### DIFF
--- a/ultralytics/trackers/utils/gmc.py
+++ b/ultralytics/trackers/utils/gmc.py
@@ -309,7 +309,7 @@ class GMC:
         currPoints = matchedKeypoints[good]
 
         # Estimate transformation matrix using RANSAC
-        if (prevPoints.shape[0] > 4) and (prevPoints.shape[0] == currPoints.shape[0]):
+        if prevPoints.shape[0] > 4:
             H, _ = cv2.estimateAffinePartial2D(prevPoints, currPoints, cv2.RANSAC)
 
             # Scale translation components back to original resolution

--- a/ultralytics/trackers/utils/gmc.py
+++ b/ultralytics/trackers/utils/gmc.py
@@ -207,7 +207,6 @@ class GMC:
         knnMatches = self.matcher.knnMatch(self.prevDescriptors, descriptors, 2)
 
         # Filter matches based on spatial distance constraints
-        matches = []
         spatialDistances = []
         maxSpatialDistance = 0.25 * np.array([width, height])
 
@@ -219,6 +218,8 @@ class GMC:
             return H
 
         # Apply Lowe's ratio test and spatial distance filtering
+        prevPoints = []
+        currPoints = []
         for m, n in knnMatches:
             if m.distance < 0.9 * n.distance:
                 prevKeyPointLocation = self.prevKeyPoints[m.queryIdx].pt
@@ -233,25 +234,19 @@ class GMC:
                     np.abs(spatialDistance[1]) < maxSpatialDistance[1]
                 ):
                     spatialDistances.append(spatialDistance)
-                    matches.append(m)
+                    prevPoints.append(prevKeyPointLocation)
+                    currPoints.append(currKeyPointLocation)
 
         # Filter outliers using statistical analysis
+        spatialDistances = np.asarray(spatialDistances).reshape(-1, 2)
         meanSpatialDistances = np.mean(spatialDistances, 0)
         stdSpatialDistances = np.std(spatialDistances, 0)
         inliers = (spatialDistances - meanSpatialDistances) < 2.5 * stdSpatialDistances
 
-        # Extract good matches and corresponding points
-        goodMatches = []
-        prevPoints = []
-        currPoints = []
-        for i in range(len(matches)):
-            if inliers[i, 0] and inliers[i, 1]:
-                goodMatches.append(matches[i])
-                prevPoints.append(self.prevKeyPoints[matches[i].queryIdx].pt)
-                currPoints.append(keypoints[matches[i].trainIdx].pt)
-
-        prevPoints = np.array(prevPoints)
-        currPoints = np.array(currPoints)
+        # Keep matched point pairs that survive the outlier filter
+        good = inliers.all(axis=1)
+        prevPoints = np.asarray(prevPoints).reshape(-1, 2)[good]
+        currPoints = np.asarray(currPoints).reshape(-1, 2)[good]
 
         # Estimate transformation matrix using RANSAC
         if prevPoints.shape[0] > 4:
@@ -309,16 +304,9 @@ class GMC:
         matchedKeypoints, status, _ = cv2.calcOpticalFlowPyrLK(self.prevFrame, frame, self.prevKeyPoints, None)
 
         # Extract successfully tracked points
-        prevPoints = []
-        currPoints = []
-
-        for i in range(len(status)):
-            if status[i]:
-                prevPoints.append(self.prevKeyPoints[i])
-                currPoints.append(matchedKeypoints[i])
-
-        prevPoints = np.array(prevPoints)
-        currPoints = np.array(currPoints)
+        good = status.ravel().astype(bool)
+        prevPoints = self.prevKeyPoints[good]
+        currPoints = matchedKeypoints[good]
 
         # Estimate transformation matrix using RANSAC
         if (prevPoints.shape[0] > 4) and (prevPoints.shape[0] == currPoints.shape[0]):


### PR DESCRIPTION
## summary

replaces the per-keypoint python loops in `GMC.apply_sparseoptflow` (bot-sort's default gmc method, runs every frame) and `GMC.apply_features` with numpy boolean-mask indexing; the orb/sift point locations are now collected in the existing lowe-ratio loop where they are already computed. output is bit-identical on a real video (per-frame warp matrices, `estimateAffinePartial2D` inputs, and end-to-end `model.track` boxes and ids all match the previous code exactly), while the sparse optical flow point filter drops from 431.6 to 15.3 µs/frame at the default 1000-corner budget.

Deleted: the per-status accumulation loop in `apply_sparseoptflow`, the second match-filtering loop in `apply_features`, and the `matches`/`goodMatches` accumulator lists (`goodMatches` was dead code, built but never read).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves camera-motion compensation by simplifying point matching and filtering, making tracking more efficient and robust. 🚀

### 📊 Key Changes

- Replaced temporary feature-match lists with direct previous/current point collection.
- Converted spatial-distance and point data to NumPy arrays for cleaner, more efficient filtering.
- Simplified outlier selection using a boolean inlier mask.
- Streamlined sparse optical-flow filtering with vectorized NumPy indexing.
- Removed a redundant point-count equality check before affine transformation estimation.

### 🎯 Purpose & Impact

- ✅ Reduces Python-level loops and intermediate data structures, improving tracking efficiency.
- 🎯 Makes feature-based and optical-flow camera-motion estimation code simpler and easier to maintain.
- 🛡️ Preserves RANSAC-based transformation estimation while using only valid, filtered point pairs.
- 📈 May improve tracker stability and performance in scenes with camera movement or visual changes.