### PR TITLE
docs: fix missing 'to' in Probs description

### DIFF
--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -755,7 +755,7 @@ For more details see the [`Keypoints` class documentation](../reference/engine/r
 
 ### Probs
 
-`Probs` object can be used index, get `top1` and `top5` indices and scores of classification.
+`Probs` object can be used to index, get `top1` and `top5` indices and scores of classification.
 
 !!! example "Probs"
 

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -755,7 +755,7 @@ For more details see the [`Keypoints` class documentation](../reference/engine/r
 
 ### Probs
 
-`Probs` object can be used to index, get `top1` and `top5` indices and scores of classification.
+`Probs` object can be used to obtain `top1` and `top5` classification indices and scores.
 
 !!! example "Probs"
 


### PR DESCRIPTION
Fix grammar: 'can be used index' → 'can be used to index'.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Corrects a grammatical omission in the `Probs` object description within the prediction documentation. ✨

### 📊 Key Changes
- Updated the `Probs` description in `docs/en/modes/predict.md` to include the missing “to” in “can be used to index.”

### 🎯 Purpose & Impact
- Improves the clarity and grammatical accuracy of the classification prediction documentation.
- Helps users better understand how to index `Probs` objects and access `top1` and `top5` results. 📚