### PR TITLE
Draw the `Heatmap` counting region once per frame instead of once per object

### DIFF
--- a/ultralytics/solutions/heatmap.py
+++ b/ultralytics/solutions/heatmap.py
@@ -92,13 +92,15 @@ class Heatmap(ObjectCounter):
         self.extract_tracks(im0)  # Extract tracks
         self.annotator = SolutionAnnotator(im0, line_width=self.line_width)  # Initialize annotator
 
+        if self.region is not None:
+            self.annotator.draw_region(reg_pts=self.region, color=(104, 0, 123), thickness=self.line_width * 2)
+
         # Iterate over bounding boxes, track ids and classes index
         for box, track_id, cls in zip(self.boxes, self.track_ids, self.clss):
             # Apply heatmap effect for the bounding box
             self.heatmap_effect(box)
 
             if self.region is not None:
-                self.annotator.draw_region(reg_pts=self.region, color=(104, 0, 123), thickness=self.line_width * 2)
                 self.store_tracking_history(track_id, box)  # Store track history
                 # Get previous position if available
                 prev_position = None


### PR DESCRIPTION
`Heatmap.process()` draws the counting region from inside the loop over tracked objects, so the region is only drawn on frames that have at least one tracked object. On a frame where tracking returns nothing — an occlusion, an object leaving the scene, or the frames right after it while the new track is not confirmed yet — the loop body never runs and the region disappears from the output video. It comes back on the next frame with a track, so the region flickers.

The same call also runs once per tracked object. `draw_region()` is `cv2.polylines()` plus one filled circle per corner, all opaque, so drawing it N times looks exactly like drawing it once: N-1 of those calls are wasted work.

Both siblings already do this the right way — `ObjectCounter.process()` (`object_counter.py:165`) and `QueueManager.process()` (`queue_management.py:65`) draw the region once, before the loop, with the same call. `Heatmap` is the only solution that does it inside. `RegionCounter` loops on purpose because it draws one region per region. And `Heatmap` is already inconsistent with itself: `display_counts()` sits outside the loop, so the counts are drawn on every frame while the region they belong to is not.

Moving the call to where the siblings have it fixes both things.

Deleted: the per-object `draw_region()` call inside the tracking loop. The line comes back above the loop, so the diff is net +1: the hoisted call needs its own `region is not None` guard, and the loop keeps its guard for the tracking and counting work.

## Verified

8 frames of `bus.jpg` with frame 3 blacked out, so tracking drops out mid-sequence (`yolo11n.pt`, `region=` a rectangle, `imgsz` default). Frames 3 and 4 have no tracked objects, frame 4 because the re-detected track is not confirmed yet:

| frame | tracked objects | pixels differing from main | of those, outside the region border |
|---|---|---|---|
| 0, 1, 2 | 5 | 0 | 0 |
| 3 | 0 | 11550 | 0 |
| 4 | 0 | 11550 | 0 |
| 5, 6, 7 | 5 | 0 | 0 |

So on frames that have tracks the output is pixel-identical to main, and on the two frames without tracks the only difference is the region border itself — 11550 pixels is the full outline plus the corner circles that `draw_region()` paints. `total_tracks`, `in_count`, `out_count` and `classwise_count` come out the same on all 8 frames.

The wasted calls, measured on the 810x1080 frame: 0.038 ms each, so 0.16 ms per frame with 5 objects and 1.72 ms with 45. That is small next to inference, it is a side effect of the move and not the reason for it.

`pytest tests/test_solutions.py` → 51 passed, 1 skipped. The existing `HeatmapWithRegion` case runs the demo video but does not look at pixels, which is why the flicker went unnoticed.

## Repro

```python
import cv2
import numpy as np
from ultralytics import solutions

im = cv2.imread("ultralytics/assets/bus.jpg")
h, w = im.shape[:2]
region = [(int(w * 0.15), int(h * 0.25)), (int(w * 0.85), int(h * 0.25)),
          (int(w * 0.85), int(h * 0.75)), (int(w * 0.15), int(h * 0.75))]

border = np.zeros((h, w), np.uint8)  # where the region outline should land
cv2.polylines(border, [np.array(region, np.int32)], True, 255, 6)

hm = solutions.Heatmap(model="yolo11n.pt", region=region, show=False)
frames = [im.copy() for _ in range(6)]
frames[3] = np.zeros_like(im)  # occlusion: no tracked objects on this frame

for i, f in enumerate(frames):
    res = hm.process(f.copy())
    drawn = int((np.any(res.plot_im != f, axis=2) & (border > 0)).sum())
    print(f"frame {i}: tracks={res.total_tracks}  region outline pixels={drawn}")

# main     frames 0-2, 5: 15478   frames 3-4: 0       <- region gone on the frames without tracks
# this PR  frames 0-2, 5: 15478   frames 3-4: 11170
# (the two counts differ because on a frame with tracks the heatmap is blended over the whole
#  frame, so every outline pixel differs from the input, drawn region or not)
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Draws the Heatmap counting region once per frame rather than repeatedly for each tracked object.

### 📊 Key Changes
- Moves `draw_region()` outside the bounding-box iteration loop.
- Preserves region-based tracking history and heatmap processing for each object.

### 🎯 Purpose & Impact
- Prevents redundant region rendering when multiple objects are present.
- Improves per-frame processing efficiency while maintaining the same visual output and tracking behavior.