### PR TITLE
Exclude flaky Gitee URL from link checks

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -46,6 +46,7 @@ jobs:
             --accept 100..=103,200..=299,401,403,429,500,502,999 \
             --exclude-all-private \
             --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com|neptune\.ai|gnu\.org/software/make|survey\.stackoverflow\.co|clear\.ml)' \
+            --exclude '^https://gitee\.com/ascend/tools/tree/master/ais-bench_workload/tool/ais_bench/?$' \
             --exclude-path docs/zh \
             --exclude-path docs/es \
             --exclude-path docs/ru \
@@ -82,6 +83,7 @@ jobs:
             --accept 100..=103,200..=299,401,403,429,500,502,999 \
             --exclude-all-private \
             --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com|neptune\.ai|gnu\.org/software/make|survey\.stackoverflow\.co|clear\.ml)' \
+            --exclude '^https://gitee\.com/ascend/tools/tree/master/ais-bench_workload/tool/ais_bench/?$' \
             --exclude 'https?://[^[:space:]]*(%7B|%7D|\{|\}|sentry\.io|google-analytics\.com/mp/collect|storage\.googleapis\.com|packages\.cloud\.google\.com/apt)(/.*)?' \
             --exclude 'https://github\.com/ultralytics/assets/releases/download/v0\.0\.0' \
             --exclude 'https://raw\.githubusercontent\.com/ultralytics/assets/main/(im/banner-tasks|yolov8/banner-yolov8)\.png/?' \


### PR DESCRIPTION
### What changed
Both repos' link checks now exclude only the exact Gitee ais_bench URL via an anchored `--exclude` regex on all three lychee commands; 405 from any other URL still fails since 405 stays out of `--accept`. Unverified: no live lychee/CI run was executed (sandbox has no network), only local regex-behavior validation.

### Why
Update the existing Lychee link-check workflows to exclude only `https://gitee.com/ascend/tools/tree/master/ais-bench_workload/tool/ais_bench`, which intermittently returns HTTP 405 to GitHub-hosted runners despite being reachable. In `ultralytics/docs`, the owner is `.github/workflows/links.yml`, specifically the existing `lychee` command in the `Check broken links` step. In `ultralytics/ultralytics`, the owner is `.github/workflows/links.yml`, specifically both existing `lychee` commands in the scheduled/manual link-check steps. Preserve the existing retry behavior, accepted status codes, headers, and all other exclusions. Acceptance boundary: this exact Gitee URL is ignored by both repositories' link checks, while HTTP 405 responses from any other URL continue to be reported as failures.

Requested by murat@ultralytics.com (job `de69eb2b41d7`).