### PR TITLE
Document class-alias weight transfer for fine-tuning

### DIFF
--- a/docs/en/guides/finetuning-guide.md
+++ b/docs/en/guides/finetuning-guide.md
@@ -37,6 +37,55 @@ When a pretrained model is fine-tuned on a dataset with a different number of cl
 
 For datasets with the same number of classes as the pretrained model (for example, fine-tuning COCO-pretrained weights on another 80-class dataset), 100% of weights transfer including the detection head.
 
+### Transfer Classes with Name Aliases
+
+Ultralytics transfers matching classification-head rows by class name across datasets, ignoring case and surrounding whitespace. When equivalent classes use different names, rename the source checkpoint classes in memory before loading. This preserves pretrained classification weights for shared concepts that would otherwise be treated as unmatched and initialized randomly.
+
+This [Objects365](../datasets/detect/objects365.md) v2-to-COCO example defines aliases as **target COCO name -> source Objects365 name** and applies them immediately before the standard weight load:
+
+```python
+from ultralytics import YOLO
+from ultralytics.models.yolo.detect.train import DetectionTrainer
+
+# Target COCO name -> source Objects365 v2 checkpoint name
+COCO_TO_OBJECTS365_ALIASES = {
+    "bird": "wild bird",
+    "handbag": "handbag/satchel",
+    "suitcase": "luggage",
+    "bowl": "bowl/basin",
+    "orange": "orange/tangerine",
+    "tv": "monitor/tv",
+    "teddy bear": "stuffed toy",
+    "hair drier": "hair dryer",
+    "skis": "skating and skiing shoes",
+    "sports ball": "baseball",
+}
+
+
+class ObjectsAliasYOLOTrainer(DetectionTrainer):
+    class_aliases = COCO_TO_OBJECTS365_ALIASES
+
+    def get_model(self, cfg=None, weights=None, verbose=True):
+        model = super().get_model(cfg=cfg, weights=None, verbose=verbose)
+        if weights:
+            self._apply_class_aliases(weights)
+            model.load(weights)
+        return model
+
+    def _apply_class_aliases(self, weights):
+        source = weights["model"] if isinstance(weights, dict) else weights
+        source.names = dict(source.names)
+        source_lookup = {name.strip().lower(): index for index, name in source.names.items()}
+        for target_name, source_name in self.class_aliases.items():
+            source_index = source_lookup.get(source_name.strip().lower())
+            if source_index is not None:
+                source.names[source_index] = target_name
+
+
+model = YOLO("path/to/yolo26s-objects365.pt")
+model.train(trainer=ObjectsAliasYOLOTrainer, data="coco.yaml", epochs=100, imgsz=640)
+```
+
 ## Basic Fine-Tuning Example
 
 !!! example

--- a/docs/en/guides/finetuning-guide.md
+++ b/docs/en/guides/finetuning-guide.md
@@ -56,7 +56,6 @@ ALIASES = {
     "monitor/tv": "tv",
     "stuffed toy": "teddy bear",
     "hair dryer": "hair drier",
-    "skating and skiing shoes": "skis",
 }
 
 model = YOLO("path/to/yolo26s-objects365.pt")

--- a/docs/en/guides/finetuning-guide.md
+++ b/docs/en/guides/finetuning-guide.md
@@ -41,49 +41,27 @@ For datasets with the same number of classes as the pretrained model (for exampl
 
 Ultralytics transfers matching classification-head rows by class name across datasets, ignoring case and surrounding whitespace. When equivalent classes use different names, rename the source checkpoint classes in memory before loading. This preserves pretrained classification weights for shared concepts that would otherwise be treated as unmatched and initialized randomly.
 
-This [Objects365](../datasets/detect/objects365.md) v2-to-COCO example defines aliases as **target COCO name -> source Objects365 name** and applies them immediately before the standard weight load:
+This [Objects365](../datasets/detect/objects365.md) v2-to-COCO example renames the source classes on the loaded checkpoint, which `train()` then passes through as the pretrained weights:
 
 ```python
 from ultralytics import YOLO
-from ultralytics.models.yolo.detect.train import DetectionTrainer
 
-# Target COCO name -> source Objects365 v2 checkpoint name
-COCO_TO_OBJECTS365_ALIASES = {
-    "bird": "wild bird",
-    "handbag": "handbag/satchel",
-    "suitcase": "luggage",
-    "bowl": "bowl/basin",
-    "orange": "orange/tangerine",
-    "tv": "monitor/tv",
-    "teddy bear": "stuffed toy",
-    "hair drier": "hair dryer",
-    "skis": "skating and skiing shoes",
-    "sports ball": "baseball",
+# Source Objects365 v2 name -> target COCO name
+ALIASES = {
+    "wild bird": "bird",
+    "handbag/satchel": "handbag",
+    "luggage": "suitcase",
+    "bowl/basin": "bowl",
+    "orange/tangerine": "orange",
+    "monitor/tv": "tv",
+    "stuffed toy": "teddy bear",
+    "hair dryer": "hair drier",
+    "skating and skiing shoes": "skis",
 }
 
-
-class ObjectsAliasYOLOTrainer(DetectionTrainer):
-    class_aliases = COCO_TO_OBJECTS365_ALIASES
-
-    def get_model(self, cfg=None, weights=None, verbose=True):
-        model = super().get_model(cfg=cfg, weights=None, verbose=verbose)
-        if weights:
-            self._apply_class_aliases(weights)
-            model.load(weights)
-        return model
-
-    def _apply_class_aliases(self, weights):
-        source = weights["model"] if isinstance(weights, dict) else weights
-        source.names = dict(source.names)
-        source_lookup = {name.strip().lower(): index for index, name in source.names.items()}
-        for target_name, source_name in self.class_aliases.items():
-            source_index = source_lookup.get(source_name.strip().lower())
-            if source_index is not None:
-                source.names[source_index] = target_name
-
-
 model = YOLO("path/to/yolo26s-objects365.pt")
-model.train(trainer=ObjectsAliasYOLOTrainer, data="coco.yaml", epochs=100, imgsz=640)
+model.model.names = {i: ALIASES.get(name, name) for i, name in model.model.names.items()}
+model.train(data="coco.yaml", epochs=100, imgsz=640)
 ```
 
 ## Basic Fine-Tuning Example


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## Summary

- Document class-alias-aware weight transfer when source and target datasets use different names for equivalent classes.
- Add an Objects365 v2-to-COCO example using a custom trainer that applies aliases before the standard pretrained-weight load.
- Reuse the existing class-name remapping in `model.load()` rather than introducing a separate weight-transfer implementation.

## Validation

- Verified RT-DETR-L transfer with synthetic Objects365 and COCO models:
  - 70 direct class matches and 10 alias matches.
  - 80/80 COCO classes resolved with 0 unresolved.
  - Correct decoder classification rows transferred.
  - 941/941 state-dict items transferred.
- Verified YOLO26s transfer with synthetic Objects365 and COCO models:
  - Source and target classification branches both used 128 input channels.
  - 80/80 COCO classes resolved.
  - All 6 classification kernels and all 6 classification biases transferred to the correct class indices.
  - 708/708 state-dict items transferred.
- Completed a one-epoch `coco8` CPU smoke test through the full `YOLO.train()` custom-trainer lifecycle.
- Confirmed the documentation example is valid Python and `git diff --check` passes.

Deleted: nothing — this documentation-only change explains an existing weight-transfer capability without superseding prior documentation.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📚 Documents how to preserve pretrained classification weights when fine-tuning across datasets with equivalent classes that use different names.

### 📊 Key Changes

- Added a **“Transfer Classes with Name Aliases”** section to the fine-tuning guide.
- Explains that matching class names are compared while ignoring case and surrounding whitespace.
- Shows how to rename source checkpoint classes in memory before training.
- Includes an Objects365 v2-to-COCO example using class aliases such as `"wild bird"` → `"bird"` and `"monitor/tv"` → `"tv"`.

### 🎯 Purpose & Impact

- ✅ Helps transfer more pretrained knowledge between datasets with different class naming conventions.
- 🚀 Reduces unnecessary random initialization of classification-head weights for equivalent classes.
- 🧩 Provides users with a practical method for improving fine-tuning results without modifying the original checkpoint or dataset files.
- 📖 Improves clarity around how Ultralytics handles class matching during transfer learning.