### PR TITLE
Remove broken Platform links

### DIFF
--- a/docs/en/datasets/semantic/cityscapes.md
+++ b/docs/en/datasets/semantic/cityscapes.md
@@ -52,7 +52,7 @@ The semantic masks are single-channel PNG files. The original Cityscapes label I
 
 Cityscapes is widely used for training and evaluating [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) models in semantic segmentation, particularly for [autonomous driving](https://www.ultralytics.com/glossary/autonomous-vehicles), advanced driver-assistance systems (ADAS), and urban robotics.
 
-Its high-resolution images and detailed annotations also make it valuable for research on real-time scene parsing, lane and obstacle understanding, and any task that requires dense pixel-level understanding of complex urban environments. Pretrained YOLO26 semantic segmentation models reach up to 83.6 mIoU on the Cityscapes validation set — see the [semantic segmentation models](../../tasks/semantic.md) page for the full benchmark table. Cityscapes annotations are also available on [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/cityscapes) for browsing and dataset management.
+Its high-resolution images and detailed annotations also make it valuable for research on real-time scene parsing, lane and obstacle understanding, and any task that requires dense pixel-level understanding of complex urban environments. Pretrained YOLO26 semantic segmentation models reach up to 83.6 mIoU on the Cityscapes validation set — see the [semantic segmentation models](../../tasks/semantic.md) page for the full benchmark table. Ultralytics Platform can help organize, visualize, and manage datasets throughout the model development workflow.
 
 ## Dataset YAML
 

--- a/docs/en/datasets/semantic/cityscapes.md
+++ b/docs/en/datasets/semantic/cityscapes.md
@@ -52,7 +52,7 @@ The semantic masks are single-channel PNG files. The original Cityscapes label I
 
 Cityscapes is widely used for training and evaluating [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) models in semantic segmentation, particularly for [autonomous driving](https://www.ultralytics.com/glossary/autonomous-vehicles), advanced driver-assistance systems (ADAS), and urban robotics.
 
-Its high-resolution images and detailed annotations also make it valuable for research on real-time scene parsing, lane and obstacle understanding, and any task that requires dense pixel-level understanding of complex urban environments. Pretrained YOLO26 semantic segmentation models reach up to 83.6 mIoU on the Cityscapes validation set — see the [semantic segmentation models](../../tasks/semantic.md) page for the full benchmark table. Ultralytics Platform provides tools for organizing, visualizing, and managing datasets throughout the model development workflow.
+Its high-resolution images and detailed annotations also make it valuable for research on real-time scene parsing, lane and obstacle understanding, and any task that requires dense pixel-level understanding of complex urban environments. Pretrained YOLO26 semantic segmentation models reach up to 83.6 mIoU on the Cityscapes validation set — see the [semantic segmentation models](../../tasks/semantic.md) page for the full benchmark table. You can organize, visualize, and manage Cityscapes data throughout the model development workflow with [Ultralytics Platform](https://platform.ultralytics.com/).
 
 ## Dataset YAML
 

--- a/docs/en/datasets/semantic/cityscapes.md
+++ b/docs/en/datasets/semantic/cityscapes.md
@@ -52,7 +52,7 @@ The semantic masks are single-channel PNG files. The original Cityscapes label I
 
 Cityscapes is widely used for training and evaluating [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) models in semantic segmentation, particularly for [autonomous driving](https://www.ultralytics.com/glossary/autonomous-vehicles), advanced driver-assistance systems (ADAS), and urban robotics.
 
-Its high-resolution images and detailed annotations also make it valuable for research on real-time scene parsing, lane and obstacle understanding, and any task that requires dense pixel-level understanding of complex urban environments. Pretrained YOLO26 semantic segmentation models reach up to 83.6 mIoU on the Cityscapes validation set — see the [semantic segmentation models](../../tasks/semantic.md) page for the full benchmark table. Ultralytics Platform can help organize, visualize, and manage datasets throughout the model development workflow.
+Its high-resolution images and detailed annotations also make it valuable for research on real-time scene parsing, lane and obstacle understanding, and any task that requires dense pixel-level understanding of complex urban environments. Pretrained YOLO26 semantic segmentation models reach up to 83.6 mIoU on the Cityscapes validation set — see the [semantic segmentation models](../../tasks/semantic.md) page for the full benchmark table. Ultralytics Platform provides tools for organizing, visualizing, and managing datasets throughout the model development workflow.
 
 ## Dataset YAML
 

--- a/docs/en/datasets/semantic/cityscapes8.md
+++ b/docs/en/datasets/semantic/cityscapes8.md
@@ -39,8 +39,6 @@ cityscapes8/
 
 Masks are paired with images via the `masks_dir: masks` field, and `label_mapping` converts source Cityscapes label IDs into the 19 contiguous train IDs described in the [full Cityscapes dataset structure](cityscapes.md#dataset-structure).
 
-Ultralytics Platform provides tools for browsing images and annotations, managing datasets, and training models in the cloud.
-
 ## Dataset YAML
 
 The Cityscapes8 dataset configuration is defined in a dataset YAML file, which specifies dataset paths, class names, and other essential metadata. You can review the official `cityscapes8.yaml` file in the [Ultralytics GitHub repository](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/cityscapes8.yaml). The YAML includes a download URL for the small packaged subset.
@@ -52,6 +50,8 @@ The Cityscapes8 dataset configuration is defined in a dataset YAML file, which s
     ```
 
 ## Usage
+
+You can also manage Cityscapes8 and train semantic segmentation models in the cloud with [Ultralytics Platform](https://platform.ultralytics.com/).
 
 To train a YOLO26n-sem model on the Cityscapes8 dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) with an image size of 1024, use the following examples. For a full list of training options, see the [YOLO Training documentation](../../modes/train.md).
 

--- a/docs/en/datasets/semantic/cityscapes8.md
+++ b/docs/en/datasets/semantic/cityscapes8.md
@@ -39,7 +39,7 @@ cityscapes8/
 
 Masks are paired with images via the `masks_dir: masks` field, and `label_mapping` converts source Cityscapes label IDs into the 19 contiguous train IDs described in the [full Cityscapes dataset structure](cityscapes.md#dataset-structure).
 
-Explore [Cityscapes8 on Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/cityscapes8) to browse every image with its segmentation masks and clone it to train in the cloud.
+Ultralytics Platform provides tools for browsing images and annotations, managing datasets, and training models in the cloud.
 
 ## Dataset YAML
 

--- a/docs/en/datasets/semantic/cityscapes8.md
+++ b/docs/en/datasets/semantic/cityscapes8.md
@@ -51,8 +51,6 @@ The Cityscapes8 dataset configuration is defined in a dataset YAML file, which s
 
 ## Usage
 
-You can also manage Cityscapes8 and train semantic segmentation models in the cloud with [Ultralytics Platform](https://platform.ultralytics.com/).
-
 To train a YOLO26n-sem model on the Cityscapes8 dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) with an image size of 1024, use the following examples. For a full list of training options, see the [YOLO Training documentation](../../modes/train.md).
 
 !!! example "Train Example"
@@ -75,6 +73,8 @@ To train a YOLO26n-sem model on the Cityscapes8 dataset for 100 [epochs](https:/
         # Train YOLO26n-sem on Cityscapes8 using the command line
         yolo semantic train data=cityscapes8.yaml model=yolo26n-sem.pt epochs=100 imgsz=1024
         ```
+
+You can also manage Cityscapes8 and train semantic segmentation models in the cloud with [Ultralytics Platform](https://platform.ultralytics.com/).
 
 ## Citations, License and Acknowledgments
 

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -63,7 +63,7 @@ def normalize_platform_uri(uri):
     """Rewrite an Ultralytics Platform web URL to its ul:// URI so it can be loaded directly as data or model.
 
     Args:
-        uri (str | Path): Resource identifier, including an Ultralytics Platform web URL.
+        uri (str | Path): Resource identifier, e.g. an Ultralytics Platform web URL ending in "/user/datasets/slug".
 
     Returns:
         (str | Path): "ul://user/datasets/slug" for Platform web URLs, otherwise the input unchanged.

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -63,7 +63,7 @@ def normalize_platform_uri(uri):
     """Rewrite an Ultralytics Platform web URL to its ul:// URI so it can be loaded directly as data or model.
 
     Args:
-        uri (str | Path): Resource identifier, e.g. "https://platform.ultralytics.com/user/datasets/slug".
+        uri (str | Path): Resource identifier, including an Ultralytics Platform web URL.
 
     Returns:
         (str | Path): "ul://user/datasets/slug" for Platform web URLs, otherwise the input unchanged.


### PR DESCRIPTION
## Summary

- remove broken Cityscapes and Cityscapes8 Platform links
- retain link-free mentions of Ultralytics Platform capabilities
- replace the concrete Platform URL in the API docstring

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📝 Updates Cityscapes documentation and clarifies Ultralytics Platform URL handling.

### 📊 Key Changes

- Updated the Cityscapes dataset page to describe Ultralytics Platform as a general workflow tool for organizing, visualizing, and managing data.
- Removed the direct Cityscapes8 dataset browsing link from the dataset overview.
- Added Ultralytics Platform guidance to the Cityscapes8 training section for cloud-based dataset management and model training.
- Refined the `normalize_platform_uri()` documentation example to clarify that Platform web URLs should end with a dataset or model path.

### 🎯 Purpose & Impact

- 📚 Keeps Cityscapes and Cityscapes8 documentation consistent with the broader Ultralytics Platform workflow.
- ☁️ Helps users discover cloud-based dataset management and training options without tying documentation to specific dataset pages.
- 🛠️ Makes Platform URI behavior clearer for developers using web URLs as model or dataset inputs.
- ✅ No functional code behavior changes are introduced; the update primarily improves documentation clarity and user guidance.