### PR TITLE
Reject unreadable image sources, and harden download failure paths

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.105"
+__version__ = "8.4.106"
 
 import importlib
 import os

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -537,10 +537,9 @@ class LoadPilAndNumpy:
             im = im[..., None] if flag == "L" else im[..., ::-1]
             return np.ascontiguousarray(im)
         im = np.atleast_3d(im)
-        # Without this a batched or zero-sized array reads shape[2] as a channel count it is not
-        assert im.ndim == 3 and im.shape[0] and im.shape[1], (
-            f"Expected a single (H, W, C) image, but got array of shape {im.shape}"
-        )
+        # Reject batched arrays, whose shape[2] is not a channel count, and any zero dimension: a zero-channel
+        # array otherwise falls through the conversions below unchanged and reaches inference empty.
+        assert im.ndim == 3 and all(im.shape), f"Expected a single (H, W, C) image, but got array of shape {im.shape}"
         c = im.shape[2]
         if c == channels:
             return im

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -530,17 +530,20 @@ class LoadPilAndNumpy:
             - PIL inputs are converted to NumPy and returned in OpenCV-compatible BGR order for color images.
             - NumPy color inputs are assumed to use OpenCV-compatible BGR order.
         """
-        assert isinstance(im, (Image.Image, np.ndarray)), f"Expected PIL/np.ndarray image type, but got {type(im)}"
-        if isinstance(im, Image.Image):
+        if not isinstance(im, (Image.Image, np.ndarray)):
+            raise TypeError(f"Expected PIL/np.ndarray image type, but got {type(im)}")
+        pil = isinstance(im, Image.Image)
+        if pil:
             flag = "L" if channels == 1 else "RGB"
             im = np.asarray(im.convert(flag))
             im = im[..., None] if flag == "L" else im[..., ::-1]
-            return np.ascontiguousarray(im)
         im = np.atleast_3d(im)
-        # Rejects batched arrays, whose shape[2] is not a channel count, and any zero dimension, which otherwise
-        # falls through the conversions below unchanged. Raised rather than asserted so `python -O` keeps it.
+        # Both routes validate here: a zero dimension divides by zero in LetterBox, and a batched array reads
+        # shape[2] as a channel count it is not. Raised rather than asserted so `python -O` keeps the check.
         if im.ndim != 3 or not all(im.shape):
             raise ValueError(f"Expected a single (H, W, C) image, but got array of shape {im.shape}")
+        if pil:
+            return np.ascontiguousarray(im)
         c = im.shape[2]
         if c == channels:
             return im
@@ -616,8 +619,8 @@ class LoadTensor:
                 raise ValueError(s)
             LOGGER.warning(s)
             im = im.unsqueeze(0)
-        if im.shape[2] % stride or im.shape[3] % stride:
-            raise ValueError(s)
+        if not all(im.shape) or im.shape[2] % stride or im.shape[3] % stride:
+            raise ValueError(s)  # a zero dimension reaches im.max() below on an empty tensor
         if im.max() > 1.0 + (torch.finfo(im.dtype).eps if im.is_floating_point() else 0):
             LOGGER.warning(
                 f"torch.Tensor inputs should be normalized 0.0-1.0 but max value is {im.max()}. Dividing input by 255."

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -537,9 +537,10 @@ class LoadPilAndNumpy:
             im = im[..., None] if flag == "L" else im[..., ::-1]
             return np.ascontiguousarray(im)
         im = np.atleast_3d(im)
-        # Reject batched arrays, whose shape[2] is not a channel count, and any zero dimension: a zero-channel
-        # array otherwise falls through the conversions below unchanged and reaches inference empty.
-        assert im.ndim == 3 and all(im.shape), f"Expected a single (H, W, C) image, but got array of shape {im.shape}"
+        # Rejects batched arrays, whose shape[2] is not a channel count, and any zero dimension, which otherwise
+        # falls through the conversions below unchanged. Raised rather than asserted so `python -O` keeps it.
+        if im.ndim != 3 or not all(im.shape):
+            raise ValueError(f"Expected a single (H, W, C) image, but got array of shape {im.shape}")
         c = im.shape[2]
         if c == channels:
             return im

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -513,6 +513,8 @@ class LoadPilAndNumpy:
         """
         if not isinstance(im0, list):
             im0 = [im0]
+        if not im0:  # an empty batch otherwise fails unnamed inside np.stack in Predictor.preprocess
+            raise FileNotFoundError("No images found in source, predict requires at least one image.")
         # use `image{i}.jpg` when Image.filename returns an empty path.
         self.paths = [getattr(im, "filename", "") or f"image{i}.jpg" for i, im in enumerate(im0)]
         self.im0 = [self._single_check(im, channels) for im in im0]
@@ -535,6 +537,10 @@ class LoadPilAndNumpy:
             im = im[..., None] if flag == "L" else im[..., ::-1]
             return np.ascontiguousarray(im)
         im = np.atleast_3d(im)
+        # Without this a batched or zero-sized array reads shape[2] as a channel count it is not
+        assert im.ndim == 3 and im.shape[0] and im.shape[1], (
+            f"Expected a single (H, W, C) image, but got array of shape {im.shape}"
+        )
         c = im.shape[2]
         if c == channels:
             return im

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -389,12 +389,15 @@ def safe_download(
                 except MemoryError:
                     raise  # Re-raise immediately - no point retrying if insufficient disk space
                 except Exception as e:
-                    f.unlink(missing_ok=True)  # a partial file is served as a cache hit by the is_file() check above
+                    # Only on the terminal failure: retries resume the partial file via curl `-C -`, but leaving
+                    # one behind makes the `not f.is_file()` guard above serve it as a complete cache hit forever.
                     if i == 0 and not is_online():
+                        f.unlink(missing_ok=True)
                         raise ConnectionError(
                             emojis(f"❌  Download failure for {uri}. Environment may be offline.")
                         ) from e
                     elif i >= retry:
+                        f.unlink(missing_ok=True)
                         raise ConnectionError(
                             emojis(f"❌  Download failure for {uri}. Retry limit reached. {e}")
                         ) from e

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -389,6 +389,7 @@ def safe_download(
                 except MemoryError:
                     raise  # Re-raise immediately - no point retrying if insufficient disk space
                 except Exception as e:
+                    f.unlink(missing_ok=True)  # a partial file is served as a cache hit by the is_file() check above
                     if i == 0 and not is_online():
                         raise ConnectionError(
                             emojis(f"❌  Download failure for {uri}. Environment may be offline.")

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -229,7 +229,9 @@ def check_disk_space(
         (bool): True if there is sufficient disk space, False otherwise.
     """
     _total, _used, free = shutil.disk_usage(path or Path.cwd())  # bytes
-    if file_bytes * sf < free:
+    # Overlay, union and quota-limited filesystems report 0 free bytes while writes still succeed, so 0 means
+    # unknowable rather than empty. A genuinely full disk still fails at write time with an OS error.
+    if not free or file_bytes * sf < free:
         return True  # sufficient space
 
     def fmt_bytes(b):

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -228,10 +228,10 @@ def check_disk_space(
     Returns:
         (bool): True if there is sufficient disk space, False otherwise.
     """
-    _total, _used, free = shutil.disk_usage(path or Path.cwd())  # bytes
-    # Overlay, union and quota-limited filesystems report 0 free bytes while writes still succeed, so 0 means
-    # unknowable rather than empty. A genuinely full disk still fails at write time with an OS error.
-    if not free or file_bytes * sf < free:
+    total, _used, free = shutil.disk_usage(path or Path.cwd())  # bytes
+    # A filesystem that cannot report usage returns 0 total blocks; free == 0 against a valid total is genuinely
+    # full and must still be caught, since `free` counts blocks available to an unprivileged process.
+    if not total or file_bytes * sf < free:
         return True  # sufficient space
 
     def fmt_bytes(b):

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -402,6 +402,8 @@ def safe_download(
                             emojis(f"❌  Download failure for {uri}. Retry limit reached. {e}")
                         ) from e
                     LOGGER.warning(f"Download failure, retrying {i + 1}/{retry} {uri}... {e}")
+            else:  # no attempt reached `break`, so every one failed size validation and unlinked its download
+                raise ConnectionError(emojis(f"❌  Download failure for {uri}. Retry limit reached."))
 
     if unzip and f.exists() and f.suffix in {"", ".zip", ".tar", ".gz"}:
         from zipfile import is_zipfile


### PR DESCRIPTION
Rejects degenerate image inputs at the loaders that own them, and closes two ways `safe_download` could leave or return a file that is not there.

> **Scope correction.** This PR originally bypassed `check_disk_space` when `free == 0`, on the theory that a spike of `0.0 MB` events across ~431 users meant an unreadable reading. **That premise was wrong** and independent review refuted it — see below. The disk check now *keeps* full-disk detection. Consequently this PR does **not** fix ULTRALYTICS-21BX / 21CW, and they are deliberately left open.

## 1. Degenerate image sources crash without naming a cause

Three routes reached the same class of unhelpful failure. All reproduced against `main`:

| Input | On `main` |
| --- | --- |
| `predict([])` | `ValueError: need at least one array to stack` |
| `predict(np.zeros((0,64,64,3)))` | `ZeroDivisionError: division by zero` |
| `predict(np.empty((8,8,0)))` | silently reshaped, reached inference empty |
| `predict(Image.new("RGB",(0,0)))` | `ZeroDivisionError` |
| `predict(img.crop((0,0,0,0)))` | `ZeroDivisionError` — a realistic route |
| `predict(torch.zeros(0,3,64,64))` | `RuntimeError: max(): Expected reduction dim...` |

Fixed at the owners. `LoadPilAndNumpy.__init__` owns the batch and rejects an empty list, reusing the "no images found" wording from `loaders.py:400`. `_single_check` now converts PIL **before** a single shared shape validation instead of returning around it, so PIL and numpy are covered by one check. `LoadTensor` owns tensors separately, so its existing rank/stride condition gains the zero-dimension case.

`assert` became `TypeError`/`ValueError`: **`python -O` strips asserts**, and under it a `(4,4,0)` array was silently reshaped into an apparent `(32,32,512)` image.

## 2. `safe_download` could leave, or return, a missing file

- **Partial file survived a failed download.** The failure path did not unlink, and the download block is guarded only by `if not f.is_file()` — so the next call served a truncated file as a complete cache hit, forever. Cleanup is on the **terminal** raises only: the retry path uses curl `-C -` to resume, so deleting between attempts would defeat it.
- **Exhausting retries on size validation returned a nonexistent path.** A response failing `min_bytes`/`expected_size` is unlinked and retried; the last attempt fell out of the loop without raising, so the function returned a path to a file it had just deleted. A `for/else` covers it exactly — the success path breaks, both terminal handlers already raise.

The disk gate moves from `free` to `total`: a filesystem that genuinely cannot report usage returns 0 total blocks (the escape hatch), while `free == 0` against a valid total is a real full disk and still raises. `total` was already unpacked and discarded.

## Why the original premise was wrong

Worth recording, because the reasoning error is instructive:

- **The evidence was a display artifact.** `fmt_bytes` uses `.1f`, so *every* free value from 0 to 52,428 bytes prints as `"0.0 MB"`. The apparent spike at zero is a 51 KB bucket collapsed into one label — exactly what a population of genuinely full disks looks like.
- **`free == 0` is the canonical full signature.** `free` is `f_bavail`, blocks available to an *unprivileged* process; on ext4's 5% root reserve it reaches 0 while root still has space.
- **The bypass would have fixed nobody** — it keyed on exactly `0`, while the reported users sit anywhere in that 51 KB band.
- **It made failure worse** — three pointless retries, then a `ConnectionError` blaming the network instead of an actionable `MemoryError`. `ConnectionError` is not in Sentry's drop list, so those users would have re-filed into a worse bucket.

## Verification

| Check | Result |
| --- | --- |
| All 8 degenerate inputs above | clean named error, identical under `python3` and `python3 -O` |
| Valid PIL modes L, LA, RGB, RGBA, P, I;16, CMYK, 1, F, I at channels 1 and 3 | byte-identical to `main` |
| Channel counts 1–5, dtypes, C/Fortran/non-contiguous, 0-d to 4-d | only 4D and zero-dim differ; both already failed on `main` |
| Full disk (`total=12MB, free=0`) | raises `MemoryError` |
| Unreportable filesystem (`total=0`) | proceeds |
| Failed download | leaves no partial file; retries still resume via `Range: bytes=…` |
| 1-byte response, `min_bytes=10` | raises instead of returning a missing path |
| Real download | unchanged |
| `test_python` + `test_engine` + `test_cli` + `test_solutions` | passing |

Reviewed independently across four rounds; findings at each round are in the commit history.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves input validation and download failure handling while updating the Ultralytics package to version 8.4.106. 🛠️

### 📊 Key Changes

- Added clear errors for empty image batches and invalid image types or shapes.
- Added validation for zero-sized or incorrectly batched NumPy and PyTorch tensor inputs.
- Replaced an `assert` with explicit `TypeError` and `ValueError` checks that remain active under optimized Python execution.
- Improved disk-space checks for filesystems that report zero total capacity.
- Removed incomplete downloads after terminal failures to prevent corrupted files from being mistaken for valid cached downloads.
- Added a final download error when all attempts fail validation without reaching a retry exit condition.
- Bumped the package version from `8.4.105` to `8.4.106`. 📦

### 🎯 Purpose & Impact

- Prevents obscure preprocessing crashes caused by empty, malformed, or zero-sized inputs.
- Provides more actionable error messages for users integrating image and tensor sources.
- Makes download retries and caching safer by removing partial files after failure.
- Improves reliability in restricted, offline, or unusual filesystem environments. ✅