### PR TITLE
Bump ultralytics-inference version to 0.0.32 in documentation

### DIFF
--- a/docs/en/inference/index.md
+++ b/docs/en/inference/index.md
@@ -78,12 +78,6 @@ ultralytics-inference predict --task pose --source video.mp4 --show
 # Depth estimation (auto-downloads yolo26n-depth.onnx)
 ultralytics-inference predict --task depth --source image.jpg
 
-# Depth with the DepthAnything-style palette (disparity is already the default)
-ultralytics-inference predict --task depth --source image.jpg --colormap spectral
-
-# Depth normalized by depth value instead (near = low color, far = high color)
-ultralytics-inference predict --task depth --source image.jpg --depth-viz metric
-
 # Tune thresholds and filter to specific classes
 ultralytics-inference predict --source image.jpg --conf 0.5 --iou 0.45 --classes "0,1,2"
 
@@ -93,21 +87,19 @@ ultralytics-inference predict --source images/ --device cuda:0 --half
 
 Common flags:
 
-| Flag             | Default        | Description                                                                                   |
-| ---------------- | -------------- | --------------------------------------------------------------------------------------------- |
-| `--model`, `-m`  | `yolo26n.onnx` | Path to an ONNX model; a known YOLO name is downloaded automatically.                         |
-| `--task`         | `detect`       | One of `detect`, `segment`, `pose`, `obb`, `classify`, `semantic`, `depth`.                   |
-| `--source`, `-s` | sample         | Image, directory, glob, video, webcam index, or URL.                                          |
-| `--conf`         | `0.25`         | Confidence threshold.                                                                         |
-| `--iou`          | `0.7`          | IoU threshold for non-maximum suppression.                                                    |
-| `--imgsz`        | model metadata | Inference image size.                                                                         |
-| `--device`       | `cpu`          | Execution device, for example `cuda:0`, `coreml`, `tensorrt:0`.                               |
-| `--half`         | `false`        | FP16 half-precision inference.                                                                |
-| `--save`         | `true`         | Save annotated results to `runs/<task>/predict`.                                              |
-| `--show`         | `false`        | Display results in a window.                                                                  |
-| `--classes`      | all            | Filter detections by class IDs, for example `"0,1,2"`.                                        |
-| `--colormap`     | `jet`          | Depth colormap: `jet`, `inferno`, `spectral`, or `gray` (depth only).                         |
-| `--depth-viz`    | `disparity`    | Depth normalization: `disparity` (inverse depth, near = high color) or `metric` (depth only). |
+| Flag             | Default        | Description                                                                 |
+| ---------------- | -------------- | --------------------------------------------------------------------------- |
+| `--model`, `-m`  | `yolo26n.onnx` | Path to an ONNX model; a known YOLO name is downloaded automatically.       |
+| `--task`         | `detect`       | One of `detect`, `segment`, `pose`, `obb`, `classify`, `semantic`, `depth`. |
+| `--source`, `-s` | sample         | Image, directory, glob, video, webcam index, or URL.                        |
+| `--conf`         | `0.25`         | Confidence threshold.                                                       |
+| `--iou`          | `0.7`          | IoU threshold for non-maximum suppression.                                  |
+| `--imgsz`        | model metadata | Inference image size.                                                       |
+| `--device`       | `cpu`          | Execution device, for example `cuda:0`, `coreml`, `tensorrt:0`.             |
+| `--half`         | `false`        | FP16 half-precision inference.                                              |
+| `--save`         | `true`         | Save annotated results to `runs/<task>/predict`.                            |
+| `--show`         | `false`        | Display results in a window.                                                |
+| `--classes`      | all            | Filter detections by class IDs, for example `"0,1,2"`.                      |
 
 ## Library quickstart
 

--- a/docs/en/inference/index.md
+++ b/docs/en/inference/index.md
@@ -4,13 +4,15 @@ description: Ultralytics Inference for Rust is a high-performance YOLO inference
 keywords: Ultralytics Inference, Rust, YOLO, ONNX Runtime, object detection, segmentation, pose, OBB, classification, semantic segmentation, depth estimation, CUDA, TensorRT, CoreML, edge AI, real-time inference
 ---
 
-# Ultralytics Inference for Rust
+<div align="center">
+    <a href="https://github.com/ultralytics/inference"><img src="https://img.shields.io/badge/GitHub-ultralytics%2Finference-181717?logo=github&logoColor=white" alt="Ultralytics Inference GitHub"></a>
+    <a href="https://crates.io/crates/ultralytics-inference"><img src="https://img.shields.io/crates/v/ultralytics-inference?logo=rust&logoColor=white&label=crates.io&color=CE422B" alt="Ultralytics Inference Crates.io"></a>
+    <a href="https://docs.rs/ultralytics-inference"><img src="https://img.shields.io/docsrs/ultralytics-inference?logo=docs.rs&logoColor=white&label=docs.rs" alt="Ultralytics Inference docs.rs"></a>
+    <a href="https://crates.io/crates/ultralytics-inference"><img src="https://img.shields.io/crates/d/ultralytics-inference?logo=rust&logoColor=white&label=downloads&color=CE422B" alt="Ultralytics Inference Downloads"></a>
+    <a href="https://crates.io/crates/ultralytics-inference"><img src="https://img.shields.io/crates/msrv/ultralytics-inference?logo=rust&logoColor=white&color=CE422B" alt="Ultralytics Inference MSRV"></a>
+</div>
 
-[![GitHub](https://img.shields.io/badge/GitHub-ultralytics%2Finference-181717?logo=github&logoColor=white)](https://github.com/ultralytics/inference)
-[![Crates.io](https://img.shields.io/crates/v/ultralytics-inference?logo=rust&logoColor=white&label=crates.io&color=CE422B)](https://crates.io/crates/ultralytics-inference)
-[![docs.rs](https://img.shields.io/docsrs/ultralytics-inference?logo=docs.rs&logoColor=white&label=docs.rs)](https://docs.rs/ultralytics-inference)
-[![Downloads](https://img.shields.io/crates/d/ultralytics-inference?logo=rust&logoColor=white&label=downloads&color=CE422B)](https://crates.io/crates/ultralytics-inference)
-[![MSRV](https://img.shields.io/crates/msrv/ultralytics-inference?logo=rust&logoColor=white&color=CE422B)](https://crates.io/crates/ultralytics-inference)
+# Ultralytics Inference for Rust
 
 [Ultralytics Inference](https://github.com/ultralytics/inference) is a high-performance [YOLO](https://www.ultralytics.com/yolo) inference library and command-line tool written in [Rust](https://rust-lang.org/). It runs exported [ONNX](../integrations/onnx.md) models through [ONNX Runtime](https://onnxruntime.ai/) to deliver fast, memory-safe predictions on images, videos, webcams, and streams, with no Python runtime required at inference time.
 

--- a/docs/en/inference/index.md
+++ b/docs/en/inference/index.md
@@ -55,7 +55,7 @@ Rust 1.89 or newer is required. The [video](#cargo-features) feature additionall
     ```toml
     # Or add it manually to Cargo.toml
     [dependencies]
-    ultralytics-inference = "0.0.31"
+    ultralytics-inference = "0.0.32"
     ```
 
 ## CLI quickstart
@@ -449,7 +449,7 @@ cargo install ultralytics-inference --features cuda,tensorrt
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.31", features = ["video"] }
+ultralytics-inference = { version = "0.0.32", features = ["video"] }
 ```
 
 ## Output and saving

--- a/docs/en/inference/index.md
+++ b/docs/en/inference/index.md
@@ -455,7 +455,7 @@ runs/
         └── image.jpg     # annotated result
 ```
 
-The subfolder matches the task (`runs/segment/`, `runs/pose/`, and so on). For video sources the annotated output is written as a video file; pass `--save-frames` to write individual frames instead. For the `semantic` task, `--save-json` writes per-pixel class-map PNGs under a `results/` subfolder. For the `depth` task the annotated image is written side by side, with the original next to the colorized depth map. Annotated image and video saving require the `annotate` feature; semantic class-map PNG export does not. Video input and output require the `video` feature.
+The subfolder matches the task (`runs/segment/`, `runs/pose/`, and so on). For video sources the annotated output is written as a video file; pass `--save-frames` to write individual frames instead. For the `semantic` task, `--save-json` writes per-pixel class-map PNGs under a `results/` subfolder. For the `depth` task the colorized depth map is blended over the source image, matching the Ultralytics Python `plot()` output. Annotated image and video saving require the `annotate` feature; semantic class-map PNG export does not. Video input and output require the `video` feature.
 
 ## FAQ
 

--- a/docs/en/inference/index.md
+++ b/docs/en/inference/index.md
@@ -55,7 +55,7 @@ Rust 1.89 or newer is required. The [video](#cargo-features) feature additionall
     ```toml
     # Or add it manually to Cargo.toml
     [dependencies]
-    ultralytics-inference = "0.0.30"
+    ultralytics-inference = "0.0.32"
     ```
 
 ## CLI quickstart
@@ -449,7 +449,7 @@ cargo install ultralytics-inference --features cuda,tensorrt
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.30", features = ["video"] }
+ultralytics-inference = { version = "0.0.32", features = ["video"] }
 ```
 
 ## Output and saving

--- a/docs/en/inference/index.md
+++ b/docs/en/inference/index.md
@@ -378,7 +378,9 @@ Inference runs on CPU by default. GPU and accelerator backends are compiled in a
 | `cuda:0`      | `Device::Cuda(0)`     | `cuda`        | NVIDIA GPU            |
 | `tensorrt:0`  | `Device::TensorRt(0)` | `tensorrt`    | NVIDIA GPU, optimized |
 | `coreml`      | `Device::CoreMl`      | `coreml`      | Apple Silicon / macOS |
-| `openvino`    | `Device::OpenVino`    | `openvino`    | Intel CPU / iGPU      |
+| `intel:cpu`   | `Device::IntelCpu`    | `openvino`    | Intel CPU             |
+| `intel:gpu`   | `Device::IntelGpu`    | `openvino`    | Intel GPU             |
+| `intel:npu`   | `Device::IntelNpu`    | `openvino`    | Intel NPU             |
 | `directml:0`  | `Device::DirectMl(0)` | `directml`    | Windows GPU           |
 | `rocm:0`      | `Device::Rocm(0)`     | `rocm`        | AMD GPU               |
 | `xnnpack`     | `Device::Xnnpack`     | `xnnpack`     | Optimized CPU         |

--- a/docs/en/inference/index.md
+++ b/docs/en/inference/index.md
@@ -55,7 +55,7 @@ Rust 1.89 or newer is required. The [video](#cargo-features) feature additionall
     ```toml
     # Or add it manually to Cargo.toml
     [dependencies]
-    ultralytics-inference = "0.0.32"
+    ultralytics-inference = "0.0.31"
     ```
 
 ## CLI quickstart
@@ -449,7 +449,7 @@ cargo install ultralytics-inference --features cuda,tensorrt
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.32", features = ["video"] }
+ultralytics-inference = { version = "0.0.31", features = ["video"] }
 ```
 
 ## Output and saving


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the Rust inference documentation for `ultralytics-inference` 0.0.32 with clearer badges, current CLI options, expanded Intel device support, and revised depth visualization behavior. 📚

### 📊 Key Changes

- Added centered status badges linking to the [GitHub repository](https://github.com/ultralytics/inference), [Crates.io package](https://crates.io/crates/ultralytics-inference), and [docs.rs documentation](https://docs.rs/ultralytics-inference).
- Updated dependency examples from version `0.0.30` to `0.0.32`.
- Removed outdated depth visualization flags and examples for `--colormap` and `--depth-viz`.
- Simplified the CLI options table to match the currently supported flags.
- Replaced the generic OpenVINO device entry with specific Intel targets:
  - `intel:cpu`
  - `intel:gpu`
  - `intel:npu`
- Clarified that depth output is blended over the source image, matching the Ultralytics Python `plot()` behavior.

### 🎯 Purpose & Impact

- Keeps the Rust inference documentation aligned with the latest package release and implementation. ✅
- Helps users identify supported Intel CPU, GPU, and NPU acceleration targets more accurately.
- Prevents confusion caused by documenting removed or outdated depth visualization options.
- Improves discoverability of package status, downloads, compatibility, and API documentation.
- Provides clearer expectations for depth-result images generated by the Rust inference tool.