### PR TITLE
Pad all multispectral channels in `RandomPerspective` warps

### DIFF
--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1187,8 +1187,7 @@ class RandomPerspective(BaseTransform):
         M = params["M"]
         size = params["size"]
         if (size[0] != img.shape[1] or size[1] != img.shape[0]) or (M != np.eye(3)).any():  # image changed
-            # cv2 tiles borderValue as a 4-element Scalar across channel blocks of 4, so a 3-tuple
-            # zeroes every 4th channel of multispectral borders; 4 identical values pad all channels alike
+            # 4 values: cv2 tiles borderValue in blocks of 4, so a 3-tuple zeroes every 4th multispectral channel
             if self.perspective:
                 img = cv2.warpPerspective(img, M, dsize=size, borderValue=(114, 114, 114, 114))
             else:  # affine

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1187,10 +1187,12 @@ class RandomPerspective(BaseTransform):
         M = params["M"]
         size = params["size"]
         if (size[0] != img.shape[1] or size[1] != img.shape[0]) or (M != np.eye(3)).any():  # image changed
+            # cv2 tiles borderValue as a 4-element Scalar across channel blocks of 4, so a 3-tuple
+            # zeroes every 4th channel of multispectral borders; 4 identical values pad all channels alike
             if self.perspective:
-                img = cv2.warpPerspective(img, M, dsize=size, borderValue=(114, 114, 114))
+                img = cv2.warpPerspective(img, M, dsize=size, borderValue=(114, 114, 114, 114))
             else:  # affine
-                img = cv2.warpAffine(img, M[:2], dsize=size, borderValue=(114, 114, 114))
+                img = cv2.warpAffine(img, M[:2], dsize=size, borderValue=(114, 114, 114, 114))
             if img.ndim == 2:
                 img = img[..., None]
         labels["img"] = img


### PR DESCRIPTION
`RandomPerspective` fills the new border regions of its warps with `borderValue=(114, 114, 114)`. cv2 treats `borderValue` as a 4-element Scalar and tiles it across channels in blocks of 4, so on a multispectral image every channel with index `k % 4 == 3` gets border 0 instead of 114 — channels 3 and 7 on the official `coco8-multispectral.yaml` (10 channels). `LetterBox` already pads all channels with 114 through its explicit multispectral branch, so the training tensors end up with inconsistent padding: 8 channels padded 114, 2 padded 0, silently.

Mosaic hides it, because the mosaic canvas pre-fills all channels with `np.full(..., 114)` before the warp. So the corruption fires exactly when mosaic is off: the `close_mosaic=10` final epochs of every multispectral training run, and any run with `mosaic=0`. RGB and grayscale never hit it, cv2 only reads the first 3 or 1 Scalar elements there.

**Changes**

- `borderValue=(114, 114, 114)` → `borderValue=(114, 114, 114, 114)` in the two warp calls of `RandomPerspective.apply_image` (`warpPerspective` and `warpAffine`), plus a short comment on why 4 values. With 4 identical values the block tiling pads every channel alike for any channel count.

Deleted: nothing — the fix is one extra Scalar element on the two existing warp calls; there is no branch to delete or relocate, and it keeps the single code path for 1/3/N channels (no `else: # multispectral` fork like `LetterBox` needs for `copyMakeBorder`).

**Validation** (current `main`, cv2 4.10.0)

- Unit: `cv2.warpAffine(np.zeros((64, 64, 10), np.uint8), M, (64, 64), borderValue=(114, 114, 114))` returns border pixels `[114, 114, 114, 0, 114, 114, 114, 0, 114, 114]`; with the 4-tuple it returns all 114. The 1-channel and 3-channel cases return `114` and `(114, 114, 114)` as before.
- End-to-end through the real training pipeline: `YOLODataset` on `coco8-multispectral.yaml` with `mosaic=0` (the close_mosaic phase) produces 8784 border pixels at 0 on channels 3 and 7 across the 4 train images on `main`, and 0 with the fix.
- No regression for standard images: warping 1/2/3-channel images with the 3-tuple vs the 4-tuple is bit-identical (`np.array_equal`, perspective and affine, 6/6 cases). For >3 channels only the `k % 4 == 3` channels change, which is the fix.
- `val`/`predict` were never affected, `LetterBox` pads >3 channels manually with `np.full`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fix multispectral image padding in `RandomPerspective` warps by supplying a four-value border color to OpenCV transformations.

### 📊 Key Changes
- Updated both perspective and affine warps in `ultralytics/data/augment.py` to use `(114, 114, 114, 114)` as `borderValue`.
- Ensured border padding is applied consistently across multispectral channel groups instead of zeroing every fourth channel.
- Preserved existing grayscale image handling after warping.

### 🎯 Purpose & Impact
- 🐛 Corrects unintended border values for multispectral images with more than three channels.
- ✅ Produces consistent padding across all channel blocks during augmentation.
- 🚀 Improves training data integrity for multispectral object detection workflows without changing standard image behavior.