### PR TITLE
fix: prevent C2PSA division by zero when c < 64

### DIFF
--- a/ultralytics/nn/modules/block.py
+++ b/ultralytics/nn/modules/block.py
@@ -1473,7 +1473,7 @@ class C2PSA(nn.Module):
         self.cv1 = Conv(c1, 2 * self.c, 1, 1)
         self.cv2 = Conv(2 * self.c, c1, 1)
 
-        self.m = nn.Sequential(*(PSABlock(self.c, attn_ratio=0.5, num_heads=self.c // 64) for _ in range(n)))
+        self.m = nn.Sequential(*(PSABlock(self.c, attn_ratio=0.5, num_heads=max(self.c // 64, 1)) for _ in range(n)))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Process the input tensor through a series of PSA blocks.


### PR DESCRIPTION
Fixes #25056

When `c < 64` in C2PSA, `num_heads = c // 64` evaluates to 0, causing PSABlock to fail. Add `max(..., 1)` consistent with sibling modules like Attention.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Prevents C2PSA initialization failures when the internal channel count is below 64 by enforcing at least one PSA attention head. 🛠️

### 📊 Key Changes
- Updates C2PSA to use `max(self.c // 64, 1)` for `num_heads`.
- Keeps the existing behavior for channel counts of 64 or greater.
- Applies a minimal, targeted fix in `ultralytics/nn/modules/block.py`.

### 🎯 Purpose & Impact
- Prevents division-by-zero or invalid attention configuration errors for smaller channel sizes.
- Improves model robustness for architectures and configurations using `c < 64`.
- Has no expected impact on standard configurations with larger channel counts. ✅