### PR TITLE
fix(export): drop `nms` from Ascend args, the ONNX NMS node segfaults ATC

### DIFF
--- a/docs/en/integrations/ascend.md
+++ b/docs/en/integrations/ascend.md
@@ -119,7 +119,6 @@ The Ascend format supports the [Export](../modes/export.md), [Predict](../modes/
 | `quantize` | `int`            | `16`            | Quantization precision. Ascend export is FP16-only and auto-enables `16` if not specified. Replaces the deprecated `half`/`int8` flags.                                                              |
 | `opset`    | `int`            | `17`            | ONNX opset for the intermediate graph. Capped at 17, the highest version the CANN ONNX parser accepts.                                                                                               |
 | `simplify` | `bool`           | `True`          | Simplifies the intermediate ONNX graph with `onnxslim`.                                                                                                                                              |
-| `nms`      | `bool`           | `False`         | Adds Non-Maximum Suppression to the exported graph.                                                                                                                                                  |
 
 !!! note "Why is FP32 unavailable?"
 

--- a/docs/macros/export-table.md
+++ b/docs/macros/export-table.md
@@ -22,4 +22,4 @@
 | [Qualcomm QNN]({{ integrations_path or "../integrations" }}/qnn.md) | `qnn` | `{{ model_name or "yolo26n" }}_qnn.onnx` | ✅ | `imgsz`, `batch`, `name`, `quantize`, `simplify`, `opset`, `data`, `fraction`, `device` |
 | [LiteRT]({{ integrations_path or "../integrations" }}/litert.md) | `litert` | `{{ model_name or "yolo26n" }}.tflite` | ✅ | `imgsz`, `quantize`, `batch`, `data`, `fraction`, `device` |
 | [Hailo]({{ integrations_path or "../integrations" }}/hailo.md) | `hailo` | `{{ model_name or "yolo26n" }}_hailo_model/` | ✅ | `imgsz`, `name`, `quantize`, `data`, `fraction`, `simplify`, `conf`, `iou` |
-| [Huawei Ascend]({{ integrations_path or "../integrations" }}/ascend.md) | `ascend` | `{{ model_name or "yolo26n" }}_ascend_model/` | ✅ | `imgsz`, `batch`, `name`, `quantize`, `opset`, `simplify`, `nms` |
+| [Huawei Ascend]({{ integrations_path or "../integrations" }}/ascend.md) | `ascend` | `{{ model_name or "yolo26n" }}_ascend_model/` | ✅ | `imgsz`, `batch`, `name`, `quantize`, `opset`, `simplify` |

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -258,7 +258,7 @@ def export_formats():
             "_ascend_model",
             False,
             False,
-            ["batch", "name", "quantize", "opset", "simplify", "nms"],
+            ["batch", "name", "quantize", "opset", "simplify"],
             "base",
         ],
     ]


### PR DESCRIPTION
`format="ascend"` accepts `nms=True` today, and the resulting ONNX kills the ATC compiler with a segmentation fault. There is no error message: `subprocess.run(check=True)` surfaces a bare `CalledProcessError`.

The cause is the **arity** of the `NonMaxSuppression` node, not graph complexity nor `max_output_boxes_per_class = INT64_MAX`. CANN maps it to `NonMaxSuppressionV6` and, with 3 or 4 inputs, passes the minimum-arity check and then reads an optional input that is not there:

| NMS inputs | result |
| :-- | :-- |
| 2 (boxes, scores) | rc=255, clean `InferShape` error |
| 3 | rc=139 SIGSEGV |
| **4** ← what `torchvision` emits | **rc=139 SIGSEGV** |
| 5 (with `score_threshold`) | rc=0, compiles |

A 202-byte ONNX with a single node reproduces it:

```bash
# boxes [1,100,4], scores [1,1,100], max_output_boxes_per_class=300, iou_threshold=0.7, opset 17
atc --model=nms_only.onnx --framework=5 --output=nms_only --input_format=ND \
    --input_shape='boxes:1,100,4;scores:1,1,100' --soc_version=Ascend310P3
# ATC start working now, please wait for a moment.
# atc: line 22: 6100 Segmentation fault (core dumped) atc.bin "$@"
```

It dies in Prepare/Optimize of GE, after `InferShapePass` (last trace `graph_prepare.cc:2112`), which is why no E-code reaches the user. Reproduced 3/3 on `yolo11n` and on `yolov8n`, with and without `--precision_mode`, with and without `--input_shape`. The same models without `nms` compile fine.

Adding `score_threshold=0.0` as a 5th input does make the real graph compile (rc=0), but the resulting `.om` is 120.7 MB against 6.7 MB without NMS: the NMS introduces a data-dependent dimension, GE partitions the model (`model_num>1`) and ATC embeds the host libraries inside the file, so it also comes out tied to the host architecture (`*_linux_x86_64.om`). Every public Ascend YOLO project I found filters on the host rather than baking NMS into the `.om`, so dropping the arg looks better than keeping a path that costs 18x the size and loses portability.

After this change the request fails immediately and clearly:

```
ERROR ❌️ argument 'nms' is not supported for format='ascend'
```

Ascend joins the formats that already leave NMS to the host (`litert`, `hailo`, `ncnn`, `rknn`, `qnn`). The two docs tables that listed `nms` for Ascend are updated in this PR so they keep matching the code: the export table macro and the arguments table in the Ascend integration page.

**Deleted:** the `nms` entry from the Ascend argument list in `export_formats()`, its cell in `docs/macros/export-table.md`, and the `nms` row in `docs/en/integrations/ascend.md`.

Environment: CANN 9.0.1 (`ascendai/cann:9.0.1-310p-ubuntu22.04-py3.11`), ATC host-side, x86-64, no NPU attached.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Removes the unsupported Ascend `nms` export argument to prevent ONNX NMS nodes from causing ATC segmentation faults. 🚀

### 📊 Key Changes
- Removes `nms` from the Huawei Ascend export options in the exporter.
- Updates the Ascend integration documentation and export parameter table.
- Keeps Ascend exports focused on ATC-compatible intermediate ONNX graphs.

### 🎯 Purpose & Impact
- Prevents segmentation faults when compiling exported models with the Ascend ATC toolchain.
- Avoids exposing an export option that can generate incompatible ONNX NMS nodes.
- Aligns user-facing documentation with the supported Ascend export arguments. ✅
