### PR TITLE
Profile models directly instead of copying them for FLOPs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
     "psutil>=5.8.0", # system utilization
     "polars>=0.20.0",
     "nvidia-ml-py>=12.0.0", # NVIDIA GPU monitoring https://pypi.org/project/nvidia-ml-py
-    "ultralytics-thop>=2.0.18", # FLOPs computation https://github.com/ultralytics/thop
+    "ultralytics-thop>=2.0.22", # FLOPs computation https://github.com/ultralytics/thop
 ]
 
 # Optional dependencies ------------------------------------------------------------------------------------------------

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -226,8 +226,7 @@ class BaseModel(torch.nn.Module):
             thop = None  # conda support without 'ultralytics-thop' installed
 
         c = m == self.model[-1] and isinstance(x, list)  # is final layer list, copy input as inplace fix
-        # profile a copy: thop leaves float64 total_ops/total_params buffers on modules, incl. the shared default_act
-        flops = thop.profile(deepcopy(m), inputs=[x.copy() if c else x], verbose=False)[0] / 1e9 * 2 if thop else 0
+        flops = thop.profile(m, inputs=[x.copy() if c else x], verbose=False)[0] / 1e9 * 2 if thop else 0
         t = time_sync()
         for _ in range(10):
             m(x.copy() if c else x)

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -506,12 +506,12 @@ def get_flops(model, imgsz=640):
             # Method 1: Use stride-based input tensor
             stride = max(int(model.stride.max()), 32) if hasattr(model, "stride") else 32  # max stride
             im = torch.empty((1, p.shape[1], stride, stride), device=p.device, dtype=p.dtype)  # input image in BCHW
-            flops = thop.profile(deepcopy(model), inputs=[im], verbose=False)[0] / 1e9 * 2  # stride GFLOPs
+            flops = thop.profile(model, inputs=[im], verbose=False)[0] / 1e9 * 2  # stride GFLOPs
             return flops * imgsz[0] / stride * imgsz[1] / stride  # imgsz GFLOPs
         except Exception:
             # Method 2: Use actual image size (required for RTDETR models)
             im = torch.empty((1, p.shape[1], *imgsz), device=p.device, dtype=p.dtype)  # input image in BCHW format
-            return thop.profile(deepcopy(model), inputs=[im], verbose=False)[0] / 1e9 * 2  # imgsz GFLOPs
+            return thop.profile(model, inputs=[im], verbose=False)[0] / 1e9 * 2  # imgsz GFLOPs
     except Exception:
         return 0.0
 
@@ -916,7 +916,7 @@ def profile_ops(input, ops, n=10, device=None, max_num_obj=0):
             m = m.half() if hasattr(m, "half") and isinstance(x, torch.Tensor) and x.dtype is torch.float16 else m
             tf, tb, t = 0, 0, [0, 0, 0]  # dt forward, backward
             try:
-                flops = thop.profile(deepcopy(m), inputs=[x], verbose=False)[0] / 1e9 * 2 if thop else 0  # GFLOPs
+                flops = thop.profile(m, inputs=[x], verbose=False)[0] / 1e9 * 2 if thop else 0  # GFLOPs
             except Exception:
                 flops = 0
 


### PR DESCRIPTION
## Summary

`get_flops()`, `profile_ops()` and `_profile_one_layer()` each profiled a `deepcopy` of the model. That copy existed purely to absorb the state THOP left behind — as the comment in `tasks.py` said outright: *"profile a copy: thop leaves float64 total_ops/total_params buffers on modules, incl. the shared default_act"*.

THOP no longer leaves anything behind, so the copies are deleted and the pin moves to `ultralytics-thop>=2.0.22`:

- ultralytics/thop#137 — buffers were only popped from modules whose type had a counting rule, so activations, containers and the root model kept them permanently. Through the shared `Conv.default_act` singleton the leak spread to models built later in the same process.
- ultralytics/thop#140 — a failed or partially-completed profile left hooks and buffers installed, and modules reachable from several parents leaked hook handles that could never be removed.

## Result

`get_flops()` roughly halves in cost, since `deepcopy` was 45–64% of it:

| model | before | after | |
| --- | --- | --- | --- |
| yolo11n | 18.9 ms | 8.0 ms | 2.4× faster |
| yolo11x | 53.8 ms | 21.2 ms | 2.5× faster |
| rtdetr-l | 349.4 ms | 330.1 ms | dominated by the 640² forward |

Peak memory drops correspondingly — the model is no longer duplicated to be measured.

## Verification

FLOPs are unchanged everywhere. `get_flops()` is identical across 13 zoo configs — yolo11n/s/m/l/x, `-seg`, `-pose`, `-cls`, `-obb`, yolov8n, yolov8n-seg, yolov10n, yolo12n — and `rtdetr-l` at 108.3437 GFLOPs. `predict(profile=True)` reports identical GFLOPs and params for all 25 layers of yolo11n.

After profiling, models are left pristine: 0 leftover buffers, 0 forward hooks, 0 extra `state_dict()` keys, training mode preserved, and subsequent forward passes work. Predictions are bit-identical before and after a `get_flops()` call (max diff 0.000e+00), including across profiles at different image sizes — `Detect`'s shape/anchor cache is keyed on input shape and recomputes itself.

The RTDETR path is worth calling out, because it is the one that exercises failure. `get_flops()` Method 1 profiles at 32×32 and is *expected* to raise for RTDETR before falling back to Method 2 at full size. Against thop 2.0.21 that path was unusable without the copy — orphaned hooks accumulated on every call and the model itself broke:

| repeated `get_flops(rtdetr-l)` | thop 2.0.21, no copy | thop 2.0.22, no copy |
| --- | --- | --- |
| 1st call | 216.687 GFLOPs | 108.344 GFLOPs |
| 2nd call | 325.031 GFLOPs | 108.344 GFLOPs |
| 3rd call | 433.375 GFLOPs | 108.344 GFLOPs |
| next forward pass | `AttributeError: 'ReLU' object has no attribute 'total_ops'` | OK |

`test_model_profile`, `test_utils_torchutils` and `test_model_methods` pass; ruff clean. The `deepcopy` imports stay in both files — they are still used by `ModelEMA` and `parse_model`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

⚡ Updates FLOPs profiling to use the upgraded `ultralytics-thop` package directly on model modules, improving profiling efficiency and reliability.

### 📊 Key Changes

- Upgraded the minimum `ultralytics-thop` dependency from `2.0.18` to `2.0.22`.
- Removed unnecessary `deepcopy()` calls before FLOPs profiling in:
  - Layer profiling in `ultralytics/nn/tasks.py`
  - Model FLOPs calculation in `ultralytics/utils/torch_utils.py`
  - Operation profiling utilities
- Continued using copied inputs where needed to safely handle final-layer in-place operations.

### 🎯 Purpose & Impact

- 🚀 Reduces profiling overhead by avoiding unnecessary model duplication.
- 📈 Benefits FLOPs and performance reporting across training, validation, and benchmarking workflows.
- 🛠️ Relies on improvements in `ultralytics-thop` to prevent profiling from leaving unwanted buffers or modifying shared model components.
- 🔄 Users should receive the updated dependency automatically when installing or upgrading Ultralytics.