### PR TITLE
Keep profiler samples when the run time variance is zero

### DIFF
--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -421,7 +421,8 @@ class ProfileModels:
         data = np.array(data)
         for _ in range(max_iters):
             mean, std = np.mean(data), np.std(data)
-            clipped_data = data[(data > mean - sigma * std) & (data < mean + sigma * std)]
+            # Include exact-boundary and zero-variance samples.
+            clipped_data = data[(data >= mean - sigma * std) & (data <= mean + sigma * std)]
             if len(clipped_data) == len(data):
                 break
             data = clipped_data


### PR DESCRIPTION
## summary

`ProfileModels.iterative_sigma_clipping` selects inliers with a strict two-sided comparison, so a sample sitting exactly on `mean ± sigma * std` is discarded. When the surviving samples have zero variance both bounds land on the samples themselves and every one of them is dropped, so `len(clipped_data) != len(data)` and the loop keeps iterating on an empty array. `profile_tensorrt_model` and `profile_onnx_model` then take `np.mean` and `np.std` of that empty array and return `nan, nan` along with five numpy `RuntimeWarning`s.

The samples do not have to start out identical for this to happen — only the survivors of some iteration do. Driving `profile_onnx_model` with the system clock quantized to the ~15.625 ms granularity `time.time()` has on Windows through Python 3.12 produced 1000 samples holding two distinct values, `{0.0: 939, 15.625: 61}`. The first iteration correctly clipped the 61 tick crossings, which left the 939 survivors constant, and the second iteration discarded all of them.

Making both bounds inclusive keeps a sample that sits exactly on the bound, so a zero-variance set stays intact and the loop terminates on it instead of emptying. This is the same correction merged for `GMC.apply_features` in #25507.

The boundary is inclusive at nonzero variance too, not only in the degenerate case: on `[5.0, 0.0, 0.0, 0.0, 0.0]`, where `mean + 2 * std` is exactly `5.0`, the strict form kept four samples and this one keeps five. On a real 568-sample profiling run (568 values, 390 distinct) both forms select an identical set of 555.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improved sigma clipping in benchmarking utilities to retain valid boundary and zero-variance samples. ✅

### 📊 Key Changes

- Updated `iterative_sigma_clipping()` to include values exactly at the lower and upper clipping boundaries.
- Added handling for zero-variance data, such as arrays where all samples are identical.
- Replaced strict comparisons (`>` and `<`) with inclusive comparisons (`>=` and `<=`).

### 🎯 Purpose & Impact

- Prevents valid samples from being unnecessarily removed during outlier filtering.
- Makes benchmark statistics more stable and accurate for constant or boundary-value datasets.
- Improves robustness without changing the function’s overall behavior for typical data.