### PR TITLE
Fuzz checkpoint loading with corrupt and foreign model files

### DIFF
--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -296,8 +296,8 @@ def precache_assets(uni):
 def prepare_models(uni):
     """Create the corrupt and foreign model files used by model trials, derived from a cached corpus weight.
 
-    `model` is otherwise pinned, so checkpoint loading went unfuzzed even though corrupt and wrong-format
-    checkpoints are a top error surface in the package's telemetry. Every entry here is an unsupported input.
+    `model` is otherwise pinned, so checkpoint loading went unfuzzed even though corrupt and wrong-format checkpoints
+    are a top error surface in the package's telemetry. Every entry here is an unsupported input.
     """
     from ultralytics.utils import ASSETS, WEIGHTS_DIR
     from ultralytics.utils.downloads import attempt_download_asset
@@ -332,8 +332,8 @@ def prepare_datasets(uni):
 def make_dataset(root, mutation):
     """Build one synthetic detect dataset under root and return the path to its YAML.
 
-    Generated entirely on disk with no downloads, so the whole pool is a few KB of 64px images against the
-    multi-MB curated corpora. Each mutation reproduces a failure signature users actually hit.
+    Generated entirely on disk with no downloads, so the whole pool is a few KB of 64px images against the multi-MB
+    curated corpora. Each mutation reproduces a failure signature users actually hit.
     """
     from PIL import Image
 

--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -51,7 +51,14 @@ PERSONALITIES = {  # mode-selection weights only; mutation kernel and classifier
     "predict-val": {"train": 0.05, "val": 0.35, "predict": 0.35, "track": 0.2, "export": 0.05},
     "chaos": {m: 0.2 for m in MODES},
 }
-STRATEGY_WEIGHTS = [("invalid", 0.3), ("combo", 0.3), ("malformed", 0.1), ("source", 0.15), ("dataset", 0.15)]
+STRATEGY_WEIGHTS = [
+    ("invalid", 0.3),
+    ("combo", 0.3),
+    ("malformed", 0.1),
+    ("model", 0.1),
+    ("source", 0.1),
+    ("dataset", 0.1),
+]
 STRATEGY_MODES = {"source": {"predict", "track"}, "dataset": {"train", "val"}}  # strategies limited to some modes
 RESAMPLE_ATTEMPTS = 20  # draws allowed to find a command no recent run has executed before accepting a repeat
 HISTORY_DAYS = 7  # re-explore a command once its history entry ages past this, so regressions are resampled
@@ -223,6 +230,8 @@ EXPECTED_MODULES = (
     "ultralytics/engine/exporter.py:__call__",  # intentional compat asserts; per-format bugs raise in deeper frames
     "ultralytics/data/base.py:get_img_files",  # the image-discovery validation layer
     "ultralytics/data/dataset.py:cache_labels",  # raises the clean "No labels found" summary; get_labels does not
+    "ultralytics/engine/model.py:_check_is_pytorch_model",  # only ever raises its intentional wrong-format error
+    "ultralytics/nn/autobackend.py:__init__",  # the format dispatcher; per-backend bugs raise in deeper frames
 )
 NETWORK_MARKERS = (  # specific download/network signatures only; bare ConnectionError is raised for local sources too
     "urlopen error",
@@ -281,6 +290,35 @@ def precache_assets(uni):
 
     prepare_sources(uni)
     prepare_datasets(uni)
+    prepare_models(uni)
+
+
+def prepare_models(uni):
+    """Create the corrupt and foreign model files used by model trials, derived from a cached corpus weight.
+
+    `model` is otherwise pinned, so checkpoint loading went unfuzzed even though corrupt and wrong-format
+    checkpoints are a top error surface in the package's telemetry. Every entry here is an unsupported input.
+    """
+    from ultralytics.utils import ASSETS, WEIGHTS_DIR
+    from ultralytics.utils.downloads import attempt_download_asset
+
+    root = WEIGHTS_DIR.parent / "fuzz-models"
+    root.mkdir(parents=True, exist_ok=True)
+    good = Path(attempt_download_asset(WEIGHTS_DIR / uni["task2model"]["detect"])).read_bytes()
+    image = (ASSETS / "bus.jpg").read_bytes()
+    blobs = {
+        "truncated.pt": good[: len(good) // 2],  # the "failed finding central directory" class of corruption
+        "header-only.pt": good[:512],
+        "empty.pt": b"",
+        "random-bytes.pt": bytes(range(256)) * 64,
+        "text.pt": b"not a checkpoint\n" * 16,
+        "image-as-pt.pt": image,
+        "garbage.onnx": b"not an onnx graph" * 100,  # right suffix, wrong contents
+        "image.jpg": image,  # a real image passed as model=, which autobackend rejects on format
+    }
+    for name, blob in blobs.items():
+        (root / name).write_bytes(blob)
+    uni["models"] = [str(root / name) for name in blobs]
 
 
 def prepare_datasets(uni):
@@ -467,6 +505,8 @@ def sample_trial(rng, uni, corpus, personality):
             key = token.partition("=")[0]
             mutated.append(key)
             validity[key] = False
+    elif strategy == "model":  # `model` is pinned for every other strategy; this one owns swapping it out
+        mutate([f"model={rng.choice(uni['models'])}"], valid=False)
     elif strategy == "dataset":  # `data` is pinned for every other strategy; this one owns swapping it out
         dataset, valid = rng.choice(uni["datasets"])
         mutate([f"data={dataset}"], valid=valid)
@@ -843,7 +883,8 @@ def cmd_repro(args):
 
             # PureWindowsPath splits on both separators, so Windows-origin issue commands remap on any OS.
             if k == "model":
-                candidates = [WEIGHTS_DIR / PureWindowsPath(v).name]
+                prepare_models(uni)  # corrupt fuzz models live beside the weights dir, not inside it
+                candidates = [WEIGHTS_DIR / PureWindowsPath(v).name, *(Path(p) for p in uni["models"])]
             elif k == "data":  # every synthetic dataset yaml is data.yaml, so the mutation directory identifies it
                 prepare_datasets(uni)
                 mutation = PureWindowsPath(v).parent.name

--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,4 @@ results.csv
 # Fuzz media and datasets generated beside the weights dir, which is the checkout root outside CI
 fuzz-sources/
 fuzz-datasets/
+fuzz-models/


### PR DESCRIPTION
> Stacked on #25426 (which is stacked on #25424). Base retargets automatically as those merge — review only this branch's commit.

## Why

`model` is pinned in `NEVER_MUTATE`, so checkpoint loading was unfuzzed — despite being a top error surface in the package's own telemetry:

| Surface | Events / users |
|---|---|
| `torch.serialization` corrupt checkpoint | 456 / 101 |
| `nn.autobackend.__init__` unsupported format | 295 / 17 |
| `engine.model._check_is_pytorch_model` wrong suffix | 224 / 91 |

## What changed

A `model` strategy over **eight locally derived files** — a real checkpoint truncated in half, a 512-byte header, an empty file, random bytes, text, an image renamed to `.pt`, an `.onnx` with the right suffix and garbage contents, and a real `.jpg` passed as `model=`. All built from an already-cached corpus weight, nothing downloaded. Trials cost **under 1.2s** because they fail at load.

Two frames join `EXPECTED_MODULES` because their rejections are the intended clean errors:

- `engine/model.py:_check_is_pytorch_model` — does nothing but raise the wrong-format `TypeError`, so it's precise
- `nn/autobackend.py:__init__` — the format dispatcher; per-backend bugs surface in deeper frames, which the onnx case below actually demonstrates

## What this immediately found

The remaining failures are **deliberately left reportable** — measuring them is the point of the axis. Corrupt checkpoints leak raw loader exceptions with no ultralytics-level message:

| Input | Leaked exception | Frame |
|---|---|---|
| `truncated.pt`, `header-only.pt` | `RuntimeError: PytorchStreamReader failed reading zip archive: failed finding central directory` | `utils/patches.py:torch_load` |
| `empty.pt` | `EOFError: Ran out of input` | `utils/patches.py:torch_load` |
| `random-bytes.pt`, `text.pt`, `image-as-pt.pt` | `_pickle.UnpicklingError: invalid load key` | `utils/patches.py:torch_load` |
| `garbage.onnx` (predict) | `onnxruntime InvalidProtobuf` | `nn/backends/onnx.py:load_model` |

Four distinct signatures, three of them from `torch_load`, all corroborated by the 456-event / 101-user telemetry cluster above. `torch_load` (`utils/patches.py:160`) passes straight through to `torch.load` with no error handling, so every malformed checkpoint surfaces whatever the loader raised.

**This means the axis will file issues on its first scheduled run** (3, against the `--max-issues` cap, with 1 deferred). They are legitimate. I'd rather fix the leak first so the axis lands quiet — happy to do that as a follow-up PR wrapping `torch_load` in a clean "checkpoint is corrupted" error, which I have deterministic repros for.

## Verification

| Check | Result |
|---|---|
| Model files reached by sampling | 8/8, across all 5 modes |
| Clean rejections classified `expected` | 3/3 |
| Gap signatures | 4 distinct, deduped as shown |
| Cross-machine repro | Windows-origin issue path remaps to local copy |
| Trial cost | ≤1.2s |

`repro` now searches `fuzz-models/` alongside the weights dir when remapping `model=`, since the corrupt files live beside it rather than inside it. `fuzz-models/` is gitignored with the other generated fuzz dirs.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧪 Expanded fuzz testing to cover corrupted, invalid, and incorrectly formatted model files.

### 📊 Key Changes

- Added a new `model` fuzzing strategy that replaces the normal model with unsupported inputs.
- Generates a local corpus of invalid model files, including:
  - Truncated, empty, text, and random-byte PyTorch files.
  - Images saved with model extensions.
  - Invalid ONNX content.
  - Real images passed directly as model inputs.
- Added model preparation to the fuzzing asset setup and portable issue reproduction logic.
- Updated exception filtering for expected model-format and backend-dispatch errors.
- Added `fuzz-models/` to `.gitignore` to prevent generated test files from being committed.
- Adjusted strategy weights to make room for model-focused fuzz cases.

### 🎯 Purpose & Impact

- 🛡️ Tests checkpoint loading and backend format validation, important error surfaces that were previously under-tested.
- 🔍 Helps uncover crashes and regressions when users provide damaged, unsupported, or incorrectly formatted models.
- 🧰 Improves reproducibility by preserving generated model inputs for replaying fuzz failures.
- ✅ Keeps expected validation errors separate from genuine defects, making fuzzing results more actionable.