### PR TITLE
Raise a clean error for corrupt or truncated checkpoints

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1805,9 +1805,10 @@ def torch_safe_load(weight, safe_only=None):
     try:
         ckpt = _load()
 
-    except (RuntimeError, EOFError, pickle.UnpicklingError) as e:
-        # An unreadable file reaches here as one of three loader-internal errors depending on how it is damaged:
-        # RuntimeError for a truncated zip, EOFError for an empty one, UnpicklingError for arbitrary bytes.
+    except (RuntimeError, EOFError) as e:
+        # A damaged file reaches here as one of two loader-internal errors: RuntimeError for a truncated zip and
+        # EOFError for an empty one. UnpicklingError is deliberately not caught here — it has its own handler
+        # below, which re-raises verbatim off the safe_only path because a legacy file raises it too.
         if isinstance(e, RuntimeError) and "PytorchStreamReader" not in str(e):
             raise  # an unrelated RuntimeError is a real failure, not a damaged file
         # Recover only a corrupt cached official asset requested by bare name; never touch user-supplied paths.

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+
+
 import contextlib
 import pickle
 import re

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-
-
 import contextlib
 import pickle
 import re

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1805,11 +1805,21 @@ def torch_safe_load(weight, safe_only=None):
     try:
         ckpt = _load()
 
-    except RuntimeError as e:
+    except (RuntimeError, EOFError, pickle.UnpicklingError) as e:
+        # An unreadable file reaches here as one of three loader-internal errors depending on how it is damaged:
+        # RuntimeError for a truncated zip, EOFError for an empty one, UnpicklingError for arbitrary bytes.
+        if isinstance(e, RuntimeError) and "PytorchStreamReader" not in str(e):
+            raise  # an unrelated RuntimeError is a real failure, not a damaged file
         # Recover only a corrupt cached official asset requested by bare name; never touch user-supplied paths.
         name = Path(str(weight)).name
-        if "PytorchStreamReader" not in str(e) or str(weight) != name or name not in GITHUB_ASSETS_NAMES:
-            raise
+        if str(weight) != name or name not in GITHUB_ASSETS_NAMES:
+            raise TypeError(
+                emojis(
+                    f"ERROR ❌️ {weight} is not a loadable checkpoint — the file is empty, truncated or corrupted "
+                    f"({type(e).__name__}: {e}).\nRecommend fixes are to re-download or re-export the file, or to "
+                    f"run a command with an official Ultralytics model, i.e. 'yolo predict model=yolo26n.pt'"
+                )
+            ) from e
         LOGGER.warning(f"Corrupt cache {file}, re-downloading {weight}...")
         Path(file).unlink(missing_ok=True)
         file = attempt_download_asset(weight)


### PR DESCRIPTION
## Why

Loading a damaged checkpoint surfaced whatever the loader happened to raise, with no indication of what was actually wrong:

| Damage | What the user saw | Telemetry |
|---|---|---|
| Truncated file | `RuntimeError: PytorchStreamReader failed reading zip archive: failed finding central directory` | ~456 events / 101 users |
| Empty file | `EOFError: Ran out of input` | ~135 events / 52 users |

Neither message tells a user their file is damaged, let alone what to do about it.

## Where the fix goes

`torch_safe_load` (`nn/tasks.py`) already **owns** this: it catches `ModuleNotFoundError` to explain YOLOv5 checkpoints and missing modules, catches `UnpicklingError` for the `safe_only` path, and catches one `RuntimeError` case to re-download a corrupt cached official asset. A user-supplied path fell straight through its bare `raise`.

So this extends that existing handler — no new abstraction, nothing wrapped around working logic. Both damage modes now raise a single `TypeError` naming the file, the underlying error and the fix, matching the style of the `ModuleNotFoundError` messages below it:

```
ERROR ❌️ best.pt is not a loadable checkpoint — the file is empty, truncated or corrupted
(RuntimeError: PytorchStreamReader failed reading zip archive: failed finding central directory).
Recommend fixes are to re-download or re-export the file, or to run a command with an official
Ultralytics model, i.e. 'yolo predict model=yolo26n.pt'
```

## What is deliberately *not* changed

**`UnpicklingError` is left alone.** My first version caught it here too, which shadowed the `except pickle.UnpicklingError` block further down and made it unreachable. That block re-raises verbatim off the `safe_only` path deliberately — its comment records that a legacy file raises `UnpicklingError` too, so labelling it "corrupted" would mislabel it — and converts it to a clean type-format error under `safe_only`. Shadowing it broke both behaviours.

Ruff `B025` in the Docs job caught this; no test covers the `safe_only` path. It is ~65 events / 12 users against ~591 / 153 for the two modes that have no owner, so the narrow change is also the higher-value one.

Two other behaviours preserved:

- The **cached-asset recovery path** is unchanged, and now also covers empty downloads — a partial download fails exactly this way.
- An **unrelated `RuntimeError` still propagates raw**. CUDA OOM is the case that matters: relabelling it as file corruption would be worse than the original problem.

## Verification

| Check | Result |
|---|---|
| truncated, 512-byte header, empty | raise the clean `TypeError` |
| random bytes, image renamed `.pt` | raise `UnpicklingError`, unchanged by design |
| Valid checkpoint | still loads |
| Unrelated `RuntimeError` (CUDA OOM) | still propagates raw |
| Ruff under the Docs job's stricter config | no new errors |
| `tests/test_engine.py` + checkpoint subset of `tests/test_python.py` | 44 passed |

## Provenance

Found by extending the fuzzer to mutate `model`, which is otherwise pinned in `NEVER_MUTATE` (#25424). That axis reports four signatures against current `main`; this removes two. The remaining two — `UnpicklingError` from `torch_load` and a raw `onnxruntime InvalidProtobuf` from `nn/backends/onnx.py:load_model` — are left reportable rather than silenced.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛠️ Improved checkpoint loading to detect, explain, and recover from empty or corrupted model files more reliably.

### 📊 Key Changes

- Handles both `RuntimeError` and `EOFError` caused by truncated or empty checkpoint files.
- Preserves unrelated `RuntimeError` exceptions so genuine loading failures are not hidden.
- Automatically removes and re-downloads corrupted cached official Ultralytics assets requested by name.
- Raises a clearer `TypeError` for corrupted user-supplied files or unsupported checkpoints, including recommended recovery steps.
- Keeps `UnpicklingError` handling unchanged for compatibility with legacy model files.

### 🎯 Purpose & Impact

- ✅ Makes model-loading errors easier to understand and troubleshoot.
- 🔄 Improves automatic recovery when an official cached model is damaged.
- 🛡️ Prevents accidental deletion or replacement of user-provided checkpoint paths.
- 📥 Encourages users to re-download or re-export invalid files, or use an official model such as `yolo26n.pt`.