### PR TITLE
Expand RKNN export support to all tasks

### DIFF
--- a/docs/en/integrations/rockchip-rknn.md
+++ b/docs/en/integrations/rockchip-rknn.md
@@ -68,7 +68,8 @@ For detailed instructions and best practices related to the installation process
 
 !!! note
 
-    Export is currently only supported for detection models. More model support will be coming in the future.
+    RKNN export supports detection, instance segmentation, classification, pose estimation, oriented bounding box
+    (OBB), semantic segmentation, and depth estimation models.
 
 The RKNN format supports the [Export](../modes/export.md), [Predict](../modes/predict.md), and [Validate](../modes/val.md) modes. Inference and validation run on Rockchip NPU hardware. Export your model, then load the exported model to run inference or validate its accuracy. By default, RKNN export uses the floating-point build path (`quantize=16`) for FP16-capable Rockchip targets. Use `quantize=8` to build an INT8-quantized RKNN model with calibration data. RKNN export does not expose a separate FP32 mode; the FP16 default does not request FP32.
 
@@ -79,24 +80,24 @@ The RKNN format supports the [Export](../modes/export.md), [Predict](../modes/pr
         ```python
         from ultralytics import YOLO
 
-        # Load a YOLO26 model
-        model = YOLO("yolo26n.pt")
+        # Load a YOLO26 model (replace with any supported task model)
+        model = YOLO("yolo26n-obb.pt")
 
         # Export the model to RKNN format
-        model.export(format="rknn", name="rk3588")  # creates '/yolo26n_rknn_model'
+        model.export(format="rknn", name="rk3588")  # creates '/yolo26n-obb_rknn_model'
 
         # Export an INT8-quantized RKNN model with calibration data
-        model.export(format="rknn", name="rk3588", quantize=8, data="coco8.yaml")
+        model.export(format="rknn", name="rk3588", quantize=8, data="dota8.yaml")
         ```
 
     === "CLI"
 
         ```bash
-        # Export a YOLO26n PyTorch model to RKNN format
-        yolo export model=yolo26n.pt format=rknn name=rk3588 # creates '/yolo26n_rknn_model'
+        # Export a YOLO26n-obb PyTorch model to RKNN format
+        yolo export model=yolo26n-obb.pt format=rknn name=rk3588 # creates '/yolo26n-obb_rknn_model'
 
         # Export an INT8-quantized RKNN model with calibration data
-        yolo export model=yolo26n.pt format=rknn name=rk3588 quantize=8 data=coco8.yaml
+        yolo export model=yolo26n-obb.pt format=rknn name=rk3588 quantize=8 data=dota8.yaml
         ```
 
 !!! example "Predict"
@@ -107,17 +108,17 @@ The RKNN format supports the [Export](../modes/export.md), [Predict](../modes/pr
         from ultralytics import YOLO
 
         # Load the exported RKNN model
-        model = YOLO("./yolo26n_rknn_model")
+        model = YOLO("./yolo26n-obb_rknn_model")
 
         # Run inference
-        results = model("https://ultralytics.com/images/bus.jpg")
+        results = model("https://ultralytics.com/images/boats.jpg")
         ```
 
     === "CLI"
 
         ```bash
         # Run inference with the exported RKNN model
-        yolo predict model=./yolo26n_rknn_model source='https://ultralytics.com/images/bus.jpg'
+        yolo predict model=./yolo26n-obb_rknn_model source='https://ultralytics.com/images/boats.jpg'
         ```
 
 !!! example "Validate"
@@ -128,17 +129,17 @@ The RKNN format supports the [Export](../modes/export.md), [Predict](../modes/pr
         from ultralytics import YOLO
 
         # Load the exported RKNN model
-        model = YOLO("./yolo26n_rknn_model")
+        model = YOLO("./yolo26n-obb_rknn_model")
 
-        # Validate accuracy on the COCO8 dataset
-        metrics = model.val(data="coco8.yaml")
+        # Validate accuracy on the DOTA8 dataset
+        metrics = model.val(data="dota8.yaml")
         ```
 
     === "CLI"
 
         ```bash
         # Validate the exported RKNN model
-        yolo val model=./yolo26n_rknn_model data=coco8.yaml
+        yolo val model=./yolo26n-obb_rknn_model data=dota8.yaml
         ```
 
 ### Export Arguments

--- a/docs/en/tasks/classify.md
+++ b/docs/en/tasks/classify.md
@@ -257,6 +257,7 @@ Export a YOLO26n-cls model to a different format like ONNX, CoreML, etc.
 
 Available YOLO26-cls export formats are in the table below. You can export to any format using the `format` argument, i.e., `format='onnx'` or `format='engine'`. You can predict or validate directly on exported models, i.e., `yolo predict model=yolo26n-cls.onnx`. Usage examples are shown for your model after export completes.
 
+{% set model_name = "yolo26n-cls" %}
 {% include "macros/export-table.md" %}
 
 See full `export` details in the [Export](../modes/export.md) page.

--- a/docs/en/tasks/depth.md
+++ b/docs/en/tasks/depth.md
@@ -360,6 +360,7 @@ Export a YOLO26n-depth model to a different format like ONNX, CoreML, etc.
 
 Available YOLO26 depth estimation export formats are in the table below. You can export to any format using the `format` argument, i.e., `format='onnx'` or `format='engine'`. You can predict or validate directly on exported models, i.e., `yolo predict model=yolo26n-depth.onnx`. Usage examples are shown for your model after export completes.
 
+{% set model_name = "yolo26n-depth" %}
 {% include "macros/export-table.md" %}
 
 See full `export` details in the [Export](../modes/export.md) page.

--- a/docs/en/tasks/obb.md
+++ b/docs/en/tasks/obb.md
@@ -226,6 +226,7 @@ Export a YOLO26n-obb model to a different format like ONNX, CoreML, etc.
 
 Available YOLO26-obb export formats are in the table below. You can export to any format using the `format` argument, i.e., `format='onnx'` or `format='engine'`. You can predict or validate directly on exported models, i.e., `yolo predict model=yolo26n-obb.onnx`. Usage examples are shown for your model after export completes.
 
+{% set model_name = "yolo26n-obb" %}
 {% include "macros/export-table.md" %}
 
 See full `export` details in the [Export](../modes/export.md) page.

--- a/docs/en/tasks/pose.md
+++ b/docs/en/tasks/pose.md
@@ -215,6 +215,7 @@ Export a YOLO26n Pose model to a different format like ONNX, CoreML, etc. This a
 
 Available YOLO26-pose export formats are in the table below. You can export to any format using the `format` argument, i.e., `format='onnx'` or `format='engine'`. You can predict or validate directly on exported models, i.e., `yolo predict model=yolo26n-pose.onnx`. Usage examples are shown for your model after export completes.
 
+{% set model_name = "yolo26n-pose" %}
 {% include "macros/export-table.md" %}
 
 See full `export` details in the [Export](../modes/export.md) page.

--- a/docs/en/tasks/segment.md
+++ b/docs/en/tasks/segment.md
@@ -203,6 +203,7 @@ Available YOLO26-seg export formats are in the table below. You can export to an
 
     CoreML embedded NMS pipelines (`nms=True`) only support object detection models. Segmentation exports to CoreML warn and force `nms=False`, producing a raw model without NMS.
 
+{% set model_name = "yolo26n-seg" %}
 {% include "macros/export-table.md" %}
 
 See full `export` details in the [Export](../modes/export.md) page.

--- a/docs/en/tasks/semantic.md
+++ b/docs/en/tasks/semantic.md
@@ -217,6 +217,7 @@ Export a YOLO26n-sem model to a different format like ONNX, CoreML, etc.
 
 Available YOLO26 semantic segmentation export formats are in the table below. You can export to any format using the `format` argument, i.e., `format='onnx'` or `format='engine'`. You can predict or validate directly on exported models, i.e., `yolo predict model=yolo26n-sem.onnx`. Usage examples are shown for your model after export completes.
 
+{% set model_name = "yolo26n-sem" %}
 {% include "macros/export-table.md" %}
 
 See full `export` details in the [Export](../modes/export.md) page.

--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -19,6 +19,9 @@
 114614220+artzuros@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/114614220?v=4
   username: artzuros
+115810876+gizembm@users.noreply.github.com:
+  avatar: https://avatars.githubusercontent.com/u/115810876?v=4
+  username: gizembm
 116908874+jk4e@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/116908874?v=4
   username: jk4e

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.109"
+__version__ = "8.4.110"
 
 import importlib
 import os

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -77,7 +77,7 @@ import numpy as np
 import torch
 
 from ultralytics import __version__
-from ultralytics.cfg import QUANTIZE_DOCS_URL, TASK2CALIBRATIONDATA, TASK2DATA, get_cfg
+from ultralytics.cfg import QUANTIZE_DOCS_URL, TASK2CALIBRATIONDATA, TASK2DATA, TASK2MODEL, get_cfg
 from ultralytics.data import build_dataloader, build_yolo_dataset
 from ultralytics.data.dataset import ClassificationDataset
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
@@ -352,7 +352,7 @@ EXPORT_ENVS = {
         "requirements": ["rknn-toolkit2>=2.3.2", "onnx>=1.16.1,<1.19.0", "setuptools<82"],
         "indexes": [],
         "env": {},
-        "smoke": ["yolo export format=rknn model=yolo26n.pt imgsz=32 quantize=16"],
+        "smoke": [f"yolo export format=rknn model={model} imgsz=32 quantize=16" for model in TASK2MODEL.values()],
     },
     "isolated-axelera": {
         # Axelera devkit 1.7.0 does not provide Python 3.13 wheels.


### PR DESCRIPTION
## Summary

- validate RKNN conversion for every current YOLO task in the isolated Linux export environment
- document detection, segmentation, classification, pose, OBB, semantic segmentation, and depth support
- render task-specific artifact names in the shared export table
- bump the package version to 8.4.110

## Validation

- local Linux/amd64 Docker conversion with `rknn-toolkit2==2.3.2` and `torch==2.4.0` produced RKNN models for detect, segment, classify, pose, OBB, depth, and semantic
- `python -m pytest tests/test_exports.py::test_export_rknn_batch_expansion tests/test_exports.py::test_export_env_has_smoke -q`
- `ruff check ultralytics/__init__.py ultralytics/engine/exporter.py tests/test_exports.py`
- ONNX export and inference smoke for all seven `TASK2MODEL` models
- `npx prettier@3.8.5 --tab-width 4 --print-width 120 --write ...`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Expanded RKNN export coverage across YOLO26 tasks and improved task-specific export documentation.

### 📊 Key Changes

- Updated RKNN documentation to support detection, classification, instance segmentation, pose, OBB, semantic segmentation, and depth estimation models.
- Added RKNN export smoke tests for every supported task model via `TASK2MODEL`.
- Updated RKNN examples to use YOLO26 OBB models and DOTA8 calibration and validation data.
- Added task-specific model names to export tables for classification, depth, OBB, pose, instance segmentation, and semantic segmentation.
- Bumped the Ultralytics package version from `8.4.109` to `8.4.110`.
- Added a GitHub author entry for @gizembm.

### 🎯 Purpose & Impact

- ✅ Enables broader validation of RKNN export compatibility across YOLO26 tasks.
- 📱 Helps Rockchip NPU users deploy more model types, not just object detection models.
- 🧪 Improves release confidence by automatically smoke-testing RKNN exports for all task models.
- 📚 Makes export documentation and generated examples more accurate and relevant to each task.