### PR TITLE
Preserve embedding distance dtype

### DIFF
--- a/ultralytics/trackers/utils/matching.py
+++ b/ultralytics/trackers/utils/matching.py
@@ -129,7 +129,9 @@ def embedding_distance(tracks: list, detections: list) -> np.ndarray:
     det_features = np.asarray([f if f is not None else zeros for f in det_feats], dtype=np.float32)
     track_norm = np.linalg.norm(track_features, axis=1, keepdims=True)
     det_norm = np.linalg.norm(det_features, axis=1, keepdims=True).T
-    cost_matrix = 1 - track_features @ det_features.T / np.maximum(track_norm * det_norm, np.finfo(float).eps)
+    cost_matrix = 1 - track_features @ det_features.T / np.maximum(
+        track_norm * det_norm, np.finfo(track_features.dtype).eps
+    )
     cost_matrix = np.maximum(0.0, cost_matrix)  # Normalized features
     missing_t = [i for i, f in enumerate(track_feats) if f is None]
     missing_d = [j for j, f in enumerate(det_feats) if f is None]


### PR DESCRIPTION
## summary

preserves float32 output for nonempty embedding-distance calculations.

uses the embedding dtype epsilon so tracker association matrices match the empty-path dtype.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves tracker embedding-distance calculations by using the feature data type’s numerical precision.

### 📊 Key Changes

- Updated `embedding_distance()` in `ultralytics/trackers/utils/matching.py`.
- Replaced the default floating-point epsilon with `np.finfo(track_features.dtype).eps`.
- Keeps cosine-distance calculations numerically stable while respecting the feature array’s precision.

### 🎯 Purpose & Impact

- 🛡️ Reduces potential numerical issues when tracker features use data types such as `float32`.
- ⚡ Maintains reliable object matching without changing the tracker’s overall behavior.
- ✅ Improves precision and consistency across different feature data types.