### PR TITLE
Restore the commented-out PERSISTENT_CACHE line

### DIFF
--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -1508,6 +1508,7 @@ SETTINGS = SettingsManager()  # initialize settings
 DATASETS_DIR = Path(SETTINGS["datasets_dir"])  # global datasets directory
 WEIGHTS_DIR = Path(SETTINGS["weights_dir"])  # global weights directory
 RUNS_DIR = Path(SETTINGS["runs_dir"])  # global runs directory
+# PERSISTENT_CACHE = JSONDict(USER_CONFIG_DIR / "persistent_cache.json")  # initialize persistent cache
 ENVIRONMENT = (
     "Colab"
     if IS_COLAB


### PR DESCRIPTION
Restores the line deleted in #25478.

It was commented out deliberately, so the persistent cache stays available in future — not left over. #25478 deleted it on a Codex dead-code finding (Delete > Replace > Add) that had no way to know that, and I applied it without checking whether the comment was intentional. My error.

Restored byte-identical to its state before that commit, same position after `RUNS_DIR`. Single line, no functional change — `PERSISTENT_CACHE` has no consumers either way, so nothing imports or executes differently.

```
RUNS_DIR = Path(SETTINGS["runs_dir"])  # global runs directory
# PERSISTENT_CACHE = JSONDict(USER_CONFIG_DIR / "persistent_cache.json")  # initialize persistent cache
```

ruff check and ruff format both clean.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🗃️ Adds a commented placeholder for a future persistent cache in Ultralytics utilities.

### 📊 Key Changes

- Introduces a commented `PERSISTENT_CACHE` initialization using `JSONDict`.
- Targets storage at `persistent_cache.json` within the user configuration directory.
- No active runtime behavior changes are included because the line remains commented out.

### 🎯 Purpose & Impact

- 🛠️ Prepares the codebase for potential persistent caching in future updates.
- ⚡ Could support retaining data between runs and improving efficiency once enabled.
- ✅ Has no immediate impact on existing users, workflows, or performance.