### PR TITLE
Escape pipes in reference tables so union types stay in one column

### DIFF
--- a/docs/build_reference.py
+++ b/docs/build_reference.py
@@ -31,8 +31,6 @@ PACKAGE_DIR = REPO_ROOT / "ultralytics"
 REFERENCE_DIR = PACKAGE_DIR.parent / "docs/en/reference"
 GITHUB_REPO = "ultralytics/ultralytics"
 SIGNATURE_LINE_LENGTH = 120
-# Use Font Awesome brand GitHub icon (CSS already loaded via mkdocs.yml and HTML head)
-GITHUB_ICON = '<i class="fa-brands fa-github" aria-hidden="true" style="margin-right:6px;"></i>'
 
 MKDOCS_YAML = PACKAGE_DIR.parent / "mkdocs.yml"
 INCLUDE_SPECIAL_METHODS = {
@@ -683,10 +681,10 @@ def _render_table(headers: list[str], rows: list[list[str]], level: int, title: 
         return ""
 
     def _clean_cell(value: str | None) -> str:
-        """Normalize table cell values for Markdown output."""
+        """Normalize table cell values for Markdown output, escaping pipes so unions stay in one column."""
         if value is None:
             return ""
-        return str(value).replace("\n", "<br>").strip()
+        return str(value).replace("\n", "<br>").replace("|", r"\|").strip()
 
     rows = [[_clean_cell(c) for c in row] for row in rows]
     table_lines = ["| " + " | ".join(headers) + " |", "| " + " | ".join("---" for _ in headers) + " |"]
@@ -759,7 +757,7 @@ def render_source_panel(item: DocItem, module_url: str, module_path: str) -> str
     return (
         "<details>\n"
         f"<summary>{summary}</summary>\n\n"
-        f'<a href="{source_url}">{GITHUB_ICON}View on GitHub</a>\n'
+        f'<a href="{source_url}">View on GitHub</a>\n'
         f"{_code_fence(item.source)}\n"
         "</details>\n"
     )


### PR DESCRIPTION
## What

Reference tables split `str | Path` across two columns: `_clean_cell` wrote cell values straight into GFM table rows, and GFM splits on `|` before inline parsing — so the pipe broke the row even inside a code span. Every union-typed parameter, return, and attribute rendered wrong, and the trailing type text landed in the neighbouring column.

Live example: https://docs.ultralytics.com/reference/utils/export/ascend#ultralytics.utils.export.ascend.onnx2ascend

```
| `onnx_file` | `str | Path` | Input ONNX model path. | *required* |   ← 5 columns, mangled
| `onnx_file` | `str \| Path` | Input ONNX model path. | *required* |  ← fixed
```

Also drops the Font Awesome GitHub `<i>` from the source panel link: the docs renderer never loads Font Awesome (mkdocs.yml uses Material's inlined icon shortcodes, not the FA stylesheet), so it emitted invisible markup into every reference page and every `.md` served to LLMs. The docs renderer now draws the GitHub mark itself (ultralytics/portal#3158).

- Deleted: `GITHUB_ICON` and its stale "CSS already loaded" comment.

## Verified

Regenerated the full reference locally (`build_reference_docs()`) — union types now render as a single `str | Path` code span in the Type column, confirmed end-to-end in the docs renderer, light and dark.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves generated API reference tables and simplifies source links in the documentation. 🛠️

### 📊 Key Changes

- Escapes pipe characters (`|`) in generated Markdown table cells so union type annotations remain in a single column.
- Removes the Font Awesome GitHub icon from “View on GitHub” source links.
- Keeps source panels functional while reducing reliance on icon-specific styling and assets.

### 🎯 Purpose & Impact

- 📚 Prevents malformed API reference tables when documentation includes types containing pipe characters.
- 🔗 Produces cleaner, more portable GitHub links in generated documentation.
- ✅ Improves documentation reliability without changing application or model functionality.