### PR TITLE
Fix INT8 export calibration ignoring `fraction` for classify models

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -187,6 +187,16 @@ def test_int8_calibration_validates_split():
         exporter.get_int8_calibration_dataloader()
 
 
+def test_int8_calibration_classify_fraction():
+    """Check classification INT8 calibration respects fraction (#25469)."""
+    exporter = object.__new__(Exporter)
+    exporter.model = SimpleNamespace(task="classify")
+    exporter.args = get_cfg(overrides={"data": "imagenet10", "fraction": 0.5, "batch": 1})
+    exporter.imgsz = [32]
+    dataloader = exporter.get_int8_calibration_dataloader()
+    assert len(dataloader.dataset) == 6  # imagenet10 val has 12 images, fraction=0.5 keeps 6
+
+
 def test_export_rknn_batch_expansion(monkeypatch, tmp_path):
     """Check RKNN calibrates batch 1 before Toolkit expands to the requested batch."""
     calls = {}

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -980,6 +980,8 @@ class Exporter:
 
             data = check_cls_dataset(self.args.data, split=self.args.split)
             dataset = ClassificationDataset(data[self.args.split or "val"], args=cfg, augment=False)
+            if self.args.fraction < 1.0:
+                dataset.samples = dataset.samples[: round(len(dataset.samples) * self.args.fraction)]
             # INT8 backends divide images by 255, so emit uint8 [0, 255] center-cropped like classify inference
             dataset.torch_transforms = T.Compose([T.Resize(cfg.imgsz), T.CenterCrop(cfg.imgsz), T.PILToTensor()])
         else:


### PR DESCRIPTION
## Problem

`fraction` is silently ignored when exporting a **classification** model with INT8 quantization — the full validation set is always used for calibration:

```python
from ultralytics import YOLO

YOLO("yolo26n-cls.pt").export(format="openvino", quantize=8, data="imagenet10", fraction=0.5)
# Before: calibrates on all 12 val images
# After:  calibrates on 6 val images
```

Detection/segmentation/pose/OBB models are unaffected — their branch passes `fraction` explicitly to `build_yolo_dataset()`.

## Root cause

Regression from #24972, which replaced `YOLODataset(..., fraction=self.args.fraction)` with `ClassificationDataset(..., augment=False)` in `Exporter.get_int8_calibration_dataloader()`. `ClassificationDataset` only applies `fraction` when `augment=True` (a deliberate gate so validation during training is never reduced), so the calibration path with `augment=False` skips it.

## Fix

Slice the calibration samples in the exporter's classify branch, mirroring what the detect branch already does by passing `fraction` to `build_yolo_dataset()`. The `augment` gate in `ClassificationDataset` is intentionally left untouched — removing it would make `fraction` shrink the val set during classification training.

## Impact scope

- Applies to **every INT8 export format** that builds its calibration set through the shared `Exporter.get_int8_calibration_dataloader()` (OpenVINO, ONNX, TensorRT, TF SavedModel, EdgeTPU, LiteRT, IMX, RKNN, Axelera, QNN, Hailo) — but **only** for `task=classify` with `fraction < 1.0`.
- No behavior change for the default `fraction=1.0`, for non-classify tasks, or for FP16/FP32 exports (no calibration set is built there).
- No change to training or validation dataset handling — `ClassificationDataset` itself is untouched.

## Verified

- imagenet10 (12 val images), `fraction=0.5` → log shows `found 6 images`, `Statistics collection 6/6`, export succeeds.
- Detect sanity check (coco8, `fraction=0.5` → 2 images) unchanged.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes INT8 classification export calibration so the configured `fraction` value is respected.

### 📊 Key Changes
- Applies `self.args.fraction` to limit classification calibration samples when the fraction is below 1.0.
- Preserves the existing full-dataset behavior when `fraction` is 1.0 or higher.
- Keeps calibration preprocessing unchanged, including resizing, center cropping, and conversion to `uint8` tensors.

### 🎯 Purpose & Impact
- 🐛 Resolves a bug where classification INT8 exports ignored the requested calibration dataset fraction.
- ⚡ Allows users to reduce calibration data and potentially shorten export times and resource usage.
- ✅ Aligns classification calibration behavior with the configured export arguments without affecting other model types.