### PR TITLE
Pick DDP rendezvous ports below the OS ephemeral range

### DIFF
--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -23,12 +23,25 @@ def find_free_network_port() -> int:
 
     Returns:
         (int): The available network port number.
+
+    Notes:
+        Candidates are drawn below the OS ephemeral range (32768+ on Linux, 49152+ on macOS and Windows) because the
+        port is released here and rebound later by the DDP subprocess. An ephemeral port can be handed to any outbound
+        connection in that window, which surfaces as an EADDRINUSE rendezvous failure at launch.
     """
+    import random
     import socket
 
+    for port in random.sample(range(10000, 32768), 10):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("127.0.0.1", port))
+                return port
+            except OSError:
+                continue  # in use by an explicit listener, try the next candidate
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]  # port
+        s.bind(("127.0.0.1", 0))  # every candidate was busy, fall back to an ephemeral port
+        return s.getsockname()[1]
 
 
 def generate_ddp_file(trainer: BaseTrainer) -> str:

--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -25,9 +25,9 @@ def find_free_network_port() -> int:
         (int): The available network port number.
 
     Notes:
-        Candidates are drawn below the OS ephemeral range (32768+ on Linux, 49152+ on macOS and Windows) because the
-        port is released here and rebound later by the DDP subprocess. An ephemeral port can be handed to any outbound
-        connection in that window, which surfaces as an EADDRINUSE rendezvous failure at launch.
+        Candidates are drawn below the default OS ephemeral floor (32768 on Linux, 49152 on macOS and Windows)
+        because the port is released here and rebound later by the DDP subprocess. An ephemeral port can be handed to
+        any outbound connection in that window, which surfaces as an EADDRINUSE rendezvous failure at launch.
     """
     import random
     import socket
@@ -40,7 +40,7 @@ def find_free_network_port() -> int:
             except OSError:
                 continue  # in use by an explicit listener, try the next candidate
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))  # every candidate was busy, fall back to an ephemeral port
+        s.bind(("127.0.0.1", 0))  # no non-ephemeral candidate available, fall back to an ephemeral port
         return s.getsockname()[1]
 
 

--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -32,7 +32,9 @@ def find_free_network_port() -> int:
     import random
     import socket
 
-    for port in random.sample(range(10000, 32768), 10):
+    # SystemRandom as init_seeds() seeds the global RNG earlier in this process, which would hand every concurrent
+    # DDP launch on a host the same candidate list
+    for port in random.SystemRandom().sample(range(10000, 32768), 10):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             try:
                 s.bind(("127.0.0.1", port))


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves DDP network-port selection to reduce distributed training startup failures caused by port conflicts. 🚀

### 📊 Key Changes

- Selects up to 10 random available ports from the non-ephemeral range `10000–32767`.
- Uses `SystemRandom` to avoid identical port selection patterns across concurrent DDP launches.
- Keeps the existing ephemeral-port behavior as a fallback when no suitable port is available.
- Adds documentation explaining why non-ephemeral ports are preferred during DDP initialization.

### 🎯 Purpose & Impact

- Reduces `EADDRINUSE` rendezvous errors when launching distributed training subprocesses.
- Improves reliability for multiple concurrent DDP jobs running on the same host.
- Preserves compatibility by falling back to the operating system’s automatic port allocation when needed.