### PR TITLE
Fit the size-independent term in `get_flops`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
     "psutil>=5.8.0", # system utilization
     "polars>=0.20.0",
     "nvidia-ml-py>=12.0.0", # NVIDIA GPU monitoring https://pypi.org/project/nvidia-ml-py
-    "ultralytics-thop>=2.1.0", # FLOPs computation https://github.com/ultralytics/thop
+    "ultralytics-thop>=2.1.1", # FLOPs computation https://github.com/ultralytics/thop
 ]
 
 # Optional dependencies ------------------------------------------------------------------------------------------------

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -479,8 +479,9 @@ def model_info_for_loggers(trainer):
 def get_flops(model, imgsz=640):
     """Calculate FLOPs (floating point operations) for a model in GFLOPs.
 
-    Attempts two calculation methods: first with a stride-based tensor for efficiency, then falls back to full image
-    size if needed (e.g., for RTDETR models). Returns 0.0 if thop library is unavailable or calculation fails.
+    Attempts two calculation methods: first with stride-based tensors for efficiency, fitting MACs as a linear
+    function of image area so that size-independent layers are not scaled, then falls back to full image size if
+    needed (e.g., for RTDETR models). Returns 0.0 if thop library is unavailable or calculation fails.
 
     Args:
         model (nn.Module): The model to calculate FLOPs for.
@@ -503,11 +504,16 @@ def get_flops(model, imgsz=640):
         if not isinstance(imgsz, list):
             imgsz = [imgsz, imgsz]  # expand if int/float
         try:
-            # Method 1: Use stride-based input tensor
+            # Method 1: Fit MACs = slope * area + const from two stride-sized inputs
             stride = max(int(model.stride.max()), 32) if hasattr(model, "stride") else 32  # max stride
             im = torch.empty((1, p.shape[1], stride, stride), device=p.device, dtype=p.dtype)  # input image in BCHW
-            flops = thop.profile(model, inputs=[im], verbose=False)[0] / 1e9 * 2  # stride GFLOPs
-            return flops * imgsz[0] / stride * imgsz[1] / stride  # imgsz GFLOPs
+            macs = thop.profile(model, inputs=[im], verbose=False)[0]  # MACs at area stride^2
+            slope, const = macs / stride**2, 0.0  # MACs per pixel, and MACs independent of image size
+            if any(isinstance(m, nn.Linear) for m in model.modules()):  # a Linear may run on pooled or text features
+                im2 = torch.empty((1, p.shape[1], stride, stride * 2), device=p.device, dtype=p.dtype)  # twice the area
+                macs2 = thop.profile(model, inputs=[im2], verbose=False)[0]  # MACs at area 2 * stride^2
+                slope, const = (macs2 - macs) / stride**2, 2 * macs - macs2  # solve MACs = slope * area + const
+            return (slope * imgsz[0] * imgsz[1] + const) / 1e9 * 2  # imgsz GFLOPs
         except Exception:
             # Method 2: Use actual image size (required for RTDETR models)
             im = torch.empty((1, p.shape[1], *imgsz), device=p.device, dtype=p.dtype)  # input image in BCHW format

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -479,9 +479,9 @@ def model_info_for_loggers(trainer):
 def get_flops(model, imgsz=640):
     """Calculate FLOPs (floating point operations) for a model in GFLOPs.
 
-    Attempts two calculation methods: first with stride-based tensors for efficiency, fitting MACs as a linear
-    function of image area so that size-independent layers are not scaled, then falls back to full image size if
-    needed (e.g., for RTDETR models). Returns 0.0 if thop library is unavailable or calculation fails.
+    Attempts two calculation methods: first with stride-based tensors for efficiency, fitting MACs as a linear function
+    of image area so that size-independent layers are not scaled, then falls back to full image size if needed (e.g.,
+    for RTDETR models). Returns 0.0 if thop library is unavailable or calculation fails.
 
     Args:
         model (nn.Module): The model to calculate FLOPs for.

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -479,9 +479,8 @@ def model_info_for_loggers(trainer):
 def get_flops(model, imgsz=640):
     """Calculate FLOPs (floating point operations) for a model in GFLOPs.
 
-    Attempts two calculation methods: first with stride-based tensors for efficiency, fitting MACs as a linear function
-    of image area so that size-independent layers are not scaled, then falls back to full image size if needed (e.g.,
-    for RTDETR models). Returns 0.0 if thop library is unavailable or calculation fails.
+    Uses THOP's stride-aware image profiling for efficiency and accurate size-independent operations. Returns 0.0 if
+    thop is unavailable or profiling fails.
 
     Args:
         model (nn.Module): The model to calculate FLOPs for.
@@ -503,21 +502,9 @@ def get_flops(model, imgsz=640):
         p = next(model.parameters())
         if not isinstance(imgsz, list):
             imgsz = [imgsz, imgsz]  # expand if int/float
-        try:
-            # Method 1: Fit MACs = slope * area + const from two stride-sized inputs
-            stride = max(int(model.stride.max()), 32) if hasattr(model, "stride") else 32  # max stride
-            im = torch.empty((1, p.shape[1], stride, stride), device=p.device, dtype=p.dtype)  # input image in BCHW
-            macs = thop.profile(model, inputs=[im], verbose=False)[0]  # MACs at area stride^2
-            slope, const = macs / stride**2, 0.0  # MACs per pixel, and MACs independent of image size
-            if any(isinstance(m, nn.Linear) for m in model.modules()):  # a Linear may run on pooled or text features
-                im2 = torch.empty((1, p.shape[1], stride, stride * 2), device=p.device, dtype=p.dtype)  # twice the area
-                macs2 = thop.profile(model, inputs=[im2], verbose=False)[0]  # MACs at area 2 * stride^2
-                slope, const = (macs2 - macs) / stride**2, 2 * macs - macs2  # solve MACs = slope * area + const
-            return (slope * imgsz[0] * imgsz[1] + const) / 1e9 * 2  # imgsz GFLOPs
-        except Exception:
-            # Method 2: Use actual image size (required for RTDETR models)
-            im = torch.empty((1, p.shape[1], *imgsz), device=p.device, dtype=p.dtype)  # input image in BCHW format
-            return thop.profile(model, inputs=[im], verbose=False)[0] / 1e9 * 2  # imgsz GFLOPs
+        stride = max(int(model.stride.max()), 32) if hasattr(model, "stride") else 32  # max stride
+        im = torch.empty((1, p.shape[1], *imgsz), device=p.device, dtype=p.dtype)  # input image in BCHW format
+        return thop.profile(model, inputs=[im], stride=stride, verbose=False)[0] / 1e9 * 2  # imgsz GFLOPs
     except Exception:
         return 0.0
 


### PR DESCRIPTION
`get_flops()` profiles at `stride × stride` and multiplies by image area, which incorrectly scales MACs that are independent of image size. This affects classification heads and YOLO-World text projections; for example, `yolov8s-worldv2` reports 51.0 GFLOPs instead of the exact 32.1 at 640.

## Owner fix

The affine image-size policy now lives in the profiler that owns it: [ultralytics/thop#149](https://github.com/ultralytics/thop/pull/149), released as [`ultralytics-thop==2.1.1`](https://pypi.org/project/ultralytics-thop/2.1.1/).

THOP's existing `profile(model, inputs=...)` API remains unchanged for YOLOv3, YOLOv5, and third-party callers. Its new opt-in `stride` argument:

- retains one stride-sized profile for spatial-only models;
- fits two proxy areas when supported size-independent operations are present;
- reuses one hook registration across proxy forwards;
- falls back to the supplied target image when proxy inputs are unsuitable.

Ultralytics now passes the desired target tensor and available stride directly to THOP:

```python
thop.profile(model, inputs=[im], stride=stride, verbose=False)
```

The dependency floor moves from `ultralytics-thop>=2.1.0` to `>=2.1.1`.

Deleted: the local affine fit, `nn.Linear` inspection, and duplicate full-image fallback from `get_flops` (final Ultralytics diff: +6/-13).

## Validation

- Released 2.1.1 wheel and sdist verified on PyPI.
- THOP suite: 20 passed; Ruff clean.
- Exact target comparison across all 66 model YAMLs at 640: 66/66 matched, including classification, YOLO-World, and five RT-DETR models.
- THOP compatibility calls without `stride` remain unchanged.
- Rectangular 32×640 and 640×32 inputs and recurrent-cell fixed costs were validated without adding extra test scaffolding.
