### PR TITLE
Report disk space in KB below 1 MB

### DIFF
--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -235,6 +235,8 @@ def check_disk_space(
         return True  # sufficient space
 
     def fmt_bytes(b):
+        if b < (1 << 20):  # without a KB tier every value under 51 KB renders "0.0 MB", hiding how full the disk is
+            return f"{b / (1 << 10):.1f} KB"
         return f"{b / (1 << 20):.1f} MB" if b < (1 << 30) else f"{b / (1 << 30):.3f} GB"
 
     # Insufficient space


### PR DESCRIPTION
## Why

`fmt_bytes` formatted with `.1f` from MB up, so **every free-space value from 0 to 52,428 bytes rendered as `"0.0 MB"`**.

The insufficient-disk-space `MemoryError` is the **largest error surface by affected users** in the package's telemetry — ~431 across [ULTRALYTICS-21BX](https://ultralytics.sentry.io/issues/6878192399/) and [ULTRALYTICS-21CW](https://ultralytics.sentry.io/issues/6880345488/) — and that formatting made all of them indistinguishable. There is currently no way to tell a genuinely full disk from one with tens of KB free, which is exactly the difference between a correct rejection and an over-aggressive check.

That ambiguity has already cost something concrete: in #25431 the apparent "spike at exactly 0.0 MB" was read as evidence that `disk_usage` must be under-reporting, and a bypass was written and nearly merged on it. The spike was the rounding bucket. This makes the same mistake harder to repeat.

## What changed

A KB tier below 1 MB:

```python
def fmt_bytes(b):
    if b < (1 << 20):
        return f"{b / (1 << 10):.1f} KB"
    return f"{b / (1 << 20):.1f} MB" if b < (1 << 30) else f"{b / (1 << 30):.3f} GB"
```

| free bytes | before | after |
| --- | --- | --- |
| 0 | `0.0 MB` | `0.0 KB` |
| 512 | `0.0 MB` | `0.5 KB` |
| 10,000 | `0.0 MB` | `9.8 KB` |
| 49,152 | `0.0 MB` | `48.0 KB` |
| 52,428 | `0.0 MB` | `51.2 KB` |

Only values under 51 **bytes** now collapse — a 1000× narrower bucket, enough for the next 90 days of events to answer whether those disks are actually full.

## Scope

Message text only; the disk-space *decision* is untouched. Tier boundaries follow the existing convention — `1048575` renders as `1024.0 KB` exactly as `1073741823` already renders as `1024.0 MB`.

## Verification

| Check | Result |
| --- | --- |
| 0 bytes vs 48 KB free | `0.0 KB` vs `48.0 KB` — distinguishable |
| KB/MB/GB tier boundaries | no gap or overlap |
| Callers parsing this message | none in package or tests |
| Deficit argument going negative | impossible on this path (failure requires `file_bytes * sf >= free`) |
| Disk-space decision | unchanged across a boundary matrix |

Reviewed independently; LGTM with no findings.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves low-disk-space warnings by displaying small amounts of available space in KB instead of inaccurately showing `0.0 MB`.

### 📊 Key Changes

- Updated `check_disk_space()` in `ultralytics/utils/downloads.py`.
- Added a KB display tier for values below 1 MB.
- Retained MB and GB formatting for larger values.

### 🎯 Purpose & Impact

- 📏 Makes disk-space messages more precise when less than 1 MB is available.
- 👀 Prevents values such as 51 KB from appearing as `0.0 MB`.
- 🛠️ Helps users better understand critically low storage before downloads or other operations.