### PR TITLE
Normalize GPU names in usage events

### DIFF
--- a/ultralytics/utils/events.py
+++ b/ultralytics/utils/events.py
@@ -148,7 +148,7 @@ class Events:
                     params["arch"] = _arch(unwrap_model(run.model))  # DDP and EMA both wrap away the .yaml
                     params["ngpu"] = run.world_size if run.world_size > 1 else None  # only a count above one informs
                     if device.type == "cuda":  # makes hours comparable
-                        params["GPU"] = get_gpu_info(device.index or 0)
+                        params["GPU"] = get_gpu_info(device.index or 0).rsplit(", ", 1)[0]
                 except Exception:
                     pass
             elif cfg.mode in {"predict", "track"}:  # track runs the predictor too, and is most of the video inference
@@ -173,7 +173,7 @@ class Events:
                     meta = getattr(model, "metadata", None) or {}
                     params["quantize"] = str(meta.get("args", {}).get("quantize") or cfg.quantize or 32)
                     if device.type == "cuda":  # CUDA is already initialized here, so this costs nothing
-                        params["GPU"] = get_gpu_info(device.index or 0)
+                        params["GPU"] = get_gpu_info(device.index or 0).rsplit(", ", 1)[0]
                     session = getattr(model, "session", None)  # ONNX Runtime provider, else OpenVINO device
                     ov = getattr(model, "ov_compiled_model", None)  # an Arc GPU run must not look like CPU
                     devices = session.get_providers() if session else ov.get_property("EXECUTION_DEVICES") if ov else []


### PR DESCRIPTION
## Summary

GA4 currently splits the same GPU model across many dimension values because `get_gpu_info()` appends driver-reported memory, for example `NVIDIA GeForce RTX 4090, 24058MiB` and `NVIDIA GeForce RTX 4090, 24564MiB`.

This PR strips that suffix only when populating the existing `GPU` telemetry parameter for train, predict, and track events. The shared helper remains unchanged for logs and other human-readable consumers.

The first processed YOLO 8.4.108 speed data contained 418 raw GPU strings but 159 names after removing the memory suffix. Portal ingestion will still normalize historical values; this change keeps future GA4 cardinality and distinct-user aggregation stable. Supports ultralytics/portal#3167.

## Validation

- `ruff format --check ultralytics/utils/events.py`
- `ruff check ultralytics/utils/events.py`
- `PYTHONPATH=. python -m pytest -q tests/test_python.py::test_events`
- Focused payload check: `NVIDIA GeForce RTX 4090, 24058MiB` emits `NVIDIA GeForce RTX 4090`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Streamlines GPU telemetry by removing trailing details from reported GPU information. 🖥️

### 📊 Key Changes

- Trims the final comma-separated field from `get_gpu_info()` results for CUDA devices.
- Applies the cleaner GPU name format during both:
  - Training and validation runs.
  - Prediction and tracking runs.
- Keeps existing device detection and telemetry handling unchanged.

### 🎯 Purpose & Impact

- Produces more consistent, concise GPU metadata in logged events. 📊
- Reduces unnecessary or potentially variable details in analytics and run tracking.
- Improves comparability of performance data across runs and environments. 🚀