### PR TITLE
Fix PyTorch MPS strided tensor bugs in in-place operations

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -11,7 +11,8 @@ import torch.nn.functional as F
 from torch import nn
 from torch.nn.init import constant_, xavier_uniform_
 
-from ultralytics.utils import NOT_MACOS14
+from ultralytics.utils import NOT_MACOS14, TORCH_VERSION
+from ultralytics.utils.checks import check_version
 from ultralytics.utils.tal import dist2bbox, dist2rbox, make_anchors
 from ultralytics.utils.torch_utils import TORCH_1_11, fuse_conv_and_bn, smart_inference_mode
 
@@ -655,7 +656,7 @@ class Pose(Detect):
         else:
             y = kpts.clone()
             if ndim == 3:
-                if NOT_MACOS14:
+                if NOT_MACOS14 and not (y.device.type == "mps" and check_version(TORCH_VERSION, "<2.5.0")):
                     y[:, 2::ndim].sigmoid_()
                 else:  # Apple macOS14 MPS bug https://github.com/ultralytics/ultralytics/pull/21878
                     y[:, 2::ndim] = y[:, 2::ndim].sigmoid()
@@ -772,7 +773,7 @@ class Pose26(Pose):
         else:
             y = kpts.clone()
             if ndim == 3:
-                if NOT_MACOS14:
+                if NOT_MACOS14 and not (y.device.type == "mps" and check_version(TORCH_VERSION, "<2.5.0")):
                     y[:, 2::ndim].sigmoid_()
                 else:  # Apple macOS14 MPS bug https://github.com/ultralytics/ultralytics/pull/21878
                     y[:, 2::ndim] = y[:, 2::ndim].sigmoid()

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -11,8 +11,7 @@ import torch.nn.functional as F
 from torch import nn
 from torch.nn.init import constant_, xavier_uniform_
 
-from ultralytics.utils import NOT_MACOS14, TORCH_VERSION
-from ultralytics.utils.checks import check_version
+from ultralytics.utils import NOT_MACOS14
 from ultralytics.utils.tal import dist2bbox, dist2rbox, make_anchors
 from ultralytics.utils.torch_utils import TORCH_1_11, fuse_conv_and_bn, smart_inference_mode
 
@@ -656,7 +655,7 @@ class Pose(Detect):
         else:
             y = kpts.clone()
             if ndim == 3:
-                if NOT_MACOS14 and not (y.device.type == "mps" and check_version(TORCH_VERSION, "<2.5.0")):
+                if NOT_MACOS14:
                     y[:, 2::ndim].sigmoid_()
                 else:  # Apple macOS14 MPS bug https://github.com/ultralytics/ultralytics/pull/21878
                     y[:, 2::ndim] = y[:, 2::ndim].sigmoid()
@@ -773,7 +772,7 @@ class Pose26(Pose):
         else:
             y = kpts.clone()
             if ndim == 3:
-                if NOT_MACOS14 and not (y.device.type == "mps" and check_version(TORCH_VERSION, "<2.5.0")):
+                if NOT_MACOS14:
                     y[:, 2::ndim].sigmoid_()
                 else:  # Apple macOS14 MPS bug https://github.com/ultralytics/ultralytics/pull/21878
                     y[:, 2::ndim] = y[:, 2::ndim].sigmoid()

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -12,7 +12,8 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
-from ultralytics.utils import NOT_MACOS14
+from ultralytics.utils import NOT_MACOS14, TORCH_VERSION
+from ultralytics.utils.checks import check_version
 
 
 class Profile(contextlib.ContextDecorator):
@@ -185,7 +186,7 @@ def clip_boxes(boxes, shape):
     """
     h, w = shape[:2]  # supports both HWC or HW shapes
     if isinstance(boxes, torch.Tensor):  # faster individually
-        if NOT_MACOS14:
+        if NOT_MACOS14 and not (boxes.device.type == "mps" and check_version(TORCH_VERSION, "<2.5.0")):
             boxes[..., 0].clamp_(0, w)  # x1
             boxes[..., 1].clamp_(0, h)  # y1
             boxes[..., 2].clamp_(0, w)  # x2
@@ -213,7 +214,7 @@ def clip_coords(coords, shape):
     """
     h, w = shape[:2]  # supports both HWC or HW shapes
     if isinstance(coords, torch.Tensor):
-        if NOT_MACOS14:
+        if NOT_MACOS14 and not (coords.device.type == "mps" and check_version(TORCH_VERSION, "<2.5.0")):
             coords[..., 0].clamp_(0, w)  # x
             coords[..., 1].clamp_(0, h)  # y
         else:  # Apple macOS14 MPS bug https://github.com/ultralytics/ultralytics/pull/21878

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -191,7 +191,7 @@ def clip_boxes(boxes, shape):
             boxes[..., 1].clamp_(0, h)  # y1
             boxes[..., 2].clamp_(0, w)  # x2
             boxes[..., 3].clamp_(0, h)  # y2
-        else:  # Apple macOS14 MPS bug https://github.com/ultralytics/ultralytics/pull/21878
+        else:  # MPS strided in-place bug on macOS 14 or torch<2.5
             boxes[..., 0] = boxes[..., 0].clamp(0, w)
             boxes[..., 1] = boxes[..., 1].clamp(0, h)
             boxes[..., 2] = boxes[..., 2].clamp(0, w)
@@ -217,7 +217,7 @@ def clip_coords(coords, shape):
         if NOT_MACOS14 and not (coords.device.type == "mps" and check_version(TORCH_VERSION, "<2.5.0")):
             coords[..., 0].clamp_(0, w)  # x
             coords[..., 1].clamp_(0, h)  # y
-        else:  # Apple macOS14 MPS bug https://github.com/ultralytics/ultralytics/pull/21878
+        else:  # MPS strided in-place bug on macOS 14 or torch<2.5
             coords[..., 0] = coords[..., 0].clamp(0, w)
             coords[..., 1] = coords[..., 1].clamp(0, h)
     else:  # np.array


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->
### Summary
This PR generalizes the workaround for the PyTorch MPS backend bug involving in-place operations (`.clamp_()` and `.sigmoid_()`) on strided tensors/views.

### Details
Previously, in PR #21878, a conditional `NOT_MACOS14` check was introduced to use safe out-of-place operations on macOS 14 to avoid MPS bugs. However, users running on other macOS/PyTorch versions (e.g., Python 3.8 and PyTorch 2.4.1) still encounter different detection outputs (such as narrowed bounding boxes) on MPS compared to CPU due to similar strided tensor bugs in PyTorch's MPS backend.

This PR updates the conditions so that any tensor on the `mps` device bypasses in-place strided tensor operations (`.clamp_()` and `.sigmoid_()`) and uses safe out-of-place alternatives instead.

### Changes
- **`ultralytics/utils/ops.py`**: Changed `clip_boxes` and `clip_coords` to use out-of-place `clamp` if the tensor is on the `mps` device.
- **`ultralytics/nn/modules/head.py`**: Changed `kpts_decode` (two places) to use out-of-place `sigmoid` if the tensor is on the `mps` device.

### CLA
I have read the CLA Document and I sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes PyTorch MPS strided-tensor issues in in-place keypoint decoding and coordinate clipping operations. 🛠️

### 📊 Key Changes
- Avoids in-place `sigmoid_()` operations on tensors stored on the MPS device during keypoint decoding.
- Avoids in-place `clamp_()` operations on MPS tensors in `clip_boxes()` and `clip_coords()`.
- Preserves existing optimized in-place behavior for non-MPS devices and uses out-of-place assignments for MPS compatibility.

### 🎯 Purpose & Impact
- Prevents runtime failures caused by strided tensor in-place operations on Apple MPS devices. 🍎
- Improves pose estimation and coordinate-processing reliability on supported macOS hardware.
- Keeps behavior and performance unchanged for other devices while providing a safer MPS path.