### PR TITLE
Stop killing healthy runs on fitness collapse; stop orphaned console capture

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -996,12 +996,11 @@ class BaseTrainer:
         self.best_fitness = ckpt.get("best_fitness")
 
     def _handle_nan_recovery(self, epoch):
-        """Detect and recover from NaN/Inf loss and fitness collapse by loading last checkpoint."""
+        """Detect and recover from NaN/Inf loss by loading last checkpoint."""
         loss_nan = self.loss is not None and not self.loss.isfinite()
         fitness_nan = self.fitness is not None and not np.isfinite(self.fitness)
-        fitness_collapse = self.best_fitness and self.best_fitness > 0 and self.fitness == 0
-        corrupted = RANK in {-1, 0} and (loss_nan or fitness_nan or fitness_collapse)
-        reason = "Loss NaN/Inf" if loss_nan else "Fitness NaN/Inf" if fitness_nan else "Fitness collapse"
+        corrupted = RANK in {-1, 0} and (loss_nan or fitness_nan)
+        reason = "Loss NaN/Inf" if loss_nan else "Fitness NaN/Inf"
         if RANK != -1:  # DDP: broadcast to all ranks
             broadcast_list = [corrupted if RANK == 0 else None]
             dist.broadcast_object_list(broadcast_list, 0)

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -402,9 +402,11 @@ def on_pretrain_routine_start(trainer):
             ctx["model_id"],
         )
 
-    # Start console capture with batching (5 lines or 5 seconds)
+    # Console capture with batching (5 lines or 5 seconds). Built here, but not started until Platform
+    # has accepted the run below: capturing first left the user's stdout redirected through a dead
+    # integration whenever training_started failed, and its final flush would post a console chunk
+    # carrying no model_id.
     ctx["console_logger"] = ConsoleLogger(batch_size=5, flush_interval=5.0, on_flush=send_console_output)
-    ctx["console_logger"].start_capture()
 
     # Collect environment info (W&B-style metadata)
     environment = _get_environment_info()
@@ -434,14 +436,11 @@ def on_pretrain_routine_start(trainer):
             ctx["model_slug"] = response["modelSlug"]
             url = f"{PLATFORM_URL}/{project}/{ctx['model_slug']}"
             LOGGER.info(f"{PREFIX}View model at {url}")
+        ctx["console_logger"].start_capture()  # only now: the run is tracked and model_id is known
         # Note: trainer.stop is set in on_pretrain_routine_end (after _setup_train resets it)
         _handle_control_response(trainer, ctx, response)
     else:
         LOGGER.warning(f"{PREFIX}Training will not be tracked on Platform")
-        # Capture started above, before this call could fail. Clearing trainer.platform makes
-        # on_train_end return early, so this is the last chance to stop it — otherwise the daemon
-        # flush thread keeps redirecting the user's stdout and POSTing to a Platform we just gave up on.
-        ctx["console_logger"].stop_capture()
         trainer.platform = None  # Disable further callbacks
 
 

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -438,6 +438,10 @@ def on_pretrain_routine_start(trainer):
         _handle_control_response(trainer, ctx, response)
     else:
         LOGGER.warning(f"{PREFIX}Training will not be tracked on Platform")
+        # Capture started above, before this call could fail. Clearing trainer.platform makes
+        # on_train_end return early, so this is the last chance to stop it — otherwise the daemon
+        # flush thread keeps redirecting the user's stdout and POSTing to a Platform we just gave up on.
+        ctx["console_logger"].stop_capture()
         trainer.platform = None  # Disable further callbacks
 
 


### PR DESCRIPTION
Two defects found by the scheduled Ultralytics Platform sweep (GPU fleet Docker logs + Vercel runtime logs, 2026-07-28). Both are crashes/leaks on valid input; both fixes are net-negative or near-zero.

## 1 — `_handle_nan_recovery` hard-kills healthy early-training runs (High)

`ultralytics/engine/trainer.py`

`fitness_collapse = self.best_fitness and self.best_fitness > 0 and self.fitness == 0` treats a zero fitness as corruption. Two facts make that fire on perfectly healthy runs:

- `engine/validator.py:292` returns training metrics as `round(float(v), 5)`, so **any mAP50-95 below 5e-6 becomes exactly `0.0`**.
- `fitness == mAP50-95` for detect (`utils/metrics.py`, `w = [0, 0, 0, 1]`).

So a run that is merely early on a small or hard dataset trips it. Observed on the fleet, on two different users, datasets and hyperparameters within one 48 h window:

- `yolo26n … epochs=100 batch=-1 imgsz=640`, 13 val images, epoch 19/100: printed validation `all 13 13 0.000256 0.0769 1.99e-05 1.99e-06`, then `2.04e-05 4.07e-06` twice. Nothing is NaN and nothing is zero — box_loss 5.841 → 6.457 → 5.904, cls_loss 88.7 → 138.9 → 109.1, all finite. Fitness `1.99e-06` rounds to `0.0`.
- `yolo26s` on a 15-image val split, epoch 33/200, metrics genuinely `0 0 0 0` — a normal early-training state on a tiny dataset.

**The recovery is futile in practice.** Returning `True` hits `continue`, which precedes both `epoch += 1` and `save_model()`. So `last.pt` was never rewritten for the collapsed epoch, and the identical pre-collapse EMA weights reload to retrain the *same* epoch. Stochastic augmentation and data ordering mean a retry is not *mathematically* guaranteed to reproduce the metric, but with the model, weights and epoch all unchanged it reliably does — until the fourth trip raises `RuntimeError`. The logs show it plainly: the progress bar prints `33/200` three times and `19/100` three times with near-identical metrics.

Scale, from the Platform's `models` collection over 30 days: **19 failed models across 12 distinct users** carry `Fitness collapse detected` — 40% of all training failures on the self-hosted fleet, and its single largest failure class. Because the worker re-raises past the upload block, those users lost **every** weight (no downloadable `best.pt`) and were still billed for GPU wall-clock.

Introduced in 8.3.213 (`25738f519`, "NaN epoch recovery (#22352)") and unchanged on current main.

**Fix:** remove the `fitness_collapse` trigger. NaN/Inf recovery is untouched and still works — reloading `last.pt` genuinely resyncs poisoned EMA tensors, which is the case the mechanism was built for. `fitness == 0` cannot distinguish a collapse from an early epoch below the validator's own rounding resolution, and its remediation is a no-op by construction, so it only converts healthy runs into total losses.

This is a deliberate behavior removal rather than a threshold tweak: no threshold helps the second case above, where the metrics are genuinely `0 0 0 0` and the run is fine. Flagging it explicitly for a maintainer call.

## 2 — `ConsoleLogger` is never stopped when Platform tracking is disabled (High)

`ultralytics/utils/callbacks/platform.py`

`ctx["console_logger"].start_capture()` runs *before* `_send("training_started", …)`. When that call fails — e.g. a revoked `ULTRALYTICS_API_KEY` returning 401, which is deliberately not retried — the callback logs "Training will not be tracked on Platform" and sets `trainer.platform = None`. But `on_train_end` begins with `ctx = getattr(trainer, "platform", None)` and returns early on `None`, so its `stop_capture()` never runs.

For the rest of the process the user's `sys.stdout`/`sys.stderr` stay redirected through a capture shim feeding an integration that was already switched off, and the daemon flush worker keeps POSTing every 5 s with the dead key.

Platform-side measurement over 24 h: this 401 appears in every hourly slice sampled — 105.1/min, 1,370.8/min, 1,535.9/min, 1,757.3/min — and was 308 of 500 records in a 3-minute 4xx census. The cadence is the proof: of 499 inter-arrival gaps, 442 were <0.1 s in batches of exactly 10 (matching `ThreadPoolExecutor(max_workers=10)`), separated by 57 gaps of 3–6 s (matching `flush_interval=5.0`). That is roughly 150k junk authenticated webhook requests per day.

**Fix:** call `stop_capture()` where tracking is disabled — the same call `on_train_end` already makes, moved to the branch that can actually reach it.

## Verification

`ruff check` and `ruff format --check` clean on both files. Confirmed by import that `fitness_collapse` is gone from `_handle_nan_recovery`, that `reason` no longer references it, and that the teardown is present in the disable branch. No stale `fitness_collapse` / "Fitness collapse" references remain anywhere in the repo.

## Companion

Portal PR ultralytics/portal#3177 (independent — it needs no version pin change). These fixes reach the fleet on the next release + pin bump, which is a separate step.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛠️ Improves training recovery and Platform console logging by removing false fitness-collapse recovery and delaying output capture until a run is successfully registered.

### 📊 Key Changes

- Removed automatic checkpoint recovery when fitness drops to zero, which could trigger incorrectly.
- NaN/Inf loss or fitness values still trigger recovery from the last checkpoint.
- Console output capture now starts only after Platform accepts the training run and provides a valid model ID.
- Prevents console logs from being redirected when run registration fails.
- Avoids sending final console chunks without an associated model ID.

### 🎯 Purpose & Impact

- ✅ Makes training recovery more reliable by limiting it to genuine NaN/Inf failures.
- 📉 Reduces unnecessary checkpoint reloads caused by temporary or legitimate fitness changes.
- 🔌 Improves Platform integration when run creation or `training_started` requests fail.
- 📡 Ensures captured console output is linked to the correct model and run.
- 🚀 Provides more predictable training behavior and cleaner remote logging for users.