### PR TITLE
Skip the redundant float32 input copy in the OpenVINO and Paddle backends

### DIFF
--- a/ultralytics/nn/backends/openvino.py
+++ b/ultralytics/nn/backends/openvino.py
@@ -84,7 +84,7 @@ class OpenVINOBackend(BaseBackend):
         Returns:
             (list[np.ndarray]): Model predictions as a list of numpy arrays, one per output layer.
         """
-        im = im.cpu().numpy().astype(np.float32)
+        im = im.cpu().numpy().astype(np.float32, copy=False)
 
         if self.inference_mode in {"THROUGHPUT", "CUMULATIVE_THROUGHPUT"}:
             # Async inference for larger batch sizes

--- a/ultralytics/nn/backends/paddle.py
+++ b/ultralytics/nn/backends/paddle.py
@@ -74,6 +74,6 @@ class PaddleBackend(BaseBackend):
         Returns:
             (list[np.ndarray]): Model predictions as a list of numpy arrays, one per output handle.
         """
-        self.input_handle.copy_from_cpu(im.cpu().numpy().astype(np.float32))
+        self.input_handle.copy_from_cpu(im.cpu().numpy().astype(np.float32, copy=False))
         self.predictor.run()
         return [self.predictor.get_output_handle(x).copy_to_cpu() for x in self.output_names]


### PR DESCRIPTION
Both the OpenVINO and the Paddle backends convert the input with `.astype(np.float32)` on every forward:

```python
im = im.cpu().numpy().astype(np.float32)                                # openvino.py
self.input_handle.copy_from_cpu(im.cpu().numpy().astype(np.float32))    # paddle.py
```

On the paths where these lines run the input is already float32, so the astype is a full-tensor copy (~4.9 MB per frame at 1x3x640x640) that changes nothing. For Paddle this is always the case: `paddle` is not in the fp16 set at `autobackend.py:196`, so its input never gets converted to half. For OpenVINO the default export is `half=False` and the input stays float32; only a model exported with `half=True` receives half input, and there the conversion is real and needs to keep working.

Passing `copy=False` keeps both cases: when the array is already float32 numpy returns a zero-copy view, and when it is half the conversion runs exactly as before.

**Deleted:** the redundant per-frame float32 memcpy in the forward of both backends (on the already-float32 path the astype now returns a view instead of copying the whole input).

**Validation** (main @ ee2c534, OpenVINO 2026.2.1, CPU):

- End-to-end bit-identical on a real OpenVINO export: yolo11n exported with defaults, same seeded input through `AutoBackend.forward` before and after the change — the `(1, 84, 8400)` output matches with max abs diff `0.0`.
- The isolated call at bs=1 640x640 goes from ~161 us to ~0.7 us per frame on my machine, the saving scales with input area and batch size.
- Half input still converts: `np.array_equal` is True against the current code and the output dtype is float32.
- The other backends in `nn/backends/` were checked and these two are the only redundant ones: rknn/hailo/deepx/coreml astype to uint8 and tensorflow/litert to the quantized dtype (real conversions), onnx/triton/ncnn pass the numpy array directly.
- `ruff format` and `ruff check` clean.

No new test: the OpenVINO export test already runs this forward on CI and the output does not change.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Optimizes OpenVINO and Paddle inference input handling by avoiding redundant float32 array copies when the data is already correctly typed.

### 📊 Key Changes
- Updates the OpenVINO backend to use `astype(np.float32, copy=False)`.
- Updates the Paddle backend to use `astype(np.float32, copy=False)`.
- Applies the same copy-avoidance optimization consistently across both backends.

### 🎯 Purpose & Impact
- Reduces unnecessary memory allocations and input preprocessing overhead.
- May improve inference efficiency, especially for larger inputs or frequent backend calls.
- Preserves existing float32 conversion behavior while allowing NumPy to reuse compatible arrays.