### PR TITLE
Store ReID appearance features as float32

### DIFF
--- a/ultralytics/trackers/utils/reid.py
+++ b/ultralytics/trackers/utils/reid.py
@@ -160,10 +160,11 @@ def smooth_feature(
         alpha (float): EMA weight on the existing `smooth` (``1.0`` keeps it unchanged).
 
     Returns:
-        curr (np.ndarray | None): The normalized current feature, or None when `feat` is zero-norm (carries no
-            appearance information, so the caller should leave its features unchanged).
-        smooth (np.ndarray | None): The updated, renormalized smoothed feature.
+        curr (np.ndarray | None): The normalized current feature as float32, or None when `feat` is zero-norm (carries
+            no appearance information, so the caller should leave its features unchanged).
+        smooth (np.ndarray | None): The updated, renormalized smoothed feature as float32.
     """
+    feat = np.asarray(feat, dtype=np.float32)  # the stored state is float32 whatever dtype the ReID backend returned
     norm = np.linalg.norm(feat)
     if norm < 1e-12:  # zero-norm feature has no appearance info; signal the caller to keep its current features
         return None, smooth

--- a/ultralytics/trackers/utils/reid.py
+++ b/ultralytics/trackers/utils/reid.py
@@ -160,9 +160,8 @@ def smooth_feature(
         alpha (float): EMA weight on the existing `smooth` (``1.0`` keeps it unchanged).
 
     Returns:
-        curr (np.ndarray | None): The normalized current feature as float32, or None when `feat` is zero-norm (carries
-            no appearance information, so the caller should leave its features unchanged).
-        smooth (np.ndarray | None): The updated, renormalized smoothed feature as float32.
+        curr (np.ndarray | None): The normalized float32 feature, or None when `feat` has zero norm.
+        smooth (np.ndarray | None): The updated, normalized float32 feature.
     """
     feat = np.asarray(feat, dtype=np.float32)  # the stored state is float32 whatever dtype the ReID backend returned
     norm = np.linalg.norm(feat)


### PR DESCRIPTION
## summary

`smooth_feature` is the single funnel through which all three ReID trackers materialize `curr_feat`/`smooth_feat` (`bot_sort.py:72`, `deep_oc_sort.py:77`, `track_tracker.py:257`), and it normalized and EMA-blended in whatever dtype the encoder returned. `model.track(..., quantize=16)` with `with_reid: True` delivers float16 embeddings, so the stored appearance state and its EMA ran in float16 — a representation that belonged to the backend rather than to the function that owns the state. Converting once at the funnel makes the storage decision local to it.

Placing the conversion *before* `np.linalg.norm` rather than at the return also removes two silent float16 failure modes: a raw feature with `||feat||^2 > 65504` overflowed the norm to `inf` and collapsed the embedding to all zeros, and a feature small enough for its squares to underflow gave `norm == 0` and an `inf` embedding. Both slipped past the `norm < 1e-12` guard, which only sees the encoder's dtype.

The narrowing cuts the other way for a float64 encoder: `||feat||` between ~1.8e19 and the float64 norm limit previously normalized cleanly and now degenerates. Measured embeddings are nowhere near either boundary — `||feat||` peaks at 10.34 on the `model: auto` path, and the shipped `yolo26n-reid.onnx` returns already-normalized features with `||feat|| == 1.0` — so the trade moves the failure window ~19 orders of magnitude away from anything a ReID head emits, in exchange for the two float16 modes that were reachable through a documented flag.

Output is unchanged on the shipped configurations. `np.asarray(..., dtype=np.float32)` is a no-copy identity return for the float32 path, so nothing there is touched at all. On a full clip at `quantize=16` with ReID enabled, tracktrack gives byte-identical track ids and boxes (326 rows, 7 ids). Instrumenting the association cost matrices for all three ReID trackers on the same clip shows identical missing-feature sentinel patterns and `max|delta|` of 6.1e-4 (tracktrack), 5.5e-4 (botsort) and 1.4e-4 (deepocsort); stored `smooth_feat` vectors agree to a minimum cosine of 0.9999990. The EMA is renormalized every step, so this error is bounded by float16 resolution rather than growing with track length — measured flat from 10 to 300 updates. `pytest tests/test_python.py -k "track"` stays green.

Deleted: nothing. The conversion has to precede the norm to fix the overflow path, so it cannot replace an existing statement. The two `dtype=np.float32` pins at `matching.py:128-129` become redundant for in-tree callers and were considered for deletion, but they are `embedding_distance`'s own input boundary rather than a duplicate of this storage decision — it is a public helper that takes arbitrary track-like objects, and deleting them would make its computation dtype depend on a non-local invariant in `trackers/utils/reid.py`. The same reasoning keeps the pin in #25475. #25482 covers `embedding_distance`'s output dtype, which is a separate promotion via `np.finfo(float).eps` and independent of the encoder.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Ensures ReID tracking features are consistently converted to `float32` before normalization and smoothing. 🎯

### 📊 Key Changes
- Converts input features with `np.asarray(..., dtype=np.float32)` in `smooth_feature`.
- Updates documentation to clarify that current and smoothed features are normalized `float32` arrays.
- Preserves existing behavior for zero-norm features by returning `None` for the current feature.

### 🎯 Purpose & Impact
- Improves consistency when ReID backends return different numeric data types.
- Keeps stored tracker state in `float32`, reducing dtype-related issues and potential memory use.
- Makes feature handling and the function’s return values clearer for developers. 🚀