### PR TITLE
Fix tracker docstring examples to run as written

### DIFF
--- a/ultralytics/trackers/bot_sort.py
+++ b/ultralytics/trackers/bot_sort.py
@@ -42,6 +42,7 @@ class BOTrack(STrack):
     Examples:
         Create a BOTrack instance and update its features
         >>> bo_track = BOTrack(xywh=np.array([100, 50, 80, 40, 0]), score=0.9, cls=1, feat=np.random.rand(128))
+        >>> bo_track.activate(KalmanFilterXYWH(), frame_id=1)
         >>> bo_track.predict()
         >>> new_track = BOTrack(xywh=np.array([110, 60, 80, 40, 0]), score=0.85, cls=1, feat=np.random.rand(128))
         >>> bo_track.update(new_track, frame_id=2)

--- a/ultralytics/trackers/byte_tracker.py
+++ b/ultralytics/trackers/byte_tracker.py
@@ -46,7 +46,7 @@ class STrack(BaseTrack):
 
     Examples:
         Initialize and activate a new track
-        >>> track = STrack(xywh=[100, 200, 50, 80, 0], score=0.9, cls="person")
+        >>> track = STrack(xywh=np.array([100, 200, 50, 80, 0]), score=0.9, cls="person")
         >>> track.activate(kalman_filter=KalmanFilterXYAH(), frame_id=1)
     """
 
@@ -135,8 +135,9 @@ class STrack(BaseTrack):
 
         Examples:
             Update the state of a track with new detection information
-            >>> track = STrack([100, 200, 50, 80, 0], score=0.9, cls=0)
-            >>> new_track = STrack([105, 205, 55, 85, 0], score=0.95, cls=0)
+            >>> track = STrack(np.array([100, 200, 50, 80, 0]), score=0.9, cls=0)
+            >>> track.activate(KalmanFilterXYAH(), 1)
+            >>> new_track = STrack(np.array([105, 205, 55, 85, 0]), score=0.95, cls=0)
             >>> track.update(new_track, 2)
         """
         self.frame_id = frame_id

--- a/ultralytics/trackers/fast_tracker.py
+++ b/ultralytics/trackers/fast_tracker.py
@@ -36,7 +36,7 @@ class FastSTrack(STrack):
 
     Examples:
         >>> from ultralytics.trackers.utils.kalman_filter import KalmanFilterXYAH
-        >>> t = FastSTrack([100, 200, 50, 80, 0], score=0.9, cls=0, history_len=8)
+        >>> t = FastSTrack(np.array([100, 200, 50, 80, 0]), score=0.9, cls=0, history_len=8)
         >>> t.activate(KalmanFilterXYAH(), frame_id=1)
         >>> len(t.mean_history)
         1

--- a/ultralytics/trackers/track_tracker.py
+++ b/ultralytics/trackers/track_tracker.py
@@ -229,7 +229,7 @@ class TTSTrack(BOTrack):
 
     Examples:
         Create and activate a new track
-        >>> track = TTSTrack([100, 200, 50, 80, 0], score=0.9, cls="person")
+        >>> track = TTSTrack(np.array([100, 200, 50, 80, 0]), score=0.9, cls="person")
         >>> track.activate(KalmanFilterXYWH(), frame_id=1)
     """
 


### PR DESCRIPTION
## summary

five docstring Examples across the tracker classes raise when executed as written.

Four of them pass a plain `list` as `xywh`. `STrack.__init__` is annotated `xywh: np.ndarray` and hands the value to `xywh2ltwh`, which indexes it as `x[..., 0]`, so a list raises `TypeError: list indices must be integers or slices, not tuple`. They now build the box with `np.array([...])`, the form the `BOTrack` Example in the same package already uses.

The other two call a method before the track has a Kalman filter. `BOTrack`'s Example calls `predict()`, which does `self.mean.copy()` while `__init__` leaves `mean` as `None`; `STrack.update`'s Example calls `update()`, which does `self.kalman_filter.update(...)` while `__init__` leaves that `None` too. Both now activate the track first, with the filter that class actually uses — `KalmanFilterXYWH` for `BOTrack`, whose `shared_kalman` and `convert_coords` are both XYWH, and `KalmanFilterXYAH` for `STrack`.

`pytest --doctest-modules` over `byte_tracker.py`, `fast_tracker.py`, `track_tracker.py` and `bot_sort.py` goes from 9 failed to 5 passed / 4 failed. The four that remain are class-level Examples that reference an undefined `args` placeholder; they are illustrative pseudo-code rather than runnable snippets and are left alone.

Nothing was deletable here: each added line is a lifecycle precondition of the call the Example exists to document, so removing the call instead would have cost the documentation rather than the defect. 7 added, 5 removed, docstrings only.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📚 Updates tracker documentation examples to use NumPy arrays and demonstrate proper track activation before prediction or updates.

### 📊 Key Changes

- Replaced list-based bounding box examples with `np.array` inputs across ByteTrack, FastTracker, and TTrack documentation.
- Added the required `activate()` step before calling `predict()` or `update()` in tracker examples.
- Updated the BOTrack example to show initialization with `KalmanFilterXYWH`.
- Improved consistency between examples and the trackers’ expected usage patterns.

### 🎯 Purpose & Impact

- ✅ Makes tracker examples more accurate and runnable for developers.
- 🧭 Clarifies the correct lifecycle for creating, activating, predicting, and updating tracks.
- 🛠️ Reduces confusion and potential errors when users build custom tracking workflows.
- 🚀 No core tracking behavior changes are introduced; this PR primarily improves documentation and examples.