### PR TITLE
Calibrate OpenVINO INT8 on the full dataset instead of nncf's 300-batch default

### DIFF
--- a/ultralytics/utils/export/openvino.py
+++ b/ultralytics/utils/export/openvino.py
@@ -53,6 +53,8 @@ def torch2openvino(
             model=ov_model,
             calibration_dataset=calibration_dataset,
             preset=nncf.QuantizationPreset.MIXED,
+            # Calibrate on the full dataset like other INT8 backends, not nncf's 300-batch default
+            subset_size=calibration_dataset.get_length() or 300,
             ignored_scope=ignored_scope,
         )
 


### PR DESCRIPTION
## Problem

`nncf.quantize()` defaults to `subset_size=300`, so OpenVINO INT8 calibration silently caps itself no matter what `data=` and `fraction=` provide — everything past the cap is still loaded and letterboxed, then thrown away. The limit also counts *batches*, not images, so the effective image budget silently scales with `batch=`: at the export default `batch=1` it is 300 images, but `batch=8` makes it 2400.

The exporter itself points the other way: when the set is smaller it warns `">300 images recommended for INT8 calibration"`. So at the default `batch=1` the two thresholds line up at 300 images — the exporter nudges users to add more, yet the 300-batch cap then discards everything they add beyond it.

This is also inconsistent with every other INT8 backend, which all consume the calibration dataloader to exhaustion:

- TensorRT: `EngineCalibrator.get_batch()` iterates until `StopIteration`
- ONNX Runtime: the calibration data reader is drained fully
- Hailo: uses `len(dataloader.dataset)` images

## Fix

```python
subset_size=calibration_dataset.get_length() or 300,
```

`nncf.Dataset.get_length()` returns the wrapped dataloader's batch count. `Exporter.get_int8_calibration_dataloader()` always returns an `InfiniteDataLoader`, which defines `__len__`, so in this code path the value is always an int.

The `or 300` fallback covers other callers: `torch2openvino()` accepts any `nncf.Dataset`, and a generator- or iterator-backed one has no `__len__`, making `get_length()` return `None`. Passing that through is not a graceful degradation — `nncf.quantize()` validates `if subset_size < 1` before anything else, so `None` raises `TypeError: '<' not supported between instances of 'NoneType' and 'int'` rather than nncf's own `ValidationError`. The fallback keeps those callers on nncf's documented default instead of crashing with a misleading error.

Note that nncf already caps iterations at `min(dataset_length, subset_size)`, so this is a no-op for calibration sets of 300 batches or fewer — coco128 collected 128/128 both before and after. The behavior only changes above that threshold, where the old default truncated (e.g. 5k val images: `min(5000, 300)` → `min(5000, 5000)`).

## Trade-off

Exports with large calibration datasets (e.g. `data=coco.yaml`, 5k val images) now take proportionally longer to quantize — which is exactly what passing a large dataset asks for. Users who want faster calibration can bound it explicitly with `fraction=`, which this change makes fully effective together with #25469.

## Verified

- `subset_size` captured at the `nncf.quantize` call site equals `len(dataloader)` (128 on coco128, 12 on imagenet10).
- Detect (coco8/coco128) and classify (imagenet10) INT8 OpenVINO exports succeed, each consuming the calibration loader in exactly one statistics pass.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Calibrates OpenVINO INT8 exports using the complete calibration dataset instead of NNCF’s default 300-batch subset. 📊

### 📊 Key Changes
- Passes `subset_size=calibration_dataset.get_length() or 300` to NNCF quantization.
- Preserves a fallback of 300 when the calibration dataset length is unavailable.
- Applies the change to OpenVINO INT8 calibration in `ultralytics/utils/export/openvino.py`.

### 🎯 Purpose & Impact
- Aligns OpenVINO calibration behavior with other INT8 backends.
- Uses more representative calibration data, which may improve quantized model accuracy.
- Can increase calibration time and resource usage for larger datasets. ⚙️