### PR TITLE
Preserve the GMC homography precision in Deep OC-SORT

### DIFF
--- a/ultralytics/trackers/deep_oc_sort.py
+++ b/ultralytics/trackers/deep_oc_sort.py
@@ -123,7 +123,7 @@ class DeepOCSortTrack(OCSortTrack):
         t = H[:2, 2]
 
         # Build 8x8 transform: rotate (x,y) and (vx,vy), identity for (a,h) and (va,vh)
-        R8x8 = np.eye(8, dtype=np.float32)
+        R8x8 = np.eye(8)  # float64 holds any homography exactly; a narrower one would round the float64 methods
         R8x8[:2, :2] = R  # rotate position (x, y)
         R8x8[4:6, 4:6] = R  # rotate velocity (vx, vy)
         # indices 2,3 (a,h) and 6,7 (va,vh) remain identity


### PR DESCRIPTION
## summary

`DeepOCSortTrack.multi_gmc` builds its 8x8 motion-compensation warp as a float32 identity and then assigns the rotation block of the homography into it. Assignment into a typed array narrows, so the rotation was applied at float32 precision to a float64 Kalman state.

The two global-motion-compensation paths in the package express the same intent and get different results, because one narrows and the other widens:

|                                             | builds the warp as                                      | effect on a float64 homography                                         |
| ------------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------- |
| `ultralytics/trackers/deep_oc_sort.py:126`  | `np.eye(8, dtype=np.float32)`, then assigns `R` into it | assignment narrows, so `R` is rounded to float32                       |
| `ultralytics/trackers/utils/stracks.py:167` | `np.kron(np.eye(4, dtype=np.float32), R)`               | `np.kron` promotes, so the requested float32 is inert and `R` is exact |

`GMC.apply` returns a float64 homography from `sparseOptFlow`, `orb` and `sift`, and a float32 one from `ecc`. Dropping the dtype makes the warp preserve the values of all four: float64 entries survive unrounded, and a float32 homography widens losslessly. `stracks.py:167` is left alone — its `np.kron` already preserves the homography.

This is not reachable on shipped defaults. `ultralytics/cfg/trackers/deepocsort.yaml` sets `gmc_method: none`, and an identity warp narrows losslessly. It is reachable through the documented moving-camera options, which is also where the warp is furthest from identity and the rounding largest.

### Behaviour

At the warp itself, with a float64 homography, the applied rotation differed from the returned one by 1.557e-08, moving the state by 9.988e-06 px in a single frame.

Full-clip A/B, 75-frame clip with `yolo11n` and `gmc_method: sparseOptFlow`, both runs from the same commit differing only in this line:

|                        |                 |
| ---------------------- | --------------- |
| rows                   | 960 / 960       |
| track ids              | identical       |
| `(frame, id)` key sets | identical       |
| max abs box delta      | 6.103516e-05 px |
| rows differing         | 264 / 960       |

Instrumenting all 1149 warps on that clip: the covariance is float64 on both revisions, and `last_observation` stays float32 on both, since it is pinned where it is written and its own transform uses `R` rather than the 8x8 matrix.

One dtype does move. `multi_gmc` is applied to `unconfirmed` as well as to `strack_pool`, and unconfirmed tracks have not been through `multi_predict`, so their mean is still the float32 one `initiate` derived from the detection while their covariance is already float64. 23 of the 1149 warps are in that state. Those means now leave the warp float64, agreeing with the covariance they sit beside and with the other 1126. The output boxes are pinned to float32 regardless, at `byte_tracker.py:491`.

`pytest tests/test_python.py -k "track"` passes: 14 passed, 120 deselected.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improved Deep OC-SORT tracking accuracy by preserving full precision when applying camera-motion transformations. 🎯

### 📊 Key Changes
- Changed the 8×8 transformation matrix in `deep_oc_sort.py` from `float32` to NumPy’s default `float64`.
- Prevented precision loss when copying or applying homography values to tracker state transformations.
- Kept position and velocity rotation behavior unchanged.

### 🎯 Purpose & Impact
- Reduces rounding errors during global camera-motion compensation. 📐
- Improves numerical stability and potentially tracking consistency in scenes with camera movement.
- Introduces no user-facing API changes and should remain backward-compatible. ✅