### PR TITLE
Fix the dangling chi2inv95 reference in the Kalman gating distance docstring

### DIFF
--- a/ultralytics/trackers/utils/kalman_filter.py
+++ b/ultralytics/trackers/utils/kalman_filter.py
@@ -242,8 +242,8 @@ class KalmanFilterXYAH:
     ) -> np.ndarray:
         """Compute gating distance between state distribution and measurements.
 
-        A suitable distance threshold is the 95% chi-square quantile `scipy.stats.chi2.ppf(0.95, df)`, where the
-        distribution has 4 degrees of freedom (9.4877) when `only_position` is False and 2 (5.9915) otherwise.
+        A suitable threshold for the `"maha"` metric is the 95% chi-square quantile `scipy.stats.chi2.ppf(0.95, df)`,
+        with 4 degrees of freedom (9.4877) when `only_position` is False and 2 (5.9915) otherwise.
 
         Args:
             mean (np.ndarray): Mean vector over the state distribution (8 dimensional).

--- a/ultralytics/trackers/utils/kalman_filter.py
+++ b/ultralytics/trackers/utils/kalman_filter.py
@@ -242,8 +242,9 @@ class KalmanFilterXYAH:
     ) -> np.ndarray:
         """Compute gating distance between state distribution and measurements.
 
-        A suitable threshold for the `"maha"` metric is the 95% chi-square quantile `scipy.stats.chi2.ppf(0.95, df)`,
-        with 4 degrees of freedom (9.4877) when `only_position` is False and 2 (5.9915) otherwise.
+        A suitable threshold for the returned squared Mahalanobis distance is the 95th-percentile chi-square value:
+        9.4877 for 4 degrees of freedom when `only_position` is False, and 5.9915 for 2 otherwise. The `"gaussian"`
+        metric returns a squared Euclidean distance, for which this threshold does not apply.
 
         Args:
             mean (np.ndarray): Mean vector over the state distribution (8 dimensional).

--- a/ultralytics/trackers/utils/kalman_filter.py
+++ b/ultralytics/trackers/utils/kalman_filter.py
@@ -242,8 +242,8 @@ class KalmanFilterXYAH:
     ) -> np.ndarray:
         """Compute gating distance between state distribution and measurements.
 
-        A suitable distance threshold can be obtained from `chi2inv95`. If `only_position` is False, the chi-square
-        distribution has 4 degrees of freedom, otherwise 2.
+        A suitable distance threshold is the 95% chi-square quantile `scipy.stats.chi2.ppf(0.95, df)`, where the
+        distribution has 4 degrees of freedom (9.4877) when `only_position` is False and 2 (5.9915) otherwise.
 
         Args:
             mean (np.ndarray): Mean vector over the state distribution (8 dimensional).


### PR DESCRIPTION
## summary

`KalmanFilterXYAH.gating_distance` tells readers that "a suitable distance threshold can be obtained from `chi2inv95`", but `chi2inv95` is not defined anywhere in the package — `hasattr(kalman_filter, "chi2inv95")` is `False`, and the module's only public names are `KalmanFilterXYAH` and `KalmanFilterXYWH`. It used to be a module-level lookup table in this file and was removed in #4374; the docstring kept pointing at it. The method is published on the reference site, so the dangling reference reaches docs.ultralytics.com.

This states the threshold in a form the reader can compute, and keeps the degrees-of-freedom distinction the original sentence carried:

```
A suitable distance threshold is the 95% chi-square quantile `scipy.stats.chi2.ppf(0.95, df)`, where the
distribution has 4 degrees of freedom (9.4877) when `only_position` is False and 2 (5.9915) otherwise.
```

Both literals were checked against `scipy.stats.chi2.ppf` and against the values the removed table carried for the same degrees of freedom (`{..., 2: 5.9915, ..., 4: 9.4877, ...}`); they agree to four decimals. Docstring text only — no import is added and no code path changes.

`pytest --doctest-modules ultralytics/trackers/utils/kalman_filter.py` is unchanged at 3 failed, 10 passed, and `python docs/build_reference.py` produces no diff.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Clarifies the `gating_distance` documentation by distinguishing Mahalanobis and Gaussian distance thresholds. 📏

### 📊 Key Changes
- Updated the docstring in `ultralytics/trackers/utils/kalman_filter.py`.
- Documents the 95th-percentile chi-square thresholds:
  - `9.4877` for four degrees of freedom.
  - `5.9915` for two degrees of freedom when `only_position=True`.
- Clarifies that the `"gaussian"` metric returns squared Euclidean distance and does not use these thresholds.

### 🎯 Purpose & Impact
- Helps developers select appropriate gating thresholds for tracker measurements. 🎯
- Prevents incorrect use of chi-square thresholds with the Gaussian distance metric.
- No runtime behavior changes are introduced; this PR improves documentation only. ✅