### PR TITLE
fix(export): bake the semantic ArgMax for Ascend too

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -877,7 +877,7 @@ class Exporter:
                 # EdgeTPU does not support FlexSplitV while split provides cleaner ONNX graph
                 m.forward = m.forward_split
 
-        if model.task == "semantic" and fmt in {"qnn", "coreml"}:
+        if model.task == "semantic" and fmt in {"qnn", "coreml", "ascend"}:
             # NPU-targeted semantic exports ship a compact uint8 class map instead of float logits: emitting logits
             # forces consumers to dequantize and argmax ~20M floats on the CPU every frame (measured erratic
             # 123-1065 ms on Hexagon). Not applied to LiteRT, where the GPU delegate cannot compile ArgMax (int64
@@ -1776,11 +1776,12 @@ class QNNModel(ExportWrapper):
 class ClassMapModel(ExportWrapper):
     """Reduces semantic-segmentation logits to a compact integer class map for export.
 
-    Applied to QNN and Core ML semantic exports, where the argmax runs on the NPU: deployment consumers want per-pixel
-    class indices, and shipping float logits instead forces a dequantize + argmax over large tensors (~8M values at the
-    standard 640px mobile input) on the consumer's CPU every frame - measured as both slow and highly variable on mobile
-    NPUs. The argmax cannot live in the model's own forward because it is non-differentiable (training needs logits), so
-    it is attached here at export time, mirroring how `NMSModel` adds suppression only for export.
+    Applied to QNN, Core ML and Ascend semantic exports, where the argmax runs on the NPU: deployment consumers want
+    per-pixel class indices, and shipping float logits instead forces a dequantize + argmax over large tensors (~8M
+    values at the standard 640px mobile input) on the consumer's CPU every frame - measured as both slow and highly
+    variable on mobile NPUs. The argmax cannot live in the model's own forward because it is non-differentiable
+    (training needs logits), so it is attached here at export time, mirroring how `NMSModel` adds suppression only for
+    export.
 
     Attributes:
         task (str): The wrapped model's task ("semantic").


### PR DESCRIPTION
`format="ascend"` exports semantic segmentation as float logits. The policy for NPU targets is already written three lines above the gate in `exporter.py`, and it applies to Ascend too.

Measured on this branch before the change, with the real checkpoint (`yolo26n-sem.pt`, imgsz 640), compiling with the exact flags the exporter emits (`--soc_version=Ascend310P3 --precision_mode=force_fp16`):

| export | `.om` output | bytes per frame |
| :-- | :-- | --: |
| `format="ascend"` | `[1, 19, 640, 640]` DT_FLOAT | 31,129,600 (29.69 MiB) |
| `format="onnx"`, same checkpoint | `[1, 640, 640]` DT_UINT8 | 409,600 (0.39 MiB) |

That is 76.0x, and the number comes from `aclmdlGetOutputSizeByIndex` on the loaded model, I did not compute it by hand.

The LiteRT exception does not apply here: ATC compiles the baked graph with no error. `ArgMaxD` runs on AIcoreEngine with blockdim 8 and not on the AI CPU, so the argmax does not move the bottleneck to the DSP, and the model only gets 8,253 B bigger (**+0.21%**).

I ran both forms and compared them: the class map from the `.om` matches the host argmax of the logits on **409,600/409,600 pixels**, including 78 pixels where the top-2 logits tie exactly.

Also, on the host side the saving is bigger. `SemanticPredictor` upsamples the 19 channels to the original resolution and argmaxes after, so it works over 16.6M floats and not 7.8M: **106.25 ms/frame** single-threaded (bus.jpg, 640 → 1080x810, i9-13900HX) against **0.40 ms** for the class map path.

But we need to be honest about one thing: at export resolution both forms agree 100%, at original resolution they agree 99.61%, and 97.65% of the pixels that differ are on class boundaries (which are 1.62% of the image). That comes from the resampling order, bilinear-then-argmax vs nearest-of-argmax, the same trade-off already accepted for onnx/mnn/openvino/qnn/coreml/TRT>=10.

`SemanticPredictor.postprocess` does not need any change: it selects the branch with `pred.ndim == 2`, so it is backend-agnostic. Verified end to end through the equivalent ONNX path: `semantic_mask` comes out `(1080, 810)` uint8 with sensible class distribution.

On the sibling formats, the reduction is baked in two places: `SemanticSegment.forward` bakes it for `onnx`, `mnn` and `openvino`, and for `engine` and `hailo` behind `bake_argmax` (TensorRT>=10, multi-class Hailo-10/15); this gate bakes it for the wrapper-based exports. LiteRT is left out for the reason already in the comment. `deepx` and `axelera` also advertise semantic support and also emit `[1, nc, H, W]` floats, but I left them out: I have neither compiler, so I cannot check that their INT8 pipelines accept an ArgMax output, and guessing there would give a compile failure instead of a fix.

**Deleted:** nothing. One word in the gate, plus the `ClassMapModel` docstring line that names the formats it applies to.

Environment: CANN 9.0.1 (`ascendai/cann:9.0.1-310p-ubuntu22.04-py3.11`), ATC host-side, x86-64, no NPU attached; execution numbers from the Ascend310P chip model shipped with the toolkit.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Extends semantic segmentation export-time ArgMax baking to Ascend exports for compact class-map outputs.

### 📊 Key Changes
- Adds `ascend` to the formats that use `ClassMapModel` for semantic exports.
- Updates `ClassMapModel` documentation to include Ascend alongside QNN and Core ML.
- Keeps training behavior unchanged by applying the non-differentiable ArgMax only during export.

### 🎯 Purpose & Impact
- Enables Ascend deployments to receive compact per-pixel class indices instead of float logits.
- Reduces CPU-side dequantization and ArgMax workload for downstream consumers, improving inference efficiency and latency consistency.
- Fixes inconsistent semantic export behavior across supported NPU-targeted formats.
