### PR TITLE
fix: add non-negative validation for loss-related float config args

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -268,6 +268,14 @@ CFG_INT_MIN = {  # minimum valid values for integer arguments used as divisors, 
     "vid_stride": 1,
     "seed": 0,
 }
+CFG_FLOAT_MIN = {  # minimum valid values for float arguments that must be non-negative
+    "dis": 0.0,
+    "box": 0.0,
+    "cls": 0.0,
+    "dfl": 0.0,
+    "pose": 0.0,
+    "kobj": 0.0,
+}
 CFG_BOOL_KEYS = frozenset(
     {  # boolean-only arguments
         "save",
@@ -428,6 +436,8 @@ def check_cfg(cfg: dict, hard: bool = True) -> None:
                         f"Valid '{k}' types are int (i.e. '{k}=0') or float (i.e. '{k}=0.5')"
                     )
                 cfg[k] = float(v)
+            if k in CFG_FLOAT_KEYS and k in CFG_FLOAT_MIN and not cfg.get(k, 0) >= CFG_FLOAT_MIN[k]:
+                raise ValueError(f"'{k}={cfg[k]}' is an invalid value. '{k}' must be >= {CFG_FLOAT_MIN[k]}.")
             elif k == "scale":
                 if isinstance(v, (list, tuple)):
                     if len(v) != 2 or not all(isinstance(x, (int, float)) for x in v):


### PR DESCRIPTION
Fixes #25056

Loss-related float arguments (dis, box, cls, dfl, pose, kobj) accept negative values via CLI without error. This adds a CFG_FLOAT_MIN dictionary and validates the post-conversion float value in check_cfg(), catching both negative inputs and NaN.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds non-negative validation for loss-related float configuration arguments.

### 📊 Key Changes
- Introduces minimum-value rules for `dis`, `box`, `cls`, `dfl`, `pose`, and `kobj`.
- Raises a clear `ValueError` when any of these arguments is configured below zero.
- Applies validation during configuration checking after float conversion.

### 🎯 Purpose & Impact
- Prevents invalid negative loss weights from reaching training workflows.
- Provides earlier, clearer feedback for configuration errors.
- Improves training reliability while preserving existing handling of valid values.