### PR TITLE
Record the GPU count instead of a ddp flag

### DIFF
--- a/ultralytics/utils/events.py
+++ b/ultralytics/utils/events.py
@@ -146,10 +146,9 @@ class Events:
                     }
                     params["flags"] = ",".join(k for k, v in flags.items() if v) or None
                     params["arch"] = _arch(unwrap_model(run.model))  # DDP and EMA both wrap away the .yaml
+                    params["ngpu"] = run.world_size if run.world_size > 1 else None  # only a count above one informs
                     if device.type == "cuda":  # makes hours comparable
                         params["GPU"] = get_gpu_info(device.index or 0)
-                    # only a count above one informs, and NPU runs need it too, so it sits outside the CUDA guard
-                    params["ngpu"] = run.world_size if run.world_size > 1 else None
                 except Exception:
                     pass
             elif cfg.mode in {"predict", "track"}:  # track runs the predictor too, and is most of the video inference

--- a/ultralytics/utils/events.py
+++ b/ultralytics/utils/events.py
@@ -148,8 +148,8 @@ class Events:
                     params["arch"] = _arch(unwrap_model(run.model))  # DDP and EMA both wrap away the .yaml
                     if device.type == "cuda":  # makes hours comparable
                         params["GPU"] = get_gpu_info(device.index or 0)
-                        # only a count informs, since GPU alone implies one; without it hours land on a single device
-                        params["ngpu"] = run.world_size if run.world_size > 1 else None
+                    # only a count above one informs, and NPU runs need it too, so it sits outside the CUDA guard
+                    params["ngpu"] = run.world_size if run.world_size > 1 else None
                 except Exception:
                     pass
             elif cfg.mode in {"predict", "track"}:  # track runs the predictor too, and is most of the video inference

--- a/ultralytics/utils/events.py
+++ b/ultralytics/utils/events.py
@@ -143,12 +143,14 @@ class Events:
                         "dropout": cfg.dropout > 0,
                         "early_stop": run.epoch + 1 < run.epochs,  # .stop is also set on the last planned epoch
                         "resume": bool(cfg.resume),  # fitness carries over, epochs and hours do not
-                        "ddp": run.world_size > 1,
                     }
                     params["flags"] = ",".join(k for k, v in flags.items() if v) or None
                     params["arch"] = _arch(unwrap_model(run.model))  # DDP and EMA both wrap away the .yaml
                     if device.type == "cuda":  # makes hours comparable
                         params["GPU"] = get_gpu_info(device.index or 0)
+                        # only a count carries information, since one GPU is implied by GPU alone; without it the
+                        # whole run's hours would be attributed to a single device
+                        params["ngpu"] = run.world_size if run.world_size > 1 else None
                 except Exception:
                     pass
             elif cfg.mode in {"predict", "track"}:  # track runs the predictor too, and is most of the video inference

--- a/ultralytics/utils/events.py
+++ b/ultralytics/utils/events.py
@@ -148,8 +148,7 @@ class Events:
                     params["arch"] = _arch(unwrap_model(run.model))  # DDP and EMA both wrap away the .yaml
                     if device.type == "cuda":  # makes hours comparable
                         params["GPU"] = get_gpu_info(device.index or 0)
-                        # only a count carries information, since one GPU is implied by GPU alone; without it the
-                        # whole run's hours would be attributed to a single device
+                        # only a count informs, since GPU alone implies one; without it hours land on a single device
                         params["ngpu"] = run.world_size if run.world_size > 1 else None
                 except Exception:
                     pass


### PR DESCRIPTION
`flags` carried `ddp` as a boolean, so a multi-GPU run reported one GPU name and the whole run's `hours`. Training throughput — `n * epochs_done / hours` — was therefore inflated by an unknown factor on exactly those runs, and the only safe aggregation was to discard every distributed run:

```sql
AND flags NOT LIKE '%ddp%'   -- world_size isn't recorded, so multi-GPU inflates per-GPU throughput
```

Replace the boolean with the count. `run.world_size` is already resolved — 0 on CPU/MPS, 1 on a single GPU, N for `device='0,1,2,3'` (`trainer.py:167-171`).

```python
params["ngpu"] = run.world_size if run.world_size > 1 else None
```

Emitted only when it carries information: a single GPU is already implied by `GPU` being present, so sending `ngpu=1` would spend a param to say nothing. `ddp` drops out of `flags` because `ngpu` being present *is* the ddp signal.

## Param budget

The event stays within GA4's hard 25-param limit in every configuration, verified by driving the branch directly:

```
CPU          23/25             ngpu=None  GPU=no
single GPU   24/25             ngpu=None  GPU=yes
2x GPU DDP   25/25 <-- AT CAP  ngpu=2     GPU=yes
8x GPU DDP   25/25 <-- AT CAP  ngpu=8     GPU=yes
```

Multi-GPU sits exactly at 25. That is deliberate rather than incidental — the conditional emission is what keeps the common single-GPU case at 24 and leaves the cap unbroken. Any future train field must displace one of these, not add to them.

`get_gpu_info` was stubbed for that check since this host has no CUDA; note it precedes `ngpu` inside the guard, so on a real CUDA box a failure there costs both fields, which is the intended ordering (least reliable read last).

## Verification

Real CPU training on the branch: 23 params, `flags='pretrained'`, `ngpu` absent — `ddp` correctly gone from flags. `tests/test_engine.py` 33 passed.

The matching `ngpu` custom dimension is registered on the GA4 property ahead of this shipping; registration is not retroactive, so it has to precede the release that carries the field.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📈 Replaces the training event’s DDP flag with an explicit multi-GPU count for clearer experiment tracking.

### 📊 Key Changes
- Removes the `ddp` boolean from logged training flags.
- Adds an `ngpu` field containing the number of GPUs used when training with more than one GPU.
- Keeps single-GPU runs unmarked by storing no `ngpu` value.
- Preserves existing GPU information logging for CUDA devices.

### 🎯 Purpose & Impact
- 🔍 Provides more precise visibility into distributed and multi-GPU training runs.
- 📊 Helps analytics and monitoring distinguish the scale of multi-GPU jobs instead of using only a true/false DDP indicator.
- ✅ Avoids adding unnecessary metadata for single-GPU training, keeping event records clean.