### PR TITLE
Pin float32 when stacking TrackTrack ReID embeddings

### DIFF
--- a/ultralytics/trackers/track_tracker.py
+++ b/ultralytics/trackers/track_tracker.py
@@ -201,8 +201,10 @@ def _cosine_distance(tracks: list[TTSTrack], dets: list[TTSTrack]) -> np.ndarray
     dfeat = [d.curr_feat for d in dets]
     dim = next((f.shape[0] for f in (*tfeat, *dfeat) if f is not None), 128)
     zeros = np.zeros(dim, dtype=np.float32)
-    T = np.stack([f if f is not None else zeros for f in tfeat])
-    D = np.stack([f if f is not None else zeros for f in dfeat])
+    # Pin float32 as `matching.embedding_distance` does: an unpinned stack inherits the encoder's dtype, so a
+    # half-precision ReID backend (`quantize=16`, or a float16 ONNX model) would decide this cost matrix' precision.
+    T = np.asarray([f if f is not None else zeros for f in tfeat], dtype=np.float32)
+    D = np.asarray([f if f is not None else zeros for f in dfeat], dtype=np.float32)
     valid = np.array([f is not None for f in tfeat])[:, None] & np.array([f is not None for f in dfeat])[None, :]
     return np.where(valid, np.clip(1 - T @ D.T, 0, 1), np.nan).astype(np.float32)
 


### PR DESCRIPTION
## summary

`_cosine_distance` stacked the ReID embeddings with `np.stack`, which takes the promoted dtype of its inputs, so the cosine product ran in whatever dtype the ReID backend returned. `model.track(..., quantize=16)` with ReID enabled yields float16 embeddings, and the association cost is then computed in float16 — a precision that belongs to the backend rather than to this function. The sibling `matching.embedding_distance` already pins float32 at the equivalent lines; this makes the two agree.

`np.asarray(..., dtype=np.float32)` rather than `np.stack(...).astype(...)`, so no widened intermediate is materialized. The function already ends in `.astype(np.float32)`, so the declared return dtype is unchanged, and ragged input still raises `ValueError` under both forms.

Output is unchanged on every shipped configuration: a full-clip `tracktrack` run with `with_reid: True` and 14 concurrent tracks gives byte-identical track ids and boxes, and `pytest tests/test_python.py -k "track"` stays green.

Deleted: nothing. The trigger could instead be relocated to `smooth_feature` in `trackers/utils/reid.py` — the single funnel for `curr_feat`/`smooth_feat` across all three ReID trackers — which would also make the two pins in `matching.py` deletable. Narrowing there changes the stored EMA values for half-precision backends, so it is not behaviour-neutral and needs its own before/after comparison rather than riding along here.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Ensures tracker cosine-distance calculations consistently use `float32` precision for reliable ReID matching. 🎯

### 📊 Key Changes
- Converts track and detection feature arrays to `float32` before computing the cost matrix.
- Prevents the encoder’s data type—such as `float16` from quantized or ONNX ReID models—from controlling matching precision.
- Preserves existing handling for missing embeddings and invalid matches.

### 🎯 Purpose & Impact
- Improves numerical consistency across different ReID backends and precision settings. ⚙️
- Makes tracking behavior more predictable when using half-precision models.
- Helps maintain stable and reliable object associations without changing the tracker’s overall matching logic. 🚀