### PR TITLE
Fix grammar in DeepSparse tutorial

### DIFF
--- a/docs/en/yolov5/tutorials/neural-magic-pruning-quantization.md
+++ b/docs/en/yolov5/tutorials/neural-magic-pruning-quantization.md
@@ -131,7 +131,7 @@ pip install ultralytics-opencv-headless
 
 #### HTTP Server
 
-DeepSparse Server runs on top of the popular [FastAPI](https://fastapi.tiangolo.com/) web framework and [Uvicorn](https://uvicorn.dev/) web server. With just a single CLI command, you can easily setup a model service endpoint with DeepSparse. The Server supports any Pipeline from DeepSparse, including [object detection](https://www.ultralytics.com/glossary/object-detection) with YOLOv5, enabling you to send raw images to the endpoint and receive the bounding boxes.
+DeepSparse Server runs on top of the popular [FastAPI](https://fastapi.tiangolo.com/) web framework and [Uvicorn](https://uvicorn.dev/) web server. With just a single CLI command, you can easily set up a model service endpoint with DeepSparse. The Server supports any Pipeline from DeepSparse, including [object detection](https://www.ultralytics.com/glossary/object-detection) with YOLOv5, enabling you to send raw images to the endpoint and receive the bounding boxes.
 
 Spin up the Server with the pruned-quantized YOLOv5s:
 


### PR DESCRIPTION
## Description

This PR fixes a minor grammatical issue in the DeepSparse tutorial.

### Changes

- Replaced "setup" with "set up" where it is used as a verb.

This change improves readability without changing the technical meaning.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Corrects the grammar of a sentence in the DeepSparse tutorial.

### 📊 Key Changes
- Replaces “setup” with the grammatically correct “set up” in the HTTP Server section of the DeepSparse pruning and quantization tutorial.

### 🎯 Purpose & Impact
- Improves the clarity and professionalism of the documentation.
- Has no functional impact on DeepSparse or YOLOv5 usage.