### PR TITLE
Skip the redundant contiguous copy in `RandomFlip`

### DIFF
--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1592,7 +1592,7 @@ class RandomFlip(BaseTransform):
                 img = np.flipud(img)
             elif params["direction"] == "horizontal":
                 img = np.fliplr(img)
-        labels["img"] = np.ascontiguousarray(img)
+        labels["img"] = img
         return labels
 
     def apply_instances(self, labels: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
@@ -1631,9 +1631,9 @@ class RandomFlip(BaseTransform):
             return labels
         if params["flip"]:
             if params["direction"] == "vertical":
-                labels["semantic_mask"] = np.ascontiguousarray(np.flipud(labels["semantic_mask"]))
+                labels["semantic_mask"] = np.flipud(labels["semantic_mask"])
             elif params["direction"] == "horizontal":
-                labels["semantic_mask"] = np.ascontiguousarray(np.fliplr(labels["semantic_mask"]))
+                labels["semantic_mask"] = np.fliplr(labels["semantic_mask"])
         return labels
 
     def apply_depth(self, labels: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
@@ -1650,9 +1650,9 @@ class RandomFlip(BaseTransform):
             return labels
         if params["flip"]:
             if params["direction"] == "vertical":
-                labels["depth"] = np.ascontiguousarray(np.flipud(labels["depth"]))
+                labels["depth"] = np.flipud(labels["depth"])
             elif params["direction"] == "horizontal":
-                labels["depth"] = np.ascontiguousarray(np.fliplr(labels["depth"]))
+                labels["depth"] = np.fliplr(labels["depth"])
         return labels
 
 


### PR DESCRIPTION
`RandomFlip` materializes the flipped array in all three of its hooks:

```python
labels["img"] = np.ascontiguousarray(img)                                           # apply_image
labels["semantic_mask"] = np.ascontiguousarray(np.fliplr(labels["semantic_mask"]))  # apply_semantic
labels["depth"] = np.ascontiguousarray(np.fliplr(labels["depth"]))                  # apply_depth
```

`np.fliplr`/`np.flipud` return a view, so this copy is what turns it into a real array. It is redundant because every consumer copies again right after, and that second copy is forced: `torch.from_numpy` rejects negative strides, so each formatter already materializes the array before tensorizing it.

- `img` -> `Format._format_img`: `transpose` then `np.ascontiguousarray`, unconditionally
- `semantic_mask` -> `SemanticFormat.apply_image`: `torch.from_numpy(mask.copy())`
- `depth` -> `DepthFormat.apply_depth`: optional `cv2.resize`, then `np.ascontiguousarray`

`RandomFlip` is only built by `v8_transforms`, and `build_transforms` always closes that list with `Format` or swaps the last entry for `SemanticFormat`/`DepthFormat`, so the view never reaches a consumer that cannot handle it. By `collate_fn` these keys are already tensors, it stacks them with `torch.stack`.

At the default `fliplr=0.5` this is one full-image copy per two training images that gets discarded right after.

The fourth `ascontiguousarray` in the class, on `keypoints` in `apply_instances`, is **not** touched: `instances.keypoints[:, flip_idx, :]` is fancy indexing, which returns a non-contiguous array, so that copy does real work.

**Deleted:** the intermediate contiguous copy in the three flip hooks. The flip stays a view and the formatter that was already copying does the single materialization. Line count is net-zero because each deletion leaves the assignment in place, and the removed work is one image-sized memcpy per flipped sample.

**Validation** (main @ 5578cc6, Linux x86_64, Python 3.12.3, torch 2.12.1, numpy 2.1.3, CPU):

- Bit-identical across five tasks: one deterministic augmented epoch dumped through `build_yolo_dataset`, once on `main` and once on the branch as separate processes with `git checkout` in between, compared tensor by tensor. **480 tensors, 0 mismatches** — detect (64 samples, coco128), segment (64, coco128-seg, includes `masks`), pose (coco8-pose, includes `keypoints`), semantic (cityscapes8, `SemanticDataset`), depth (depth8, `DepthDataset`). `flipud` was raised to 0.5 so the vertical hook runs too.
- The harness was verified against itself first: `main` vs `main` gives 0 mismatches only after seeding Albumentations through its `Compose.set_random_seed` — its RNG ignores `random.seed`, and its four `p=0.01` transforms otherwise produce 1-2 spurious diffs per 64 samples. It runs before `RandomFlip` and is not affected by this change, worth knowing if you want to reproduce the comparison.
- Full default train pipeline on coco128, 12 alternating runs, flip firing at the default `fliplr=0.5`: **5.41 -> 4.80 ms/img median (-11%)**, best-run vs best-run -14%. The numbers match the mechanism: the copy alone is 1.27 ms per 640x640 image on half the images, so 0.63 ms/img expected against 0.61 measured.
- `flip(p=1)` + `Format` in isolation: 2.46 -> 1.19 ms per image (2.1x).
- Real dataloader with `workers=2`: detect, segment, semantic and depth all collate normally and every batch tensor comes out contiguous.
- `ruff format` and `ruff check` clean.

No new test: the augmentation pipeline is already exercised by the training tests on CI and the tensors it produces do not change.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Skip redundant contiguous array copies in `RandomFlip` augmentation outputs.

### 📊 Key Changes
- Removed `np.ascontiguousarray` from flipped images, semantic masks, and depth maps.
- Retained the direct results from NumPy flip operations in the corresponding label fields.

### 🎯 Purpose & Impact
- Reduces unnecessary memory allocation and copying during augmentation.
- Improves preprocessing efficiency while preserving flip behavior.
- Downstream code should be checked to ensure it does not require contiguous arrays at this stage.