### PR TITLE
Replace the per-object array scans in `ConfusionMatrix.process_batch` with a lookup

### DIFF
--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -456,24 +456,26 @@ class ConfusionMatrix(DataExportMixin):
         else:
             matches = np.zeros((0, 3))
 
-        n = matches.shape[0] > 0
         m0, m1, _ = matches.transpose().astype(int)
+        # matches is deduplicated on both columns, so each gt and each detection appears at most once
+        gt_match = np.full(len(gt_classes), -1)
+        gt_match[m0] = m1
+        matched_det = set(m1.tolist())
         for i, gc in enumerate(gt_classes):
-            j = m0 == i
-            if n and sum(j) == 1:
-                dc = detection_classes[m1[j].item()]
+            if (di := gt_match[i].item()) >= 0:
+                dc = detection_classes[di]
                 self.matrix[dc, gc] += 1  # TP if class is correct else both an FP and an FN
                 if dc == gc:
-                    self._append_matches("TP", detections, m1[j].item())
+                    self._append_matches("TP", detections, di)
                 else:
-                    self._append_matches("FP", detections, m1[j].item())
+                    self._append_matches("FP", detections, di)
                     self._append_matches("FN", batch, i)
             else:
                 self.matrix[self.nc, gc] += 1  # FN
                 self._append_matches("FN", batch, i)
 
         for i, dc in enumerate(detection_classes):
-            if not any(m1 == i):
+            if i not in matched_det:
                 self.matrix[dc, self.nc] += 1  # FP
                 self._append_matches("FP", detections, i)
 


### PR DESCRIPTION
`ConfusionMatrix.process_batch()` runs once per image whenever `plots=True`, which is the default for `val` and for the validation pass of every training epoch. Two of its reductions are Python-level scans over NumPy arrays, and both run inside per-object loops:

- `sum(j)` with `j = m0 == i`, once per ground truth. `sum()` here is the builtin, so it iterates the boolean array element by element.
- `any(m1 == i)`, once per detection. Same problem, and it also builds a new comparison array every time.

`matches` is already deduplicated on both columns a few lines above, each ground truth and each detection can appear at most once. So a single lookup is enough for both checks and the scans are not needed at all.

The cost shows up on the default val path because `max_det=300` and `conf=0.001` keep the detection loop at 300 iterations even on an image with 4 objects.

Deleted: the `n` flag, the per-ground-truth mask `j`, and the two Python-level reductions (`sum(j)` and `any(m1 == i)`). Net +2 lines: the two array scans are replaced by one lookup table plus one membership set, built once per image.

## Measured

128 images of coco128 with `yolo11n.pt`, default args, the real `process_batch` calls captured from a val run and replayed 40 times per variant (median):

| | ms per 128 images | ms/image |
|---|---|---|
| main | 50.6 | 0.399 |
| this PR | 24.3 | 0.190 |

**2.1x**, 0.21 ms/image saved. I also interleaved main-vs-main runs as a control, and their spread is 9%, much smaller than the gap. The gain scales with the objects per image, so dense datasets benefit more: with 300 ground truths and 300 detections the same call drops from about 13 ms to about 1.9 ms, roughly 7x (the repro below).

Confusion matrix is bit-identical over 728 cases (600 synthetic including 0-gt, 0-detection and 0-vs-0, plus the 128 real calls), in all three modes: `save_matches=False`, `save_matches=True`, and with masks. The `matches` dict is compared tensor by tensor, 0 discrepancies.

mAP unchanged on all four tasks that reach this code:

```
yolo11n.pt         map50=0.846179 map=0.630430
yolo11n-seg.pt     map50=0.885305 map=0.674108 seg_map=0.571395
yolo11n-pose.pt    map50=0.916564 map=0.723393 pose_map=0.349210
yolo11n-obb.pt     map50=0.995000 map=0.801500
```

`pytest tests/test_python.py -k "val or confusion or metric or plot or predict"` → 36 passed, 2 skipped.

## Repro

```python
import time
import torch
from ultralytics.utils.metrics import ConfusionMatrix

torch.manual_seed(0)
torch.set_num_threads(8)  # the default thread count makes small-tensor timings very noisy
g = torch.rand(300, 4) * 540
g[:, 2:] = g[:, :2] + 20 + torch.rand(300, 2) * 80
d = g + torch.randn(300, 4) * 3
det = {"bboxes": d, "conf": torch.rand(300) * 0.5 + 0.5, "cls": torch.arange(300.0) % 80}
batch = {"bboxes": g, "cls": torch.arange(300.0) % 80, "im_file": "x.jpg"}

cm = ConfusionMatrix(names={i: str(i) for i in range(80)}, task="detect")
cm.process_batch(dict(det), dict(batch), conf=0.001)  # warmup
t = time.perf_counter()
for _ in range(200):
    cm.process_batch(dict(det), dict(batch), conf=0.001)
print(f"{(time.perf_counter() - t) / 200 * 1e3:.2f} ms per image")
# main: 10-16 ms   this PR: 1.8-2.2 ms  (my laptop scatters run to run, the ratio holds)
```

## Siblings

`process_cls_preds()` is the other counting loop in the class, but it runs once per val over the whole set, not per image: 36 ms for 50k samples (a full ImageNet val), so there is nothing to gain there and I left it alone. A grep for the same pattern elsewhere (`sum(<array>) ==`, `any(<array> == i)`) returns no other hit in `ultralytics/` — the remaining `sum()`/`any()` calls take lists or generators, which is what they are for.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Replaces repeated per-object array scans in `ConfusionMatrix.process_batch` with direct lookup structures for faster matching.

### 📊 Key Changes
- Builds a ground-truth-to-detection lookup array from deduplicated matches.
- Tracks matched detections with a set instead of repeatedly scanning match arrays.
- Preserves TP, FP, and FN confusion-matrix updates and match recording behavior.

### 🎯 Purpose & Impact
- Improves the efficiency of confusion-matrix processing, especially for batches with many objects.
- Reduces unnecessary array scans while maintaining existing detection-matching results.
- Keeps the change focused within the metrics implementation, with no user-facing API changes.