### PR TITLE
Fix autocast crash on MPS with torch<2.5.0

### DIFF
--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -45,6 +45,7 @@ TORCH_2_0 = check_version(TORCH_VERSION, "2.0.0")
 TORCH_2_1 = check_version(TORCH_VERSION, "2.1.0")
 TORCH_2_3 = check_version(TORCH_VERSION, "2.3.0")
 TORCH_2_4 = check_version(TORCH_VERSION, "2.4.0")
+TORCH_2_5 = check_version(TORCH_VERSION, "2.5.0")
 TORCH_2_8 = check_version(TORCH_VERSION, "2.8.0")
 TORCH_2_9 = check_version(TORCH_VERSION, "2.9.0")
 TORCH_2_10 = check_version(TORCH_VERSION, "2.10.0")
@@ -109,6 +110,8 @@ def autocast(enabled: bool, device: str = "cuda"):
         - For older versions, it uses `torch.cuda.amp.autocast`.
     """
     if TORCH_1_13:
+        if device == "mps" and not TORCH_2_5:  # MPS autocast added in torch 2.5.0, errors on older versions
+            device, enabled = "cpu", False
         return torch.amp.autocast(device, enabled=enabled)
     else:
         return torch.cuda.amp.autocast(enabled)


### PR DESCRIPTION
Reported in https://github.com/ultralytics/ultralytics/issues/25485 as side issue

`yolo val device=mps` crashes on torch older than 2.5.0:

```
RuntimeError: unsupported scalarType
```

The crash comes from the `autocast` helper. On MPS, `torch.amp.autocast("mps", ...)` fails inside its constructor because `torch.get_autocast_dtype("mps")` is unsupported before torch 2.5.0. It fails even with `enabled=False`, so plain `val` (where autocast is a no-op) still crashes.

MPS autocast was added to torch in [pytorch/pytorch#99272](https://github.com/pytorch/pytorch/pull/99272), which landed after the `v2.4.1` tag and first shipped in `torch 2.5.0`.

The fix gates on version: for `torch<2.5.0` on MPS, fall back to a no-op `cpu` autocast context so the call does not crash. On `torch>=2.5.0` MPS autocast is used as before.

| device | torch | before | after |
|---|---|---|---|
| mps | <2.5.0 | crash | runs (no-op autocast) |
| mps | >=2.5.0 | works | works |
| cuda, cpu | any | works | works |

Verified `yolo val data=coco8.yaml device=mps` runs to completion on torch 2.4.1.

Deleted: nothing. The guard lives in the `autocast` helper that owns the version and device dispatch, so no symptom is patched elsewhere. Net +3 lines: one new `TORCH_2_5` constant matching the existing `TORCH_2_*` list and a two-line device guard.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ Prevents autocast crashes on MPS devices when using PyTorch versions older than 2.5.0.

### 📊 Key Changes
- Adds a `TORCH_2_5` version check in `torch_utils.py`.
- Disables autocast and falls back to CPU when MPS is requested with PyTorch <2.5.0.
- Preserves the existing `torch.amp.autocast` behavior for supported versions and devices.

### 🎯 Purpose & Impact
- ✅ Fixes runtime errors caused by unsupported MPS autocast in older PyTorch releases.
- 🍎 Improves compatibility for Ultralytics users running on Apple MPS hardware.
- 🔄 Provides a safe fallback without affecting MPS autocast on PyTorch 2.5.0 and newer.