### PR TITLE
Update OrangePi Huawei Ascend 310B Platform support

### DIFF
--- a/docs/en/integrations/ascend.md
+++ b/docs/en/integrations/ascend.md
@@ -42,14 +42,14 @@ Ascend export supports all seven Ultralytics tasks. Detection, instance segmenta
 
 ## Supported Devices
 
-Pass the target SoC with `name`; ATC bakes it into the `.om` as `--soc_version`, so it must match the board you deploy to. Locally you can compile for any SoC your CANN installation provides kernels for. On [Ultralytics Platform](https://platform.ultralytics.com), the 310B targets are listed as coming soon while their operator kernels are added to the build image.
+Pass the target SoC with `name`; ATC bakes it into the `.om` as `--soc_version`, so it must match the board you deploy to. Locally you can compile for any SoC your CANN installation provides kernels for. [Ultralytics Platform](https://platform.ultralytics.com) supports the Ascend310P1, Ascend310P3, Ascend310B1, and Ascend310B4 targets.
 
-| `name`        | Devices                           | Local export | Platform    |
-| :------------ | :-------------------------------- | :----------- | :---------- |
-| `Ascend310P3` | Atlas 300I Pro, Atlas 300V Pro    | ✅           | ✅          |
-| `Ascend310P1` | Atlas 300I                        | ✅           | ✅          |
-| `Ascend310B4` | OrangePi AIPro 20T, Atlas 200I A2 | ✅           | Coming soon |
-| `Ascend310B1` | OrangePi AIPro 8T                 | ✅           | Coming soon |
+| `name`        | Devices                           | Local export | Platform |
+| :------------ | :-------------------------------- | :----------- | :------- |
+| `Ascend310P3` | Atlas 300I Pro, Atlas 300V Pro    | ✅           | ✅       |
+| `Ascend310P1` | Atlas 300I                        | ✅           | ✅       |
+| `Ascend310B4` | OrangePi AIPro 20T, Atlas 200I A2 | ✅           | ✅       |
+| `Ascend310B1` | OrangePi AIPro 8T                 | ✅           | ✅       |
 
 ## Export to Ascend: Converting Your YOLO Model
 

--- a/docs/en/platform/train/models.md
+++ b/docs/en/platform/train/models.md
@@ -294,14 +294,14 @@ Export jobs progress through the following statuses:
 
 Some export formats have architecture or task restrictions:
 
-| Format       | Restriction                                                 |
-| ------------ | ----------------------------------------------------------- |
-| **IMX500**   | Available only for `YOLOv8n` and `YOLO11n`; INT8 only       |
-| **Axelera**  | Detect models only; INT8 only                               |
-| **DeepX**    | INT8 only                                                   |
-| **Hailo**    | INT8 HEF output; select the target Hailo architecture       |
-| **Huawei**   | FP16 .om output; Ascend310P targets today, 310B coming soon |
-| **Qualcomm** | Fixed W8A16 quantization; end-to-end export is unavailable  |
+| Format       | Restriction                                                                     |
+| ------------ | ------------------------------------------------------------------------------- |
+| **IMX500**   | Available only for `YOLOv8n` and `YOLO11n`; INT8 only                           |
+| **Axelera**  | Detect models only; INT8 only                                                   |
+| **DeepX**    | INT8 only                                                                       |
+| **Hailo**    | INT8 HEF output; select the target Hailo architecture                           |
+| **Huawei**   | FP16 .om output; Ascend310P1, Ascend310P3, Ascend310B1, and Ascend310B4 targets |
+| **Qualcomm** | Fixed W8A16 quantization; end-to-end export is unavailable                      |
 
 !!! note "Additional Export Rules"
 


### PR DESCRIPTION
## Summary

- mark Ascend310B1 and Ascend310B4 as supported on Ultralytics Platform
- list all four supported Huawei Ascend targets in the Platform export documentation
- retain the matching local CANN kernel requirement for local exports

Companion docs update for ultralytics/portal#3165.

## Validation

- formatted both Markdown files with the repository-pinned Prettier command
- verified no Ascend 310B coming-soon references remain in English docs
- ran `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Updated documentation to show that all supported Huawei Ascend 310 targets are now available on Ultralytics Platform.

### 📊 Key Changes

- Updated the Ascend integration guide to mark `Ascend310B1` and `Ascend310B4` as supported on Ultralytics Platform.
- Removed outdated “coming soon” messaging for Ascend 310B targets.
- Updated the platform export restrictions table to list all supported Huawei targets:
  - `Ascend310P1`
  - `Ascend310P3`
  - `Ascend310B1`
  - `Ascend310B4`

### 🎯 Purpose & Impact

- ✅ Keeps documentation aligned with current Ultralytics Platform capabilities.
- 📦 Confirms users can export FP16 `.om` models for all listed Ascend 310 targets through the platform.
- 🛠️ Helps developers select the correct Ascend system-on-chip target for deployment and avoid relying on outdated availability information.