### PR TITLE
Add Labelbox, CVAT, and Label Studio Platform integration docs

### DIFF
--- a/docs/en/platform/integrations/cvat.md
+++ b/docs/en/platform/integrations/cvat.md
@@ -15,10 +15,23 @@ Until then there is a short path that works today, because CVAT already exports 
 
 ## Import from CVAT Today
 
-1. In CVAT, open your task or project and choose **Export dataset**.
-2. Select the **[Ultralytics YOLO](https://docs.cvat.ai/docs/dataset_management/formats/format-yolo-ultralytics/)** format matching your task — CVAT lists Detection, Segmentation, Oriented Bounding Boxes, and Pose separately — and include the images.
-3. [Upload the exported ZIP](../data/datasets.md) to Platform as a new dataset.
-4. [Edit the annotations](../data/annotation.md), [train](../train/index.md), and [deploy](../deploy/index.md) without leaving the workspace.
+1. **Export from CVAT.** Open your task and choose **Actions > Export task dataset** (from a job it is **Menu > Export job dataset**).
+2. **Pick the format.** Choose the **[Ultralytics YOLO](https://docs.cvat.ai/docs/dataset_management/formats/format-yolo-ultralytics/)** entry matching your task — CVAT lists `Ultralytics YOLO Detection 1.0`, `Ultralytics YOLO Segmentation 1.0`, `Ultralytics YOLO Oriented Bounding Boxes 1.0`, and `Ultralytics YOLO Pose 1.0` separately.
+3. **Turn on Save images**, name the `.zip`, and click **OK**. Without the images the archive holds annotations only, and Platform has nothing to import.
+4. **Download the archive.** The export runs in the background — collect it from CVAT's [Requests](https://docs.cvat.ai/docs/workspace/requests-page/) page when it finishes.
+5. **Upload to Platform.** [Create a new dataset](../data/datasets.md) from the ZIP.
+6. **Train.** [Edit the annotations](../data/annotation.md), [train](../train/index.md), and [deploy](../deploy/index.md) without leaving the workspace.
+
+### Export with the CLI
+
+[CVAT's CLI](https://docs.cvat.ai/docs/api_sdk/cli/) exports the same archive from a terminal:
+
+```bash
+pip install cvat-cli
+cvat-cli task export-dataset --format "Ultralytics YOLO Detection 1.0" 103 dataset.zip
+```
+
+Replace `103` with your task ID and the format string with the variant matching your task.
 
 CVAT's Ultralytics YOLO export produces the layout Platform expects, so nothing needs converting:
 

--- a/docs/en/platform/integrations/cvat.md
+++ b/docs/en/platform/integrations/cvat.md
@@ -9,7 +9,7 @@ title: CVAT Dataset Import - Ultralytics Platform
 
 # CVAT Integration
 
-Direct [CVAT](https://www.cvat.ai/) imports are coming to [Ultralytics Platform](https://platform.ultralytics.com), so that a CVAT export uploads as-is with no format to choose.
+Direct [CVAT](https://www.cvat.ai/) imports are coming to [Ultralytics Platform](https://platform.ultralytics.com), so that a CVAT image detection or segmentation export uploads as-is with no format to choose.
 
 Until then there is a short path that works today, because CVAT already exports in the Ultralytics YOLO layout Platform reads.
 
@@ -54,7 +54,7 @@ CVAT offers [many export formats](https://docs.cvat.ai/docs/dataset_management/f
 
 !!! warning "Pascal VOC imports without annotations"
 
-    Platform does not read Pascal VOC XML labels, and a VOC export fails quietly rather than loudly: the images import, the annotations do not, and a VOC export with more than a handful of images also picks up a single class named after its image folder. Choose Ultralytics YOLO or COCO instead.
+    Platform does not read Pascal VOC XML labels, and a VOC export fails quietly rather than loudly: the images import, the annotations do not, and a VOC export of five or more images also picks up a single class named after its image folder. Choose Ultralytics YOLO or COCO instead.
 
 ## What the Integration Will Add
 

--- a/docs/en/platform/integrations/cvat.md
+++ b/docs/en/platform/integrations/cvat.md
@@ -1,0 +1,24 @@
+---
+plans: [free, pro, enterprise]
+coming_soon: true
+comments: true
+description: Bring CVAT annotation projects into Ultralytics Platform to edit annotations, train YOLO models, and deploy them.
+keywords: Ultralytics Platform, CVAT, CVAT export, dataset import, annotation, integrations, YOLO, computer vision
+title: CVAT Dataset Import - Ultralytics Platform
+---
+
+# CVAT Integration
+
+Direct [CVAT](https://www.cvat.ai/) imports are coming soon to [Ultralytics Platform](https://platform.ultralytics.com). Once available, you will export your CVAT project and upload it to Platform to [annotate](../data/annotation.md), [train](../train/index.md), and [deploy](../deploy/index.md) without converting the data yourself.
+
+## Import from CVAT Today
+
+CVAT exports datasets in several formats, including YOLO, which Platform already supports:
+
+1. In CVAT, export your task or project in a **YOLO** format.
+2. [Upload the export](../data/datasets.md) to Platform as a new dataset.
+3. Edit the annotations and train the dataset like any other Platform dataset.
+
+!!! tip "Already have labels elsewhere?"
+
+    The [Labelbox](labelbox.md) and [Roboflow](roboflow.md) integrations are available today, and Platform also imports YOLO, COCO, and Ultralytics NDJSON datasets directly.

--- a/docs/en/platform/integrations/cvat.md
+++ b/docs/en/platform/integrations/cvat.md
@@ -54,11 +54,11 @@ CVAT offers [many export formats](https://docs.cvat.ai/docs/dataset_management/f
 
 !!! warning "Pascal VOC imports without annotations"
 
-    Platform does not read Pascal VOC XML labels, and a VOC export fails quietly rather than loudly: the images import, the annotations do not, and the dataset picks up a single class named after the export's image folder. Choose Ultralytics YOLO or COCO instead.
+    Platform does not read Pascal VOC XML labels, and a VOC export fails quietly rather than loudly: the images import, the annotations do not, and a VOC export with more than a handful of images also picks up a single class named after its image folder. Choose Ultralytics YOLO or COCO instead.
 
 ## What the Integration Will Add
 
-Picking the right export format is the step the integration removes. Once it ships, you will export from CVAT however you like, upload it, and Platform will map the annotations to the matching [YOLO task](../data/index.md#supported-tasks) itself.
+Picking the right export format is the step the integration removes. Once it ships, you will export any of CVAT's image detection and segmentation formats, upload it, and Platform will map the annotations to the matching [YOLO task](../data/index.md#supported-tasks) itself.
 
 - **No format to choose** — CVAT's image detection and segmentation exports map to a YOLO dataset with label names preserved
 - **One workspace** — labeling, training, and deployment stop spanning separate tools and a conversion script

--- a/docs/en/platform/integrations/cvat.md
+++ b/docs/en/platform/integrations/cvat.md
@@ -35,9 +35,9 @@ CVAT offers [many export formats](https://docs.cvat.ai/docs/dataset_management/f
 
 | CVAT Format          | Works  | Notes                                                                                        |
 | -------------------- | ------ | -------------------------------------------------------------------------------------------- |
-| **Ultralytics YOLO** | Best   | Ships `data.yaml`, so your label names come across intact                                     |
-| **COCO 1.0**         | Yes    | Platform reads COCO JSON annotations and category names                                       |
-| **YOLO 1.1**         | Partly | Boxes import, but its `obj.names` file is not read — classes arrive as `class0`, `class1`, …  |
+| **Ultralytics YOLO** | Best   | Ships `data.yaml`, so your label names come across intact                                    |
+| **COCO 1.0**         | Yes    | Platform reads COCO JSON annotations and category names                                      |
+| **YOLO 1.1**         | Partly | Boxes import, but its `obj.names` file is not read — classes arrive as `class0`, `class1`, … |
 
 !!! warning "Pascal VOC XML is not supported"
 

--- a/docs/en/platform/integrations/cvat.md
+++ b/docs/en/platform/integrations/cvat.md
@@ -2,23 +2,40 @@
 plans: [free, pro, enterprise]
 coming_soon: true
 comments: true
-description: Bring CVAT annotation projects into Ultralytics Platform to edit annotations, train YOLO models, and deploy them.
+description: Bring CVAT annotation projects into Ultralytics Platform to edit annotations, train YOLO models, and deploy them from one workspace.
 keywords: Ultralytics Platform, CVAT, CVAT export, dataset import, annotation, integrations, YOLO, computer vision
 title: CVAT Dataset Import - Ultralytics Platform
 ---
 
 # CVAT Integration
 
-Direct [CVAT](https://www.cvat.ai/) imports are coming soon to [Ultralytics Platform](https://platform.ultralytics.com). Once available, you will export your CVAT project and upload it to Platform to [annotate](../data/annotation.md), [train](../train/index.md), and [deploy](../deploy/index.md) without converting the data yourself.
+Direct [CVAT](https://www.cvat.ai/) imports are coming to [Ultralytics Platform](https://platform.ultralytics.com). Today, moving a CVAT project into training means choosing an export format and matching it to what your training code expects. The integration removes that step: upload the export and Platform maps the annotations to the matching [YOLO task](../data/index.md#supported-tasks) for you.
+
+## How It Will Work
+
+1. **Export from CVAT.** Export the task or project you want to train on.
+2. **Upload to Platform.** Create a new dataset from the export — no conversion step and no format to choose.
+3. **Train.** [Edit the annotations](../data/annotation.md), [train](../train/index.md), and [deploy](../deploy/index.md) from the same workspace.
+
+## Why It Helps
+
+- **No conversion scripts** — annotations and class names map to a YOLO dataset automatically, so there is nothing to keep in sync as your label schema changes
+- **One workspace** — labeling, training, and deployment live together instead of spanning a labeling tool, a conversion step, and a training environment
+- **Keep annotating** — imported datasets open in Platform's [annotation editor](../data/annotation.md), including SAM-powered smart annotation
+- **Train immediately** — datasets are ready for [cloud training](../train/cloud-training.md) as soon as they finish processing
 
 ## Import from CVAT Today
 
-CVAT exports datasets in several formats, including YOLO, which Platform already supports:
+CVAT already exports in formats Platform ingests, so you do not have to wait:
 
-1. In CVAT, export your task or project in a **YOLO** format.
+1. In CVAT, export your task or project in a **YOLO** or **COCO** format.
 2. [Upload the export](../data/datasets.md) to Platform as a new dataset.
 3. Edit the annotations and train the dataset like any other Platform dataset.
 
-!!! tip "Already have labels elsewhere?"
+!!! warning "Pascal VOC XML is not supported"
 
-    The [Labelbox](labelbox.md) and [Roboflow](roboflow.md) integrations are available today, and Platform also imports YOLO, COCO, and Ultralytics NDJSON datasets directly.
+    Choose a YOLO or COCO export rather than Pascal VOC. Platform flags XML label files during upload because it cannot read them.
+
+!!! tip "Available now"
+
+    The [Labelbox](labelbox.md), [Roboflow](roboflow.md), and [Ultralytics HUB](ultralytics-hub.md) integrations work today, and Platform imports YOLO, COCO, and Ultralytics NDJSON datasets directly.

--- a/docs/en/platform/integrations/cvat.md
+++ b/docs/en/platform/integrations/cvat.md
@@ -16,7 +16,7 @@ Until then there is a short path that works today, because CVAT already exports 
 ## Import from CVAT Today
 
 1. In CVAT, open your task or project and choose **Export dataset**.
-2. Select the **[Ultralytics YOLO](https://docs.cvat.ai/docs/dataset_management/formats/format-yolo-ultralytics/)** format that matches your task, and include the images.
+2. Select the **[Ultralytics YOLO](https://docs.cvat.ai/docs/dataset_management/formats/format-yolo-ultralytics/)** format matching your task — CVAT lists Detection, Segmentation, Oriented Bounding Boxes, and Pose separately — and include the images.
 3. [Upload the exported ZIP](../data/datasets.md) to Platform as a new dataset.
 4. [Edit the annotations](../data/annotation.md), [train](../train/index.md), and [deploy](../deploy/index.md) without leaving the workspace.
 
@@ -39,9 +39,9 @@ CVAT offers [many export formats](https://docs.cvat.ai/docs/dataset_management/f
 | **COCO 1.0**         | Yes    | Platform reads COCO JSON annotations and category names                                      |
 | **YOLO 1.1**         | Partly | Boxes import, but its `obj.names` file is not read — classes arrive as `class0`, `class1`, … |
 
-!!! warning "Pascal VOC XML is not supported"
+!!! warning "Pascal VOC imports without annotations"
 
-    Platform cannot read XML label files and flags them during upload. Choose Ultralytics YOLO or COCO instead.
+    Platform does not read Pascal VOC XML labels, and a VOC export fails quietly rather than loudly: the images import, the annotations do not, and the dataset picks up a single class named after the export's image folder. Choose Ultralytics YOLO or COCO instead.
 
 ## What the Integration Will Add
 

--- a/docs/en/platform/integrations/cvat.md
+++ b/docs/en/platform/integrations/cvat.md
@@ -2,39 +2,55 @@
 plans: [free, pro, enterprise]
 coming_soon: true
 comments: true
-description: Bring CVAT annotation projects into Ultralytics Platform to edit annotations, train YOLO models, and deploy them from one workspace.
-keywords: Ultralytics Platform, CVAT, CVAT export, dataset import, annotation, integrations, YOLO, computer vision
+description: Move a CVAT task or project into Ultralytics Platform with the Ultralytics YOLO export, then edit annotations, train YOLO models, and deploy from one workspace.
+keywords: Ultralytics Platform, CVAT, CVAT export, Ultralytics YOLO format, dataset import, annotation, integrations, YOLO, computer vision
 title: CVAT Dataset Import - Ultralytics Platform
 ---
 
 # CVAT Integration
 
-Direct [CVAT](https://www.cvat.ai/) imports are coming to [Ultralytics Platform](https://platform.ultralytics.com). Today, moving a CVAT project into training means choosing an export format and matching it to what your training code expects. The integration removes that step: upload the export and Platform maps the annotations to the matching [YOLO task](../data/index.md#supported-tasks) for you.
+Direct [CVAT](https://www.cvat.ai/) imports are coming to [Ultralytics Platform](https://platform.ultralytics.com), so that any CVAT export uploads as-is with no format to choose.
 
-## How It Will Work
-
-1. **Export from CVAT.** Export the task or project you want to train on.
-2. **Upload to Platform.** Create a new dataset from the export — no conversion step and no format to choose.
-3. **Train.** [Edit the annotations](../data/annotation.md), [train](../train/index.md), and [deploy](../deploy/index.md) from the same workspace.
-
-## Why It Helps
-
-- **No conversion scripts** — annotations and class names map to a YOLO dataset automatically, so there is nothing to keep in sync as your label schema changes
-- **One workspace** — labeling, training, and deployment live together instead of spanning a labeling tool, a conversion step, and a training environment
-- **Keep annotating** — imported datasets open in Platform's [annotation editor](../data/annotation.md), including SAM-powered smart annotation
-- **Train immediately** — datasets are ready for [cloud training](../train/cloud-training.md) as soon as they finish processing
+Until then there is a short path that works today, because CVAT already exports in the Ultralytics YOLO layout Platform reads.
 
 ## Import from CVAT Today
 
-CVAT already exports in formats Platform ingests, so you do not have to wait:
+1. In CVAT, open your task or project and choose **Export dataset**.
+2. Select the **[Ultralytics YOLO](https://docs.cvat.ai/docs/dataset_management/formats/format-yolo-ultralytics/)** format that matches your task, and include the images.
+3. [Upload the exported ZIP](../data/datasets.md) to Platform as a new dataset.
+4. [Edit the annotations](../data/annotation.md), [train](../train/index.md), and [deploy](../deploy/index.md) without leaving the workspace.
 
-1. In CVAT, export your task or project in a **YOLO** or **COCO** format.
-2. [Upload the export](../data/datasets.md) to Platform as a new dataset.
-3. Edit the annotations and train the dataset like any other Platform dataset.
+CVAT's Ultralytics YOLO export produces the layout Platform expects, so nothing needs converting:
+
+```
+archive.zip/
+├── data.yaml          # class names Platform reads
+├── images/train/
+└── labels/train/
+```
+
+## Choosing an Export Format
+
+CVAT offers [many export formats](https://docs.cvat.ai/docs/dataset_management/formats/). Three matter here:
+
+| CVAT Format          | Works  | Notes                                                                                        |
+| -------------------- | ------ | -------------------------------------------------------------------------------------------- |
+| **Ultralytics YOLO** | Best   | Ships `data.yaml`, so your label names come across intact                                     |
+| **COCO 1.0**         | Yes    | Platform reads COCO JSON annotations and category names                                       |
+| **YOLO 1.1**         | Partly | Boxes import, but its `obj.names` file is not read — classes arrive as `class0`, `class1`, …  |
 
 !!! warning "Pascal VOC XML is not supported"
 
-    Choose a YOLO or COCO export rather than Pascal VOC. Platform flags XML label files during upload because it cannot read them.
+    Platform cannot read XML label files and flags them during upload. Choose Ultralytics YOLO or COCO instead.
+
+## What the Integration Will Add
+
+Picking the right export format is the step the integration removes. Once it ships, you will export from CVAT however you like, upload it, and Platform will map the annotations to the matching [YOLO task](../data/index.md#supported-tasks) itself.
+
+- **No format to choose** — every CVAT export maps to a YOLO dataset with label names preserved
+- **One workspace** — labeling, training, and deployment stop spanning separate tools and a conversion script
+- **Keep annotating** — imported datasets open in Platform's [annotation editor](../data/annotation.md), including SAM-powered smart annotation
+- **Train immediately** — datasets are ready for [cloud training](../train/cloud-training.md) as soon as they finish processing
 
 !!! tip "Available now"
 

--- a/docs/en/platform/integrations/cvat.md
+++ b/docs/en/platform/integrations/cvat.md
@@ -9,7 +9,7 @@ title: CVAT Dataset Import - Ultralytics Platform
 
 # CVAT Integration
 
-Direct [CVAT](https://www.cvat.ai/) imports are coming to [Ultralytics Platform](https://platform.ultralytics.com), so that any CVAT export uploads as-is with no format to choose.
+Direct [CVAT](https://www.cvat.ai/) imports are coming to [Ultralytics Platform](https://platform.ultralytics.com), so that a CVAT export uploads as-is with no format to choose.
 
 Until then there is a short path that works today, because CVAT already exports in the Ultralytics YOLO layout Platform reads.
 
@@ -28,10 +28,10 @@ Until then there is a short path that works today, because CVAT already exports 
 
 ```bash
 pip install cvat-cli
-cvat-cli task export-dataset --format "Ultralytics YOLO Detection 1.0" 103 dataset.zip
+cvat-cli project export-dataset --format "Ultralytics YOLO Detection 1.0" --with-images yes 104 dataset.zip
 ```
 
-Replace `103` with your task ID and the format string with the variant matching your task.
+Replace `104` with your project ID and the format string with the variant matching your task. `--with-images yes` is the CLI equivalent of the **Save images** switch; without it the archive holds annotations only.
 
 CVAT's Ultralytics YOLO export produces the layout Platform expects, so nothing needs converting:
 
@@ -49,7 +49,7 @@ CVAT offers [many export formats](https://docs.cvat.ai/docs/dataset_management/f
 | CVAT Format          | Works  | Notes                                                                                        |
 | -------------------- | ------ | -------------------------------------------------------------------------------------------- |
 | **Ultralytics YOLO** | Best   | Ships `data.yaml`, so your label names come across intact                                    |
-| **COCO 1.0**         | Yes    | Platform reads COCO JSON annotations and category names                                      |
+| **COCO 1.0**         | Yes    | Read too; a mix of polygons and boxes imports as segment, and the box-only ones are dropped  |
 | **YOLO 1.1**         | Partly | Boxes import, but its `obj.names` file is not read — classes arrive as `class0`, `class1`, … |
 
 !!! warning "Pascal VOC imports without annotations"
@@ -60,7 +60,7 @@ CVAT offers [many export formats](https://docs.cvat.ai/docs/dataset_management/f
 
 Picking the right export format is the step the integration removes. Once it ships, you will export from CVAT however you like, upload it, and Platform will map the annotations to the matching [YOLO task](../data/index.md#supported-tasks) itself.
 
-- **No format to choose** — every CVAT export maps to a YOLO dataset with label names preserved
+- **No format to choose** — CVAT's image detection and segmentation exports map to a YOLO dataset with label names preserved
 - **One workspace** — labeling, training, and deployment stop spanning separate tools and a conversion script
 - **Keep annotating** — imported datasets open in Platform's [annotation editor](../data/annotation.md), including SAM-powered smart annotation
 - **Train immediately** — datasets are ready for [cloud training](../train/cloud-training.md) as soon as they finish processing

--- a/docs/en/platform/integrations/index.md
+++ b/docs/en/platform/integrations/index.md
@@ -32,8 +32,8 @@ it directly. Cloud storage connections verify list and read access before anythi
 | [**Ultralytics HUB**](ultralytics-hub.md)           | Imports datasets, projects, models, and balance     |
 | [**Roboflow**](roboflow.md)                         | Imports datasets                                    |
 | [**Labelbox**](labelbox.md)                         | Imports NDJSON exports as datasets                  |
-| [**CVAT**](cvat.md)                                 | Imports CVAT exports as datasets — coming soon      |
-| [**Label Studio**](label-studio.md)                 | Imports Label Studio exports — coming soon          |
+| [**CVAT**](cvat.md)                                 | Imports CVAT image datasets — coming soon           |
+| [**Label Studio**](label-studio.md)                 | Imports Label Studio image datasets — coming soon   |
 | [**Google Cloud Storage**](google-cloud-storage.md) | Indexes datasets in place from your GCS buckets     |
 | [**Amazon S3**](amazon-s3.md)                       | Indexes datasets in place from your S3 buckets      |
 | [**Azure Blob Storage**](azure-blob-storage.md)     | Indexes datasets in place from your blob containers |

--- a/docs/en/platform/integrations/index.md
+++ b/docs/en/platform/integrations/index.md
@@ -32,8 +32,8 @@ it directly. Cloud storage connections verify list and read access before anythi
 | [**Ultralytics HUB**](ultralytics-hub.md)           | Imports datasets, projects, models, and balance     |
 | [**Roboflow**](roboflow.md)                         | Imports datasets                                    |
 | [**Labelbox**](labelbox.md)                         | Imports NDJSON exports as datasets                  |
-| [**CVAT**](cvat.md)                                 | Imports datasets — coming soon                      |
-| [**Label Studio**](label-studio.md)                 | Imports datasets — coming soon                      |
+| [**CVAT**](cvat.md)                                 | Imports CVAT exports as datasets — coming soon      |
+| [**Label Studio**](label-studio.md)                 | Imports Label Studio exports — coming soon          |
 | [**Google Cloud Storage**](google-cloud-storage.md) | Indexes datasets in place from your GCS buckets     |
 | [**Amazon S3**](amazon-s3.md)                       | Indexes datasets in place from your S3 buckets      |
 | [**Azure Blob Storage**](azure-blob-storage.md)     | Indexes datasets in place from your blob containers |

--- a/docs/en/platform/integrations/index.md
+++ b/docs/en/platform/integrations/index.md
@@ -3,7 +3,7 @@ plans: [free, pro, enterprise]
 title: Platform Integrations
 comments: true
 description: Connect Ultralytics Platform to Slack, existing tools, cloud storage, and Enterprise On Premise compute and datasets.
-keywords: Ultralytics Platform, integrations, Slack, alerts, data import, Roboflow, Ultralytics HUB, cloud storage, GCS, Amazon S3, Azure Blob Storage, On Premise, dataset migration, YOLO, computer vision
+keywords: Ultralytics Platform, integrations, Slack, alerts, data import, Roboflow, Labelbox, CVAT, Label Studio, Ultralytics HUB, cloud storage, GCS, Amazon S3, Azure Blob Storage, On Premise, dataset migration, YOLO, computer vision
 ---
 
 # Integrations
@@ -21,7 +21,8 @@ All integrations are managed from your account settings:
 3. Follow the connection prompts
 
 HUB and Roboflow imports start with a preview so you can review what will be transferred and confirm that you have
-enough [storage](../account/billing.md). Cloud storage connections verify list and read access before anything is saved.
+enough [storage](../account/billing.md). Labelbox needs no connection at all — upload the export file and Platform reads
+it directly. Cloud storage connections verify list and read access before anything is saved.
 
 ## Available Integrations
 
@@ -30,6 +31,9 @@ enough [storage](../account/billing.md). Cloud storage connections verify list a
 | [**Slack**](slack.md)                               | Posts selected job results to one Slack channel     |
 | [**Ultralytics HUB**](ultralytics-hub.md)           | Imports datasets, projects, models, and balance     |
 | [**Roboflow**](roboflow.md)                         | Imports datasets                                    |
+| [**Labelbox**](labelbox.md)                         | Imports NDJSON exports as datasets                  |
+| [**CVAT**](cvat.md)                                 | Imports datasets — coming soon                      |
+| [**Label Studio**](label-studio.md)                 | Imports datasets — coming soon                      |
 | [**Google Cloud Storage**](google-cloud-storage.md) | Indexes datasets in place from your GCS buckets     |
 | [**Amazon S3**](amazon-s3.md)                       | Indexes datasets in place from your S3 buckets      |
 | [**Azure Blob Storage**](azure-blob-storage.md)     | Indexes datasets in place from your blob containers |

--- a/docs/en/platform/integrations/label-studio.md
+++ b/docs/en/platform/integrations/label-studio.md
@@ -15,10 +15,22 @@ Until then there is a short path that works today, because Label Studio exports 
 
 ## Import from Label Studio Today
 
-1. In Label Studio, open your project and click **Export**.
-2. Choose the **[YOLO](https://labelstud.io/guide/export)** format. COCO works too.
-3. [Upload the exported ZIP](../data/datasets.md) to Platform as a new dataset.
-4. [Edit the annotations](../data/annotation.md), [train](../train/index.md), and [deploy](../deploy/index.md) without leaving the workspace.
+1. **Export from Label Studio.** Open your project and click **Export**.
+2. **Pick the format.** Choose **[YOLO](https://labelstud.io/guide/export)** — COCO works too — and click **Export** to download the archive.
+3. **Upload to Platform.** [Create a new dataset](../data/datasets.md) from the ZIP.
+4. **Train.** [Edit the annotations](../data/annotation.md), [train](../train/index.md), and [deploy](../deploy/index.md) without leaving the workspace.
+
+### Export with the API
+
+Label Studio's [export API](https://labelstud.io/guide/export) returns the same archive, with the format in `exportType`:
+
+```bash
+curl -X GET "https://<your-label-studio>/api/projects/<project-id>/export?exportType=YOLO&download_all_tasks=true" \
+  -H "Authorization: Bearer <your-token>" \
+  -o dataset.zip
+```
+
+Use `exportType=COCO` for the COCO variant. Large projects should use the [snapshot endpoints](https://labelstud.io/guide/export) instead, which create the export as a background job and then download it by ID.
 
 A Label Studio YOLO export carries its class list alongside the labels, and Platform reads it:
 

--- a/docs/en/platform/integrations/label-studio.md
+++ b/docs/en/platform/integrations/label-studio.md
@@ -11,26 +11,22 @@ title: Label Studio Dataset Import - Ultralytics Platform
 
 Direct [Label Studio](https://labelstud.io/) imports are coming to [Ultralytics Platform](https://platform.ultralytics.com), so that a raw project export uploads as-is with no format to choose.
 
-Until then there is a short path that works today, because Label Studio exports YOLO directly and Platform reads the class list that export ships.
+Until then there is a short path that works today, because Label Studio's YOLO with Images export is a layout Platform reads, class list included.
 
 ## Import from Label Studio Today
 
 1. **Export from Label Studio.** Open your project and click **Export**.
-2. **Pick the format.** Choose **[YOLO](https://labelstud.io/guide/export)** — COCO works too — and click **Export** to download the archive.
+2. **Pick a format that includes the images.** Choose **[YOLO with Images](https://labelstud.io/guide/export)** and click **Export**.
 3. **Upload to Platform.** [Create a new dataset](../data/datasets.md) from the ZIP.
 4. **Train.** [Edit the annotations](../data/annotation.md), [train](../train/index.md), and [deploy](../deploy/index.md) without leaving the workspace.
 
-### Export with the API
+!!! warning "Plain YOLO and COCO export annotations only"
 
-Label Studio's [export API](https://labelstud.io/guide/export) returns the same archive, with the format in `exportType`:
+    Label Studio's `YOLO` and `COCO` options write label files without the images, because your images normally live behind the URLs Label Studio was pointed at. Uploading one of those archives to Platform gives you a dataset with no images. Pick the **with Images** variant instead.
 
-```bash
-curl -X GET "https://<your-label-studio>/api/projects/<project-id>/export?exportType=YOLO&download_all_tasks=true" \
-  -H "Authorization: Bearer <your-token>" \
-  -o dataset.zip
-```
+### Export with the SDK
 
-Use `exportType=COCO` for the COCO variant. Large projects should use the [snapshot endpoints](https://labelstud.io/guide/export) instead, which create the export as a background job and then download it by ID.
+Label Studio's SDK ships an [`export_yolo_with_images.py` example](https://github.com/HumanSignal/label-studio-sdk/blob/master/examples/export_yolo_with_images.py) for a repeatable pipeline. It creates a JSON export snapshot, downloads it, and runs the bundled converter locally to produce the YOLO directory with images alongside it — zip that directory and upload it the same way.
 
 A Label Studio YOLO export carries its class list alongside the labels, and Platform reads it:
 
@@ -48,21 +44,22 @@ Upload the archive exactly as Label Studio produced it. Platform looks for `clas
 
 Label Studio offers [several export formats](https://labelstud.io/guide/export). For image detection and segmentation:
 
-| Label Studio Format | Works | Notes                                                   |
-| ------------------- | ----- | ------------------------------------------------------- |
-| **YOLO**            | Best  | Ships `classes.txt`, so your label names carry over     |
-| **COCO**            | Yes   | Platform reads COCO JSON annotations and category names |
-| **Pascal VOC XML**  | No    | XML label files cannot be read                          |
+| Label Studio Format  | Works | Notes                                                              |
+| -------------------- | ----- | ------------------------------------------------------------------ |
+| **YOLO with Images** | Best  | Ships `classes.txt` and the images, so a single upload is enough    |
+| **COCO with Images** | Yes   | Read too; a mix of polygons and boxes imports as segment, dropping the box-only ones |
+| **YOLO** / **COCO**  | No    | Annotation files only — the dataset imports with no images          |
+| **Pascal VOC XML**   | No    | XML label files cannot be read                                      |
 
 !!! warning "Pascal VOC imports without annotations"
 
-    Platform does not read Pascal VOC XML labels, and a VOC export fails quietly rather than loudly: the images import and the annotations do not. Choose YOLO or COCO instead.
+    Platform does not read Pascal VOC XML labels, and a VOC export fails quietly rather than loudly: the images import and the annotations do not. Choose YOLO with Images or COCO with Images instead.
 
 ## What the Integration Will Add
 
 Picking the right export format is the step the integration removes. Once it ships, you will export from Label Studio however you like, upload it, and Platform will map the annotations to the matching [YOLO task](../data/index.md#supported-tasks) itself.
 
-- **No format to choose** — every Label Studio export maps to a YOLO dataset with label names preserved
+- **No format to choose** — Label Studio's image detection and segmentation exports map to a YOLO dataset with label names preserved
 - **One workspace** — labeling, training, and deployment stop spanning separate tools and a conversion script
 - **Keep annotating** — imported datasets open in Platform's [annotation editor](../data/annotation.md), including SAM-powered smart annotation
 - **Train immediately** — datasets are ready for [cloud training](../train/cloud-training.md) as soon as they finish processing

--- a/docs/en/platform/integrations/label-studio.md
+++ b/docs/en/platform/integrations/label-studio.md
@@ -34,11 +34,11 @@ archive.zip/
 
 Label Studio offers [several export formats](https://labelstud.io/guide/export). For image detection and segmentation:
 
-| Label Studio Format | Works | Notes                                                              |
-| ------------------- | ----- | ------------------------------------------------------------------ |
+| Label Studio Format | Works | Notes                                                                |
+| ------------------- | ----- | -------------------------------------------------------------------- |
 | **YOLO**            | Best  | Ships `classes.txt` and `notes.json`, so your label names carry over |
-| **COCO**            | Yes   | Platform reads COCO JSON annotations and category names             |
-| **Pascal VOC XML**  | No    | XML label files cannot be read                                      |
+| **COCO**            | Yes   | Platform reads COCO JSON annotations and category names              |
+| **Pascal VOC XML**  | No    | XML label files cannot be read                                       |
 
 !!! warning "Pascal VOC XML is not supported"
 

--- a/docs/en/platform/integrations/label-studio.md
+++ b/docs/en/platform/integrations/label-studio.md
@@ -2,39 +2,56 @@
 plans: [free, pro, enterprise]
 coming_soon: true
 comments: true
-description: Bring Label Studio annotation projects into Ultralytics Platform to edit annotations, train YOLO models, and deploy them from one workspace.
-keywords: Ultralytics Platform, Label Studio, Label Studio export, dataset import, annotation, integrations, YOLO, computer vision
+description: Move a Label Studio project into Ultralytics Platform with the YOLO export, then edit annotations, train YOLO models, and deploy from one workspace.
+keywords: Ultralytics Platform, Label Studio, Label Studio export, YOLO export, dataset import, annotation, integrations, YOLO, computer vision
 title: Label Studio Dataset Import - Ultralytics Platform
 ---
 
 # Label Studio Integration
 
-Direct [Label Studio](https://labelstud.io/) imports are coming to [Ultralytics Platform](https://platform.ultralytics.com). Today, moving a Label Studio project into training means choosing an export format and matching it to what your training code expects. The integration removes that step: upload the export and Platform maps the annotations to the matching [YOLO task](../data/index.md#supported-tasks) for you.
+Direct [Label Studio](https://labelstud.io/) imports are coming to [Ultralytics Platform](https://platform.ultralytics.com), so that a raw project export uploads as-is with no format to choose.
 
-## How It Will Work
-
-1. **Export from Label Studio.** Export the project you want to train on.
-2. **Upload to Platform.** Create a new dataset from the export — no conversion step and no format to choose.
-3. **Train.** [Edit the annotations](../data/annotation.md), [train](../train/index.md), and [deploy](../deploy/index.md) from the same workspace.
-
-## Why It Helps
-
-- **No conversion scripts** — annotations and class names map to a YOLO dataset automatically, so there is nothing to keep in sync as your label schema changes
-- **One workspace** — labeling, training, and deployment live together instead of spanning a labeling tool, a conversion step, and a training environment
-- **Keep annotating** — imported datasets open in Platform's [annotation editor](../data/annotation.md), including SAM-powered smart annotation
-- **Train immediately** — datasets are ready for [cloud training](../train/cloud-training.md) as soon as they finish processing
+Until then there is a short path that works today, because Label Studio exports YOLO directly and Platform reads the class list that export ships.
 
 ## Import from Label Studio Today
 
-Label Studio already exports in formats Platform ingests, so you do not have to wait:
+1. In Label Studio, open your project and click **Export**.
+2. Choose the **[YOLO](https://labelstud.io/guide/export)** format. COCO works too.
+3. [Upload the exported ZIP](../data/datasets.md) to Platform as a new dataset.
+4. [Edit the annotations](../data/annotation.md), [train](../train/index.md), and [deploy](../deploy/index.md) without leaving the workspace.
 
-1. In Label Studio, export your project in a **YOLO** or **COCO** format.
-2. [Upload the export](../data/datasets.md) to Platform as a new dataset.
-3. Edit the annotations and train the dataset like any other Platform dataset.
+A Label Studio YOLO export carries its class list alongside the labels, and Platform reads both files:
+
+```
+archive.zip/
+├── classes.txt        # class names Platform reads
+├── notes.json         # also read, when classes.txt is absent
+├── images/
+└── labels/
+```
+
+## Choosing an Export Format
+
+Label Studio offers [several export formats](https://labelstud.io/guide/export). For image detection and segmentation:
+
+| Label Studio Format | Works | Notes                                                              |
+| ------------------- | ----- | ------------------------------------------------------------------ |
+| **YOLO**            | Best  | Ships `classes.txt` and `notes.json`, so your label names carry over |
+| **COCO**            | Yes   | Platform reads COCO JSON annotations and category names             |
+| **Pascal VOC XML**  | No    | XML label files cannot be read                                      |
 
 !!! warning "Pascal VOC XML is not supported"
 
-    Choose a YOLO or COCO export rather than Pascal VOC. Platform flags XML label files during upload because it cannot read them.
+    Platform cannot read XML label files and flags them during upload. Choose YOLO or COCO instead.
+
+## What the Integration Will Add
+
+Picking the right export format is the step the integration removes. Once it ships, you will export from Label Studio however you like, upload it, and Platform will map the annotations to the matching [YOLO task](../data/index.md#supported-tasks) itself.
+
+- **No format to choose** — every Label Studio export maps to a YOLO dataset with label names preserved
+- **One workspace** — labeling, training, and deployment stop spanning separate tools and a conversion script
+- **Keep annotating** — imported datasets open in Platform's [annotation editor](../data/annotation.md), including SAM-powered smart annotation
+- **Train immediately** — datasets are ready for [cloud training](../train/cloud-training.md) as soon as they finish processing
 
 !!! tip "Available now"
 

--- a/docs/en/platform/integrations/label-studio.md
+++ b/docs/en/platform/integrations/label-studio.md
@@ -9,7 +9,7 @@ title: Label Studio Dataset Import - Ultralytics Platform
 
 # Label Studio Integration
 
-Direct [Label Studio](https://labelstud.io/) imports are coming to [Ultralytics Platform](https://platform.ultralytics.com), so that a raw project export uploads as-is with no format to choose.
+Direct [Label Studio](https://labelstud.io/) imports are coming to [Ultralytics Platform](https://platform.ultralytics.com), so that a raw image detection or segmentation export uploads as-is with no format to choose.
 
 Until then there is a short path that works today, because Label Studio's YOLO with Images export is a layout Platform reads, class list included.
 
@@ -30,11 +30,11 @@ Label Studio's [export API](https://labelstud.io/guide/export) returns the same 
 
 ```bash
 curl -X GET "https://<your-label-studio>/api/projects/<project-id>/export?exportType=YOLO_WITH_IMAGES&download_all_tasks=true" \
-  -H "Authorization: Bearer <your-token>" \
+  -H "Authorization: Token <your-legacy-token>" \
   -o dataset.zip
 ```
 
-`COCO_WITH_IMAGES` and `YOLO_OBB_WITH_IMAGES` work the same way. Large projects should use the [snapshot endpoints](https://labelstud.io/guide/export) instead, which create the export as a background job and download it by ID; the SDK's [`export_yolo_with_images.py`](https://github.com/HumanSignal/label-studio-sdk/blob/master/examples/export_yolo_with_images.py) example does exactly that.
+`COCO_WITH_IMAGES` and `YOLO_OBB_WITH_IMAGES` work the same way. Newer [personal access tokens](https://labelstud.io/guide/access_tokens) are exchanged for a short-lived bearer token before use, so check which token type your instance issues. Large projects should use the [snapshot endpoints](https://labelstud.io/guide/export) instead, which create the export as a background job and download it by ID; the SDK's [`export_yolo_with_images.py`](https://github.com/HumanSignal/label-studio-sdk/blob/master/examples/export_yolo_with_images.py) example does exactly that.
 
 A Label Studio YOLO export carries its class list alongside the labels, and Platform reads it:
 

--- a/docs/en/platform/integrations/label-studio.md
+++ b/docs/en/platform/integrations/label-studio.md
@@ -20,29 +20,31 @@ Until then there is a short path that works today, because Label Studio exports 
 3. [Upload the exported ZIP](../data/datasets.md) to Platform as a new dataset.
 4. [Edit the annotations](../data/annotation.md), [train](../train/index.md), and [deploy](../deploy/index.md) without leaving the workspace.
 
-A Label Studio YOLO export carries its class list alongside the labels, and Platform reads both files:
+A Label Studio YOLO export carries its class list alongside the labels, and Platform reads it:
 
 ```
 archive.zip/
-├── classes.txt        # class names Platform reads
-├── notes.json         # also read, when classes.txt is absent
+├── classes.txt        # class names Platform reads first
+├── notes.json         # fallback, used only when classes.txt is missing or empty
 ├── images/
 └── labels/
 ```
+
+Upload the archive exactly as Label Studio produced it. Platform looks for `classes.txt` and `notes.json` at the root of the archive, so re-zipping the export inside another folder loses your label names and the classes import as `class0`, `class1`, and so on.
 
 ## Choosing an Export Format
 
 Label Studio offers [several export formats](https://labelstud.io/guide/export). For image detection and segmentation:
 
-| Label Studio Format | Works | Notes                                                                |
-| ------------------- | ----- | -------------------------------------------------------------------- |
-| **YOLO**            | Best  | Ships `classes.txt` and `notes.json`, so your label names carry over |
-| **COCO**            | Yes   | Platform reads COCO JSON annotations and category names              |
-| **Pascal VOC XML**  | No    | XML label files cannot be read                                       |
+| Label Studio Format | Works | Notes                                                              |
+| ------------------- | ----- | ------------------------------------------------------------------ |
+| **YOLO**            | Best  | Ships `classes.txt`, so your label names carry over                 |
+| **COCO**            | Yes   | Platform reads COCO JSON annotations and category names             |
+| **Pascal VOC XML**  | No    | XML label files cannot be read                                      |
 
-!!! warning "Pascal VOC XML is not supported"
+!!! warning "Pascal VOC imports without annotations"
 
-    Platform cannot read XML label files and flags them during upload. Choose YOLO or COCO instead.
+    Platform does not read Pascal VOC XML labels, and a VOC export fails quietly rather than loudly: the images import and the annotations do not. Choose YOLO or COCO instead.
 
 ## What the Integration Will Add
 

--- a/docs/en/platform/integrations/label-studio.md
+++ b/docs/en/platform/integrations/label-studio.md
@@ -24,9 +24,17 @@ Until then there is a short path that works today, because Label Studio's YOLO w
 
     Label Studio's `YOLO` and `COCO` options write label files without the images, because your images normally live behind the URLs Label Studio was pointed at. Uploading one of those archives to Platform gives you a dataset with no images. Pick the **with Images** variant instead.
 
-### Export with the SDK
+### Export with the API
 
-Label Studio's SDK ships an [`export_yolo_with_images.py` example](https://github.com/HumanSignal/label-studio-sdk/blob/master/examples/export_yolo_with_images.py) for a repeatable pipeline. It creates a JSON export snapshot, downloads it, and runs the bundled converter locally to produce the YOLO directory with images alongside it — zip that directory and upload it the same way.
+Label Studio's [export API](https://labelstud.io/guide/export) returns the same archive, with the format name in `exportType`:
+
+```bash
+curl -X GET "https://<your-label-studio>/api/projects/<project-id>/export?exportType=YOLO_WITH_IMAGES&download_all_tasks=true" \
+  -H "Authorization: Bearer <your-token>" \
+  -o dataset.zip
+```
+
+`COCO_WITH_IMAGES` and `YOLO_OBB_WITH_IMAGES` work the same way. Large projects should use the [snapshot endpoints](https://labelstud.io/guide/export) instead, which create the export as a background job and download it by ID; the SDK's [`export_yolo_with_images.py`](https://github.com/HumanSignal/label-studio-sdk/blob/master/examples/export_yolo_with_images.py) example does exactly that.
 
 A Label Studio YOLO export carries its class list alongside the labels, and Platform reads it:
 
@@ -57,7 +65,7 @@ Label Studio offers [several export formats](https://labelstud.io/guide/export).
 
 ## What the Integration Will Add
 
-Picking the right export format is the step the integration removes. Once it ships, you will export from Label Studio however you like, upload it, and Platform will map the annotations to the matching [YOLO task](../data/index.md#supported-tasks) itself.
+Picking the right export format is the step the integration removes. Once it ships, you will export any of Label Studio's image detection and segmentation formats, upload it, and Platform will map the annotations to the matching [YOLO task](../data/index.md#supported-tasks) itself.
 
 - **No format to choose** — Label Studio's image detection and segmentation exports map to a YOLO dataset with label names preserved
 - **One workspace** — labeling, training, and deployment stop spanning separate tools and a conversion script

--- a/docs/en/platform/integrations/label-studio.md
+++ b/docs/en/platform/integrations/label-studio.md
@@ -44,12 +44,12 @@ Upload the archive exactly as Label Studio produced it. Platform looks for `clas
 
 Label Studio offers [several export formats](https://labelstud.io/guide/export). For image detection and segmentation:
 
-| Label Studio Format  | Works | Notes                                                              |
-| -------------------- | ----- | ------------------------------------------------------------------ |
-| **YOLO with Images** | Best  | Ships `classes.txt` and the images, so a single upload is enough    |
+| Label Studio Format  | Works | Notes                                                                                |
+| -------------------- | ----- | ------------------------------------------------------------------------------------ |
+| **YOLO with Images** | Best  | Ships `classes.txt` and the images, so a single upload is enough                     |
 | **COCO with Images** | Yes   | Read too; a mix of polygons and boxes imports as segment, dropping the box-only ones |
-| **YOLO** / **COCO**  | No    | Annotation files only — the dataset imports with no images          |
-| **Pascal VOC XML**   | No    | XML label files cannot be read                                      |
+| **YOLO** / **COCO**  | No    | Annotation files only — the dataset imports with no images                           |
+| **Pascal VOC XML**   | No    | XML label files cannot be read                                                       |
 
 !!! warning "Pascal VOC imports without annotations"
 

--- a/docs/en/platform/integrations/label-studio.md
+++ b/docs/en/platform/integrations/label-studio.md
@@ -36,11 +36,11 @@ Upload the archive exactly as Label Studio produced it. Platform looks for `clas
 
 Label Studio offers [several export formats](https://labelstud.io/guide/export). For image detection and segmentation:
 
-| Label Studio Format | Works | Notes                                                              |
-| ------------------- | ----- | ------------------------------------------------------------------ |
-| **YOLO**            | Best  | Ships `classes.txt`, so your label names carry over                 |
-| **COCO**            | Yes   | Platform reads COCO JSON annotations and category names             |
-| **Pascal VOC XML**  | No    | XML label files cannot be read                                      |
+| Label Studio Format | Works | Notes                                                   |
+| ------------------- | ----- | ------------------------------------------------------- |
+| **YOLO**            | Best  | Ships `classes.txt`, so your label names carry over     |
+| **COCO**            | Yes   | Platform reads COCO JSON annotations and category names |
+| **Pascal VOC XML**  | No    | XML label files cannot be read                          |
 
 !!! warning "Pascal VOC imports without annotations"
 

--- a/docs/en/platform/integrations/label-studio.md
+++ b/docs/en/platform/integrations/label-studio.md
@@ -1,0 +1,24 @@
+---
+plans: [free, pro, enterprise]
+coming_soon: true
+comments: true
+description: Bring Label Studio annotation projects into Ultralytics Platform to edit annotations, train YOLO models, and deploy them.
+keywords: Ultralytics Platform, Label Studio, Label Studio export, dataset import, annotation, integrations, YOLO, computer vision
+title: Label Studio Dataset Import - Ultralytics Platform
+---
+
+# Label Studio Integration
+
+Direct [Label Studio](https://labelstud.io/) imports are coming soon to [Ultralytics Platform](https://platform.ultralytics.com). Once available, you will export your Label Studio project and upload it to Platform to [annotate](../data/annotation.md), [train](../train/index.md), and [deploy](../deploy/index.md) without converting the data yourself.
+
+## Import from Label Studio Today
+
+Label Studio exports datasets in several formats, including YOLO, which Platform already supports:
+
+1. In Label Studio, export your project in a **YOLO** format.
+2. [Upload the export](../data/datasets.md) to Platform as a new dataset.
+3. Edit the annotations and train the dataset like any other Platform dataset.
+
+!!! tip "Already have labels elsewhere?"
+
+    The [Labelbox](labelbox.md) and [Roboflow](roboflow.md) integrations are available today, and Platform also imports YOLO, COCO, and Ultralytics NDJSON datasets directly.

--- a/docs/en/platform/integrations/label-studio.md
+++ b/docs/en/platform/integrations/label-studio.md
@@ -2,23 +2,40 @@
 plans: [free, pro, enterprise]
 coming_soon: true
 comments: true
-description: Bring Label Studio annotation projects into Ultralytics Platform to edit annotations, train YOLO models, and deploy them.
+description: Bring Label Studio annotation projects into Ultralytics Platform to edit annotations, train YOLO models, and deploy them from one workspace.
 keywords: Ultralytics Platform, Label Studio, Label Studio export, dataset import, annotation, integrations, YOLO, computer vision
 title: Label Studio Dataset Import - Ultralytics Platform
 ---
 
 # Label Studio Integration
 
-Direct [Label Studio](https://labelstud.io/) imports are coming soon to [Ultralytics Platform](https://platform.ultralytics.com). Once available, you will export your Label Studio project and upload it to Platform to [annotate](../data/annotation.md), [train](../train/index.md), and [deploy](../deploy/index.md) without converting the data yourself.
+Direct [Label Studio](https://labelstud.io/) imports are coming to [Ultralytics Platform](https://platform.ultralytics.com). Today, moving a Label Studio project into training means choosing an export format and matching it to what your training code expects. The integration removes that step: upload the export and Platform maps the annotations to the matching [YOLO task](../data/index.md#supported-tasks) for you.
+
+## How It Will Work
+
+1. **Export from Label Studio.** Export the project you want to train on.
+2. **Upload to Platform.** Create a new dataset from the export — no conversion step and no format to choose.
+3. **Train.** [Edit the annotations](../data/annotation.md), [train](../train/index.md), and [deploy](../deploy/index.md) from the same workspace.
+
+## Why It Helps
+
+- **No conversion scripts** — annotations and class names map to a YOLO dataset automatically, so there is nothing to keep in sync as your label schema changes
+- **One workspace** — labeling, training, and deployment live together instead of spanning a labeling tool, a conversion step, and a training environment
+- **Keep annotating** — imported datasets open in Platform's [annotation editor](../data/annotation.md), including SAM-powered smart annotation
+- **Train immediately** — datasets are ready for [cloud training](../train/cloud-training.md) as soon as they finish processing
 
 ## Import from Label Studio Today
 
-Label Studio exports datasets in several formats, including YOLO, which Platform already supports:
+Label Studio already exports in formats Platform ingests, so you do not have to wait:
 
-1. In Label Studio, export your project in a **YOLO** format.
+1. In Label Studio, export your project in a **YOLO** or **COCO** format.
 2. [Upload the export](../data/datasets.md) to Platform as a new dataset.
 3. Edit the annotations and train the dataset like any other Platform dataset.
 
-!!! tip "Already have labels elsewhere?"
+!!! warning "Pascal VOC XML is not supported"
 
-    The [Labelbox](labelbox.md) and [Roboflow](roboflow.md) integrations are available today, and Platform also imports YOLO, COCO, and Ultralytics NDJSON datasets directly.
+    Choose a YOLO or COCO export rather than Pascal VOC. Platform flags XML label files during upload because it cannot read them.
+
+!!! tip "Available now"
+
+    The [Labelbox](labelbox.md), [Roboflow](roboflow.md), and [Ultralytics HUB](ultralytics-hub.md) integrations work today, and Platform imports YOLO, COCO, and Ultralytics NDJSON datasets directly.

--- a/docs/en/platform/integrations/labelbox.md
+++ b/docs/en/platform/integrations/labelbox.md
@@ -32,8 +32,7 @@ client = labelbox.Client(api_key="YOUR_LABELBOX_API_KEY")
 export_task = labelbox.ExportTask.get_task(client, "YOUR_EXPORT_TASK_ID")
 
 with open("dataset.ndjson", "w") as f:
-    for data_row in export_task.get_buffered_stream():
-        f.write(json.dumps(data_row.json) + "\n")
+    f.writelines(json.dumps(data_row.json) + "\n" for data_row in export_task.get_buffered_stream())
 ```
 
 !!! warning "Write NDJSON, not a JSON array"
@@ -56,28 +55,28 @@ A single data row looks like this, trimmed to the fields Platform reads:
 
 ```json
 {
-  "data_row": {
-    "external_id": "000000000307.jpg",
-    "row_data": "https://storage.labelbox.com/...?Expires=...&Signature=..."
-  },
-  "media_attributes": { "height": 480, "width": 640, "mime_type": "image/jpeg" },
-  "projects": {
-    "<project-id>": {
-      "labels": [
-        {
-          "annotations": {
-            "objects": [
-              {
-                "name": "Dog",
-                "annotation_kind": "ImageBoundingBox",
-                "bounding_box": { "top": 200.0, "left": 407.0, "height": 172.0, "width": 176.0 }
-              }
+    "data_row": {
+        "external_id": "000000000307.jpg",
+        "row_data": "https://storage.labelbox.com/...?Expires=...&Signature=..."
+    },
+    "media_attributes": { "height": 480, "width": 640, "mime_type": "image/jpeg" },
+    "projects": {
+        "<project-id>": {
+            "labels": [
+                {
+                    "annotations": {
+                        "objects": [
+                            {
+                                "name": "Dog",
+                                "annotation_kind": "ImageBoundingBox",
+                                "bounding_box": { "top": 200.0, "left": 407.0, "height": 172.0, "width": 176.0 }
+                            }
+                        ]
+                    }
+                }
             ]
-          }
         }
-      ]
     }
-  }
 }
 ```
 

--- a/docs/en/platform/integrations/labelbox.md
+++ b/docs/en/platform/integrations/labelbox.md
@@ -12,11 +12,33 @@ title: Labelbox Dataset Import - Ultralytics Platform
 
 ## Import from Labelbox
 
-1. **Export from Labelbox.** Open the [labeling project](https://docs.labelbox.com/docs/export-labels) or [catalog](https://docs.labelbox.com/docs/export-from-catalog) you want to bring over, go to the **Data Rows** tab, select **All**, and click **Export data**. Labelbox runs the export as a background job — watch for it in [Notifications](https://app.labelbox.com/notifications) and download the NDJSON file once the job finishes.
-2. **Upload to Platform.** Create a new dataset and upload the `.ndjson` file, or paste a direct link to it. You can also start from **Settings > [Integrations](index.md) > Labelbox**.
-3. **Train.** Once processing finishes, [edit the annotations](../data/annotation.md) and [train](../train/index.md) exactly like any other Platform dataset.
+1. **Export from Labelbox.** Open the [labeling project](https://docs.labelbox.com/docs/export-labels) or [catalog](https://docs.labelbox.com/docs/export-from-catalog) you want to bring over and go to the **Data Rows** tab. Select **All**, click **Export data**, choose the fields to include, and confirm.
+2. **Download the file.** Labelbox runs the export as a background job. Watch for it in [Notifications](https://app.labelbox.com/notifications) and click **Download** when it finishes to save the `.ndjson` file.
+3. **Upload to Platform.** Create a new dataset and upload the `.ndjson` file, or paste a direct link to it. You can also start from **Settings > [Integrations](index.md) > Labelbox**.
+4. **Train.** Once processing finishes, [edit the annotations](../data/annotation.md) and [train](../train/index.md) exactly like any other Platform dataset.
 
 Unlike [CVAT](cvat.md) and [Label Studio](label-studio.md), there is no format to choose — Labelbox's own export is the supported one.
+
+### Export with the SDK
+
+Labelbox also offers the export task in its Python SDK, which is the easier route for a repeatable pipeline. Stream the task and write **one JSON object per line**:
+
+```python
+import json
+
+import labelbox
+
+client = labelbox.Client(api_key="YOUR_LABELBOX_API_KEY")
+export_task = labelbox.ExportTask.get_task(client, "YOUR_EXPORT_TASK_ID")
+
+with open("dataset.ndjson", "w") as f:
+    for data_row in export_task.get_buffered_stream():
+        f.write(json.dumps(data_row.json) + "\n")
+```
+
+!!! warning "Write NDJSON, not a JSON array"
+
+    NDJSON is one JSON object per line. `json.dump(list_of_rows, f)` writes a single array instead, and Platform skips any line that is not a JSON object — the import finds no data rows at all. Use the loop above, or `"\n".join(json.dumps(r) for r in rows)`.
 
 ## What Gets Imported
 
@@ -28,7 +50,38 @@ Platform recognizes the Labelbox format on its own and maps bounding boxes and p
 | Polygon                                          | [Segment](../../datasets/segment/index.md) |
 | Segmentation mask, point, polyline, relationship | Not yet                                    |
 
-Your Labelbox annotation names become the dataset's class names, and pixel coordinates are normalized using the image dimensions recorded in the export. A catalog export with no annotations imports as an unlabeled image dataset, ready to label in Platform's [annotation editor](../data/annotation.md).
+Each object's `name` becomes the class name — so a `"name": "Dog"` annotation imports as the class `Dog`, not its lowercase `value` — and pixel coordinates are normalized against the `media_attributes` dimensions in the export. A catalog export with no annotations imports as an unlabeled image dataset, ready to label in Platform's [annotation editor](../data/annotation.md).
+
+A single data row looks like this, trimmed to the fields Platform reads:
+
+```json
+{
+  "data_row": {
+    "external_id": "000000000307.jpg",
+    "row_data": "https://storage.labelbox.com/...?Expires=...&Signature=..."
+  },
+  "media_attributes": { "height": 480, "width": 640, "mime_type": "image/jpeg" },
+  "projects": {
+    "<project-id>": {
+      "labels": [
+        {
+          "annotations": {
+            "objects": [
+              {
+                "name": "Dog",
+                "annotation_kind": "ImageBoundingBox",
+                "bounding_box": { "top": 200.0, "left": 407.0, "height": 172.0, "width": 176.0 }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Everything else in the export — `embeddings`, `metadata_fields`, `attachments`, `project_details` — is ignored. The embeddings are worth deselecting when you export: in a sample export they were around four-fifths of the file, against a fifth for the fields Platform actually reads.
 
 !!! warning "Mask and point projects import without annotations"
 

--- a/docs/en/platform/integrations/labelbox.md
+++ b/docs/en/platform/integrations/labelbox.md
@@ -20,14 +20,19 @@ Unlike [CVAT](cvat.md) and [Label Studio](label-studio.md), there is no format t
 
 ## What Gets Imported
 
-Platform recognizes the Labelbox format on its own and maps each annotation to the matching [YOLO task type](../data/index.md#supported-tasks):
+Platform recognizes the Labelbox format on its own and maps bounding boxes and polygons to the matching [YOLO task type](../data/index.md#supported-tasks):
 
-| Labelbox Annotation | Platform Task                              |
-| ------------------- | ------------------------------------------ |
-| Bounding box        | [Detect](../../datasets/detect/index.md)   |
-| Polygon             | [Segment](../../datasets/segment/index.md) |
+| Labelbox Annotation                              | Imported                                   |
+| ------------------------------------------------ | ------------------------------------------ |
+| Bounding box                                     | [Detect](../../datasets/detect/index.md)   |
+| Polygon                                          | [Segment](../../datasets/segment/index.md) |
+| Segmentation mask, point, polyline, relationship | Not yet                                    |
 
 Your Labelbox annotation names become the dataset's class names, and pixel coordinates are normalized using the image dimensions recorded in the export. A catalog export with no annotations imports as an unlabeled image dataset, ready to label in Platform's [annotation editor](../data/annotation.md).
+
+!!! warning "Mask and point projects import without annotations"
+
+    Only bounding boxes and polygons are read today. A project labeled entirely with the segmentation-mask (brush) tool, points, or polylines imports its images and class names but no annotations, and no error is raised. Check the dataset's annotation count after import.
 
 !!! note "Image URLs must be reachable"
 
@@ -35,4 +40,4 @@ Your Labelbox annotation names become the dataset's class names, and pixel coord
 
 !!! tip "Mixed annotations import as segment"
 
-    An export containing both bounding boxes and polygons is imported as a segment dataset.
+    An export containing both bounding boxes and polygons is imported as a segment dataset. Polygons need at least three points to be read.

--- a/docs/en/platform/integrations/labelbox.md
+++ b/docs/en/platform/integrations/labelbox.md
@@ -34,9 +34,9 @@ Your Labelbox annotation names become the dataset's class names, and pixel coord
 
     Only bounding boxes and polygons are read today. A project labeled entirely with the segmentation-mask (brush) tool, points, or polylines imports its images and class names but no annotations, and no error is raised. You can spot it on the dataset page: an imported dataset that kept its labels shows a labeled and annotation count next to the image count, and one that lost them shows neither.
 
-!!! note "Image URLs must be reachable"
+!!! note "Upload the export while its links are fresh"
 
-    A Labelbox export references each image by URL rather than embedding the pixels. Platform downloads the images from those URLs, probing a sample first, so the import fails fast and tells you why if the images cannot be reached.
+    A Labelbox export references each image by signed URL rather than embedding the pixels, and those signatures expire. Platform downloads the images from those URLs, probing a sample before it starts, so an export whose links have all lapsed fails immediately and tells you why — re-export from Labelbox and upload the new file. An export that is only partly expired imports the images it can still reach and skips the rest, so upload soon after exporting.
 
 !!! tip "Mixed annotations import as segment"
 

--- a/docs/en/platform/integrations/labelbox.md
+++ b/docs/en/platform/integrations/labelbox.md
@@ -12,9 +12,11 @@ title: Labelbox Dataset Import - Ultralytics Platform
 
 ## Import from Labelbox
 
-1. **Export from Labelbox.** Export the project or catalog you want to bring over. Labelbox produces an NDJSON file.
+1. **Export from Labelbox.** Export the [labeling project](https://docs.labelbox.com/docs/export-labels) or [catalog](https://docs.labelbox.com/docs/export-from-catalog) you want to bring over. Labelbox exports produce an NDJSON file.
 2. **Upload to Platform.** Create a new dataset and upload the `.ndjson` file, or paste a direct link to it. You can also start from **Settings > [Integrations](index.md) > Labelbox**.
 3. **Train.** Once processing finishes, [edit the annotations](../data/annotation.md) and [train](../train/index.md) exactly like any other Platform dataset.
+
+Unlike [CVAT](cvat.md) and [Label Studio](label-studio.md), there is no format to choose — Labelbox's own export is the supported one.
 
 ## What Gets Imported
 

--- a/docs/en/platform/integrations/labelbox.md
+++ b/docs/en/platform/integrations/labelbox.md
@@ -12,7 +12,7 @@ title: Labelbox Dataset Import - Ultralytics Platform
 
 ## Import from Labelbox
 
-1. **Export from Labelbox.** Open the [labeling project](https://docs.labelbox.com/docs/export-labels) or [catalog](https://docs.labelbox.com/docs/export-from-catalog) you want to bring over and go to the **Data Rows** tab. Select **All**, click **Export data**, choose the fields to include, and confirm.
+1. **Export from Labelbox.** Open the [labeling project](https://docs.labelbox.com/docs/export-labels) or [catalog](https://docs.labelbox.com/docs/export-from-catalog) you want to bring over and go to the **Data Rows** tab. Select **All**, click **Export data**, choose the fields to include, and confirm. Exporting from Catalog rather than a project? Enable **Export labels from project** and pick the project, or the file arrives with no annotations at all.
 2. **Download the file.** Labelbox runs the export as a background job. Watch for it in [Notifications](https://app.labelbox.com/notifications) and click **Download** when it finishes to save the `.ndjson` file.
 3. **Upload to Platform.** Create a new dataset and upload the `.ndjson` file, or paste a direct link to it. You can also start from **Settings > [Integrations](index.md) > Labelbox**.
 4. **Train.** Once processing finishes, [edit the annotations](../data/annotation.md) and [train](../train/index.md) exactly like any other Platform dataset.

--- a/docs/en/platform/integrations/labelbox.md
+++ b/docs/en/platform/integrations/labelbox.md
@@ -12,7 +12,7 @@ title: Labelbox Dataset Import - Ultralytics Platform
 
 ## Import from Labelbox
 
-1. **Export from Labelbox.** Export the [labeling project](https://docs.labelbox.com/docs/export-labels) or [catalog](https://docs.labelbox.com/docs/export-from-catalog) you want to bring over. Labelbox exports produce an NDJSON file.
+1. **Export from Labelbox.** Open the [labeling project](https://docs.labelbox.com/docs/export-labels) or [catalog](https://docs.labelbox.com/docs/export-from-catalog) you want to bring over, go to the **Data Rows** tab, select **All**, and click **Export data**. Labelbox runs the export as a background job — watch for it in [Notifications](https://app.labelbox.com/notifications) and download the NDJSON file once the job finishes.
 2. **Upload to Platform.** Create a new dataset and upload the `.ndjson` file, or paste a direct link to it. You can also start from **Settings > [Integrations](index.md) > Labelbox**.
 3. **Train.** Once processing finishes, [edit the annotations](../data/annotation.md) and [train](../train/index.md) exactly like any other Platform dataset.
 

--- a/docs/en/platform/integrations/labelbox.md
+++ b/docs/en/platform/integrations/labelbox.md
@@ -1,0 +1,36 @@
+---
+plans: [free, pro, enterprise]
+comments: true
+description: Upload a Labelbox NDJSON export straight to Ultralytics Platform and start editing annotations and training YOLO models.
+keywords: Ultralytics Platform, Labelbox, Labelbox export, NDJSON, dataset import, annotation, integrations, YOLO, computer vision
+title: Labelbox Dataset Import - Ultralytics Platform
+---
+
+# Labelbox Integration
+
+[Ultralytics Platform](https://platform.ultralytics.com) reads Labelbox NDJSON exports directly, so there is no connection to set up and no API key to paste. Export from Labelbox, upload the file, and the dataset is ready to edit and train.
+
+## Import from Labelbox
+
+1. **Export from Labelbox.** Export the project or catalog you want to bring over. Labelbox produces an NDJSON file.
+2. **Upload to Platform.** Create a new dataset and upload the `.ndjson` file, or paste a direct link to it. You can also start from **Settings > [Integrations](index.md) > Labelbox**.
+3. **That's it.** Once processing finishes, [edit the annotations](../data/annotation.md) and [train](../train/index.md) the dataset like any other Platform dataset.
+
+## What Gets Imported
+
+Platform detects the Labelbox format automatically and maps each annotation to the matching [YOLO task type](../data/index.md#supported-tasks):
+
+| Labelbox Annotation | Platform Task                              |
+| ------------------- | ------------------------------------------ |
+| Bounding box        | [Detect](../../datasets/detect/index.md)   |
+| Polygon             | [Segment](../../datasets/segment/index.md) |
+
+Class names come from your Labelbox annotation names, and pixel coordinates are normalized using the image dimensions in the export. A catalog export with no annotations imports as an unlabeled image dataset that you can annotate in Platform.
+
+!!! note "Image URLs must be reachable"
+
+    A Labelbox export references each image by URL rather than embedding the pixels. Platform downloads the images from those URLs, probing a sample first, so the export fails fast if the images are not publicly accessible.
+
+!!! tip "Mixed annotations import as segment"
+
+    An export that contains both bounding boxes and polygons is imported as a segment dataset.

--- a/docs/en/platform/integrations/labelbox.md
+++ b/docs/en/platform/integrations/labelbox.md
@@ -32,7 +32,7 @@ Your Labelbox annotation names become the dataset's class names, and pixel coord
 
 !!! warning "Mask and point projects import without annotations"
 
-    Only bounding boxes and polygons are read today. A project labeled entirely with the segmentation-mask (brush) tool, points, or polylines imports its images and class names but no annotations, and no error is raised. You can spot it on the dataset page: an imported dataset that kept its labels shows a labeled and annotation count next to the image count, and one that lost them shows the image count alone.
+    Only bounding boxes and polygons are read today. A project labeled entirely with the segmentation-mask (brush) tool, points, or polylines imports its images and class names but no annotations, and no error is raised. You can spot it on the dataset page: an imported dataset that kept its labels shows a labeled and annotation count next to the image count, and one that lost them shows neither.
 
 !!! note "Image URLs must be reachable"
 

--- a/docs/en/platform/integrations/labelbox.md
+++ b/docs/en/platform/integrations/labelbox.md
@@ -30,6 +30,7 @@ import labelbox
 
 client = labelbox.Client(api_key="YOUR_LABELBOX_API_KEY")
 export_task = labelbox.ExportTask.get_task(client, "YOUR_EXPORT_TASK_ID")
+export_task.wait_till_done()  # streaming a task that isn't COMPLETE raises
 
 with open("dataset.ndjson", "w") as f:
     f.writelines(json.dumps(data_row.json) + "\n" for data_row in export_task.get_buffered_stream())
@@ -43,11 +44,11 @@ with open("dataset.ndjson", "w") as f:
 
 Platform recognizes the Labelbox format on its own and maps bounding boxes and polygons to the matching [YOLO task type](../data/index.md#supported-tasks):
 
-| Labelbox Annotation                              | Imported                                   |
-| ------------------------------------------------ | ------------------------------------------ |
-| Bounding box                                     | [Detect](../../datasets/detect/index.md)   |
-| Polygon                                          | [Segment](../../datasets/segment/index.md) |
-| Segmentation mask, point, polyline, relationship | Not yet                                    |
+| Labelbox Annotation                                              | Imported                                   |
+| ---------------------------------------------------------------- | ------------------------------------------ |
+| Bounding box                                                     | [Detect](../../datasets/detect/index.md)   |
+| Polygon                                                          | [Segment](../../datasets/segment/index.md) |
+| Segmentation mask, point, polyline, relationship, classification | Not yet                                    |
 
 Each object's `name` becomes the class name — so a `"name": "Dog"` annotation imports as the class `Dog`, not its lowercase `value` — and pixel coordinates are normalized against the `media_attributes` dimensions in the export. A catalog export with no annotations imports as an unlabeled image dataset, ready to label in Platform's [annotation editor](../data/annotation.md).
 
@@ -84,12 +85,12 @@ Everything else in the export — `embeddings`, `metadata_fields`, `attachments`
 
 !!! warning "Mask and point projects import without annotations"
 
-    Only bounding boxes and polygons are read today. A project labeled entirely with the segmentation-mask (brush) tool, points, or polylines imports its images and class names but no annotations, and no error is raised. You can spot it on the dataset page: an imported dataset that kept its labels shows a labeled and annotation count next to the image count, and one that lost them shows neither.
+    Only bounding boxes and polygons are read today, and only from an object annotation — image-level classifications live elsewhere in the export and are skipped. A project labeled entirely with the segmentation-mask (brush) tool, points, polylines, or classifications imports its images but no annotations, and no error is raised. You can spot it on the dataset page: an imported dataset that kept its labels shows a labeled and annotation count next to the image count, and one that lost them shows neither.
 
 !!! note "Upload the export while its links are fresh"
 
     A Labelbox export references each image by signed URL rather than embedding the pixels, and those signatures expire. Platform downloads the images from those URLs, probing a sample before it starts, so an export whose links have all lapsed fails immediately and tells you why — re-export from Labelbox and upload the new file. An export that is only partly expired imports the images it can still reach and skips the rest, so upload soon after exporting.
 
-!!! tip "Mixed annotations import as segment"
+!!! warning "In a mixed export, the boxes are dropped"
 
-    An export containing both bounding boxes and polygons is imported as a segment dataset. Polygons need at least three points to be read.
+    An export containing both bounding boxes and polygons is imported as a segment dataset, and a segment dataset carries polygon geometry only — the box annotations are not used for training or included in version exports. Export boxes and polygons as separate Labelbox projects if you need both. Polygons also need at least three points to be read.

--- a/docs/en/platform/integrations/labelbox.md
+++ b/docs/en/platform/integrations/labelbox.md
@@ -32,7 +32,7 @@ Your Labelbox annotation names become the dataset's class names, and pixel coord
 
 !!! warning "Mask and point projects import without annotations"
 
-    Only bounding boxes and polygons are read today. A project labeled entirely with the segmentation-mask (brush) tool, points, or polylines imports its images and class names but no annotations, and no error is raised. Check the dataset's annotation count after import.
+    Only bounding boxes and polygons are read today. A project labeled entirely with the segmentation-mask (brush) tool, points, or polylines imports its images and class names but no annotations, and no error is raised. You can spot it on the dataset page: an imported dataset that kept its labels shows a labeled and annotation count next to the image count, and one that lost them shows the image count alone.
 
 !!! note "Image URLs must be reachable"
 

--- a/docs/en/platform/integrations/labelbox.md
+++ b/docs/en/platform/integrations/labelbox.md
@@ -8,29 +8,29 @@ title: Labelbox Dataset Import - Ultralytics Platform
 
 # Labelbox Integration
 
-[Ultralytics Platform](https://platform.ultralytics.com) reads Labelbox NDJSON exports directly, so there is no connection to set up and no API key to paste. Export from Labelbox, upload the file, and the dataset is ready to edit and train.
+[Ultralytics Platform](https://platform.ultralytics.com) reads Labelbox NDJSON exports directly. There is no key to paste, no connection to keep alive, and no conversion script to maintain — export from Labelbox, upload the file, and your labels arrive as a normal Platform dataset.
 
 ## Import from Labelbox
 
 1. **Export from Labelbox.** Export the project or catalog you want to bring over. Labelbox produces an NDJSON file.
 2. **Upload to Platform.** Create a new dataset and upload the `.ndjson` file, or paste a direct link to it. You can also start from **Settings > [Integrations](index.md) > Labelbox**.
-3. **That's it.** Once processing finishes, [edit the annotations](../data/annotation.md) and [train](../train/index.md) the dataset like any other Platform dataset.
+3. **Train.** Once processing finishes, [edit the annotations](../data/annotation.md) and [train](../train/index.md) exactly like any other Platform dataset.
 
 ## What Gets Imported
 
-Platform detects the Labelbox format automatically and maps each annotation to the matching [YOLO task type](../data/index.md#supported-tasks):
+Platform recognizes the Labelbox format on its own and maps each annotation to the matching [YOLO task type](../data/index.md#supported-tasks):
 
 | Labelbox Annotation | Platform Task                              |
 | ------------------- | ------------------------------------------ |
 | Bounding box        | [Detect](../../datasets/detect/index.md)   |
 | Polygon             | [Segment](../../datasets/segment/index.md) |
 
-Class names come from your Labelbox annotation names, and pixel coordinates are normalized using the image dimensions in the export. A catalog export with no annotations imports as an unlabeled image dataset that you can annotate in Platform.
+Your Labelbox annotation names become the dataset's class names, and pixel coordinates are normalized using the image dimensions recorded in the export. A catalog export with no annotations imports as an unlabeled image dataset, ready to label in Platform's [annotation editor](../data/annotation.md).
 
 !!! note "Image URLs must be reachable"
 
-    A Labelbox export references each image by URL rather than embedding the pixels. Platform downloads the images from those URLs, probing a sample first, so the export fails fast if the images are not publicly accessible.
+    A Labelbox export references each image by URL rather than embedding the pixels. Platform downloads the images from those URLs, probing a sample first, so the import fails fast and tells you why if the images cannot be reached.
 
 !!! tip "Mixed annotations import as segment"
 
-    An export that contains both bounding boxes and polygons is imported as a segment dataset.
+    An export containing both bounding boxes and polygons is imported as a segment dataset.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -683,6 +683,9 @@ nav:
           - Slack: platform/integrations/slack.md
           - Ultralytics HUB: platform/integrations/ultralytics-hub.md
           - Roboflow: platform/integrations/roboflow.md
+          - Labelbox: platform/integrations/labelbox.md
+          - CVAT: platform/integrations/cvat.md
+          - Label Studio: platform/integrations/label-studio.md
           - Google Cloud Storage: platform/integrations/google-cloud-storage.md
           - Amazon S3: platform/integrations/amazon-s3.md
           - Azure Blob Storage: platform/integrations/azure-blob-storage.md


### PR DESCRIPTION
## Summary

Documents the Labelbox integration in Ultralytics Platform and adds Coming Soon placeholders for CVAT and Label Studio.

Platform already ingests Labelbox NDJSON exports directly — no connection, no API key. The page covers the export → upload → train flow, and the annotation → task mapping (bounding box → detect, polygon → segment), the class-name behavior, and the requirement that the image URLs referenced by the export stay reachable during processing. Every claim was read off the ingest worker rather than assumed.

- `platform/integrations/labelbox.md` — new
- `platform/integrations/cvat.md`, `platform/integrations/label-studio.md` — new, `coming_soon: true`, pointing at the YOLO-export path that works today
- `platform/integrations/index.md` — table rows, keywords, and a note that Labelbox needs no connection
- `mkdocs.yml` — nav entries under Roboflow

The `coming_soon` frontmatter renders as a Coming Soon badge in the docs page header; the renderer side ships in ultralytics/portal#3168, and the field is inert until it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📚 Adds Ultralytics Platform documentation for Labelbox, CVAT, and Label Studio dataset integrations, including current workflows and upcoming direct-import support.

### 📊 Key Changes
- Added a **Labelbox integration guide** for importing NDJSON exports directly into Ultralytics Platform.
- Documented supported Labelbox annotations, including bounding boxes and polygons, along with current limitations for masks, points, polylines, and classifications.
- Added **CVAT** and **Label Studio** integration guides marked as coming soon.
- Provided step-by-step export and upload instructions for CVAT and Label Studio, including CLI and API examples.
- Documented supported export formats, image-inclusion requirements, class-name handling, and unsupported formats such as Pascal VOC.
- Updated the integrations index and navigation to include Labelbox, CVAT, and Label Studio.
- Clarified that Labelbox uploads require no persistent connection or credentials, while CVAT and Label Studio currently rely on YOLO-compatible exports.

### 🎯 Purpose & Impact
- 🚀 Makes it easier to move annotated datasets from popular labeling tools into Ultralytics Platform for annotation, training, and deployment.
- 🧩 Reduces confusion around export formats, missing images, class names, expired URLs, and unsupported annotation types.
- 🏷️ Preserves label names and maps supported annotations to the appropriate YOLO task, such as detection or segmentation.
- 🔄 Enables more repeatable workflows through Labelbox SDK, CVAT CLI, and Label Studio API examples.
- 🔮 Prepares users for future direct CVAT and Label Studio imports that will remove the need to select or convert export formats.