### PR TITLE
Fix reference truncation, constructor signatures, and empty argument tables

### DIFF
--- a/docs/build_reference.py
+++ b/docs/build_reference.py
@@ -340,6 +340,8 @@ def format_signature(
 
     if len(signature) <= SIGNATURE_LINE_LENGTH or not params:
         return signature
+    if is_class:  # the raw source of a long constructor is `def __init__(self, ...)`, not the call form
+        return "{}(\n    {},\n)".format(name, ",\n    ".join(params))
 
     raw_signature = _get_definition_signature(node, src)
     return raw_signature or signature

--- a/docs/build_reference.py
+++ b/docs/build_reference.py
@@ -216,7 +216,7 @@ def _format_parameter(arg: ast.arg, default: ast.AST | None, src: str) -> str:
         rendered += f": {annotation}"
     default_value = _format_default(default, src)
     if default_value is not None:
-        rendered += f" = {default_value}"
+        rendered += f" = {default_value}" if annotation else f"={default_value}"  # PEP 8 spacing
     return rendered
 
 
@@ -298,8 +298,13 @@ def format_signature(
     default_offset = total_regular - len(defaults)
 
     combined = posonly + regular
-    for idx, arg in enumerate(combined):
-        default = defaults[idx - default_offset] if idx >= default_offset else None
+    pairs = [
+        (arg, defaults[idx - default_offset] if idx >= default_offset else None) for idx, arg in enumerate(combined)
+    ]
+    if is_class:  # a constructor is called as Class(...), so the bound self/cls is never passed
+        pairs = [(arg, default) for arg, default in pairs if arg.arg not in {"self", "cls"}]
+        posonly = [arg for arg in posonly if arg.arg not in {"self", "cls"}]
+    for idx, (arg, default) in enumerate(pairs):
         params.append(_format_parameter(arg, default, src))
         if posonly and idx == len(posonly) - 1:
             params.append("/")
@@ -324,7 +329,7 @@ def format_signature(
 
     return_annotation = (
         _format_annotation(node.returns, src)
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.returns
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.returns and not is_class
         else None
     )
 
@@ -391,13 +396,16 @@ def _parse_returns(lines: list[str]) -> list[ReturnDoc]:
         text = textwrap.dedent("\n".join(block)).strip()
         if not text:
             continue
-        match = RETURNS_RE.match(text)
+        first_line, *rest = text.splitlines()
+        match = RETURNS_RE.match(first_line)
         if match:
             type_hint, desc = match.groups()
             cleaned_type = type_hint.strip()
             if cleaned_type.startswith("(") and cleaned_type.endswith(")"):
                 cleaned_type = cleaned_type[1:-1].strip()
-            entries.append(ReturnDoc(type=cleaned_type, description=_normalize_text(desc.strip())))
+            # Continuation lines carry the rest of the sentence; dedent them so _normalize_text reflows the paragraph.
+            description = "\n".join([desc.strip(), textwrap.dedent("\n".join(rest))]).strip()
+            entries.append(ReturnDoc(type=cleaned_type, description=_normalize_text(description)))
         else:
             entries.append(ReturnDoc(type=None, description=_normalize_text(text)))
     return entries
@@ -600,10 +608,12 @@ def parse_class(node: ast.ClassDef, module_path: str, src: str) -> DocItem:
     """Parse a class node, merging __init__ docs and collecting methods."""
     class_doc = parse_google_docstring(ast.get_docstring(node))
 
-    init_node: ast.FunctionDef | ast.AsyncFunctionDef | None = next(
-        (n for n in node.body if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n.name == "__init__"),
-        None,
-    )
+    methods_or_init = [n for n in node.body if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]
+    init_node = next((n for n in methods_or_init if n.name == "__init__"), None)
+    # The class definition runs to the end of its __init__, or to its first method when it declares none;
+    # 0 leaves _collect_source_block on its own end_lineno fallback for classes that define no methods at all.
+    first_method = next((n for n in methods_or_init if n is not init_node), None)
+    class_end = min([first_method.lineno, *(d.lineno for d in first_method.decorator_list)]) - 1 if first_method else 0
     signature_params: list[ParameterDoc] = []
     if init_node:
         init_doc = parse_google_docstring(ast.get_docstring(init_node))
@@ -633,7 +643,7 @@ def parse_class(node: ast.ClassDef, module_path: str, src: str) -> DocItem:
         bases=bases,
         children=methods,
         module_path=module_path,
-        source=_collect_source_block(src, node, end_line=init_node.end_lineno if init_node else node.lineno),
+        source=_collect_source_block(src, node, end_line=init_node.end_lineno if init_node else class_end),
     )
 
 
@@ -782,7 +792,8 @@ def render_docstring(
 
     sections: dict[str, str] = {}
 
-    if merged_params:
+    # A table whose Type and Description cells are all empty repeats the signature above it and nothing else.
+    if merged_params and any(p.type or p.description.strip() for p in merged_params):
         rows = []
         for p in merged_params:
             default_val = f"`{p.default}`" if p.default not in (None, "") else "*required*"

--- a/docs/build_reference.py
+++ b/docs/build_reference.py
@@ -301,9 +301,10 @@ def format_signature(
     pairs = [
         (arg, defaults[idx - default_offset] if idx >= default_offset else None) for idx, arg in enumerate(combined)
     ]
-    if is_class:  # a constructor is called as Class(...), so the bound self/cls is never passed
-        pairs = [(arg, default) for arg, default in pairs if arg.arg not in {"self", "cls"}]
-        posonly = [arg for arg in posonly if arg.arg not in {"self", "cls"}]
+    # A constructor is called as Class(...), so drop __init__'s leading bound parameter — and only that one,
+    # since `cls` is a real argument elsewhere (e.g. BOTrack(xywh, score, cls, feat=None)).
+    if is_class and pairs and pairs[0][0].arg in {"self", "cls"}:
+        pairs, posonly = pairs[1:], posonly[1:]
     for idx, (arg, default) in enumerate(pairs):
         params.append(_format_parameter(arg, default, src))
         if posonly and idx == len(posonly) - 1:


### PR DESCRIPTION
## What

Five defects in the reference generator, all visible on pages like [`engine/exporter`](https://docs.ultralytics.com/reference/engine/exporter). Counts are from regenerating the full reference (235 modules) before and after.

| Defect | Impact |
|---|---|
| **Multi-line `Returns:`/`Yields:` truncated mid-sentence.** `RETURNS_RE.match()` ran on the whole entry block and `(.*)` stops at the first newline, so continuation lines were dropped — `NMSModel.forward` ended at *"…where B is the batch size, or a"*. Now mirrors the Args path (first line + dedented rest). | **127 rows** regained their lost text |
| **Class source panels showed only `class X:`.** The snippet ended at `node.lineno` when a class declared no `__init__`, while the GitHub link still pointed at the full line range. Now it ends at the first method, so the docstring and class attributes are included. | **63 classes** (incl. `BaseModel`, and dataclasses like `SolutionConfig`: 2 → 90 lines) |
| **`self` in constructor signatures.** `Exporter(self, cfg=DEFAULT_CFG, …)` — you never pass the bound argument to `Class(...)`, and the Args table already skipped it. | **289 classes** |
| **`-> None` on constructor signatures.** `FeatureHook(…) -> None` came from annotating `__init__`; a constructor returns the instance. | **73 classes** |
| **Args tables with every Type and Description cell blank.** Undocumented, unannotated parameters produced a 4-column table that only repeated the name and default already shown in the signature above it. Tables with any real content are untouched. | **323 tables removed** |

Also drops the space around `=` for unannotated defaults (`prefix=colorstr("Ascend:")`), so the rendered signature matches the source shown directly beneath it.

Net effect on generated docs: 178 files, **-1469 lines**, with no class source panel shrinking and no table row losing content (verified by diffing full before/after generations).

## Known, not fixed here

12 classes that inherit `__init__` from an in-module base still advertise a no-arg constructor (`QNNModel()`, `SemanticMask()`). Resolving that needs base-class lookup, which costs more code than the fix is worth on its own — happy to do it separately if wanted.

## Verified

Full reference regenerated with `build_reference_docs()` before and after; diffed every file. `ruff format` + `ruff check` clean.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves automated API reference generation by producing cleaner, more accurate class signatures and documentation output. ✨

### 📊 Key Changes
- Formats constructor signatures as class calls, removing only the bound `self` or `cls` parameter.
- Omits return annotations from class constructor signatures and improves formatting for long signatures.
- Applies correct spacing around default values when type annotations are absent.
- Preserves and reflows continuation lines in Google-style `Returns` documentation.
- Refines class source extraction boundaries, especially for classes with multiple methods or no `__init__`.
- Suppresses redundant parameter tables when they contain no useful type or description information.

### 🎯 Purpose & Impact
- Makes generated Ultralytics API reference pages clearer and closer to how users actually call classes. 📚
- Prevents constructor documentation from exposing implementation details such as `self`.
- Improves readability of multi-line return descriptions and long signatures.
- Reduces redundant or misleading content in generated documentation.
- Helps keep developer documentation more accurate and consistent across the repository. ✅