### PR TITLE
Fuse distillation checkpoints to the student model

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.104"
+__version__ = "8.4.105"
 
 import importlib
 import os

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -445,7 +445,7 @@ class Model(torch.nn.Module):
             >>> # Model is now fused and ready for optimized inference
         """
         self._check_is_pytorch_model()
-        self.model.fuse()
+        self.model = self.model.fuse()  # DistillationModel fuses to its student, so adopt the return
         return self
 
     def embed(

--- a/ultralytics/nn/distill_model.py
+++ b/ultralytics/nn/distill_model.py
@@ -49,6 +49,7 @@ class DistillationModel(nn.Module):
         loss: Compute combined detection and distillation loss.
         loss_sl2: Compute score-weighted L2 distillation loss for a feature pair.
         decouple_outputs: Normalize teacher/student head outputs across train/val formats.
+        fuse: Fuse and return the student model for inference and export.
         train: Set training mode while keeping teacher frozen.
 
     Examples:
@@ -197,6 +198,11 @@ class DistillationModel(nn.Module):
         if isinstance(x, dict):  # for cases of training and validating while training.
             return self.loss(x, *args, **kwargs)
         return self.student_model.predict(x, *args, **kwargs)
+
+    def fuse(self, verbose: bool = True):
+        """Fuse and return the student model, dropping the training-only distillation wrapper."""
+        self._remove_feature_hooks()
+        return self.student_model.fuse(verbose=verbose)
 
     def loss(self, batch, preds=None):
         """Compute loss.


### PR DESCRIPTION
Fixes a crash found while sweeping the Ultralytics Platform GPU-worker Docker logs and both Sentry projects on 2026-07-24.

## The bug

`yolo export` / `predict` / `val` on a checkpoint whose `ema` is still a `DistillationModel` crashed:

```
AttributeError: 'DistillationModel' object has no attribute 'fuse'
  cfg/__init__.py:1112 entrypoint -> engine/model.py:762 export -> engine/exporter.py:806 __call__
```

`engine/exporter.py:806` does `model = model.fuse()`. `strip_optimizer` already unwraps a distillation checkpoint to its student, but it only runs at `final_eval` — so any interrupted or mid-training `last.pt` keeps the wrapper and every downstream consumer fails on it.

**Sentry:** ULTRALYTICS-1X40 (project `ultralytics`, env `runpod`, 5 events / 3 users, last seen 2026-07-24, release 8.4.104).

## The fix

`DistillationModel` already delegates `forward` to its student, so `fuse` delegates the same way and returns the fused student — the wrapper is training-only scaffolding.

| File | Change | Kind |
|---|---|---|
| `ultralytics/nn/distill_model.py` | `fuse()` delegates to `student_model.fuse()` after dropping the feature hooks | Add (6 lines) |
| `ultralytics/engine/model.py:448` | `self.model.fuse()` → `self.model = self.model.fuse()`, adopting the non-identity return | Replace (1 line) |
| `ultralytics/__init__.py` | 8.4.104 → 8.4.105 | Patch bump |

**Loading is deliberately untouched.** An earlier attempt unwrapped inside `nn/tasks.py load_checkpoint`; review caught that it makes the distillation resume branch at `engine/trainer.py:803` unreachable, silently dropping `weights.projector` restoration. `nn/tasks.py` is byte-identical to `main`.

## Verification

- Reproduced the exact reported `AttributeError` on the pre-fix tree, then confirmed the fix resolves it.
- `YOLO(distill_ckpt).export(format="torchscript")` now succeeds end to end.
- Resume contract preserved: `load_checkpoint` still returns `DistillationModel` and `ckpt["ema"].projector` is intact.
- Facade: `model.model` becomes `DetectionModel` and `model.info()` works; a normal `yolo11n.pt` still fuses with `info()` working.
- `ruff check` + `ruff format --check` clean; `pytest tests/test_python.py -k "fuse or method or export or info"` → 2 passed.

## Review

Adversarially reviewed by Codex (cross-model — it did not write this code), iterated delta-only across three rounds to **LGTM**. Round 1 caught the resume regression, round 2 caught the discarded `fuse()` return in the facade; both were accepted and fixed, and each claim was independently re-verified here by executing the affected paths. The in-harness reviewer agents did not return results in this session, so Codex is the only completed second opinion.

**Deleted:** nothing. This is a crash on a valid user path with no wrong code path to remove — `strip_optimizer`'s existing unwrap is still needed for finalized checkpoints, so the wrapper's missing inference interface had to be supplied where the class already delegates `forward`. Net +8/−2 across three files.

Cross-reference: ultralytics/portal#3106 pins 8.4.105 and accompanies this.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Updated model fusion to correctly unwrap distillation models and return their optimized student model.

### 📊 Key Changes

- Bumped the Ultralytics package version from `8.4.104` to `8.4.105`.
- Added `DistillationModel.fuse()` to:
  - Remove training-only feature hooks.
  - Fuse the student model.
  - Return the student model for inference and export.
- Updated `Model.fuse()` to adopt the model returned by `.fuse()`, ensuring fused distillation models are stored correctly.

### 🎯 Purpose & Impact

- ✅ Fixes fusion behavior for knowledge-distillation models.
- ⚡ Produces a clean, optimized student model for faster inference and reliable export.
- 🧹 Prevents unnecessary distillation wrappers and feature hooks from remaining after training.
- 🔄 Existing non-distillation model fusion continues to work as before.