### PR TITLE
Make GMC outlier filter reject deviations on both sides of the mean

### DIFF
--- a/ultralytics/trackers/utils/gmc.py
+++ b/ultralytics/trackers/utils/gmc.py
@@ -238,7 +238,7 @@ class GMC:
         # Filter outliers using statistical analysis
         meanSpatialDistances = np.mean(spatialDistances, 0)
         stdSpatialDistances = np.std(spatialDistances, 0)
-        inliers = (spatialDistances - meanSpatialDistances) < 2.5 * stdSpatialDistances
+        inliers = np.abs(spatialDistances - meanSpatialDistances) < 2.5 * stdSpatialDistances
 
         # Extract good matches and corresponding points
         goodMatches = []


### PR DESCRIPTION
## summary

the statistical outlier filter in `GMC.apply_features` (the orb/sift global-motion-compensation path) compares the signed deviation against `2.5 * std`, so it rejects matches whose displacement is more positive than the mean by that margin while equally distant negative deviations always pass. wrapping the deviation in `np.abs` makes the test symmetric, matching the `np.abs` bound the same function already applies to `maxSpatialDistance` three lines above.

measured on real video and on synthetic frame pairs with a known affine warp plus a differently-moving foreground block: identical outliers were rejected 0% of the time when they fell on the negative side and 63-100% when they fell on the positive side, and are now rejected on both. end-to-end `model.track` with `gmc_method=orb` returns identical track ids and bit-identical boxes, translation error against the known warp stays at 0.04-0.26 px across 640 trials either way, and no frame drops below the minimum point count `estimateAffinePartial2D` needs.

Deleted: nothing — this replaces one expression in place with no net line change, and the dead `goodMatches` accumulator in the same function is already removed in #25398.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves GMC feature matching by correctly filtering spatial-distance outliers in both directions. 🎯

### 📊 Key Changes

- Updated the inlier filter in `ultralytics/trackers/utils/gmc.py`.
- Applies the absolute distance from the mean when identifying valid feature matches.
- Continues using the existing statistical threshold of 2.5 standard deviations.

### 🎯 Purpose & Impact

- Prevents unusually large and unusually small spatial distances from being incorrectly accepted as inliers.
- Improves the reliability of global motion compensation during object tracking. 🚀
- May produce more stable tracking results, particularly in scenes with camera movement or noisy feature matches.