### PR TITLE
Only send events for a valid mode and task

### DIFF
--- a/ultralytics/utils/events.py
+++ b/ultralytics/utils/events.py
@@ -8,6 +8,7 @@ from threading import Thread
 from urllib.request import Request, urlopen
 
 from ultralytics import SETTINGS, __version__
+from ultralytics.cfg import MODES, TASKS
 from ultralytics.utils import (
     ARGV,
     ENVIRONMENT,
@@ -99,8 +100,9 @@ class Events:
             device (torch.device | str, optional): The device type (e.g., 'cpu', 'cuda').
             run (BasePredictor | BaseTrainer, optional): The completed run, read for the mode's result fields.
         """
-        if not self.enabled:
-            # Events disabled, do nothing
+        # An event is named for its mode, so an arbitrary mode becomes an arbitrary event name, and GA4 drops every new
+        # name once a property reaches 500 of them - eventually the real ones.
+        if not self.enabled or cfg.mode not in MODES or cfg.task not in TASKS:
             return
 
         # Attempt to enqueue a new event


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛡️ Prevents invalid training modes or tasks from generating unusable analytics events.

### 📊 Key Changes

- Added validation against the supported `MODES` and `TASKS` configuration lists.
- Analytics events are now skipped when:
  - Event reporting is disabled.
  - The configured mode is unsupported.
  - The configured task is unsupported.
- Imported centralized mode and task definitions from `ultralytics.cfg`.

### 🎯 Purpose & Impact

- 📈 Protects Google Analytics 4 from being flooded with arbitrary event names, which could exceed its event-name limit.
- 🧹 Keeps telemetry data focused on valid Ultralytics workflows.
- 🚀 Improves analytics reliability without affecting valid training, validation, prediction, or export operations.