### PR TITLE
Exclude gitee.com from broken link checks

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -45,7 +45,7 @@ jobs:
             --insecure \
             --accept 100..=103,200..=299,401,403,429,500,502,999 \
             --exclude-all-private \
-            --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com|neptune\.ai|gnu\.org/software/make|survey\.stackoverflow\.co|clear\.ml)' \
+            --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com|neptune\.ai|gnu\.org/software/make|survey\.stackoverflow\.co|clear\.ml|gitee\.com)' \
             --exclude-path docs/zh \
             --exclude-path docs/es \
             --exclude-path docs/ru \
@@ -81,7 +81,7 @@ jobs:
             --insecure \
             --accept 100..=103,200..=299,401,403,429,500,502,999 \
             --exclude-all-private \
-            --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com|neptune\.ai|gnu\.org/software/make|survey\.stackoverflow\.co|clear\.ml)' \
+            --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com|neptune\.ai|gnu\.org/software/make|survey\.stackoverflow\.co|clear\.ml|gitee\.com)' \
             --exclude 'https?://[^[:space:]]*(%7B|%7D|\{|\}|sentry\.io|google-analytics\.com/mp/collect|storage\.googleapis\.com|packages\.cloud\.google\.com/apt)(/.*)?' \
             --exclude 'https://github\.com/ultralytics/assets/releases/download/v0\.0\.0' \
             --exclude 'https://raw\.githubusercontent\.com/ultralytics/assets/main/(im/banner-tasks|yolov8/banner-yolov8)\.png/?' \


### PR DESCRIPTION
The daily link check fails on `https://gitee.com/ascend/tools/tree/master/ais-bench_workload/tool/ais_bench` (linked from `docs/en/integrations/ascend.md`) with `405 Method Not Allowed`. The URL loads fine in a browser — gitee.com's bot protection rejects CI requests, the same reason the other domains in this exclusion list are there.

Adds `gitee\.com` to the exclusion regex in both lychee steps, keeping the canonical Huawei source linked for readers.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔗 Updated link-checking workflows to ignore Gitee URLs and prevent false-positive failures.

### 📊 Key Changes

- Added `gitee.com` to the excluded URL patterns in both link-checking jobs.
- Applied the exclusion consistently across the repository’s automated link validation workflow.

### 🎯 Purpose & Impact

- ✅ Prevents external Gitee links from causing unnecessary CI failures.
- ⚡ Makes documentation and link checks more reliable and focused on actionable issues.
- 🛠️ No changes to application code or user-facing functionality.