### PR TITLE
Keep gmc matches when the spatial distance variance is zero

### DIFF
--- a/ultralytics/trackers/utils/gmc.py
+++ b/ultralytics/trackers/utils/gmc.py
@@ -241,7 +241,9 @@ class GMC:
         spatialDistances = np.asarray(spatialDistances).reshape(-1, 2)
         meanSpatialDistances = np.mean(spatialDistances, 0)
         stdSpatialDistances = np.std(spatialDistances, 0)
-        inliers = np.abs(spatialDistances - meanSpatialDistances) < 2.5 * stdSpatialDistances
+        # Non-strict, so a zero-variance pair keeps its matches instead of rejecting every one of them; a
+        # deviation landing exactly on the bound counts as an inlier rather than an outlier.
+        inliers = np.abs(spatialDistances - meanSpatialDistances) <= 2.5 * stdSpatialDistances
 
         # Keep matched point pairs that survive the outlier filter
         good = inliers.all(axis=1)

--- a/ultralytics/trackers/utils/gmc.py
+++ b/ultralytics/trackers/utils/gmc.py
@@ -241,8 +241,7 @@ class GMC:
         spatialDistances = np.asarray(spatialDistances).reshape(-1, 2)
         meanSpatialDistances = np.mean(spatialDistances, 0)
         stdSpatialDistances = np.std(spatialDistances, 0)
-        # Non-strict, so a zero-variance pair keeps its matches instead of rejecting every one of them; a
-        # deviation landing exactly on the bound counts as an inlier rather than an outlier.
+        # Include exact-boundary and zero-variance matches.
         inliers = np.abs(spatialDistances - meanSpatialDistances) <= 2.5 * stdSpatialDistances
 
         # Keep matched point pairs that survive the outlier filter


### PR DESCRIPTION
## summary

`GMC.apply_features` rejects spatial-distance outliers with a strict `<` against the 2.5-sigma bound. When every surviving match has the same spatial distance the standard deviation is zero and the comparison becomes `0 < 0`, so `inliers.all(axis=1)` selects nothing and a duplicated frame pair falls through to the `not enough matching points` branch with thousands of perfectly consistent matches in hand.

Making the bound non-strict keeps those matches, so `cv2.estimateAffinePartial2D` runs on them instead of being skipped. It also makes the boundary itself inclusive: a deviation landing exactly on 2.5 sigma is now an inlier. That is reachable with a nonzero variance — `[2.5, 0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5]` has mean 0 and population std 1, so its first entry sits exactly on the bound — and it is the intended reading, since a point at 2.5 sigma is within 2.5 sigma.

Measured on a 12-frame clip with `gmc_method: orb`, half of whose frames repeat the previous one: 4 shortage warnings before, 0 after, with identical track ids and identical boxes. Tracking output does not move here because the estimate for a duplicated pair is identity, which is what the skipped branch already returned; what the change removes is the misleading warning and the bypassed estimate.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improved GMC feature matching by retaining valid matches at the outlier threshold and in zero-variance cases. ✅

### 📊 Key Changes

- Updated the inlier filter in `ultralytics/trackers/utils/gmc.py`.
- Changed the boundary comparison from `<` to `<=`.
- Added handling for exact-boundary matches and zero-variance feature distributions.

### 🎯 Purpose & Impact

- Prevents valid feature matches from being discarded when they lie exactly on the filtering threshold.
- Improves robustness in tracking scenarios with identical or highly consistent spatial distances.
- May provide more stable global motion compensation and tracking results, especially in low-variation scenes. 📈