### PR TITLE
Fix gmc docstring examples to run as written

### DIFF
--- a/ultralytics/trackers/utils/gmc.py
+++ b/ultralytics/trackers/utils/gmc.py
@@ -100,7 +100,7 @@ class GMC:
 
         Examples:
             >>> gmc = GMC(method="sparseOptFlow")
-            >>> raw_frame = np.random.rand(480, 640, 3)
+            >>> raw_frame = np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
             >>> transformation_matrix = gmc.apply(raw_frame)
             >>> print(transformation_matrix.shape)
             (2, 3)
@@ -125,10 +125,10 @@ class GMC:
 
         Examples:
             >>> gmc = GMC(method="ecc")
-            >>> processed_frame = gmc.apply_ecc(np.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]))
-            >>> print(processed_frame)
-            [[1. 0. 0.]
-             [0. 1. 0.]]
+            >>> raw_frame = np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
+            >>> transformation_matrix = gmc.apply_ecc(raw_frame)
+            >>> print(transformation_matrix.shape)
+            (2, 3)
         """
         height, width, c = raw_frame.shape
         frame = cv2.cvtColor(raw_frame, cv2.COLOR_BGR2GRAY) if c == 3 else raw_frame
@@ -282,10 +282,10 @@ class GMC:
 
         Examples:
             >>> gmc = GMC()
-            >>> result = gmc.apply_sparseoptflow(np.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]))
-            >>> print(result)
-            [[1. 0. 0.]
-             [0. 1. 0.]]
+            >>> raw_frame = np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
+            >>> transformation_matrix = gmc.apply_sparseoptflow(raw_frame)
+            >>> print(transformation_matrix.shape)
+            (2, 3)
         """
         height, width, c = raw_frame.shape
         frame = cv2.cvtColor(raw_frame, cv2.COLOR_BGR2GRAY) if c == 3 else raw_frame


### PR DESCRIPTION
## summary

the `GMC.apply`, `GMC.apply_ecc` and `GMC.apply_sparseoptflow` docstring examples raised `cv2.error` when executed as written, because they fed float64 and int64 arrays into `cv2.cvtColor`, which accepts only 8-bit and 16-bit or float32 depths. they now build the frame with `np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)`, the same form the class-level example already uses.

the expected outputs of the two examples that printed the warp matrix were also unreachable: `ultralytics/utils/__init__.py` installs a numpy float formatter, so a printed float array never renders as `[[1. 0. 0.]]`. those two now print the returned shape, matching the three examples in the file that already pass. `pytest --doctest-modules ultralytics/trackers/utils/gmc.py` goes from 3 failed / 2 passed to 5 passed.

Deleted: two unreachable expected-output blocks and the int64 array literals feeding them; net line count unchanged (9 added, 9 removed).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📝 Updates GMC tracking examples to use realistic `uint8` image frames and clearly show the expected transformation matrix output.

### 📊 Key Changes

- Replaced small, manually created NumPy arrays with realistic `480×640` random color images.
- Specified the correct `uint8` image data type expected by OpenCV operations.
- Updated examples for:
  - `GMC.apply()`
  - `GMC.apply_ecc()`
  - `GMC.apply_sparseoptflow()`
- Simplified examples to verify the returned transformation matrix shape: `(2, 3)`.

### 🎯 Purpose & Impact

- ✅ Makes GMC documentation examples more accurate and representative of real video frames.
- 🛠️ Reduces confusion and potential OpenCV errors caused by unsuitable input formats.
- 📚 Improves onboarding and testing for developers using global motion compensation in tracking workflows.
- 🚀 No functional behavior changes to the tracking implementation; the update is documentation-only.