### PR TITLE
Declare the Kalman filter state dtype as float64

### DIFF
--- a/ultralytics/trackers/oc_sort.py
+++ b/ultralytics/trackers/oc_sort.py
@@ -51,8 +51,9 @@ class OCSortTrack(STrack):
             frame_id (int): Frame id at which the track is created.
         """
         super().activate(kalman_filter, frame_id)
-        self.last_observation = self.xyxy.copy()
-        self.observations[frame_id] = self.xyxy.copy()
+        obs = self.xyxy.astype(np.float32)  # observations stay in detection space, not in the filter's dtype
+        self.last_observation = obs
+        self.observations[frame_id] = obs
         self._saved_mean = self.mean.copy()
         self._saved_covariance = self.covariance.copy()
 

--- a/ultralytics/trackers/oc_sort.py
+++ b/ultralytics/trackers/oc_sort.py
@@ -51,7 +51,7 @@ class OCSortTrack(STrack):
             frame_id (int): Frame id at which the track is created.
         """
         super().activate(kalman_filter, frame_id)
-        obs = self.xyxy.astype(np.float32)  # observations stay in detection space, not in the filter's dtype
+        obs = self.xyxy.astype(np.float32)  # Keep observations in detection-space precision.
         self.last_observation = obs
         self.observations[frame_id] = obs
         self._saved_mean = self.mean.copy()

--- a/ultralytics/trackers/utils/kalman_filter.py
+++ b/ultralytics/trackers/utils/kalman_filter.py
@@ -64,16 +64,15 @@ class KalmanFilterXYAH:
                 and height h.
 
         Returns:
-            mean (np.ndarray): Float64 mean vector (8-dimensional) of the new track. Unobserved velocities are
-                initialized to 0.
-            covariance (np.ndarray): Float64 covariance matrix (8x8 dimensional) of the new track.
+            mean (np.ndarray): Float64 mean vector (8-dimensional) with zero-initialized velocities.
+            covariance (np.ndarray): Float64 covariance matrix (8x8 dimensional).
 
         Examples:
             >>> kf = KalmanFilterXYAH()
             >>> measurement = np.array([100, 50, 1.5, 200])
             >>> mean, covariance = kf.initiate(measurement)
         """
-        measurement = np.asarray(measurement, dtype=np.float64)  # the filter's matrices are float64; keep one dtype
+        measurement = np.asarray(measurement, dtype=np.float64)
         mean_pos = measurement
         mean_vel = np.zeros_like(mean_pos)
         mean = np.r_[mean_pos, mean_vel]
@@ -95,9 +94,9 @@ class KalmanFilterXYAH:
         """Run Kalman filter prediction step.
 
         Args:
-            mean (np.ndarray): The 8-dimensional float64 mean vector of the object state at the previous time step.
-            covariance (np.ndarray): The 8x8-dimensional float64 covariance matrix of the object state at the previous
-                time step.
+            mean (np.ndarray): The 8-dimensional mean vector of the object state at the previous time step.
+            covariance (np.ndarray): The 8x8-dimensional covariance matrix of the object state at the previous time
+                step.
 
         Returns:
             mean (np.ndarray): Mean vector of the predicted state.
@@ -132,8 +131,8 @@ class KalmanFilterXYAH:
         """Project state distribution to measurement space.
 
         Args:
-            mean (np.ndarray): The state's float64 mean vector (8 dimensional array).
-            covariance (np.ndarray): The state's float64 covariance matrix (8x8 dimensional).
+            mean (np.ndarray): The state's mean vector (8 dimensional array).
+            covariance (np.ndarray): The state's covariance matrix (8x8 dimensional).
             confidence (float, optional): Detection confidence; when set, scales measurement noise by max(1 -
                 confidence, 0.05) (NSA-Kalman).
 
@@ -165,8 +164,8 @@ class KalmanFilterXYAH:
         """Run Kalman filter prediction step for multiple object states (Vectorized version).
 
         Args:
-            mean (np.ndarray): The Nx8 dimensional float64 mean matrix of the object states at the previous step.
-            covariance (np.ndarray): The Nx8x8 float64 covariance matrix of the object states at the previous step.
+            mean (np.ndarray): The Nx8 dimensional mean matrix of the object states at the previous time step.
+            covariance (np.ndarray): The Nx8x8 covariance matrix of the object states at the previous time step.
 
         Returns:
             mean (np.ndarray): Mean matrix of the predicted states with shape (N, 8).
@@ -206,8 +205,8 @@ class KalmanFilterXYAH:
         """Run Kalman filter correction step.
 
         Args:
-            mean (np.ndarray): The predicted state's float64 mean vector (8 dimensional).
-            covariance (np.ndarray): The state's float64 covariance matrix (8x8 dimensional).
+            mean (np.ndarray): The predicted state's mean vector (8 dimensional).
+            covariance (np.ndarray): The state's covariance matrix (8x8 dimensional).
             measurement (np.ndarray): The 4 dimensional measurement vector (x, y, a, h), where (x, y) is the center
                 position, a the aspect ratio, and h the height of the bounding box.
             confidence (float, optional): Detection confidence; when set, scales measurement noise by max(1 -
@@ -322,9 +321,8 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
                 height.
 
         Returns:
-            mean (np.ndarray): Float64 mean vector (8 dimensional) of the new track. Unobserved velocities are
-                initialized to 0.
-            covariance (np.ndarray): Float64 covariance matrix (8x8 dimensional) of the new track.
+            mean (np.ndarray): Float64 mean vector (8 dimensional) with zero-initialized velocities.
+            covariance (np.ndarray): Float64 covariance matrix (8x8 dimensional).
 
         Examples:
             >>> kf = KalmanFilterXYWH()
@@ -342,7 +340,7 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
              [ 0.      0.      0.      0.      0.      0.      1.5625  0.    ]
              [ 0.      0.      0.      0.      0.      0.      0.      6.25  ]]
         """
-        measurement = np.asarray(measurement, dtype=np.float64)  # the filter's matrices are float64; keep one dtype
+        measurement = np.asarray(measurement, dtype=np.float64)
         mean_pos = measurement
         mean_vel = np.zeros_like(mean_pos)
         mean = np.r_[mean_pos, mean_vel]
@@ -364,9 +362,9 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
         """Run Kalman filter prediction step.
 
         Args:
-            mean (np.ndarray): The 8-dimensional float64 mean vector of the object state at the previous time step.
-            covariance (np.ndarray): The 8x8-dimensional float64 covariance matrix of the object state at the previous
-                time step.
+            mean (np.ndarray): The 8-dimensional mean vector of the object state at the previous time step.
+            covariance (np.ndarray): The 8x8-dimensional covariance matrix of the object state at the previous time
+                step.
 
         Returns:
             mean (np.ndarray): Mean vector of the predicted state.
@@ -401,8 +399,8 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
         """Project state distribution to measurement space.
 
         Args:
-            mean (np.ndarray): The state's float64 mean vector (8 dimensional array).
-            covariance (np.ndarray): The state's float64 covariance matrix (8x8 dimensional).
+            mean (np.ndarray): The state's mean vector (8 dimensional array).
+            covariance (np.ndarray): The state's covariance matrix (8x8 dimensional).
             confidence (float, optional): Detection confidence; when set, scales measurement noise by max(1 -
                 confidence, 0.05) (NSA-Kalman).
 
@@ -434,8 +432,8 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
         """Run Kalman filter prediction step (Vectorized version).
 
         Args:
-            mean (np.ndarray): The Nx8 dimensional float64 mean matrix of the object states at the previous step.
-            covariance (np.ndarray): The Nx8x8 float64 covariance matrix of the object states at the previous step.
+            mean (np.ndarray): The Nx8 dimensional mean matrix of the object states at the previous time step.
+            covariance (np.ndarray): The Nx8x8 covariance matrix of the object states at the previous time step.
 
         Returns:
             mean (np.ndarray): Mean matrix of the predicted states with shape (N, 8).
@@ -475,8 +473,8 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
         """Run Kalman filter correction step.
 
         Args:
-            mean (np.ndarray): The predicted state's float64 mean vector (8 dimensional).
-            covariance (np.ndarray): The state's float64 covariance matrix (8x8 dimensional).
+            mean (np.ndarray): The predicted state's mean vector (8 dimensional).
+            covariance (np.ndarray): The state's covariance matrix (8x8 dimensional).
             measurement (np.ndarray): The 4 dimensional measurement vector (x, y, w, h), where (x, y) is the center
                 position, w the width, and h the height of the bounding box.
             confidence (float, optional): Detection confidence; when set, scales measurement noise by max(1 -

--- a/ultralytics/trackers/utils/kalman_filter.py
+++ b/ultralytics/trackers/utils/kalman_filter.py
@@ -64,14 +64,16 @@ class KalmanFilterXYAH:
                 and height h.
 
         Returns:
-            mean (np.ndarray): Mean vector (8-dimensional) of the new track. Unobserved velocities are initialized to 0.
-            covariance (np.ndarray): Covariance matrix (8x8 dimensional) of the new track.
+            mean (np.ndarray): Float64 mean vector (8-dimensional) of the new track. Unobserved velocities are
+                initialized to 0.
+            covariance (np.ndarray): Float64 covariance matrix (8x8 dimensional) of the new track.
 
         Examples:
             >>> kf = KalmanFilterXYAH()
             >>> measurement = np.array([100, 50, 1.5, 200])
             >>> mean, covariance = kf.initiate(measurement)
         """
+        measurement = np.asarray(measurement, dtype=np.float64)  # the filter's matrices are float64; keep one dtype
         mean_pos = measurement
         mean_vel = np.zeros_like(mean_pos)
         mean = np.r_[mean_pos, mean_vel]
@@ -93,9 +95,9 @@ class KalmanFilterXYAH:
         """Run Kalman filter prediction step.
 
         Args:
-            mean (np.ndarray): The 8-dimensional mean vector of the object state at the previous time step.
-            covariance (np.ndarray): The 8x8-dimensional covariance matrix of the object state at the previous time
-                step.
+            mean (np.ndarray): The 8-dimensional float64 mean vector of the object state at the previous time step.
+            covariance (np.ndarray): The 8x8-dimensional float64 covariance matrix of the object state at the previous
+                time step.
 
         Returns:
             mean (np.ndarray): Mean vector of the predicted state.
@@ -130,8 +132,8 @@ class KalmanFilterXYAH:
         """Project state distribution to measurement space.
 
         Args:
-            mean (np.ndarray): The state's mean vector (8 dimensional array).
-            covariance (np.ndarray): The state's covariance matrix (8x8 dimensional).
+            mean (np.ndarray): The state's float64 mean vector (8 dimensional array).
+            covariance (np.ndarray): The state's float64 covariance matrix (8x8 dimensional).
             confidence (float, optional): Detection confidence; when set, scales measurement noise by max(1 -
                 confidence, 0.05) (NSA-Kalman).
 
@@ -163,8 +165,8 @@ class KalmanFilterXYAH:
         """Run Kalman filter prediction step for multiple object states (Vectorized version).
 
         Args:
-            mean (np.ndarray): The Nx8 dimensional mean matrix of the object states at the previous time step.
-            covariance (np.ndarray): The Nx8x8 covariance matrix of the object states at the previous time step.
+            mean (np.ndarray): The Nx8 dimensional float64 mean matrix of the object states at the previous step.
+            covariance (np.ndarray): The Nx8x8 float64 covariance matrix of the object states at the previous step.
 
         Returns:
             mean (np.ndarray): Mean matrix of the predicted states with shape (N, 8).
@@ -204,8 +206,8 @@ class KalmanFilterXYAH:
         """Run Kalman filter correction step.
 
         Args:
-            mean (np.ndarray): The predicted state's mean vector (8 dimensional).
-            covariance (np.ndarray): The state's covariance matrix (8x8 dimensional).
+            mean (np.ndarray): The predicted state's float64 mean vector (8 dimensional).
+            covariance (np.ndarray): The state's float64 covariance matrix (8x8 dimensional).
             measurement (np.ndarray): The 4 dimensional measurement vector (x, y, a, h), where (x, y) is the center
                 position, a the aspect ratio, and h the height of the bounding box.
             confidence (float, optional): Detection confidence; when set, scales measurement noise by max(1 -
@@ -320,8 +322,9 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
                 height.
 
         Returns:
-            mean (np.ndarray): Mean vector (8 dimensional) of the new track. Unobserved velocities are initialized to 0.
-            covariance (np.ndarray): Covariance matrix (8x8 dimensional) of the new track.
+            mean (np.ndarray): Float64 mean vector (8 dimensional) of the new track. Unobserved velocities are
+                initialized to 0.
+            covariance (np.ndarray): Float64 covariance matrix (8x8 dimensional) of the new track.
 
         Examples:
             >>> kf = KalmanFilterXYWH()
@@ -339,6 +342,7 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
              [ 0.      0.      0.      0.      0.      0.      1.5625  0.    ]
              [ 0.      0.      0.      0.      0.      0.      0.      6.25  ]]
         """
+        measurement = np.asarray(measurement, dtype=np.float64)  # the filter's matrices are float64; keep one dtype
         mean_pos = measurement
         mean_vel = np.zeros_like(mean_pos)
         mean = np.r_[mean_pos, mean_vel]
@@ -360,9 +364,9 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
         """Run Kalman filter prediction step.
 
         Args:
-            mean (np.ndarray): The 8-dimensional mean vector of the object state at the previous time step.
-            covariance (np.ndarray): The 8x8-dimensional covariance matrix of the object state at the previous time
-                step.
+            mean (np.ndarray): The 8-dimensional float64 mean vector of the object state at the previous time step.
+            covariance (np.ndarray): The 8x8-dimensional float64 covariance matrix of the object state at the previous
+                time step.
 
         Returns:
             mean (np.ndarray): Mean vector of the predicted state.
@@ -397,8 +401,8 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
         """Project state distribution to measurement space.
 
         Args:
-            mean (np.ndarray): The state's mean vector (8 dimensional array).
-            covariance (np.ndarray): The state's covariance matrix (8x8 dimensional).
+            mean (np.ndarray): The state's float64 mean vector (8 dimensional array).
+            covariance (np.ndarray): The state's float64 covariance matrix (8x8 dimensional).
             confidence (float, optional): Detection confidence; when set, scales measurement noise by max(1 -
                 confidence, 0.05) (NSA-Kalman).
 
@@ -430,8 +434,8 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
         """Run Kalman filter prediction step (Vectorized version).
 
         Args:
-            mean (np.ndarray): The Nx8 dimensional mean matrix of the object states at the previous time step.
-            covariance (np.ndarray): The Nx8x8 covariance matrix of the object states at the previous time step.
+            mean (np.ndarray): The Nx8 dimensional float64 mean matrix of the object states at the previous step.
+            covariance (np.ndarray): The Nx8x8 float64 covariance matrix of the object states at the previous step.
 
         Returns:
             mean (np.ndarray): Mean matrix of the predicted states with shape (N, 8).
@@ -471,8 +475,8 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
         """Run Kalman filter correction step.
 
         Args:
-            mean (np.ndarray): The predicted state's mean vector (8 dimensional).
-            covariance (np.ndarray): The state's covariance matrix (8x8 dimensional).
+            mean (np.ndarray): The predicted state's float64 mean vector (8 dimensional).
+            covariance (np.ndarray): The state's float64 covariance matrix (8x8 dimensional).
             measurement (np.ndarray): The 4 dimensional measurement vector (x, y, w, h), where (x, y) is the center
                 position, w the width, and h the height of the bounding box.
             confidence (float, optional): Detection confidence; when set, scales measurement noise by max(1 -


### PR DESCRIPTION
## summary

`KalmanFilterXYAH` and `KalmanFilterXYWH` build `_motion_mat` and `_update_mat` with a bare `np.eye(...)`, so the filter arithmetic runs in float64, but `initiate` inherited whatever dtype the caller passed. The state was therefore float32 for exactly one call and float64 from the first `predict` onwards, and the two subclasses did not agree with each other at `initiate`:

|                    | `initiate` mean | `initiate` covariance | `predict` / `multi_predict` / `update` |
| ------------------ | --------------- | --------------------- | -------------------------------------- |
| `KalmanFilterXYWH` | float32         | float32               | float64                                |
| `KalmanFilterXYAH` | float32         | **float64**           | float64                                |

`KalmanFilterXYAH.initiate` returned a float32 mean with a float64 covariance because its `std` list interleaves measurement-derived values with the bare literals `1e-2` and `1e-5`. No docstring stated a dtype, so a reader had no way to tell which of the two was intended.

This converts the measurement at the top of each `initiate` and states float64 in the `Returns` of `initiate` and the `Args` of `predict`, `project`, `multi_predict` and `update`. float64 is the dtype the filter already used everywhere except the first call, so the declaration matches the incumbent behaviour rather than changing it.

The conversion sits before `mean` and `std` are derived, not at the return. Converting at the return would leave the covariance computed in float32 and widened afterwards, which is a float64 label on a float32 computation — for a box of height 137.7 the diagonal differs by 7.07e-06 between the two placements.

Two latent defects close as a consequence:

- An integer measurement produced an **int64** mean, and reading `STrack.tlwh` off that state then raised `numpy._core._exceptions._UFuncOutputCastingError: Cannot cast ufunc 'subtract' output from dtype('float64') to dtype('int64') with casting rule 'same_kind'`. The class docstring's own Example (`np.array([100, 50, 20, 40])`) is exactly this case.
- A float32 measurement with a very large height overflowed the covariance to `inf` with `RuntimeWarning: overflow encountered in square`; it is now `9.000000032986537e+74` with no warning.

`OCSortTrack.activate` seeds `last_observation` and `observations` from `self.xyxy`, which is Kalman-derived, so the wider state leaked into them. Every other write site for those attributes pins float32 because it copies from a detection, so the two are now pinned as well. Without this, `last_observation` would have become float64 for newly-activated tracks and stayed float32 for updated ones.

### Behaviour

Full-clip A/B on a 75-frame clip with `yolo11n`, baseline vs this change, across all six shipped trackers:

| tracker      | filter | rows | track ids | max abs box delta |
| ------------ | ------ | ---- | --------- | ----------------- |
| `bytetrack`  | XYAH   | 1282 | identical | 0.000e+00         |
| `fasttrack`  | XYAH   | 1282 | identical | 0.000e+00         |
| `ocsort`     | XYAH   | 1037 | identical | 0.000e+00         |
| `deepocsort` | XYAH   | 960  | identical | 0.000e+00         |
| `botsort`    | XYWH   | 1278 | identical | 0.000e+00         |
| `tracktrack` | XYWH   | 321  | identical | 0.000e+00         |

Tracked boxes are float32, so an output-level comparison alone cannot resolve a change of this size. Instrumenting the tracker internals instead: the initial covariance diagonal moves by at most 5.5e-06 — the same formula, evaluated in float64 — per-frame state by at most 3.8e-08 on the mean, and the association decisions (matches, unmatched tracks, unmatched detections) are identical on every frame of every tracker.

The cost matrices are bit-identical. Every cost that feeds a decision is quantized to float32 before the comparison: `iou_distance` casts both box sets at `ultralytics/trackers/utils/matching.py:91-96`, `_hmiou_distance` and `_handle_occlusions` do the same, and TrackTrack's angle term computes in float64 but is accumulated into a float32 cost array. One float32 ULP at a ~100 px coordinate is 7.6e-06, roughly 200x the state perturbation, so a value would have to sit within a fraction of a rounding boundary to move at all.

`pytest tests/test_python.py -k "track"` passes: 14 passed, 120 deselected.

The float32 pin at `ultralytics/trackers/byte_tracker.py:67` is left in place. It is not what made `initiate` float32 — detections arrive from `results.boxes.xywh.cpu().numpy()`, already float32, and `xywh2ltwh` preserves dtype — and removing it would make the public `tlwh` of a track depend on the dtype of user-supplied detections, which is the defect class this change removes.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🎯 Standardizes OC-SORT and Kalman filter numeric precision for more consistent tracking initialization.

### 📊 Key Changes
- 🧮 OC-SORT observations are explicitly stored as `float32`, matching detection-space precision.
- 🔢 Kalman filter initialization now converts measurements to `float64` for both XYAH and XYWH filters.
- 📝 Updated documentation to clearly describe the resulting `float64` mean vectors and covariance matrices.

### 🎯 Purpose & Impact
- ✅ Reduces potential dtype inconsistencies between detections, observations, and Kalman filter state.
- 📈 Improves numerical stability and predictability when initializing tracks.
- 🚀 Helps maintain more reliable object tracking across different input array types, with minimal performance impact.