### PR TITLE
Add https://youtu.be/i-V1kRCJD0M to docs

### DIFF
--- a/docs/en/tasks/depth.md
+++ b/docs/en/tasks/depth.md
@@ -17,6 +17,17 @@ The output of a depth model is a dense float map of shape `(H, W)` aligned to th
 
     Use `task=depth` or the `yolo depth` CLI task for monocular depth estimation. YOLO26 depth model files use the `-depth` suffix, such as `yolo26n-depth.pt`.
 
+<p align="center">
+  <br>
+  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/i-V1kRCJD0M"
+    title="YouTube video player" frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen>
+  </iframe>
+  <br>
+  <strong>Watch:</strong> Monocular Depth Estimation with Ultralytics YOLO26 | Python Tutorial | Vision AI 🚀
+</p>
+
 ## [Models](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/cfg/models/26)
 
 YOLO26 depth models pretrained on a broad multi-dataset mix (indoor + outdoor, ~2.19M images) are shown below. The metrics columns are reported on the [NYU Depth V2](https://cs.nyu.edu/~silberman/datasets/nyu_depth_v2.html) Eigen test split.


### PR DESCRIPTION
@glenn-jocher @Laughing-q FYI.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a YouTube tutorial embed for monocular depth estimation to the YOLO26 depth task documentation.

### 📊 Key Changes
- Added a centered, lazy-loaded YouTube iframe to `docs/en/tasks/depth.md`.
- Included the tutorial title beneath the embedded video.

### 🎯 Purpose & Impact
- Gives users a practical visual guide to monocular depth estimation with Ultralytics YOLO26.
- Improves discoverability and usability of the depth documentation without changing package functionality.