### PR TITLE
Remove the unused Kalman filter gating distance method

### DIFF
--- a/ultralytics/trackers/utils/kalman_filter.py
+++ b/ultralytics/trackers/utils/kalman_filter.py
@@ -25,7 +25,6 @@ class KalmanFilterXYAH:
         project: Project the state distribution to measurement space.
         multi_predict: Run the Kalman filter prediction step (vectorized version).
         update: Run the Kalman filter correction step.
-        gating_distance: Compute the gating distance between state distribution and measurements.
 
     Examples:
         Initialize the Kalman filter and create a track from a measurement
@@ -231,56 +230,6 @@ class KalmanFilterXYAH:
         new_mean = mean + np.dot(innovation, kalman_gain.T)
         new_covariance = covariance - np.linalg.multi_dot((kalman_gain, projected_cov, kalman_gain.T))
         return new_mean, new_covariance
-
-    def gating_distance(
-        self,
-        mean: np.ndarray,
-        covariance: np.ndarray,
-        measurements: np.ndarray,
-        only_position: bool = False,
-        metric: str = "maha",
-    ) -> np.ndarray:
-        """Compute gating distance between state distribution and measurements.
-
-        A suitable distance threshold can be obtained from `chi2inv95`. If `only_position` is False, the chi-square
-        distribution has 4 degrees of freedom, otherwise 2.
-
-        Args:
-            mean (np.ndarray): Mean vector over the state distribution (8 dimensional).
-            covariance (np.ndarray): Covariance of the state distribution (8x8 dimensional).
-            measurements (np.ndarray): An (N, 4) matrix of N measurements, each in format (x, y, a, h) where (x, y) is
-                the bounding box center position, a the aspect ratio, and h the height.
-            only_position (bool, optional): If True, distance computation is done with respect to box center position
-                only.
-            metric (str, optional): The metric to use for calculating the distance. Options are 'gaussian' for the
-                squared Euclidean distance and 'maha' for the squared Mahalanobis distance.
-
-        Returns:
-            (np.ndarray): Returns an array of length N, where the i-th element contains the squared distance between
-                (mean, covariance) and `measurements[i]`.
-
-        Examples:
-            Compute gating distance using Mahalanobis metric:
-            >>> kf = KalmanFilterXYAH()
-            >>> mean = np.array([0, 0, 1, 1, 0, 0, 0, 0])
-            >>> covariance = np.eye(8)
-            >>> measurements = np.array([[1, 1, 1, 1], [2, 2, 1, 1]])
-            >>> distances = kf.gating_distance(mean, covariance, measurements, only_position=False, metric="maha")
-        """
-        mean, covariance = self.project(mean, covariance)
-        if only_position:
-            mean, covariance = mean[:2], covariance[:2, :2]
-            measurements = measurements[:, :2]
-
-        d = measurements - mean
-        if metric == "gaussian":
-            return np.sum(d * d, axis=1)
-        elif metric == "maha":
-            cholesky_factor = np.linalg.cholesky(covariance)
-            z = np.linalg.solve(cholesky_factor, d.T)
-            return np.sum(z * z, axis=0)  # square maha
-        else:
-            raise ValueError("Invalid distance metric")
 
 
 class KalmanFilterXYWH(KalmanFilterXYAH):


### PR DESCRIPTION
## summary

`KalmanFilterXYAH.gating_distance` has no callers. Both of them — `gate_cost_matrix` and `fuse_motion` in `ultralytics/trackers/utils/matching.py` — were removed in #4374, together with the module-level `chi2inv95` threshold table its docstring still points at and the copy of the method that `KalmanFilterXYWH` carried before that PR made it inherit from `KalmanFilterXYAH`. The method itself was left standing, so the package has carried it for three years with a docstring directing readers to a symbol they cannot import: `chi2inv95` is not defined anywhere in the repository, and `hasattr(kalman_filter, "chi2inv95")` is `False`.

No tracker in the package gates by Mahalanobis distance — association runs through `iou_distance` / `embedding_distance` and the `lap` solver. Across `ultralytics/trackers/`, the only methods invoked on a Kalman filter instance are `initiate`, `predict`, `multi_predict`, `update` and `project`.

`pytest tests/test_python.py -k "track"` stays at 14 passed. `python docs/build_reference.py` produces no diff, since the generated reference page carries one directive per class rather than per method.

## breaking change

This is an intentional removal of a public method, stated explicitly rather than left implicit. External code calling `KalmanFilterXYAH.gating_distance` or `KalmanFilterXYWH.gating_distance` will raise `AttributeError` after this change. No deprecation cycle is included, for three reasons:

- **Precedent in this exact namespace.** #4374 removed seven public top-level functions from `ultralytics/trackers/utils/matching.py` in one commit — `merge_matches`, `ious`, `v_iou_distance`, `gate_cost_matrix`, `fuse_motion`, `fuse_iou`, `bbox_ious`. All were published on the reference site with their own `:::` directives, none got a deprecation path, and the docs page was not touched in that commit.
- **No mechanism exists to deprecate a Python API method here.** The package's only deprecation machinery is `_handle_deprecation` in `ultralytics/cfg/__init__.py`, which maps retired CLI and config argument keys. There is no `@deprecated` decorator and no `DeprecationWarning` raised for API removal anywhere in `ultralytics/`. A wrapper would be new scaffolding, which `AGENTS.md` rules out under "Avoid … compatibility shims".
- **No evidence of use.** `gh search issues "gating_distance" --owner ultralytics` returns nothing, and no merged PR mentions the symbol. Inside the repository there is no `getattr`/`hasattr` access, string dispatch, config key, serialization path or docs macro that reaches it; the literal string "gating" does not appear anywhere under `ultralytics/`.

If a deprecation cycle is preferred, the alternative that keeps the method is a one-line docstring correction: replace the `chi2inv95` reference with "a 95% chi-square gating threshold is `scipy.stats.chi2.ppf(0.95, df)`: 9.4877 at `df=4` when `only_position=False`, 5.9915 at `df=2` otherwise".

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧹 Removes the unused `gating_distance` method from the Kalman filter tracker utility.

### 📊 Key Changes

- Deleted `gating_distance` from `KalmanFilterXYAH`.
- Removed its related class documentation entry.
- Eliminated support for Gaussian and Mahalanobis gating-distance calculations in this class.

### 🎯 Purpose & Impact

- 🛠️ Simplifies the Kalman filter implementation by removing unused code.
- 📦 Reduces maintenance overhead and avoids exposing functionality that is no longer required.
- ⚠️ Any external code calling `KalmanFilterXYAH.gating_distance()` will need to be updated, as the method is no longer available.