### PR TITLE
Fix Examples captions and hard-wrapped table descriptions

### DIFF
--- a/docs/build_reference.py
+++ b/docs/build_reference.py
@@ -383,9 +383,8 @@ def _parse_named_entries(lines: list[str]) -> list[ParameterDoc]:
         match = SECTION_ENTRY_RE.match(first_line)
         if match:
             name, type_hint, desc = match.groups()
-            description = " ".join(desc.split())
-            if rest:
-                description = f"{description}\n" + "\n".join(rest)
+            # Dedent continuations so _normalize_text reflows a wrapped sentence; lists and code keep their breaks.
+            description = "\n".join([" ".join(desc.split()), textwrap.dedent("\n".join(rest))]).strip()
             entries.append(ParameterDoc(name=name, type=type_hint, description=_normalize_text(description)))
         else:
             entries.append(ParameterDoc(name=text, type=None, description=""))
@@ -442,8 +441,11 @@ def _normalize_text(text: str) -> str:
     """Normalize text while preserving Markdown structures like tables, admonitions, and code blocks."""
     if not text:
         return ""
-    # Check if text contains Markdown structures that need line preservation
-    if any(marker in text for marker in ("|", "!!!", "```", "\n#", "\n- ", "\n* ", "\n1. ", "\n    ")):
+    # Check if text contains Markdown structures that need line preservation. The table check is line-anchored:
+    # a bare pipe is usually a union type in prose ("Array[M, 4] | Array[M, 5]"), not a table.
+    if re.search(r"(?m)^\s*\|", text) or any(
+        marker in text for marker in ("!!!", "```", "\n#", "\n- ", "\n* ", "\n1. ", "\n    ")
+    ):
         # Preserve Markdown formatting - just strip trailing whitespace from lines
         return "\n".join(line.rstrip() for line in text.splitlines()).strip()
     # Simple text - collapse single newlines within paragraphs

--- a/docs/build_reference.py
+++ b/docs/build_reference.py
@@ -819,9 +819,17 @@ def render_docstring(
         sections["returns"] = f"**Returns**\n\n{table}"
 
     if doc.examples:
-        code_block = "\n\n".join(f"```python\n{example.strip()}\n```" for example in doc.examples if example.strip())
-        if code_block:
-            sections["examples"] = f"**Examples**\n\n{code_block}\n\n"
+        # Google-style Examples interleave captions with >>> runs; fence only the runs so the captions stay prose.
+        blocks: list[str] = []
+        for paragraph in (p.strip() for example in doc.examples for p in re.split(r"\n\s*\n", example.strip())):
+            lines = paragraph.splitlines()
+            prompt = next((i for i, line in enumerate(lines) if line.lstrip().startswith(">>>")), 0)
+            if prompt:
+                blocks.append("\n".join(lines[:prompt]).strip())
+            if paragraph:
+                blocks.append(_code_fence("\n".join(lines[prompt:]).strip()))
+        if blocks:
+            sections["examples"] = "**Examples**\n\n" + "\n\n".join(blocks) + "\n\n"
 
     if doc.notes:
         note_text = "\n\n".join(doc.notes).strip()


### PR DESCRIPTION
## What

Two rendering defects on every reference page.

### 1. Examples captions fenced as Python

Google-style `Examples:` interleave captions with `>>>` runs, but the whole block was fenced as Python — captions rendered as syntax-highlighted code, and copying gave a snippet that raises `SyntaxError` on line 1.

[`cfg2dict`](https://docs.ultralytics.com/reference/cfg/__init__#ultralytics.cfg.__init__.cfg2dict) had one code box containing three captions; it now renders as three captions, each above its own code block.

Each Examples block is split on blank lines and fenced only from the first `>>>` in a paragraph. A paragraph with no prompt (REPL output separated by a blank line, or a plain snippet) is fenced exactly as before.

**Scale:** 171 prose lines across 53 files — 116 leading captions plus 55 between runs.

### 2. Hard line break in the middle of wrapped descriptions

`cfg2dict`'s first argument rendered as:

> Configuration object to be converted. Can be a file path, a string, a
> dictionary, or a SimpleNamespace object.

A docstring that wraps across source lines kept that wrap as a real newline: the continuation lines still carried their source indentation, so `_normalize_text` treated the text as structured Markdown and `_clean_cell` turned the newline into a `<br>`. Continuations are now dedented before normalizing, so the sentence reflows — the same shape already used for `Returns` in #25457.

The Markdown-table check in `_normalize_text` is also line-anchored now: a bare `|` in prose (`Array[M, 4] | Array[M, 5]`) is a union type, not a table, and it was forcing line preservation on its own.

**Scale:** 299 descriptions carried a mid-sentence break; 3 remain, all from docstrings whose continuation lines use an inconsistent hanging indent (e.g. `GPUInfo.gpu_stats`) or start with an escaped pipe — genuinely ambiguous input rather than a generator bug.

## Verified

Full reference generated from clean stubs before and after. Word-level diff across all 208 files: **the only tokens removed are 321 `<br>` tags** — no prose lost, all 2672 symbols intact. `ruff format` + `ruff check` clean.

Preview of both fixes (docs built against this branch): https://docs-l27o6xma1-ultralytics.vercel.app/reference/cfg/__init__#ultralytics.cfg.__init__.cfg2dict

## Note

`create_markdown` rebuilds frontmatter by splitting an existing page on every `---`, so regenerating over generated output (instead of the committed stubs) folds table separators into the frontmatter and corrupts the page. CI never hits it — each build starts from a fresh clone — but it will bite anyone running the generator twice locally. Not fixed here.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves API reference generation by preserving Markdown formatting and rendering mixed prose/code examples correctly. 🛠️

### 📊 Key Changes

- Dedents continuation lines in parameter descriptions so wrapped text is reflowed cleanly.
- Detects Markdown tables only when lines begin with a pipe, preventing union types in prose from being treated as tables.
- Preserves structured Markdown such as lists, headings, admonitions, and code blocks.
- Updates example rendering to keep captions as prose while fencing only interactive `>>>` code blocks.
- Handles multiple example paragraphs and mixed prose/code content more reliably.

### 🎯 Purpose & Impact

- 📚 Produces cleaner, more readable generated API documentation.
- ✅ Prevents formatting errors when descriptions contain union types such as `Array[M, 4] | Array[M, 5]`.
- 💻 Makes Google-style examples easier to understand by separating explanatory text from executable code.
- 🔄 Improves consistency for contributors writing docstrings without changing runtime library behavior.