### PR TITLE
Drop get_flops_with_torch_profiler and require thop>=2.1.0

### DIFF
--- a/docs/en/reference/utils/torch_utils.md
+++ b/docs/en/reference/utils/torch_utils.md
@@ -80,10 +80,6 @@ keywords: Ultralytics, torch utils, model optimization, device selection, infere
 
 <br><br><hr><br>
 
-## ::: ultralytics.utils.torch_utils.get_flops_with_torch_profiler
-
-<br><br><hr><br>
-
 ## ::: ultralytics.utils.torch_utils.initialize_weights
 
 <br><br><hr><br>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
     "psutil>=5.8.0", # system utilization
     "polars>=0.20.0",
     "nvidia-ml-py>=12.0.0", # NVIDIA GPU monitoring https://pypi.org/project/nvidia-ml-py
-    "ultralytics-thop>=2.0.22", # FLOPs computation https://github.com/ultralytics/thop
+    "ultralytics-thop>=2.1.0", # FLOPs computation https://github.com/ultralytics/thop
 ]
 
 # Optional dependencies ------------------------------------------------------------------------------------------------

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1302,13 +1302,12 @@ def test_utils_benchmarks():
 def test_utils_torchutils():
     """Test Torch utility functions including profiling and FLOP calculations."""
     from ultralytics.nn.modules.conv import Conv
-    from ultralytics.utils.torch_utils import get_flops_with_torch_profiler, profile_ops, time_sync
+    from ultralytics.utils.torch_utils import profile_ops, time_sync
 
     x = torch.randn(1, 64, 20, 20)
     m = Conv(64, 64, k=1, s=2)
 
     profile_ops(x, [m], n=3)
-    get_flops_with_torch_profiler(m)
     time_sync()
 
 

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -516,39 +516,6 @@ def get_flops(model, imgsz=640):
         return 0.0
 
 
-def get_flops_with_torch_profiler(model, imgsz=640):
-    """Compute model FLOPs using torch profiler (alternative to thop package, but 2-10x slower).
-
-    Args:
-        model (nn.Module): The model to calculate FLOPs for.
-        imgsz (int | list, optional): Input image size.
-
-    Returns:
-        (float): The model's GFLOPs (billions of floating point operations).
-    """
-    if not TORCH_2_0:  # torch profiler implemented in torch>=2.0
-        return 0.0
-    model = unwrap_model(model)
-    p = next(model.parameters())
-    if not isinstance(imgsz, list):
-        imgsz = [imgsz, imgsz]  # expand if int/float
-    try:
-        # Use stride size for input tensor
-        stride = (max(int(model.stride.max()), 32) if hasattr(model, "stride") else 32) * 2  # max stride
-        im = torch.empty((1, p.shape[1], stride, stride), device=p.device, dtype=p.dtype)  # input image in BCHW
-        with torch.profiler.profile(with_flops=True) as prof:
-            model(im)
-        flops = sum(x.flops for x in prof.key_averages()) / 1e9
-        flops = flops * imgsz[0] / stride * imgsz[1] / stride  # 640x640 GFLOPs
-    except Exception:
-        # Use actual image size for input tensor (i.e. required for RTDETR models)
-        im = torch.empty((1, p.shape[1], *imgsz), device=p.device, dtype=p.dtype)  # input image in BCHW format
-        with torch.profiler.profile(with_flops=True) as prof:
-            model(im)
-        flops = sum(x.flops for x in prof.key_averages()) / 1e9
-    return flops
-
-
 def initialize_weights(model):
     """Initialize model weights, biases, and module settings to default values."""
     for m in model.modules():


### PR DESCRIPTION
## Remove `get_flops_with_torch_profiler`

It was never called by the library — only by a smoke test in `test_utils_torchutils` and a reference docs entry. Benchmarked head-to-head against the `thop` path it was meant to be an alternative to, it is **11–117x slower** *and* disagrees on the answer:

| model | `get_flops` (thop) | `get_flops_with_torch_profiler` |
|---|---|---|
| yolo11n | **5.4 ms** — 6.614 GFLOPs | 405.0 ms — 6.483 GFLOPs |
| yolo11m | **8.7 ms** — 68.528 GFLOPs | 1015.2 ms — 67.988 GFLOPs |
| rtdetr-l | **358.3 ms** — 108.344 GFLOPs | 4085.3 ms — 109.567 GFLOPs |

Not a viable contender on either speed or agreement, so it goes, along with its test call and docs entry.

## Bump `ultralytics-thop` to >=2.1.0

[thop 2.1.0](https://github.com/ultralytics/thop/pull/141) cuts ~2.4x off thop's own hook layer (13.4 ms → 5.6 ms on an 801-module compute-free model) by replacing float64 buffers with plain int attributes and fusing two forward hooks into one.

Results are unchanged: **GFLOPs verified identical for all 66 model YAMLs in `cfg/models`**, plus 18 mixed torchvision/YOLO/RNN models.

End-to-end `get_flops` across all 66 YAMLs: 2575 ms → 1962 ms.

## Note on RTDETR

RTDETR profiling remains slow (~343 ms for rtdetr-l), but thop is not the cause — it accounts for ~3% of the total. The breakdown is ~26% a doomed 32x32 attempt that runs most of the model before `topk(300)` fails on 21 anchors, and ~71% the genuine 640x640 forward. Filed separately as a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧹 Removes the slower Torch Profiler-based FLOPs utility and updates the THOP dependency for FLOPs calculation.

### 📊 Key Changes

- Deleted `get_flops_with_torch_profiler` from `ultralytics.utils.torch_utils`.
- Removed the function from its API documentation and test coverage.
- Updated `ultralytics-thop` from version `2.0.22` to `2.1.0` in `pyproject.toml`.
- Retained the existing `get_flops` implementation for model FLOPs estimation.

### 🎯 Purpose & Impact

- ⚡ Simplifies FLOPs calculation by relying on the maintained THOP-based implementation.
- 🧩 Reduces duplicate functionality and removes a profiling method described as significantly slower.
- 📦 Ensures users receive newer FLOPs computation improvements through `ultralytics-thop>=2.1.0`.
- 🛠️ Users calling `get_flops_with_torch_profiler` directly will need to switch to `get_flops`.