### PR TITLE
Expand fuzz exploration: cross-run history, device, malformed CLI, datasets, checkpoints

### DIFF
--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -296,8 +296,8 @@ def precache_assets(uni):
 def prepare_models(uni):
     """Create the corrupt and foreign model files used by model trials, derived from a cached corpus weight.
 
-    `model` is otherwise pinned, so checkpoint loading went unfuzzed even though corrupt and wrong-format
-    checkpoints are a top error surface in the package's telemetry. Every entry here is an unsupported input.
+    `model` is otherwise pinned, so checkpoint loading went unfuzzed even though corrupt and wrong-format checkpoints
+    are a top error surface in the package's telemetry. Every entry here is an unsupported input.
     """
     from ultralytics.utils import ASSETS, WEIGHTS_DIR
     from ultralytics.utils.downloads import attempt_download_asset
@@ -332,8 +332,8 @@ def prepare_datasets(uni):
 def make_dataset(root, mutation):
     """Build one synthetic detect dataset under root and return the path to its YAML.
 
-    Generated entirely on disk with no downloads, so the whole pool is a few KB of 64px images against the
-    multi-MB curated corpora. Each mutation reproduces a failure signature users actually hit.
+    Generated entirely on disk with no downloads, so the whole pool is a few KB of 64px images against the multi-MB
+    curated corpora. Each mutation reproduces a failure signature users actually hit.
     """
     from PIL import Image
 

--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -51,7 +51,10 @@ PERSONALITIES = {  # mode-selection weights only; mutation kernel and classifier
     "predict-val": {"train": 0.05, "val": 0.35, "predict": 0.35, "track": 0.2, "export": 0.05},
     "chaos": {m: 0.2 for m in MODES},
 }
-STRATEGY_WEIGHTS = [("invalid", 0.4), ("combo", 0.4), ("source", 0.2)]
+STRATEGY_WEIGHTS = [("invalid", 0.35), ("combo", 0.35), ("malformed", 0.1), ("source", 0.2)]
+SOURCE_MODES = {"predict", "track"}  # the `source` strategy only applies where a source argument is meaningful
+RESAMPLE_ATTEMPTS = 20  # draws allowed to find a command no prior run has executed before accepting a repeat
+HISTORY_LIMIT = 200_000  # explored-command hashes retained across runs (~3MB, ~50 days at current throughput)
 
 # Cost/hazard keys pinned to clamped known-good values, never mutated (`time` is training duration in HOURS)
 NEVER_MUTATE = frozenset(
@@ -62,7 +65,6 @@ NEVER_MUTATE = frozenset(
         "imgsz",
         "batch",
         "workers",
-        "device",
         "source",
         "project",
         "name",
@@ -116,6 +118,9 @@ ENUM_POOLS = {
     "auto_augment": {"valid": ["randaugment", "autoaugment", "augmix"], "invalid": ["randaug", ""]},
     "copy_paste_mode": {"valid": ["flip", "mixup"], "invalid": ["paste", ""]},
     "quantize": {"valid": ["fp16", "w8a8", "none"], "invalid": ["half", "int8_dynamic", "int4"]},
+    # CPU runners make every accelerator request invalid; `mps` is genuinely valid on the macOS shard, so an mps
+    # failure there tiers T2 instead of T1. Accepted: select_device is the layer under test, not the tier.
+    "device": {"valid": ["cpu"], "invalid": ["0,1", "cuda:5", "mps", "-1", "gpu0", "0"]},
 }
 PROBES = {  # boundary and wrong-type probes per typed key family (values are CLI strings)
     "fraction": {"valid": ["0.0", "1.0", "0.5"], "invalid": ["-0.1", "1.5", "half", "True", "none"]},
@@ -124,6 +129,17 @@ PROBES = {  # boundary and wrong-type probes per typed key family (values are CL
     "float": {"valid": ["0.0", "0.1", "10"], "invalid": ["-5", "big", "none"]},
 }
 CHAOS_PROBES = ["[]", "[1,2]", "{}", "🚀", "1e309", "nan", "-0"]  # chaos shard extras for any key, all invalid
+MALFORMED_KERNELS = [  # token-level CLI corruptions; see malformed_tokens()
+    "no_equals",
+    "bad_mode",
+    "bad_task",
+    "bare_word",
+    "dash_flag",
+    "empty_value",
+    "double_equals",
+    "split_list",
+    "typo_key",
+]
 
 # Valid-but-rare combinations (mode, extra args) — where the T1 semantic bugs live
 COMBO_POOL = [
@@ -172,6 +188,7 @@ EXPECTED_TYPES = {"SyntaxError", "ValueError", "TypeError", "AssertionError", "F
 EXPECTED_MODULES = (
     "ultralytics/cfg/__init__.py",
     "ultralytics/utils/checks.py",
+    "ultralytics/utils/torch_utils.py:select_device",  # the device-validation layer; its ValueError is intentional
     "ultralytics/data/utils.py",
     "ultralytics/data/augment.py:classify_augmentations",
     "ultralytics/data/loaders.py:__init__",  # source loaders ARE the source-validation layer; their raises are clean
@@ -314,7 +331,7 @@ def sample_trial(rng, uni, corpus, personality):
     mode = rng.choices(MODES, weights=[weights[m] for m in MODES])[0]
     base = rng.choice([c for c in corpus if c["mode"] == mode])
     argv, mutated = list(base["argv"]), []
-    strategies = STRATEGY_WEIGHTS if mode in {"predict", "track"} else STRATEGY_WEIGHTS[:2]
+    strategies = [(s, w) for s, w in STRATEGY_WEIGHTS if s != "source" or mode in SOURCE_MODES]
     strategy = rng.choices([s for s, _ in strategies], weights=[w for _, w in strategies])[0]
 
     validity = {}  # key -> is its EFFECTIVE value supported: stripped args contribute nothing, duplicates last-win
@@ -363,6 +380,12 @@ def sample_trial(rng, uni, corpus, personality):
         for _ in range(n_keys):
             key, value, valid = sample_mutation(rng, uni, chaos=personality == "chaos")
             mutate([f"{key}={value}"], valid=valid)
+    elif strategy == "malformed":  # appended raw: these tokens are deliberately not well-formed k=v pairs
+        for token in malformed_tokens(rng):
+            argv.append(token)
+            key = token.partition("=")[0]
+            mutated.append(key)
+            validity[key] = False
     else:
         source, valid = rng.choice(uni["sources"][mode])
         mutate([f"source={source}"], valid=valid)
@@ -407,6 +430,35 @@ def sample_mutation(rng, uni, chaos=False):
         return key, value, valid and probe_supported(key, value)
     value = rng.choice(pool["valid"] + pool["invalid"] + (CHAOS_PROBES if chaos else []))
     return key, value, value in pool["valid"] and probe_supported(key, value)
+
+
+def malformed_tokens(rng):
+    """Build CLI tokens malformed at the token level, the way users actually mistype `yolo` commands.
+
+    Value mutation alone never produces a malformed *token*, so the argument parser only ever sees well-formed
+    `k=v` pairs with known keys. Each kernel here mirrors a real signature from the package's own telemetry,
+    where `ultralytics.cfg:entrypoint` is a top error surface by user count. All of them should raise a clean
+    SyntaxError or ValueError from the cfg layer; anything deeper is a validation gap.
+    """
+    key = rng.choice(["data", "epochs", "imgsz", "conf", "model", "source"])
+    kernel = rng.choice(MALFORMED_KERNELS)
+    if kernel == "no_equals":
+        return [key]  # "'data' is a valid YOLO argument but is missing an '=' sign"
+    if kernel == "bad_mode":
+        return [f"mode={rng.choice(['checks', 'settings', 'help', 'traln'])}"]
+    if kernel == "bad_task":
+        return [f"task={rng.choice(['detection', 'segmentaion', 'classify_', ''])}"]
+    if kernel == "bare_word":
+        return [rng.choice(["yolo", "epochs10", "?", "coco8"])]
+    if kernel == "dash_flag":
+        return [f"{rng.choice(['--', '-'])}{key}", "1"]
+    if kernel == "empty_value":
+        return [f"{key}="]
+    if kernel == "double_equals":
+        return [f"{key}==1"]
+    if kernel == "split_list":
+        return ["classes=[0,", "2]"]  # an unquoted list the shell split into two tokens
+    return [f"{rng.choice(['epocs', 'imgz', 'batchsize', 'devise'])}=1"]  # near-miss key: exercises did-you-mean
 
 
 def run_trial(trial, timeout=None):
@@ -522,6 +574,23 @@ def stderr_tail(stderr, lines=30):
     return "\n".join(stderr.strip().splitlines()[-lines:])
 
 
+def command_hash(argv):
+    """Return a stable short hash of one exact command, used to dedupe draws within and across runs."""
+    return hashlib.sha256("\x00".join(argv).encode()).hexdigest()[:16]
+
+
+def read_history(path):
+    """Load the ordered command hashes explored by prior runs (empty when unset or absent)."""
+    return Path(path).read_text().split() if path and Path(path).exists() else []
+
+
+def write_history(path, history, new_keys):
+    """Persist this run's newly explored hashes, retaining the most recent HISTORY_LIMIT entries."""
+    if path:
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        Path(path).write_text("\n".join([*history, *new_keys][-HISTORY_LIMIT:]))
+
+
 def cmd_fuzz(args):
     """Run the budgeted fuzzing loop and write trials JSONL + findings JSON for the report job."""
     uni = load_universe()
@@ -607,31 +676,41 @@ def cmd_fuzz(args):
         changed = " ".join(a for a in trial["argv"] if a.partition("=")[0] in set(trial.get("mutated", [])))
         log.info(f"[fuzz] #{n} {outcome:>13} {duration:6.1f}s  yolo {trial['mode']} {trial['task']} {changed}".rstrip())
 
-    executed, duplicate_samples = set(), 0
+    history = read_history(args.history)  # commands explored by every prior run, so each run breaks new ground
+    explored, new_keys, duplicate_samples, saturated_samples = set(history), [], 0, 0
+    log.info(f"[fuzz] history: {len(history)} commands explored by prior runs")
     for base in corpus:  # canaries first: unmutated corpus must pass or the environment itself is broken
         if time.time() > deadline or (args.max_trials and n >= args.max_trials):
             break
-        executed.add(tuple(base["argv"]))
+        explored.add(command_hash(base["argv"]))
         execute(dict(base), canary=True)
     while time.time() < deadline and (not args.max_trials or n < args.max_trials):
         if shutil.disk_usage(tempfile.gettempdir()).free < MIN_FREE_GB * 1024**3:
             log.warning(f"[fuzz] stopping early: <{MIN_FREE_GB}GB free disk")
             break
-        trial = sample_trial(rng, uni, corpus, args.personality)
-        command = tuple(trial["argv"])
-        if command in executed:
+        for _ in range(RESAMPLE_ATTEMPTS):  # redraw until the command is one no run has executed before
+            trial = sample_trial(rng, uni, corpus, args.personality)
+            key = command_hash(trial["argv"])
+            if key not in explored:
+                break
             duplicate_samples += 1
-            continue
-        executed.add(command)
+        if key in explored:  # the reachable space is saturated for this personality: run the repeat rather than spin
+            saturated_samples += 1
+        else:
+            explored.add(key)
+            new_keys.append(key)
         execute(trial)
+    write_history(args.history, history, new_keys)
 
     infra_failed = bool(canary_results) and (canary_results.count(False) / len(canary_results)) > CANARY_FAIL_FRACTION
     summary = {
         "personality": args.personality,
         "seed": args.seed,
         "trials": n,
-        "unique_commands": len(executed),
+        "unique_commands": len(new_keys),  # never executed by this or any prior run
         "duplicate_samples": duplicate_samples,
+        "saturated_samples": saturated_samples,  # draws that repeated a prior command after RESAMPLE_ATTEMPTS
+        "history_size": len(history) + len(new_keys),
         "counters": counters,
         "infra_failed": infra_failed,
         "findings": sorted(findings.values(), key=lambda x: (x["tier"], x["signature"])),
@@ -701,7 +780,8 @@ def cmd_report(args):
         print("[report] no findings files found")
         return
     run_url = f"https://github.com/{args.repo}/actions/runs/{os.environ.get('GITHUB_RUN_ID', '')}"
-    findings, counters, flagged, unique_commands, duplicate_samples = {}, {}, [], 0, 0
+    findings, counters, flagged = {}, {}, []
+    unique_commands = duplicate_samples = saturated_samples = history_size = 0
     for shard in shards:
         for k, v in shard["counters"].items():
             counters[k] = counters.get(k, 0) + v
@@ -709,6 +789,8 @@ def cmd_report(args):
             flagged.append(shard["personality"])
         unique_commands += shard.get("unique_commands", shard["trials"])
         duplicate_samples += shard.get("duplicate_samples", 0)
+        saturated_samples += shard.get("saturated_samples", 0)
+        history_size += shard.get("history_size", 0)
         for f in shard["findings"]:
             prev = findings.get(f["signature"])
             if not prev or (prev["tier"] == "T2" and f["tier"] == "T1"):  # prefer the T1 view of a shared signature
@@ -853,7 +935,8 @@ def cmd_report(args):
     summary = (
         f"## Fuzz — {total} trials\n\n"
         + "\n".join(table)
-        + f"\n\nExploration: {unique_commands} unique commands · {duplicate_samples} duplicate samples skipped"
+        + f"\n\nExploration: {unique_commands} never-before-run commands · {duplicate_samples} duplicate draws"
+        + f" · {saturated_samples} saturated · {history_size} commands explored all-time"
         + f"\n\nNew issue threads created: {created} (cap {args.max_issues})"
         + (f" · ⚠️ shards with >20% canary failures: {', '.join(flagged)}" if flagged else "")
     )
@@ -908,6 +991,7 @@ def main():
     p.add_argument("--personality", choices=sorted(PERSONALITIES), default="chaos")
     p.add_argument("--out", default="fuzz-out")
     p.add_argument("--max-trials", type=int, default=0, help="optional hard trial cap (smoke tests)")
+    p.add_argument("--history", default=None, help="file of command hashes explored by prior runs, read and updated")
     p.add_argument("--debug-timeout", type=float, default=None, help="override all trial timeouts (test hang path)")
 
     p = sub.add_parser("repro", help="replay one exact command and classify it")

--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -435,10 +435,10 @@ def sample_mutation(rng, uni, chaos=False):
 def malformed_tokens(rng):
     """Build CLI tokens malformed at the token level, the way users actually mistype `yolo` commands.
 
-    Value mutation alone never produces a malformed *token*, so the argument parser only ever sees well-formed
-    `k=v` pairs with known keys. Each kernel here mirrors a real signature from the package's own telemetry,
-    where `ultralytics.cfg:entrypoint` is a top error surface by user count. All of them should raise a clean
-    SyntaxError or ValueError from the cfg layer; anything deeper is a validation gap.
+    Value mutation alone never produces a malformed *token*, so the argument parser only ever sees well-formed `k=v`
+    pairs with known keys. Each kernel here mirrors a real signature from the package's own telemetry, where
+    `ultralytics.cfg:entrypoint` is a top error surface by user count. All of them should raise a clean SyntaxError or
+    ValueError from the cfg layer; anything deeper is a validation gap.
     """
     key = rng.choice(["data", "epochs", "imgsz", "conf", "model", "source"])
     kernel = rng.choice(MALFORMED_KERNELS)

--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -51,7 +51,14 @@ PERSONALITIES = {  # mode-selection weights only; mutation kernel and classifier
     "predict-val": {"train": 0.05, "val": 0.35, "predict": 0.35, "track": 0.2, "export": 0.05},
     "chaos": {m: 0.2 for m in MODES},
 }
-STRATEGY_WEIGHTS = [("invalid", 0.3), ("combo", 0.3), ("malformed", 0.1), ("source", 0.15), ("dataset", 0.15)]
+STRATEGY_WEIGHTS = [
+    ("invalid", 0.3),
+    ("combo", 0.3),
+    ("malformed", 0.1),
+    ("model", 0.1),
+    ("source", 0.1),
+    ("dataset", 0.1),
+]
 STRATEGY_MODES = {"source": {"predict", "track"}, "dataset": {"train", "val"}}  # strategies limited to some modes
 RESAMPLE_ATTEMPTS = 20  # draws allowed to find a command no recent run has executed before accepting a repeat
 HISTORY_DAYS = 7  # re-explore a command once its history entry ages past this, so regressions are resampled
@@ -223,6 +230,8 @@ EXPECTED_MODULES = (
     "ultralytics/engine/exporter.py:__call__",  # intentional compat asserts; per-format bugs raise in deeper frames
     "ultralytics/data/base.py:get_img_files",  # the image-discovery validation layer
     "ultralytics/data/dataset.py:cache_labels",  # raises the clean "No labels found" summary; get_labels does not
+    "ultralytics/engine/model.py:_check_is_pytorch_model",  # only ever raises its intentional wrong-format error
+    "ultralytics/nn/autobackend.py:__init__",  # the format dispatcher; per-backend bugs raise in deeper frames
 )
 NETWORK_MARKERS = (  # specific download/network signatures only; bare ConnectionError is raised for local sources too
     "urlopen error",
@@ -281,6 +290,35 @@ def precache_assets(uni):
 
     prepare_sources(uni)
     prepare_datasets(uni)
+    prepare_models(uni)
+
+
+def prepare_models(uni):
+    """Create the corrupt and foreign model files used by model trials, derived from a cached corpus weight.
+
+    `model` is otherwise pinned, so checkpoint loading went unfuzzed even though corrupt and wrong-format
+    checkpoints are a top error surface in the package's telemetry. Every entry here is an unsupported input.
+    """
+    from ultralytics.utils import ASSETS, WEIGHTS_DIR
+    from ultralytics.utils.downloads import attempt_download_asset
+
+    root = WEIGHTS_DIR.parent / "fuzz-models"
+    root.mkdir(parents=True, exist_ok=True)
+    good = Path(attempt_download_asset(WEIGHTS_DIR / uni["task2model"]["detect"])).read_bytes()
+    image = (ASSETS / "bus.jpg").read_bytes()
+    blobs = {
+        "truncated.pt": good[: len(good) // 2],  # the "failed finding central directory" class of corruption
+        "header-only.pt": good[:512],
+        "empty.pt": b"",
+        "random-bytes.pt": bytes(range(256)) * 64,
+        "text.pt": b"not a checkpoint\n" * 16,
+        "image-as-pt.pt": image,
+        "garbage.onnx": b"not an onnx graph" * 100,  # right suffix, wrong contents
+        "image.jpg": image,  # a real image passed as model=, which autobackend rejects on format
+    }
+    for name, blob in blobs.items():
+        (root / name).write_bytes(blob)
+    uni["models"] = [str(root / name) for name in blobs]
 
 
 def prepare_datasets(uni):
@@ -467,6 +505,8 @@ def sample_trial(rng, uni, corpus, personality):
             key = token.partition("=")[0]
             mutated.append(key)
             validity[key] = False
+    elif strategy == "model":  # `model` is pinned for every other strategy; this one owns swapping it out
+        mutate([f"model={rng.choice(uni['models'])}"], valid=False)
     elif strategy == "dataset":  # `data` is pinned for every other strategy; this one owns swapping it out
         dataset, valid = rng.choice(uni["datasets"])
         mutate([f"data={dataset}"], valid=valid)
@@ -843,7 +883,8 @@ def cmd_repro(args):
 
             # PureWindowsPath splits on both separators, so Windows-origin issue commands remap on any OS.
             if k == "model":
-                candidates = [WEIGHTS_DIR / PureWindowsPath(v).name]
+                prepare_models(uni)  # corrupt fuzz models live beside the weights dir, not inside it
+                candidates = [WEIGHTS_DIR / PureWindowsPath(v).name, *(Path(p) for p in uni["models"])]
             elif k == "data":  # every synthetic dataset yaml is data.yaml, so the mutation directory identifies it
                 prepare_datasets(uni)
                 mutation = PureWindowsPath(v).parent.name

--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -52,9 +52,8 @@ PERSONALITIES = {  # mode-selection weights only; mutation kernel and classifier
     "chaos": {m: 0.2 for m in MODES},
 }
 STRATEGY_WEIGHTS = [("invalid", 0.35), ("combo", 0.35), ("malformed", 0.1), ("source", 0.2)]
-SOURCE_MODES = {"predict", "track"}  # the `source` strategy only applies where a source argument is meaningful
-RESAMPLE_ATTEMPTS = 20  # draws allowed to find a command no prior run has executed before accepting a repeat
-HISTORY_LIMIT = 200_000  # explored-command hashes retained across runs (~3MB, ~50 days at current throughput)
+RESAMPLE_ATTEMPTS = 20  # draws allowed to find a command no recent run has executed before accepting a repeat
+HISTORY_DAYS = 7  # re-explore a command once its history entry ages past this, so regressions are resampled
 
 # Cost/hazard keys pinned to clamped known-good values, never mutated (`time` is training duration in HOURS)
 NEVER_MUTATE = frozenset(
@@ -129,17 +128,6 @@ PROBES = {  # boundary and wrong-type probes per typed key family (values are CL
     "float": {"valid": ["0.0", "0.1", "10"], "invalid": ["-5", "big", "none"]},
 }
 CHAOS_PROBES = ["[]", "[1,2]", "{}", "🚀", "1e309", "nan", "-0"]  # chaos shard extras for any key, all invalid
-MALFORMED_KERNELS = [  # token-level CLI corruptions; see malformed_tokens()
-    "no_equals",
-    "bad_mode",
-    "bad_task",
-    "bare_word",
-    "dash_flag",
-    "empty_value",
-    "double_equals",
-    "split_list",
-    "typo_key",
-]
 
 # Valid-but-rare combinations (mode, extra args) — where the T1 semantic bugs live
 COMBO_POOL = [
@@ -331,7 +319,7 @@ def sample_trial(rng, uni, corpus, personality):
     mode = rng.choices(MODES, weights=[weights[m] for m in MODES])[0]
     base = rng.choice([c for c in corpus if c["mode"] == mode])
     argv, mutated = list(base["argv"]), []
-    strategies = [(s, w) for s, w in STRATEGY_WEIGHTS if s != "source" or mode in SOURCE_MODES]
+    strategies = [(s, w) for s, w in STRATEGY_WEIGHTS if s != "source" or mode in {"predict", "track"}]
     strategy = rng.choices([s for s, _ in strategies], weights=[w for _, w in strategies])[0]
 
     validity = {}  # key -> is its EFFECTIVE value supported: stripped args contribute nothing, duplicates last-win
@@ -441,24 +429,19 @@ def malformed_tokens(rng):
     ValueError from the cfg layer; anything deeper is a validation gap.
     """
     key = rng.choice(["data", "epochs", "imgsz", "conf", "model", "source"])
-    kernel = rng.choice(MALFORMED_KERNELS)
-    if kernel == "no_equals":
-        return [key]  # "'data' is a valid YOLO argument but is missing an '=' sign"
-    if kernel == "bad_mode":
-        return [f"mode={rng.choice(['checks', 'settings', 'help', 'traln'])}"]
-    if kernel == "bad_task":
-        return [f"task={rng.choice(['detection', 'segmentaion', 'classify_', ''])}"]
-    if kernel == "bare_word":
-        return [rng.choice(["yolo", "epochs10", "?", "coco8"])]
-    if kernel == "dash_flag":
-        return [f"{rng.choice(['--', '-'])}{key}", "1"]
-    if kernel == "empty_value":
-        return [f"{key}="]
-    if kernel == "double_equals":
-        return [f"{key}==1"]
-    if kernel == "split_list":
-        return ["classes=[0,", "2]"]  # an unquoted list the shell split into two tokens
-    return [f"{rng.choice(['epocs', 'imgz', 'batchsize', 'devise'])}=1"]  # near-miss key: exercises did-you-mean
+    return rng.choice(
+        [
+            [key],  # "'data' is a valid YOLO argument but is missing an '=' sign"
+            [f"mode={rng.choice(['checks', 'settings', 'help', 'traln'])}"],
+            [f"task={rng.choice(['detection', 'segmentaion', 'classify_', ''])}"],
+            [rng.choice(["yolo", "epochs10", "?", "coco8"])],  # bare word that is not an argument at all
+            [f"{rng.choice(['--', '-'])}{key}", "1"],  # argparse-style flag the yolo CLI does not use
+            [f"{key}="],
+            [f"{key}==1"],
+            ["classes=[0,", "2]"],  # an unquoted list the shell split into two tokens
+            [f"{rng.choice(['epocs', 'imgz', 'batchsize', 'devise'])}=1"],  # near-miss key: did-you-mean path
+        ]
+    )
 
 
 def run_trial(trial, timeout=None):
@@ -579,16 +562,27 @@ def command_hash(argv):
     return hashlib.sha256("\x00".join(argv).encode()).hexdigest()[:16]
 
 
-def read_history(path):
-    """Load the ordered command hashes explored by prior runs (empty when unset or absent)."""
-    return Path(path).read_text().split() if path and Path(path).exists() else []
+def read_history(path, max_age_days):
+    """Load `hash day` lines from prior runs, dropping entries older than max_age_days.
+
+    Expiry is what keeps exploration honest about regressions: this repository moves fast, so a command that
+    passed a week ago says nothing about today's code. Ageing each entry out individually gives a rolling
+    window rather than a cliff — every day drops the oldest day and every command is retried about weekly —
+    where permanent exclusion would mean a regression in already-covered ground was never resampled.
+    """
+    if not path or not Path(path).exists():
+        return []
+    cutoff = int(time.time() // 86400) - max_age_days
+    lines = (line.partition(" ") for line in Path(path).read_text().splitlines())
+    return [f"{key} {day}" for key, _, day in lines if key and day.isdigit() and int(day) >= cutoff]
 
 
 def write_history(path, history, new_keys):
-    """Persist this run's newly explored hashes, retaining the most recent HISTORY_LIMIT entries."""
+    """Persist this run's newly explored hashes, stamped with today so future runs can age them out."""
     if path:
+        today = int(time.time() // 86400)
         Path(path).parent.mkdir(parents=True, exist_ok=True)
-        Path(path).write_text("\n".join([*history, *new_keys][-HISTORY_LIMIT:]))
+        Path(path).write_text("\n".join([*history, *(f"{key} {today}" for key in new_keys)]))
 
 
 def cmd_fuzz(args):
@@ -676,9 +670,10 @@ def cmd_fuzz(args):
         changed = " ".join(a for a in trial["argv"] if a.partition("=")[0] in set(trial.get("mutated", [])))
         log.info(f"[fuzz] #{n} {outcome:>13} {duration:6.1f}s  yolo {trial['mode']} {trial['task']} {changed}".rstrip())
 
-    history = read_history(args.history)  # commands explored by every prior run, so each run breaks new ground
-    explored, new_keys, duplicate_samples, saturated_samples = set(history), [], 0, 0
-    log.info(f"[fuzz] history: {len(history)} commands explored by prior runs")
+    history = read_history(args.history, HISTORY_DAYS)  # recent runs' commands, so each run breaks new ground
+    explored = {line.partition(" ")[0] for line in history}
+    new_keys, duplicate_samples, saturated_samples = [], 0, 0
+    log.info(f"[fuzz] history: {len(history)} commands explored in the last {HISTORY_DAYS} days")
     for base in corpus:  # canaries first: unmutated corpus must pass or the environment itself is broken
         if time.time() > deadline or (args.max_trials and n >= args.max_trials):
             break
@@ -707,9 +702,9 @@ def cmd_fuzz(args):
         "personality": args.personality,
         "seed": args.seed,
         "trials": n,
-        "unique_commands": len(new_keys),  # never executed by this or any prior run
+        "unique_commands": len(new_keys),  # not executed by this or any run inside the history window
         "duplicate_samples": duplicate_samples,
-        "saturated_samples": saturated_samples,  # draws that repeated a prior command after RESAMPLE_ATTEMPTS
+        "saturated_samples": saturated_samples,  # draws that repeated a recent command after RESAMPLE_ATTEMPTS
         "history_size": len(history) + len(new_keys),
         "counters": counters,
         "infra_failed": infra_failed,
@@ -935,8 +930,8 @@ def cmd_report(args):
     summary = (
         f"## Fuzz — {total} trials\n\n"
         + "\n".join(table)
-        + f"\n\nExploration: {unique_commands} never-before-run commands · {duplicate_samples} duplicate draws"
-        + f" · {saturated_samples} saturated · {history_size} commands explored all-time"
+        + f"\n\nExploration: {unique_commands} newly explored commands · {duplicate_samples} duplicate draws"
+        + f" · {saturated_samples} saturated · {history_size} in the {HISTORY_DAYS}-day history window"
         + f"\n\nNew issue threads created: {created} (cap {args.max_issues})"
         + (f" · ⚠️ shards with >20% canary failures: {', '.join(flagged)}" if flagged else "")
     )

--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -51,7 +51,8 @@ PERSONALITIES = {  # mode-selection weights only; mutation kernel and classifier
     "predict-val": {"train": 0.05, "val": 0.35, "predict": 0.35, "track": 0.2, "export": 0.05},
     "chaos": {m: 0.2 for m in MODES},
 }
-STRATEGY_WEIGHTS = [("invalid", 0.35), ("combo", 0.35), ("malformed", 0.1), ("source", 0.2)]
+STRATEGY_WEIGHTS = [("invalid", 0.3), ("combo", 0.3), ("malformed", 0.1), ("source", 0.15), ("dataset", 0.15)]
+STRATEGY_MODES = {"source": {"predict", "track"}, "dataset": {"train", "val"}}  # strategies limited to some modes
 RESAMPLE_ATTEMPTS = 20  # draws allowed to find a command no recent run has executed before accepting a repeat
 HISTORY_DAYS = 7  # re-explore a command once its history entry ages past this, so regressions are resampled
 
@@ -129,6 +130,43 @@ PROBES = {  # boundary and wrong-type probes per typed key family (values are CL
 }
 CHAOS_PROBES = ["[]", "[1,2]", "{}", "🚀", "1e309", "nan", "-0"]  # chaos shard extras for any key, all invalid
 
+# Label file contents per dataset mutation; anything unlisted gets one well-formed box.
+LABEL_ROWS = {
+    "class-index-oob": "22 0.5 0.5 0.2 0.2",  # "Label class 22 exceeds dataset class count 1"
+    "coords-out-of-range": "0 1.5 0.5 0.2 0.2",
+    "negative-coords": "0 -0.5 0.5 0.2 0.2",
+    "wrong-columns": "0 0.5 0.5",
+    "nonnumeric": "cat 0.5 0.5 0.2 0.2",
+    "duplicate-rows": "0 0.5 0.5 0.2 0.2\n0 0.5 0.5 0.2 0.2",
+    "tiny-boxes": "0 0.5 0.5 0.0001 0.0001",
+    "background-only": "",
+}
+# Dataset mutation -> are its contents supported. `data` is otherwise pinned, leaving dataset loading — the
+# largest error surface by affected users in the package's telemetry — entirely unfuzzed. Background-only,
+# grayscale, webp and CRLF inputs ARE supported, so a deep failure on those is a T1 bug rather than a gap.
+DATASET_MUTATIONS = {
+    "baseline": True,
+    "background-only": True,
+    "mixed-background": True,
+    "grayscale": True,
+    "webp": True,
+    "crlf-labels": True,
+    "duplicate-rows": True,
+    "tiny-boxes": True,
+    "single-image": True,
+    "class-index-oob": False,
+    "coords-out-of-range": False,
+    "negative-coords": False,
+    "wrong-columns": False,
+    "nonnumeric": False,
+    "tiny-image": False,
+    "missing-val-key": False,
+    "missing-val-dir": False,
+    "nc-names-mismatch": False,
+    "bad-yaml": False,
+    "empty-train-dir": False,
+}
+
 # Valid-but-rare combinations (mode, extra args) — where the T1 semantic bugs live
 COMBO_POOL = [
     ("train", "rect=True"),
@@ -183,6 +221,8 @@ EXPECTED_MODULES = (
     "ultralytics/engine/trainer.py:_build_train_pipeline",  # actual train batch/imgsz validation before optimizer setup
     "ultralytics/engine/exporter.py:validate_args",  # exporter's intentional per-format argument validation
     "ultralytics/engine/exporter.py:__call__",  # intentional compat asserts; per-format bugs raise in deeper frames
+    "ultralytics/data/base.py:get_img_files",  # the image-discovery validation layer
+    "ultralytics/data/dataset.py:cache_labels",  # raises the clean "No labels found" summary; get_labels does not
 )
 NETWORK_MARKERS = (  # specific download/network signatures only; bare ConnectionError is raised for local sources too
     "urlopen error",
@@ -240,6 +280,57 @@ def precache_assets(uni):
         attempt_download_asset(WEIGHTS_DIR / model)
 
     prepare_sources(uni)
+    prepare_datasets(uni)
+
+
+def prepare_datasets(uni):
+    """Create the synthetic detect datasets used by dataset trials, one directory per mutation."""
+    from ultralytics.utils import WEIGHTS_DIR
+
+    root = WEIGHTS_DIR.parent / "fuzz-datasets"
+    uni["datasets"] = [(str(make_dataset(root / name, name)), valid) for name, valid in DATASET_MUTATIONS.items()]
+
+
+def make_dataset(root, mutation):
+    """Build one synthetic detect dataset under root and return the path to its YAML.
+
+    Generated entirely on disk with no downloads, so the whole pool is a few KB of 64px images against the
+    multi-MB curated corpora. Each mutation reproduces a failure signature users actually hit.
+    """
+    from PIL import Image
+
+    shutil.rmtree(root, ignore_errors=True)
+    extension = "webp" if mutation == "webp" else "jpg"
+    image_mode = "L" if mutation == "grayscale" else "RGB"
+    size = (8, 8) if mutation == "tiny-image" else (64, 64)  # the loader requires >9px, so 8px is a rejection
+    rows = LABEL_ROWS.get(mutation, "0 0.5 0.5 0.2 0.2")
+    if mutation == "crlf-labels":
+        rows = rows.replace("\n", "\r\n") + "\r\n"
+    count = 1 if mutation == "single-image" else 4
+    for split in ("train", "val"):
+        images, labels = root / "images" / split, root / "labels" / split
+        images.mkdir(parents=True, exist_ok=True)
+        labels.mkdir(parents=True, exist_ok=True)
+        if mutation == "empty-train-dir" and split == "train":
+            continue
+        for i in range(count):
+            shade = i * 60 % 256
+            Image.new(image_mode, size, shade if image_mode == "L" else (shade, shade, 90)).save(
+                images / f"{i}.{extension}"
+            )
+            # mixed-background leaves only the odd images labelled, the batch composition all-background misses
+            (labels / f"{i}.txt").write_text("" if mutation == "mixed-background" and i % 2 == 0 else rows)
+    if mutation == "missing-val-dir":
+        shutil.rmtree(root / "images" / "val")
+    yaml = f"path: {root}\ntrain: images/train\nval: images/val\nnames:\n  0: item\n"
+    if mutation == "missing-val-key":
+        yaml = f"path: {root}\ntrain: images/train\nnames:\n  0: item\n"
+    elif mutation == "nc-names-mismatch":
+        yaml = f"path: {root}\ntrain: images/train\nval: images/val\nnc: 1\nnames: [a, b, c, d]\n"
+    elif mutation == "bad-yaml":
+        yaml = f"path: {root}\ntrain: [images/train\nval: images/val\nnames: {{0: item\n"
+    (root / "data.yaml").write_text(yaml)
+    return root / "data.yaml"
 
 
 def prepare_sources(uni):
@@ -314,13 +405,15 @@ def build_corpus(uni):
 
 
 def sample_trial(rng, uni, corpus, personality):
-    """Sample one trial with canonical arguments from invalid, valid-combination, or source strategies."""
+    """Sample one trial with canonical arguments from one of the mutation strategies."""
     weights = PERSONALITIES[personality]
     mode = rng.choices(MODES, weights=[weights[m] for m in MODES])[0]
-    base = rng.choice([c for c in corpus if c["mode"] == mode])
-    argv, mutated = list(base["argv"]), []
-    strategies = [(s, w) for s, w in STRATEGY_WEIGHTS if s != "source" or mode in {"predict", "track"}]
+    strategies = [(s, w) for s, w in STRATEGY_WEIGHTS if mode in STRATEGY_MODES.get(s, MODES)]
     strategy = rng.choices([s for s, _ in strategies], weights=[w for _, w in strategies])[0]
+    # the synthetic datasets are detect-format, so dataset trials must start from a detect base
+    pool = [c for c in corpus if c["mode"] == mode and (strategy != "dataset" or c["task"] == "detect")]
+    base = rng.choice(pool)
+    argv, mutated = list(base["argv"]), []
 
     validity = {}  # key -> is its EFFECTIVE value supported: stripped args contribute nothing, duplicates last-win
 
@@ -374,6 +467,11 @@ def sample_trial(rng, uni, corpus, personality):
             key = token.partition("=")[0]
             mutated.append(key)
             validity[key] = False
+    elif strategy == "dataset":  # `data` is pinned for every other strategy; this one owns swapping it out
+        dataset, valid = rng.choice(uni["datasets"])
+        mutate([f"data={dataset}"], valid=valid)
+        mutate_combos(max_groups=2)  # combine with rect/single_cls/etc, where dataset-shape bugs actually surface
+        mutate_boundary()
     else:
         source, valid = rng.choice(uni["sources"][mode])
         mutate([f"source={source}"], valid=valid)
@@ -545,6 +643,18 @@ def classify(trial, rc, stderr):
         or (exc == "NotImplementedError" and "not found in list of available optimizers" in stderr)
         or (exc == "ValueError" and "Expected `mode` to be `flip` or `mixup`" in stderr)
         or (exc == "AssertionError" and "RTDETR export requires opset>=16" in stderr)
+        # Both dataset-validation layers summarise as RuntimeError, so the wrapper — not data/utils.py — is the
+        # deepest frame: get_dataset re-raises YAML errors, and get_labels reports the per-file reasons once the
+        # label cache exists (an uncached first trial raises ValueError from cache_labels instead). Excused only
+        # for trials that deliberately supplied an unsupported dataset: a supported one failing here, or a
+        # malformed one failing anywhere else, still reports.
+        or (
+            exc == "RuntimeError"
+            and trial.get("strategy") == "dataset"
+            and not trial.get("valid_input", True)
+            and frames
+            and frames[-1] in {"ultralytics/engine/trainer.py:get_dataset", "ultralytics/data/dataset.py:get_labels"}
+        )
         or (exc in EXPECTED_TYPES and frames and frames[-1].startswith(EXPECTED_MODULES))
     ):
         return "expected", None, None  # clean validation errors are expected only for trials we actually mutated
@@ -726,14 +836,18 @@ def cmd_repro(args):
         argv = argv[1:]
 
     def portable(arg):
-        """Remap runner-local absolute model/source paths from issue commands to this machine's copies."""
+        """Remap runner-local absolute model/source/data paths from issue commands to this machine's copies."""
         k, _, v = arg.partition("=")
-        if k in {"model", "source"} and ("/" in v or "\\" in v) and not Path(v).exists():
+        if k in {"model", "source", "data"} and ("/" in v or "\\" in v) and not Path(v).exists():
             from ultralytics.utils import ASSETS, WEIGHTS_DIR
 
             # PureWindowsPath splits on both separators, so Windows-origin issue commands remap on any OS.
             if k == "model":
                 candidates = [WEIGHTS_DIR / PureWindowsPath(v).name]
+            elif k == "data":  # every synthetic dataset yaml is data.yaml, so the mutation directory identifies it
+                prepare_datasets(uni)
+                mutation = PureWindowsPath(v).parent.name
+                candidates = [Path(p) for p, _valid in uni["datasets"] if Path(p).parent.name == mutation]
             else:
                 prepare_sources(uni)
                 candidates = [ASSETS, ASSETS / PureWindowsPath(v).name]

--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -565,10 +565,10 @@ def command_hash(argv):
 def read_history(path, max_age_days):
     """Load `hash day` lines from prior runs, dropping entries older than max_age_days.
 
-    Expiry is what keeps exploration honest about regressions: this repository moves fast, so a command that
-    passed a week ago says nothing about today's code. Ageing each entry out individually gives a rolling
-    window rather than a cliff — every day drops the oldest day and every command is retried about weekly —
-    where permanent exclusion would mean a regression in already-covered ground was never resampled.
+    Expiry is what keeps exploration honest about regressions: this repository moves fast, so a command that passed a
+    week ago says nothing about today's code. Ageing each entry out individually gives a rolling window rather than a
+    cliff — every day drops the oldest day and every command is retried about weekly — where permanent exclusion would
+    mean a regression in already-covered ground was never resampled.
     """
     if not path or not Path(path).exists():
         return []

--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -137,17 +137,6 @@ PROBES = {  # boundary and wrong-type probes per typed key family (values are CL
 }
 CHAOS_PROBES = ["[]", "[1,2]", "{}", "🚀", "1e309", "nan", "-0"]  # chaos shard extras for any key, all invalid
 
-# Label file contents per dataset mutation; anything unlisted gets one well-formed box.
-LABEL_ROWS = {
-    "class-index-oob": "22 0.5 0.5 0.2 0.2",  # "Label class 22 exceeds dataset class count 1"
-    "coords-out-of-range": "0 1.5 0.5 0.2 0.2",
-    "negative-coords": "0 -0.5 0.5 0.2 0.2",
-    "wrong-columns": "0 0.5 0.5",
-    "nonnumeric": "cat 0.5 0.5 0.2 0.2",
-    "duplicate-rows": "0 0.5 0.5 0.2 0.2\n0 0.5 0.5 0.2 0.2",
-    "tiny-boxes": "0 0.5 0.5 0.0001 0.0001",
-    "background-only": "",
-}
 # Dataset mutation -> are its contents supported. `data` is otherwise pinned, leaving dataset loading — the
 # largest error surface by affected users in the package's telemetry — entirely unfuzzed. Background-only,
 # grayscale, webp and CRLF inputs ARE supported, so a deep failure on those is a T1 bug rather than a gap.
@@ -225,12 +214,12 @@ EXPECTED_MODULES = (
     "ultralytics/data/utils.py",
     "ultralytics/data/augment.py:classify_augmentations",
     "ultralytics/data/loaders.py:__init__",  # source loaders ARE the source-validation layer; their raises are clean
-    "ultralytics/engine/trainer.py:_build_train_pipeline",  # actual train batch/imgsz validation before optimizer setup
-    "ultralytics/engine/exporter.py:validate_args",  # exporter's intentional per-format argument validation
-    "ultralytics/engine/exporter.py:__call__",  # intentional compat asserts; per-format bugs raise in deeper frames
     "ultralytics/data/base.py:get_img_files",  # the image-discovery validation layer
     "ultralytics/data/dataset.py:cache_labels",  # raises the clean "No labels found" summary; get_labels does not
+    "ultralytics/engine/trainer.py:_build_train_pipeline",  # actual train batch/imgsz validation before optimizer setup
     "ultralytics/engine/model.py:_check_is_pytorch_model",  # only ever raises its intentional wrong-format error
+    "ultralytics/engine/exporter.py:validate_args",  # exporter's intentional per-format argument validation
+    "ultralytics/engine/exporter.py:__call__",  # intentional compat asserts; per-format bugs raise in deeper frames
     "ultralytics/nn/autobackend.py:__init__",  # the format dispatcher; per-backend bugs raise in deeper frames
 )
 NETWORK_MARKERS = (  # specific download/network signatures only; bare ConnectionError is raised for local sources too
@@ -308,10 +297,8 @@ def prepare_models(uni):
     image = (ASSETS / "bus.jpg").read_bytes()
     blobs = {
         "truncated.pt": good[: len(good) // 2],  # the "failed finding central directory" class of corruption
-        "header-only.pt": good[:512],
         "empty.pt": b"",
         "random-bytes.pt": bytes(range(256)) * 64,
-        "text.pt": b"not a checkpoint\n" * 16,
         "image-as-pt.pt": image,
         "garbage.onnx": b"not an onnx graph" * 100,  # right suffix, wrong contents
         "image.jpg": image,  # a real image passed as model=, which autobackend rejects on format
@@ -341,7 +328,16 @@ def make_dataset(root, mutation):
     extension = "webp" if mutation == "webp" else "jpg"
     image_mode = "L" if mutation == "grayscale" else "RGB"
     size = (8, 8) if mutation == "tiny-image" else (64, 64)  # the loader requires >9px, so 8px is a rejection
-    rows = LABEL_ROWS.get(mutation, "0 0.5 0.5 0.2 0.2")
+    rows = {  # label file contents; anything unlisted gets one well-formed box
+        "class-index-oob": "22 0.5 0.5 0.2 0.2",  # "Label class 22 exceeds dataset class count 1"
+        "coords-out-of-range": "0 1.5 0.5 0.2 0.2",
+        "negative-coords": "0 -0.5 0.5 0.2 0.2",
+        "wrong-columns": "0 0.5 0.5",
+        "nonnumeric": "cat 0.5 0.5 0.2 0.2",
+        "duplicate-rows": "0 0.5 0.5 0.2 0.2\n0 0.5 0.5 0.2 0.2",
+        "tiny-boxes": "0 0.5 0.5 0.0001 0.0001",
+        "background-only": "",
+    }.get(mutation, "0 0.5 0.5 0.2 0.2")
     if mutation == "crlf-labels":
         rows = rows.replace("\n", "\r\n") + "\r\n"
     count = 1 if mutation == "single-image" else 4

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -79,13 +79,14 @@ jobs:
             ultralytics-fuzz-assets-${{ runner.os }}-
             ultralytics-test-assets-${{ runner.os }}-
       - name: Cache fuzz exploration history
-        # Separate from the asset cache: this entry is rewritten every run (cache keys are immutable, so the key
-        # carries the run id and restore-keys picks up the newest prior entry) while the multi-GB assets are not.
-        # Entries age out inside fuzz.py (--history-days), so the file stays bounded without a second expiry here.
+        # Separate from the asset cache: this entry is rewritten every run while the multi-GB assets are not. Cache
+        # entries are immutable, so the key carries run id AND attempt — a re-run reuses the run id and would
+        # otherwise hit its own entry, skip the save, and discard everything it explored. restore-keys then picks
+        # up the newest prior entry. Entries age out inside fuzz.py (HISTORY_DAYS), bounding the file.
         uses: actions/cache@v6
         with:
           path: fuzz-history
-          key: ultralytics-fuzz-history-${{ matrix.personality }}-${{ github.run_id }}
+          key: ultralytics-fuzz-history-${{ matrix.personality }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
             ultralytics-fuzz-history-${{ matrix.personality }}-
       - name: Precache fuzz assets

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -78,6 +78,15 @@ jobs:
           restore-keys: |
             ultralytics-fuzz-assets-${{ runner.os }}-
             ultralytics-test-assets-${{ runner.os }}-
+      - name: Cache fuzz exploration history
+        # Separate from the asset cache: this entry is rewritten every run (cache keys are immutable, so the key
+        # carries the run id and restore-keys picks up the newest prior entry) while the multi-GB assets are not.
+        uses: actions/cache@v6
+        with:
+          path: fuzz-history
+          key: ultralytics-fuzz-history-${{ matrix.personality }}-${{ github.run_id }}
+          restore-keys: |
+            ultralytics-fuzz-history-${{ matrix.personality }}-
       - name: Precache fuzz assets
         if: github.event.inputs.repro_command == ''
         uses: ultralytics/actions/retry@main
@@ -94,6 +103,7 @@ jobs:
             --budget-minutes "$MINUTES" \
             --seed ${{ github.run_id }} \
             --personality ${{ matrix.personality }} \
+            --history fuzz-history/${{ matrix.personality }}.txt \
             --out fuzz-out
       - name: Reproduce command
         if: github.event.inputs.repro_command != '' && matrix.personality == 'chaos'

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -81,6 +81,7 @@ jobs:
       - name: Cache fuzz exploration history
         # Separate from the asset cache: this entry is rewritten every run (cache keys are immutable, so the key
         # carries the run id and restore-keys picks up the newest prior entry) while the multi-GB assets are not.
+        # Entries age out inside fuzz.py (--history-days), so the file stays bounded without a second expiry here.
         uses: actions/cache@v6
         with:
           path: fuzz-history

--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,4 @@ results.csv
 # Fuzz media and datasets generated beside the weights dir, which is the checkout root outside CI
 fuzz-sources/
 fuzz-datasets/
+fuzz-models/

--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,7 @@ results.csv
 
 # CI test asset cache
 .ultralytics_cache/
+
+# Fuzz media and datasets generated beside the weights dir, which is the checkout root outside CI
+fuzz-sources/
+fuzz-datasets/


### PR DESCRIPTION
## Why

The daily Fuzz workflow filed no new issues after 2026-07-22, but not because it stopped looking — it runs **~13.6k trials/day**. It kept looking in the same place.

| Run | Trials | bug-candidates | Distinct signatures | New issues |
|---|---|---|---|---|
| Jul 22 | 12,741 | 151 | 3 | 1 (#25361) |
| Jul 23 | 14,336 | 164 | 2 | 0 |
| Jul 25 | 13,596 | 136 | 4 | 0 |

Two independent causes, both addressed here:

1. **The sampler re-covered its own ground.** A birthday estimate off the duplicate counters puts its effective support at ~30k commands, and `executed` was per-run only.
2. **The most-used surfaces were unreachable.** `model`, `data` and `device` are pinned in `NEVER_MUTATE` — and per the package's own telemetry they are exactly where users break.

## Exploration

**Cross-run history on a rolling 7-day window.** A small dedicated Actions cache (keyed by run id *and* run attempt — a re-run reuses the run id and would otherwise hit its own immutable entry, skip the save, and discard everything it explored) carries command hashes forward. Draws resample up to `RESAMPLE_ATTEMPTS` for something no recent run has executed; when a personality's space is genuinely exhausted the loop runs a repeat rather than spinning, and `saturated_samples` surfaces that in the run summary.

Entries age out **individually**, so a regression in already-covered ground still gets resampled — this repo moves fast enough that a command passing last week says nothing about today. A rolling window retries everything after ~7 days; a whole-file reset would swing between total novelty and total saturation. At ~4.4k draws/day against a ~30k space, 7 days is about one full pass.

## New axes, ordered by telemetry

| Axis | Telemetry | What it adds |
|---|---|---|
| **Datasets** | ~8.8k events / ~400 users | 20 detect datasets generated on disk, **90 KB total**, no downloads (vs 6.9–65 MB per pinned corpus) |
| **CLI tokens** | ~1.9k events / ~130 users | 9 token-level corruptions: missing `=`, `mode=checks`, bare words, `--flags`, near-miss keys |
| **Device** | ~1.5k events / 200 users | `device=0,1`, `cuda:5`, `mps`, `gpu0` — `select_device` was unreachable |
| **Checkpoints** | ~750 events / ~118 users | 8 corrupt/foreign model files derived from a cached weight |

Dataset and model trials combine with the existing combo/boundary mutations, so each axis multiplies into the explored space rather than adding a fixed pool. Half the dataset mutations are *supported* inputs (background-only, grayscale, webp, CRLF labels), so a deep failure there is a T1 bug, not a validation gap.

## The oracle changes are the substance

Every axis was measured against the real classifier **before** being wired up, which is what caught these:

- **Datasets would have filed 11 false positives on day one.** Both validation layers summarise as `RuntimeError`, so the deepest frame is the wrapper, not `data/utils.py`: `trainer.py:get_dataset` re-raises YAML errors, and `dataset.py:get_labels` reports per-file reasons once the label cache exists — an uncached first trial instead raises `ValueError` from `cache_labels`, so classification depended on cache state.
- **Unpinning `device` alone would have flooded findings**, since `select_device`'s `ValueError` is the intentional clean error.
- **Checkpoints:** `_check_is_pytorch_model` and `autobackend.__init__` reject cleanly and are excused; the raw-loader leaks are deliberately left reportable.

Every exemption is narrow: the dataset one applies only to `dataset`-strategy trials that deliberately supplied an unsupported dataset, in two named frames. `get_labels` is not blanket-excused, so its `IndexError` class of bug (#25138) stays reportable.

## What it already found

Corrupt checkpoints leak raw loader internals with no ultralytics-level message — `PytorchStreamReader failed reading zip archive`, `Ran out of input`, `invalid load key` — three exception types for one condition, matching a **456-event / 101-user** telemetry cluster. Fixed separately in **#25428**, which should merge first so this lands quiet; otherwise this axis files 3 issues about a bug already fixed there.

The 4th signature, a raw `onnxruntime InvalidProtobuf` from `nn/backends/onnx.py:load_model`, is the same class in a different backend and is left reportable.

## Verification

All local, all measured:

| Check | Result |
|---|---|
| Dataset mutations classified | 20/20 correct — 8 train, 12 clean errors, **0 false positives**, 0 malformed datasets silently training |
| Model files classified | 8/8 — 3 clean rejections excused, 4 gap signatures reported |
| Malformed CLI + device probes | 15/15 `expected` or `pass` |
| Same-seed replay vs populated history | 974 duplicate draws, resampled past them, **817 commands never run before** (previously: identical 900 rerun) |
| History expiry | ages out by day, survivors persist, pre-expiry unstamped lines self-heal |
| Sampling coverage | 20/20 datasets, 8/8 models, correctly mode- and task-constrained |
| Cross-machine repro | Windows-origin dataset and model paths remap to local copies |
| Trial cost | datasets 2.7–5.3s, models ≤1.2s, malformed ~0.7s (vs 30–180s for existing train trials) |

`repro` now remaps `data=` and `model=` the way it already remapped `source=`, so filed issues reproduce across machines. Generated `fuzz-datasets/`, `fuzz-models/` and the pre-existing `fuzz-sources/` are gitignored — they land in the checkout root outside CI.

## Note

`background-only` trains cleanly, so this does **not** yet reproduce the `loss.py:get_assigned_targets_and_loss` tensor-size-0 crash from telemetry. `mixed-background` is included because uniform all-background batches are the likelier miss; combining it with the existing `rect`/`single_cls` combos is what should surface it. Unconfirmed, stated as such.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧪 Expands Ultralytics CI fuzz testing to cover malformed commands, invalid models, synthetic datasets, device settings, and cross-run command history.

### 📊 Key Changes

- Added new fuzzing strategies for:
  - Malformed CLI tokens and mistyped arguments.
  - Corrupt, unsupported, or incorrectly formatted model files.
  - Valid and invalid synthetic dataset configurations.
  - Device-validation inputs such as unsupported CUDA, MPS, and GPU values.
- Added generated test assets for corrupted models and dataset mutations, including:
  - Missing or malformed YAML fields.
  - Invalid labels and coordinates.
  - Empty directories, tiny images, grayscale images, WebP files, and background-only data.
- Expanded expected validation locations to recognize clean errors from model loading, dataset discovery, device selection, and backend initialization.
- Added command hashing and a rolling seven-day history to avoid repeatedly testing recently explored commands.
- Added resampling limits and saturation tracking when the available fuzzing space is exhausted.
- Updated the fuzzing GitHub Actions workflow to cache exploration history between runs.
- Enhanced reproduction support to remap local model and dataset paths.
- Added generated fuzz assets to `.gitignore`.

### 🎯 Purpose & Impact

- 🔍 Improves coverage of high-impact failure areas that were previously largely untested, especially dataset loading and checkpoint validation.
- 🛡️ Helps detect regressions in CLI parsing, device validation, model import, and data handling earlier in CI.
- ⚡ Makes fuzzing more efficient by prioritizing new commands instead of repeating recent trials.
- 📈 Enables broader, more realistic testing while preserving expected behavior for intentionally invalid inputs.
- 🧰 Provides more reliable reproduction of fuzz findings across different machines and CI environments.