### PR TITLE
Fix NCNN inference dropping all but the first image of a batch

### DIFF
--- a/ultralytics/nn/backends/ncnn.py
+++ b/ultralytics/nn/backends/ncnn.py
@@ -64,9 +64,10 @@ class NCNNBackend(BaseBackend):
         Returns:
             (list[np.ndarray]): Model predictions as a list of numpy arrays, one per output layer.
         """
-        mat_in = self.pyncnn.Mat(im[0].cpu().numpy())
-        with self.net.create_extractor() as ex:
-            ex.input(self.net.input_names()[0], mat_in)
-            # Sort output names as temporary fix for pnnx issue
-            y = [np.array(ex.extract(x)[1])[None] for x in sorted(self.net.output_names())]
-        return y
+        outputs = []
+        for sample in im.cpu().numpy():
+            with self.net.create_extractor() as ex:
+                ex.input(self.net.input_names()[0], self.pyncnn.Mat(sample))
+                # Sort output names as temporary fix for pnnx issue
+                outputs.append([np.array(ex.extract(x)[1]) for x in sorted(self.net.output_names())])
+        return [np.stack(y) for y in zip(*outputs)]


### PR DESCRIPTION
`NCNNBackend.forward` only takes the first batch element — `self.pyncnn.Mat(im[0].cpu().numpy())` — and discards the rest. When a batch>1 reaches it the backend returns predictions for a single image, and the predictor crashes later, far from the real cause, with `IndexError: list index out of range` at `predictor.py:353` (`self.results[i].speed`).

This is easy to hit with normal documented usage on an official model: `YOLO("yolo11n_ncnn_model").predict([img1, img2])` — a list source is loaded by `LoadPilAndNumpy` with `bs=len(list)` no matter the `batch` argument, and the same happens with a batched tensor source or an explicit `batch=N`. The most common NCNN use (single image on edge devices, video/folder sources that go one frame at a time) never reaches this path, so the bug was not visible. The NCNN docs already document this as supported — the export arguments table in `docs/en/integrations/ncnn.md` describes `batch` as "the max number of images the exported model will process concurrently in `predict` mode". `DeepXBackend` already handles this same case with a per-image loop, and ONNX raises a clear dimension error instead of dropping data.

**Changes**

- Run the NCNN extractor once per image of the batch, with the same loop that `DeepXBackend` already uses, and stack each output along the batch dimension:

```python
outputs = []
for sample in im.cpu().numpy():
    with self.net.create_extractor() as ex:
        ex.input(self.net.input_names()[0], self.pyncnn.Mat(sample))
        # Sort output names as temporary fix for pnnx issue
        outputs.append([np.array(ex.extract(x)[1]) for x in sorted(self.net.output_names())])
return [np.stack(y) for y in zip(*outputs)]
```

Deleted: the `im[0]` hard index and its `[None]` batch-dim workaround, replaced by the same per-image loop of the DeepX backend (net +1 line; the single-image maths is unchanged, `np.stack([a])` is exactly `a[None]`).

**Validation** (yolo11n exported to NCNN, imgsz=320, pyncnn 1.0.20260526)

- On `main`: `predict([bus.jpg, zidane.jpg])` crashes with `IndexError` at `predictor.py:353`; single-image predict works.
- With the fix: the list predict returns 2 results (5 and 3 boxes), and each one is bit-identical (`np.array_equal` on `boxes.data`) to its own single-image run.
- No regression on the single-image path: `boxes.data` for both images is bit-identical before and after the fix.
- The only other backend indexing `im[0]` is CoreML's non-dynamic path, but there the exported mlmodel is batch-1 by design — an explicit constraint, not a silent drop, so it is out of scope here.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes NCNN inference to preserve predictions for every image in a batch instead of processing only the first image.

### 📊 Key Changes
- Iterates over each sample in the input batch and runs NCNN extraction independently.
- Collects outputs for all samples and stacks them by output layer.
- Retains sorted output names to preserve the existing compatibility workaround.

### 🎯 Purpose & Impact
- Resolves incorrect NCNN batch inference where all but the first image were silently dropped.
- Enables reliable batched inference with NCNN backends while maintaining the expected output structure.
- May increase inference overhead for batched inputs because each sample creates a separate extractor.