### PR TITLE
fix: preserve text ordering during dedup in BaseMixTransform

### DIFF
--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -422,7 +422,7 @@ class BaseMixTransform(BaseTransform):
             return labels
 
         mix_texts = [*labels["texts"], *(item for x in labels["mix_labels"] for item in x["texts"])]
-        mix_texts = list({tuple(x) for x in mix_texts})
+        mix_texts = list(dict.fromkeys(tuple(x) for x in mix_texts))
         text2id = {text: i for i, text in enumerate(mix_texts)}
 
         for label in [labels] + labels["mix_labels"]:


### PR DESCRIPTION
Fixes #25056

set() deduplication in _update_label_text breaks the index→text mapping because sets are unordered. Replace with dict.fromkeys() which preserves insertion order while still deduplicating.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Preserves the original text ordering when deduplicating text labels in `BaseMixTransform`.

### 📊 Key Changes
- Replaces unordered set-based deduplication with insertion-order-preserving dictionary-based deduplication.
- Keeps text-to-ID mappings aligned with the order in which texts first appear.

### 🎯 Purpose & Impact
- 🐛 Fixes inconsistent text ordering and potentially unstable text IDs during mixed-label augmentation.
- ✅ Improves reproducibility and ensures existing text references remain correctly aligned after deduplication.
- 🔧 Limited, targeted Python change with no expected impact outside text-label processing.