### PR TITLE
fix: guard empty category_freq and remove redundant list() in collate_fn

### DIFF
--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -354,6 +354,8 @@ class YOLODataset(BaseDataset):
     @staticmethod
     def _get_neg_texts(category_freq: dict) -> list[str]:
         """Get negative text samples with frequency above the dataset threshold."""
+        if not category_freq:
+            return []
         threshold = min(max(category_freq.values()), 100)
         return [k for k, v in category_freq.items() if v >= threshold]
 
@@ -414,7 +416,7 @@ class YOLODataset(BaseDataset):
         new_batch = {}
         batch = [dict(sorted(b.items())) for b in batch]  # make sure the keys are in the same order
         keys = batch[0].keys()
-        values = list(zip(*[list(b.values()) for b in batch]))
+        values = list(zip(*[b.values() for b in batch]))
         for i, k in enumerate(keys):
             value = values[i]
             if k in {"img", "text_feats", "semantic_mask", "sem_masks", "depth"}:


### PR DESCRIPTION
Fixes #25056

- _get_neg_texts: return early on empty category_freq dict to avoid ValueError from max()
- collate_fn: remove inner list() wrapping on dict.values() which is already a view

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Guards against empty category-frequency inputs and simplifies batch collation in the dataset pipeline. 🛠️

### 📊 Key Changes
- Returns an empty list from `_get_neg_texts()` when `category_freq` is empty, preventing invalid threshold calculation.
- Removes the redundant `list()` conversion when collecting batch dictionary values in `collate_fn()`.

### 🎯 Purpose & Impact
- Improves robustness for datasets without category-frequency data.
- Reduces unnecessary intermediate list creation during collation while preserving behavior.
- No user-facing API changes are expected. ✅