### PR TITLE
Add T4 TensorRT speed comparison against Depth Anything V2 to depth docs

### DIFF
--- a/docs/en/tasks/depth.md
+++ b/docs/en/tasks/depth.md
@@ -1,7 +1,7 @@
 ---
 comments: true
 description: Learn about monocular depth estimation using YOLO26. Predict per-pixel depth maps from single RGB images with NYU Depth V2 and custom dataset support.
-keywords: monocular depth estimation, YOLO26, depth map, per-pixel depth, NYU Depth V2, DPT, dense prediction, Ultralytics
+keywords: monocular depth estimation, YOLO26, depth map, per-pixel depth, NYU Depth V2, DPT, dense prediction, Depth Anything V2, Ultralytics
 model_name: yolo26n-depth
 ---
 
@@ -31,6 +31,38 @@ YOLO26 depth models pretrained on a broad multi-dataset mix (indoor + outdoor, ~
 - **rmse** is the root mean squared error in meters.
 - **Speed** is inference-only latency (pre/post-processing excluded) at `imgsz=768`, `batch=1`, reported as mean ± std over timed runs after warmup. **CPU ONNX** is ONNX Runtime fp32 on a 32-core Intel Xeon (Skylake); **T4 TensorRT10** is TensorRT fp16 on a Tesla T4.
 - **params** and **FLOPs** are measured at 768×768, the training resolution of the released weights.
+
+## Speed compared to Depth Anything V2
+
+Depth Anything V2 is a widely used open baseline for monocular depth. Its DINOv2 [vision transformer](https://www.ultralytics.com/glossary/vision-transformer-vit) backbone is compute-heavy, so on the same Tesla T4 under TensorRT fp16 the smallest released Depth Anything V2 model is slower than every YOLO26 depth model — including YOLO26x-depth, which carries more than twice the parameters.
+
+At `imgsz=768`, the resolution the released weights are trained at:
+
+| Model                   | params (M) | FLOPs (B) | T4 TensorRT10 (ms) |   FPS | Speedup vs V2 Small | Speedup vs V2 Base |
+| ----------------------- | ---------: | --------: | -----------------: | ----: | ------------------: | -----------------: |
+| Depth Anything V2 Base  |       97.5 |    1025.5 |              55.40 |  18.1 |                   — |                  — |
+| Depth Anything V2 Small |       24.8 |     346.9 |              20.99 |  47.6 |                   — |                  — |
+| YOLO26x-depth           |       57.0 |     302.0 |              13.57 |  73.7 |                1.5× |               4.1× |
+| YOLO26l-depth           |       27.7 |     157.2 |               7.68 | 130.2 |                2.7× |               7.2× |
+| YOLO26m-depth           |       23.3 |     130.7 |               6.00 | 166.7 |                3.5× |               9.2× |
+| YOLO26s-depth           |       13.2 |      67.9 |               3.82 | 261.6 |                5.5× |              14.5× |
+| YOLO26n-depth           |        6.4 |      46.9 |               2.73 | 365.8 |                7.7× |              20.3× |
+
+At `imgsz=640` the ordering is unchanged, and YOLO26n-depth is 5.9× faster than Depth Anything V2 Small:
+
+| Model                   | T4 TensorRT10 (ms) |   FPS |
+| ----------------------- | -----------------: | ----: |
+| Depth Anything V2 Base  |              35.10 |  28.5 |
+| Depth Anything V2 Small |              13.62 |  73.4 |
+| YOLO26x-depth           |              10.26 |  97.5 |
+| YOLO26l-depth           |               6.14 | 162.8 |
+| YOLO26m-depth           |               4.71 | 212.1 |
+| YOLO26s-depth           |               3.08 | 324.4 |
+| YOLO26n-depth           |               2.29 | 436.9 |
+
+- Latency is inference-only, `batch=1`, TensorRT fp16 on a Tesla T4 — the same harness as the model table above, shown here to two decimals; FPS is the reciprocal of the unrounded latency. The **Speedup** columns divide the Depth Anything V2 Small (20.99 ms) and Base (55.40 ms) latency by the YOLO26 latency.
+- Depth Anything V2 Small and Base are the released ViT-S and ViT-B checkpoints, measured at 770 and 644 px rather than 768 and 640 because DINOv2 requires the input size to be a multiple of its patch size of 14.
+- The comparison covers latency only — the two model families are not evaluated here under a shared accuracy protocol.
 
 ## Depth range and the log-depth head
 

--- a/docs/en/tasks/depth.md
+++ b/docs/en/tasks/depth.md
@@ -34,7 +34,7 @@ YOLO26 depth models pretrained on a broad multi-dataset mix (indoor + outdoor, ~
 
 ## Speed compared to Depth Anything V2
 
-Depth Anything V2 is a widely used open baseline for monocular depth. Its DINOv2 [vision transformer](https://www.ultralytics.com/glossary/vision-transformer-vit) backbone is compute-heavy, so on the same Tesla T4 under TensorRT fp16 the smallest released Depth Anything V2 model is slower than every YOLO26 depth model — including YOLO26x-depth, which carries more than twice the parameters.
+Depth Anything V2 is a widely used open baseline for monocular depth. Its DINOv2 [vision transformer](https://www.ultralytics.com/glossary/vision-transformer-vit) backbone and DPT decoder are compute-heavy, so on the same Tesla T4 under TensorRT fp16 the smallest released Depth Anything V2 model is slower than every YOLO26 depth model — including YOLO26x-depth, which carries more than twice the parameters.
 
 At ~768 px — `imgsz=768` for YOLO26, the resolution its released weights are trained at, and 770 px for Depth Anything V2, whose DINOv2 backbone requires a multiple of its patch size of 14:
 

--- a/docs/en/tasks/depth.md
+++ b/docs/en/tasks/depth.md
@@ -36,7 +36,7 @@ YOLO26 depth models pretrained on a broad multi-dataset mix (indoor + outdoor, ~
 
 Depth Anything V2 is a widely used open baseline for monocular depth. Its DINOv2 [vision transformer](https://www.ultralytics.com/glossary/vision-transformer-vit) backbone is compute-heavy, so on the same Tesla T4 under TensorRT fp16 the smallest released Depth Anything V2 model is slower than every YOLO26 depth model — including YOLO26x-depth, which carries more than twice the parameters.
 
-At `imgsz=768`, the resolution the released weights are trained at:
+At ~768 px — `imgsz=768` for YOLO26, the resolution its released weights are trained at, and 770 px for Depth Anything V2, whose DINOv2 backbone requires a multiple of its patch size of 14:
 
 | Model                   | params (M) | FLOPs (B) | T4 TensorRT10 (ms) |   FPS | Speedup vs V2 Small | Speedup vs V2 Base |
 | ----------------------- | ---------: | --------: | -----------------: | ----: | ------------------: | -----------------: |
@@ -48,7 +48,7 @@ At `imgsz=768`, the resolution the released weights are trained at:
 | YOLO26s-depth           |       13.2 |      67.9 |               3.82 | 261.6 |                5.5× |              14.5× |
 | YOLO26n-depth           |        6.4 |      46.9 |               2.73 | 365.8 |                7.7× |              20.3× |
 
-At `imgsz=640` the ordering is unchanged, and YOLO26n-depth is 5.9× faster than Depth Anything V2 Small:
+At ~640 px — `imgsz=640` and 644 px respectively — the ordering is unchanged, and YOLO26n-depth is 5.9× faster than Depth Anything V2 Small:
 
 | Model                   | T4 TensorRT10 (ms) |   FPS |
 | ----------------------- | -----------------: | ----: |
@@ -61,7 +61,7 @@ At `imgsz=640` the ordering is unchanged, and YOLO26n-depth is 5.9× faster than
 | YOLO26n-depth           |               2.29 | 436.9 |
 
 - Latency is inference-only, `batch=1`, TensorRT fp16 on a Tesla T4 — the same harness as the model table above, shown here to two decimals; FPS is the reciprocal of the unrounded latency. The **Speedup** columns divide the Depth Anything V2 Small (20.99 ms) and Base (55.40 ms) latency by the YOLO26 latency.
-- Depth Anything V2 Small and Base are the released ViT-S and ViT-B checkpoints, measured at 770 and 644 px rather than 768 and 640 because DINOv2 requires the input size to be a multiple of its patch size of 14.
+- Depth Anything V2 Small and Base are the released ViT-S and ViT-B checkpoints.
 - The comparison covers latency only — the two model families are not evaluated here under a shared accuracy protocol.
 
 ## Depth range and the log-depth head


### PR DESCRIPTION
## Summary

- Adds a `Speed compared to Depth Anything V2` section to the depth task page with T4 TensorRT fp16 inference latency for the YOLO26 depth family against Depth Anything V2 Small and Base, at `imgsz=768` and `imgsz=640`.
- The `imgsz=768` latency column is the same measurement already published in `docs/macros/yolo-depth-perf.md` (2.7 / 3.8 / 6.0 / 7.7 / 13.6 ms), shown to two decimals so the speedup ratios are checkable.
- Adds `Depth Anything V2` to the page keywords.

Deleted: nothing — this adds a benchmark that had no prior home on the page; no existing table or claim is superseded.

## Numbers

- YOLO26 `params` and `FLOPs` are taken from the page's own model table so the two tables agree. Verified locally against the released v8.4.0 checkpoints: `yolo26n-depth` 6.356 M params / 46.9 GFLOPs and `yolo26s-depth` 13.224 M / 67.9 GFLOPs at 768, unfused, matching the published 6.4 / 46.9 and 13.2 / 67.9.
- Depth Anything V2 parameter counts were verified independently from the released checkpoints: 24.79 M (ViT-S) and 97.47 M (ViT-B).
- Every speedup ratio and FPS value was recomputed from the latency figures.

## Notes

- The tables are inline rather than a macro: `docs/macros/` is used for tables rendered in two or more places, and this one has a single render site with no README mirror.
- Depth Anything V2 is named without a link, matching how the rest of the depth docs reference it.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Expanded YOLO26 depth documentation with detailed speed comparisons against Depth Anything V2.

### 📊 Key Changes

- Added **Depth Anything V2** to the page’s search keywords.
- Introduced benchmark tables comparing YOLO26 depth models with Depth Anything V2 Base and Small.
- Reported parameter counts, FLOPs, latency, FPS, and relative speedups at approximately **768 px** and **640 px** input sizes.
- Clarified that benchmarks use **TensorRT FP16 on a Tesla T4**, with batch size 1 and inference-only latency.
- Noted that the comparison measures speed only and does not represent a shared accuracy evaluation.

### 🎯 Purpose & Impact

- ⚡ Shows that all YOLO26 depth models are faster than the compared Depth Anything V2 models, including the larger YOLO26x-depth model.
- 📈 Helps users select a YOLO26 depth model based on deployment speed and hardware constraints.
- 🔍 Provides transparent benchmark conditions and clarifies differences in input resolution and model architecture.
- 🧭 Improves documentation discoverability for users comparing YOLO26 with Depth Anything V2 for monocular depth estimation.