### PR TITLE
Set imgsz in SAM pre_transform docstring examples

### DIFF
--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -159,6 +159,7 @@ class Predictor(BasePredictor):
 
         Examples:
             >>> predictor = Predictor()
+            >>> predictor.imgsz = [1024, 1024]  # normally set by setup_source()
             >>> image = np.random.rand(480, 640, 3)  # Single HWC image
             >>> transformed = predictor.pre_transform([image])
             >>> print(len(transformed))
@@ -2244,7 +2245,8 @@ class SAM3SemanticPredictor(SAM3Predictor):
             AssertionError: If the input list contains more than one image.
 
         Examples:
-            >>> predictor = Predictor()
+            >>> predictor = SAM3SemanticPredictor()
+            >>> predictor.imgsz = [1024, 1024]  # normally set by setup_source()
             >>> image = np.random.rand(480, 640, 3)  # Single HWC image
             >>> transformed = predictor.pre_transform([image])
             >>> print(len(transformed))


### PR DESCRIPTION
## summary

The `Examples:` blocks for `Predictor.pre_transform` and the `SAM3SemanticPredictor.pre_transform` override in `ultralytics/models/sam/predict.py` raise `TypeError: 'NoneType' object is not subscriptable` when run as written. `BasePredictor.__init__` leaves `self.imgsz` as `None` and only `setup_source()` populates it, while `pre_transform` builds `LetterBox(self.imgsz, ...)`, whose `get_params` subscripts it.

Both Examples now set `predictor.imgsz = [1024, 1024]` before the call. `1024` is what SAM predictors run with (`ultralytics/models/sam/model.py` sets `imgsz: 1024`), and a list matches what `check_imgsz(..., min_dim=2)` assigns at runtime. Passing `imgsz` through the constructor does not work here — `Predictor(overrides={"imgsz": 640}).imgsz` is still `None`, since the value only reaches `self.imgsz` in `setup_source()`.

The SAM3 Example also constructed the base `Predictor()`, so it exercised the base implementation rather than the override it documents (the override passes `scale_fill=True`). It now constructs `SAM3SemanticPredictor()`.

`pytest --doctest-modules ultralytics/models/sam/predict.py` goes from 14 failed to 12 failed / 2 passed; the two newly passing doctests are exactly these. The remaining failures are unrelated Examples that reference placeholder identifiers or need a downloaded model.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛠️ Updated SAM predictor documentation examples to accurately reflect required image-size setup and the correct predictor class.

### 📊 Key Changes

- Added `predictor.imgsz = [1024, 1024]` to examples where `imgsz` is normally initialized by `setup_source()`.
- Corrected the semantic segmentation example to use `SAM3SemanticPredictor`.
- Improved documentation consistency for SAM preprocessing methods.

### 🎯 Purpose & Impact

- 📚 Makes SAM predictor examples clearer and more reliable for developers running them directly.
- ✅ Helps prevent confusion or errors caused by missing `imgsz` initialization.
- 🎯 Ensures the semantic segmentation documentation uses the appropriate predictor implementation.