### PR TITLE
Declare the expected output in basetrack docstring examples

### DIFF
--- a/ultralytics/trackers/basetrack.py
+++ b/ultralytics/trackers/basetrack.py
@@ -17,6 +17,7 @@ class TrackState:
         >>> state = TrackState.New
         >>> if state == TrackState.New:
         ...     print("Object is newly detected.")
+        Object is newly detected.
     """
 
     New = 0
@@ -51,7 +52,8 @@ class BaseTrack:
         Initialize a new track and mark it as lost:
         >>> track = BaseTrack()
         >>> track.mark_lost()
-        >>> print(track.state)  # Output: 2 (TrackState.Lost)
+        >>> print(track.state)
+        2
     """
 
     _count = 0


### PR DESCRIPTION
## summary

the `TrackState` and `BaseTrack` class examples in `ultralytics/trackers/basetrack.py` each end in a `print()` whose output the docstring never declares, so a doctest run compares the real output against "expected nothing" and both fail. this moves each printed value onto the expected-output line, the form the passing examples elsewhere in the package already use, and drops the now-redundant `# Output: 2 (TrackState.Lost)` trailing comment whose `(TrackState.Lost)` half the attributes block above already carries.

`pytest --doctest-modules ultralytics/trackers/basetrack.py` goes from 2 failed to 2 passed.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📚 Updates tracker documentation examples to show correct doctest-style output.

### 📊 Key Changes

- Added the expected output for the `TrackState` example in `ultralytics/trackers/basetrack.py`.
- Updated the `BaseTrack` example to display output on a separate line instead of using an inline comment.

### 🎯 Purpose & Impact

- ✅ Makes documentation examples compatible with doctest conventions.
- 🧪 Improves clarity and reliability for automated documentation and example testing.
- 🚀 No functional tracking behavior or user-facing API changes.