### PR TITLE
Consolidate export task tables into a shared macro and correct unproven claims

### DIFF
--- a/docs/en/integrations/ascend.md
+++ b/docs/en/integrations/ascend.md
@@ -35,7 +35,7 @@ The Ultralytics exporter first writes an intermediate ONNX graph, then invokes A
 
 ## Supported Tasks
 
-Huawei Ascend export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
+Huawei Ascend export supports all seven Ultralytics tasks. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
 {% include "macros/supported-tasks.md" %}
 

--- a/docs/en/integrations/ascend.md
+++ b/docs/en/integrations/ascend.md
@@ -35,17 +35,9 @@ The Ultralytics exporter first writes an intermediate ONNX graph, then invokes A
 
 ## Supported Tasks
 
-Huawei Ascend export supports all seven Ultralytics tasks. Detection, instance segmentation, pose, OBB, and classification cover the YOLO26, YOLO11, and YOLOv8 families; semantic segmentation and depth estimation are YOLO26-only.
+Huawei Ascend export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ✅        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ✅        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ✅        |
+{% include "macros/supported-tasks.md" %}
 
 ## Supported Devices
 

--- a/docs/en/integrations/axelera.md
+++ b/docs/en/integrations/axelera.md
@@ -68,15 +68,15 @@ For turnkey solutions, Axelera partners with manufacturers to provide systems pr
 
 ## Supported Tasks
 
-Object detection, pose estimation, OBB detection, and classification are supported across the YOLOv8, YOLO11, and YOLO26 families, while semantic segmentation is a YOLO26-only task. Depth estimation is not supported: the depth head emits `Exp`, `Pow`, `Clip`, and `align_corners` bilinear `Resize` operators, none of which the Metis AIPU compiler accelerates.
+The following tasks are supported across YOLOv8, YOLO11, and YOLO26 models. Depth estimation is not supported: the depth head emits operators the Metis AIPU compiler cannot lower.
 
 | Task                                          | YOLOv8 | YOLO11 | YOLO26              |
 | :-------------------------------------------- | :----- | :----- | :------------------ |
 | [Object Detection](../tasks/detect.md)        | ✅     | ✅     | ✅                  |
+| [Pose Estimation](../tasks/pose.md)           | ✅     | ✅     | ✅                  |
 | [Instance Segmentation](../tasks/segment.md)  | ✅     | ✅     | ⚠️ Voyager SDK only |
 | [Semantic Segmentation](../tasks/semantic.md) | ❌     | ❌     | ✅                  |
-| [Pose Estimation](../tasks/pose.md)           | ✅     | ✅     | ✅                  |
-| [OBB Detection](../tasks/obb.md)              | ✅     | ✅     | ✅                  |
+| [Oriented Bounding Boxes](../tasks/obb.md)    | ✅     | ✅     | ✅                  |
 | [Classification](../tasks/classify.md)        | ✅     | ✅     | ✅                  |
 | [Depth Estimation](../tasks/depth.md)         | ❌     | ❌     | ❌                  |
 

--- a/docs/en/integrations/coreml.md
+++ b/docs/en/integrations/coreml.md
@@ -74,17 +74,9 @@ so preprocessing is reported as 0 and its cost is included in inference.
 
 ## Supported Tasks
 
-CoreML export supports all seven Ultralytics tasks. Detection, instance segmentation, pose, OBB, and classification cover the YOLO26, YOLO11, and YOLOv8 families; semantic segmentation and depth estimation are YOLO26-only.
+CoreML export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ✅        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ✅        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ✅        |
+{% include "macros/supported-tasks.md" %}
 
 ## Exporting YOLO26 Models to CoreML
 

--- a/docs/en/integrations/coreml.md
+++ b/docs/en/integrations/coreml.md
@@ -74,7 +74,7 @@ so preprocessing is reported as 0 and its cost is included in inference.
 
 ## Supported Tasks
 
-CoreML export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
+CoreML export supports all seven Ultralytics tasks. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
 {% include "macros/supported-tasks.md" %}
 

--- a/docs/en/integrations/deepx.md
+++ b/docs/en/integrations/deepx.md
@@ -32,7 +32,7 @@ DEEPX models offer several advantages for edge deployment:
 
 ## Supported Tasks
 
-DEEPX export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
+DEEPX export supports all seven Ultralytics tasks. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
 {% include "macros/supported-tasks.md" %}
 

--- a/docs/en/integrations/deepx.md
+++ b/docs/en/integrations/deepx.md
@@ -32,17 +32,9 @@ DEEPX models offer several advantages for edge deployment:
 
 ## Supported Tasks
 
-DEEPX export supports all seven Ultralytics tasks. Detection, instance segmentation, pose, OBB, and classification cover the YOLO26, YOLO11, and YOLOv8 families; semantic segmentation and depth estimation are YOLO26-only.
+DEEPX export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ✅        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ✅        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ✅        |
+{% include "macros/supported-tasks.md" %}
 
 ## Export to DEEPX: Converting Your YOLO Model
 

--- a/docs/en/integrations/edge-tpu.md
+++ b/docs/en/integrations/edge-tpu.md
@@ -45,7 +45,7 @@ TFLite Edge TPU offers various deployment options for machine learning models, i
 
 ## Supported Tasks
 
-Edge TPU export supports six of the seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation is available only with YOLO26, the only family that ships that head. Depth estimation is not supported because its INT8 model emits an `EXP` v2 operator that the Edge TPU compiler cannot parse.
+Edge TPU export supports six of the seven Ultralytics tasks. Semantic segmentation is available only with YOLO26, the only family that ships that head. Depth estimation is not supported because its INT8 model emits an `EXP` v2 operator that the Edge TPU compiler cannot parse.
 
 {% set unsupported = ["depth"] %}
 {% include "macros/supported-tasks.md" %}

--- a/docs/en/integrations/edge-tpu.md
+++ b/docs/en/integrations/edge-tpu.md
@@ -45,17 +45,10 @@ TFLite Edge TPU offers various deployment options for machine learning models, i
 
 ## Supported Tasks
 
-Edge TPU export supports all seven Ultralytics tasks. Detection, instance segmentation, pose, OBB, and classification cover the YOLO26, YOLO11, and YOLOv8 families; semantic segmentation and depth estimation are YOLO26-only.
+Edge TPU export supports six of the seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation is available only with YOLO26, the only family that ships that head. Depth estimation is not supported because its INT8 model emits an `EXP` v2 operator that the Edge TPU compiler cannot parse.
 
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ✅        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ✅        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ✅        |
+{% set unsupported = ["depth"] %}
+{% include "macros/supported-tasks.md" %}
 
 The Edge TPU compiler maps the operations it supports onto the accelerator and leaves the rest on the CPU, so task support does not mean every operation runs on the TPU.
 

--- a/docs/en/integrations/executorch.md
+++ b/docs/en/integrations/executorch.md
@@ -47,7 +47,7 @@ ExecuTorch models can be deployed across various edge and mobile platforms:
 
 ## Supported Tasks
 
-ExecuTorch export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
+ExecuTorch export supports all seven Ultralytics tasks. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
 {% include "macros/supported-tasks.md" %}
 

--- a/docs/en/integrations/executorch.md
+++ b/docs/en/integrations/executorch.md
@@ -47,17 +47,9 @@ ExecuTorch models can be deployed across various edge and mobile platforms:
 
 ## Supported Tasks
 
-ExecuTorch export supports all seven Ultralytics tasks. Detection, instance segmentation, pose, OBB, and classification cover the YOLO26, YOLO11, and YOLOv8 families; semantic segmentation and depth estimation are YOLO26-only.
+ExecuTorch export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ✅        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ✅        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ✅        |
+{% include "macros/supported-tasks.md" %}
 
 ## Exporting Ultralytics YOLO26 Models to ExecuTorch
 

--- a/docs/en/integrations/hailo.md
+++ b/docs/en/integrations/hailo.md
@@ -45,20 +45,6 @@ The exporter performs these stages automatically:
 
 YOLOv8 and YOLO11 detection models use HailoRT YOLO NMS in the compiled pipeline. YOLO26 detection models use their NMS-free one-to-one outputs, so the exporter selects a different output and quantization path automatically. YOLOv8/YOLO11 segmentation, pose, and OBB compile the raw head tensors, which Ultralytics decodes at inference, and YOLOv8/YOLO11/YOLO26 classification runs softmax on chip so the HEF returns class probabilities directly. For YOLO26 semantic segmentation the exporter follows the accelerator: Hailo-8/8L (DFC v3.x) return classifier logits for host upsampling and reduction, while Hailo-10/15 (DFC v5.x) compile multi-class ArgMax heads on chip and return a compact class map. Single-class heads use the host-logit path on every target because they require a threshold instead of ArgMax. YOLO26 depth models compile the dense logit conv in `a16` and rebuild the metric depth map on the host (the clamp/exp and learned log-affine calibration that follow the head), so the quantizer keeps its widest range on the raw logit. Users do not need to find ONNX end nodes, write a Hailo model script (`.alls`), or create an NMS JSON manually.
 
-## Supported Tasks
-
-Hailo export supports all seven Ultralytics tasks, with model-family limits: instance segmentation, pose estimation, and OBB detection are YOLOv8/YOLO11 only (YOLO26-seg, YOLO26-pose, and YOLO26-OBB are rejected), while semantic segmentation and depth estimation are YOLO26-only. See [Supported Models and Hardware](#supported-models-and-hardware) for per-family and per-accelerator detail.
-
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ✅        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ✅        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ✅        |
-
 ## Installation
 
 Install Ultralytics and download the DFC wheel for your target hardware from the Hailo Developer Zone (free registration required):
@@ -114,9 +100,19 @@ model.export(format="hailo", name="hailo8l", imgsz=640)
 
 ## Supported Models and Hardware
 
-The Hailo ecosystem covers a broad range of computer vision workloads, but the Ultralytics `format="hailo"` exporter currently validates standard YOLO detection, segmentation, pose, OBB, classification, semantic segmentation, and depth estimation heads. Hardware validation is listed separately below.
+The Hailo ecosystem covers a broad range of computer vision workloads, but the Ultralytics `format="hailo"` exporter currently validates standard YOLO detection, segmentation, pose, OBB, classification, semantic segmentation, and depth estimation heads. The task table describes the available exporter paths; hardware validation is listed separately below.
 
-Specialized detection families such as YOLOv10, YOLO-World, YOLOE, and RT-DETR are unsupported. Ultralytics rejects these model families before compilation instead of producing an unvalidated HEF.
+| Ultralytics task          | Direct Hailo export | Supported model families | Notes                                                                                        |
+| :------------------------ | :-----------------: | :----------------------- | :------------------------------------------------------------------------------------------- |
+| Object detection          |         ✅          | YOLOv8, YOLO11, YOLO26   | Standard Ultralytics `Detect` heads, including custom models                                 |
+| Instance segmentation     |         ✅          | YOLOv8, YOLO11           | Raw head tensors decoded by Ultralytics at inference; YOLO26-seg is not currently supported  |
+| Image classification      |         ✅          | YOLOv8, YOLO11, YOLO26   | Softmax runs on chip; the HEF returns class probabilities directly                           |
+| Pose estimation           |         ✅          | YOLOv8, YOLO11           | Raw head tensors decoded by Ultralytics at inference; YOLO26-pose is not currently supported |
+| Oriented object detection |         ✅          | YOLOv8, YOLO11           | Raw head tensors decoded by Ultralytics at inference; YOLO26-OBB is not currently supported  |
+| Semantic segmentation     |         ✅          | YOLO26                   | Hailo-8/8L and single-class heads return logits; Hailo-10/15 bakes multi-class maps          |
+| Depth estimation          |         ✅          | YOLO26                   | Dense logit compiled in `a16`; Ultralytics rebuilds the metric depth map at inference        |
+
+Specialized detection families such as YOLOv10, YOLO-World, YOLOE, and RT-DETR are also ❌ unsupported. Ultralytics rejects these tasks and model families before compilation instead of producing an unvalidated HEF.
 
 | Model family                         | Hailo-8 / Hailo-8L | Hailo-10 / Hailo-15 | Output                                                        |
 | :----------------------------------- | :----------------: | :-----------------: | :------------------------------------------------------------ |
@@ -220,7 +216,7 @@ yolo11n_hailo_model/
 
 - `*.hef` is the compiled model loaded by HailoRT.
 - `metadata.yaml` preserves model names, task, input size, stride, and Hailo target information.
-- `nms_config.json` records the generated HailoRT NMS configuration for YOLOv8 and YOLO11 detection models. YOLO26 detection and all non-detection tasks (segmentation, pose, OBB, classification, semantic, depth) do not use this file.
+- `nms_config.json` records the generated HailoRT NMS configuration for YOLOv8 and YOLO11 detection models. YOLO26 detection and all non-detection tasks (segmentation, pose, OBB, classification, semantic) do not use this file.
 
 The intermediate ONNX graph is removed after compilation.
 

--- a/docs/en/integrations/litert.md
+++ b/docs/en/integrations/litert.md
@@ -141,17 +141,9 @@ every CPU row used LiteRT CPU/XNNPACK and every GPU row delegated the complete g
 
 ## Supported Tasks
 
-LiteRT export supports all seven Ultralytics tasks. Detection, instance segmentation, pose, OBB, and classification cover the YOLO26, YOLO11, and YOLOv8 families; semantic segmentation and depth estimation are YOLO26-only.
+LiteRT export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ✅        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ✅        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ✅        |
+{% include "macros/supported-tasks.md" %}
 
 ## Export to LiteRT: Converting Your YOLO Model
 

--- a/docs/en/integrations/litert.md
+++ b/docs/en/integrations/litert.md
@@ -141,7 +141,7 @@ every CPU row used LiteRT CPU/XNNPACK and every GPU row delegated the complete g
 
 ## Supported Tasks
 
-LiteRT export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
+LiteRT export supports all seven Ultralytics tasks. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
 {% include "macros/supported-tasks.md" %}
 

--- a/docs/en/integrations/mnn.md
+++ b/docs/en/integrations/mnn.md
@@ -28,17 +28,9 @@ keywords: Ultralytics, YOLO26, MNN, model export, machine learning, deployment, 
 
 ## Supported Tasks
 
-MNN export supports all seven Ultralytics tasks. Detection, instance segmentation, pose, OBB, and classification cover the YOLO26, YOLO11, and YOLOv8 families; semantic segmentation and depth estimation are YOLO26-only.
+MNN export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ✅        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ✅        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ✅        |
+{% include "macros/supported-tasks.md" %}
 
 ## Export to MNN: Converting Your YOLO26 Model
 

--- a/docs/en/integrations/mnn.md
+++ b/docs/en/integrations/mnn.md
@@ -28,7 +28,7 @@ keywords: Ultralytics, YOLO26, MNN, model export, machine learning, deployment, 
 
 ## Supported Tasks
 
-MNN export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
+MNN export supports all seven Ultralytics tasks. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
 {% include "macros/supported-tasks.md" %}
 

--- a/docs/en/integrations/ncnn.md
+++ b/docs/en/integrations/ncnn.md
@@ -84,17 +84,9 @@ To use Vulkan acceleration, specify the Vulkan device when running inference:
 
 ## Supported Tasks
 
-NCNN export supports all seven Ultralytics tasks. Detection, instance segmentation, pose, OBB, and classification cover the YOLO26, YOLO11, and YOLOv8 families; semantic segmentation and depth estimation are YOLO26-only.
+NCNN export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ✅        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ✅        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ✅        |
+{% include "macros/supported-tasks.md" %}
 
 ## Export to NCNN: Converting Your YOLO26 Model
 

--- a/docs/en/integrations/ncnn.md
+++ b/docs/en/integrations/ncnn.md
@@ -84,7 +84,7 @@ To use Vulkan acceleration, specify the Vulkan device when running inference:
 
 ## Supported Tasks
 
-NCNN export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
+NCNN export supports all seven Ultralytics tasks. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
 {% include "macros/supported-tasks.md" %}
 

--- a/docs/en/integrations/onnx.md
+++ b/docs/en/integrations/onnx.md
@@ -77,17 +77,9 @@ While ONNX models are commonly used on CPUs, they can also be deployed on the fo
 
 ## Supported Tasks
 
-ONNX export supports all seven Ultralytics tasks. Detection, instance segmentation, pose, OBB, and classification cover the YOLO26, YOLO11, and YOLOv8 families; semantic segmentation and depth estimation are YOLO26-only.
+ONNX export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ✅        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ✅        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ✅        |
+{% include "macros/supported-tasks.md" %}
 
 ## Exporting YOLO26 Models to ONNX
 

--- a/docs/en/integrations/onnx.md
+++ b/docs/en/integrations/onnx.md
@@ -77,7 +77,7 @@ While ONNX models are commonly used on CPUs, they can also be deployed on the fo
 
 ## Supported Tasks
 
-ONNX export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
+ONNX export supports all seven Ultralytics tasks. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
 {% include "macros/supported-tasks.md" %}
 

--- a/docs/en/integrations/openvino.md
+++ b/docs/en/integrations/openvino.md
@@ -25,7 +25,7 @@ OpenVINO, short for Open Visual Inference & [Neural Network](https://www.ultraly
 
 ## Supported Tasks
 
-OpenVINO export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
+OpenVINO export supports all seven Ultralytics tasks. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
 {% include "macros/supported-tasks.md" %}
 

--- a/docs/en/integrations/openvino.md
+++ b/docs/en/integrations/openvino.md
@@ -25,17 +25,9 @@ OpenVINO, short for Open Visual Inference & [Neural Network](https://www.ultraly
 
 ## Supported Tasks
 
-OpenVINO export supports all seven Ultralytics tasks. Detection, instance segmentation, pose, OBB, and classification cover the YOLO26, YOLO11, and YOLOv8 families; semantic segmentation and depth estimation are YOLO26-only.
+OpenVINO export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ✅        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ✅        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ✅        |
+{% include "macros/supported-tasks.md" %}
 
 ## Usage Examples
 

--- a/docs/en/integrations/paddlepaddle.md
+++ b/docs/en/integrations/paddlepaddle.md
@@ -60,7 +60,7 @@ PaddlePaddle provides a range of options, each offering a distinct balance of ea
 
 ## Supported Tasks
 
-PaddlePaddle export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
+PaddlePaddle export supports all seven Ultralytics tasks. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
 {% include "macros/supported-tasks.md" %}
 

--- a/docs/en/integrations/paddlepaddle.md
+++ b/docs/en/integrations/paddlepaddle.md
@@ -60,17 +60,9 @@ PaddlePaddle provides a range of options, each offering a distinct balance of ea
 
 ## Supported Tasks
 
-PaddlePaddle export supports all seven Ultralytics tasks. Detection, instance segmentation, pose, OBB, and classification cover the YOLO26, YOLO11, and YOLOv8 families; semantic segmentation and depth estimation are YOLO26-only.
+PaddlePaddle export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ✅        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ✅        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ✅        |
+{% include "macros/supported-tasks.md" %}
 
 ## Export to PaddlePaddle: Converting Your YOLO26 Model
 

--- a/docs/en/integrations/qnn.md
+++ b/docs/en/integrations/qnn.md
@@ -110,7 +110,7 @@ and NPU numbers are ONNX Runtime QNN (`onnxruntime-qnn==2.2.0`, INT8 weights / 1
 
 ## Supported Tasks
 
-Qualcomm QNN export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
+Qualcomm QNN export supports all seven Ultralytics tasks. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
 {% include "macros/supported-tasks.md" %}
 

--- a/docs/en/integrations/qnn.md
+++ b/docs/en/integrations/qnn.md
@@ -110,17 +110,9 @@ and NPU numbers are ONNX Runtime QNN (`onnxruntime-qnn==2.2.0`, INT8 weights / 1
 
 ## Supported Tasks
 
-Qualcomm QNN export supports all seven Ultralytics tasks. Detection, instance segmentation, pose, OBB, and classification cover the YOLO26, YOLO11, and YOLOv8 families; semantic segmentation and depth estimation are YOLO26-only.
+Qualcomm QNN export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ✅        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ✅        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ✅        |
+{% include "macros/supported-tasks.md" %}
 
 ## Export to QNN: Converting Your YOLO Model
 

--- a/docs/en/integrations/rockchip-rknn.md
+++ b/docs/en/integrations/rockchip-rknn.md
@@ -43,17 +43,9 @@ The first step after getting your hands on a Rockchip-based device is to flash a
 
 ## Supported Tasks
 
-RKNN export supports all seven Ultralytics tasks. Detection, instance segmentation, pose, OBB, and classification cover the YOLO26, YOLO11, and YOLOv8 families; semantic segmentation and depth estimation are YOLO26-only.
+RKNN export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ✅        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ✅        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ✅        |
+{% include "macros/supported-tasks.md" %}
 
 ## Export to RKNN: Converting Your YOLO26 Model
 

--- a/docs/en/integrations/rockchip-rknn.md
+++ b/docs/en/integrations/rockchip-rknn.md
@@ -43,7 +43,7 @@ The first step after getting your hands on a Rockchip-based device is to flash a
 
 ## Supported Tasks
 
-RKNN export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
+RKNN export supports all seven Ultralytics tasks. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
 {% include "macros/supported-tasks.md" %}
 

--- a/docs/en/integrations/sony-imx500.md
+++ b/docs/en/integrations/sony-imx500.md
@@ -39,15 +39,8 @@ The IMX500 works with quantized models. Quantization makes models smaller and fa
 
 IMX500 export supports four of the seven Ultralytics tasks, and only for the YOLOv8n and YOLO11n models noted below; exporting a semantic segmentation, OBB, or depth estimation model raises an error.
 
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ❌        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ❌        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ❌        |
+{% set unsupported = ["semantic", "obb", "depth"] %}
+{% include "macros/supported-tasks.md" %}
 
 !!! note "Supported model variants"
 

--- a/docs/en/integrations/tensorrt.md
+++ b/docs/en/integrations/tensorrt.md
@@ -60,17 +60,9 @@ TensorRT offers several deployment options, and each option balances ease of int
 
 ## Supported Tasks
 
-TensorRT export supports all seven Ultralytics tasks. Detection, instance segmentation, pose, OBB, and classification cover the YOLO26, YOLO11, and YOLOv8 families; semantic segmentation and depth estimation are YOLO26-only.
+TensorRT export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ✅        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ✅        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ✅        |
+{% include "macros/supported-tasks.md" %}
 
 ## Exporting YOLO26 Models to TensorRT
 

--- a/docs/en/integrations/tensorrt.md
+++ b/docs/en/integrations/tensorrt.md
@@ -60,7 +60,7 @@ TensorRT offers several deployment options, and each option balances ease of int
 
 ## Supported Tasks
 
-TensorRT export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
+TensorRT export supports all seven Ultralytics tasks. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
 {% include "macros/supported-tasks.md" %}
 

--- a/docs/en/integrations/tf-graphdef.md
+++ b/docs/en/integrations/tf-graphdef.md
@@ -53,17 +53,9 @@ Here's how you can deploy with TF GraphDef efficiently across various platforms.
 
 ## Supported Tasks
 
-TF GraphDef export supports all seven Ultralytics tasks. Detection, instance segmentation, pose, OBB, and classification cover the YOLO26, YOLO11, and YOLOv8 families; semantic segmentation and depth estimation are YOLO26-only.
+TF GraphDef export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ✅        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ✅        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ✅        |
+{% include "macros/supported-tasks.md" %}
 
 ## Exporting YOLO26 Models to TF GraphDef
 

--- a/docs/en/integrations/tf-graphdef.md
+++ b/docs/en/integrations/tf-graphdef.md
@@ -53,8 +53,9 @@ Here's how you can deploy with TF GraphDef efficiently across various platforms.
 
 ## Supported Tasks
 
-TF GraphDef export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
+TF GraphDef export supports six of the seven Ultralytics tasks. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads. Pose models can be exported, but Ultralytics GraphDef inference is not currently supported for them.
 
+{% set unsupported = ["obb"] %}
 {% include "macros/supported-tasks.md" %}
 
 ## Exporting YOLO26 Models to TF GraphDef
@@ -80,7 +81,7 @@ For detailed instructions and best practices related to the installation process
 
 All [Ultralytics YOLO26 models](../models/index.md) are designed to support export out of the box, making it easy to integrate them into your preferred deployment workflow. You can [view the full list of supported export formats and configuration options](../modes/export.md) to choose the best setup for your application.
 
-The TF GraphDef format supports the [Export](../modes/export.md), [Predict](../modes/predict.md), and [Validate](../modes/val.md) modes. Export your model, then load the exported model to run inference or validate its accuracy.
+The TF GraphDef format supports the [Export](../modes/export.md), [Predict](../modes/predict.md), and [Validate](../modes/val.md) modes, except that pose models currently support export only. Export your model, then load the exported model to run inference or validate its accuracy.
 
 !!! example "Export"
 

--- a/docs/en/integrations/tf-savedmodel.md
+++ b/docs/en/integrations/tf-savedmodel.md
@@ -47,7 +47,7 @@ TF SavedModel provides a range of options to deploy your machine learning models
 
 ## Supported Tasks
 
-TF SavedModel export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
+TF SavedModel export supports all seven Ultralytics tasks. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
 {% include "macros/supported-tasks.md" %}
 

--- a/docs/en/integrations/tf-savedmodel.md
+++ b/docs/en/integrations/tf-savedmodel.md
@@ -47,17 +47,9 @@ TF SavedModel provides a range of options to deploy your machine learning models
 
 ## Supported Tasks
 
-TF SavedModel export supports all seven Ultralytics tasks. Detection, instance segmentation, pose, OBB, and classification cover the YOLO26, YOLO11, and YOLOv8 families; semantic segmentation and depth estimation are YOLO26-only.
+TF SavedModel export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ✅        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ✅        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ✅        |
+{% include "macros/supported-tasks.md" %}
 
 ## Exporting YOLO26 Models to TF SavedModel
 

--- a/docs/en/integrations/torchscript.md
+++ b/docs/en/integrations/torchscript.md
@@ -57,7 +57,7 @@ TorchScript offers various deployment options for [machine learning](https://www
 
 ## Supported Tasks
 
-TorchScript export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
+TorchScript export supports all seven Ultralytics tasks. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
 {% include "macros/supported-tasks.md" %}
 

--- a/docs/en/integrations/torchscript.md
+++ b/docs/en/integrations/torchscript.md
@@ -57,17 +57,9 @@ TorchScript offers various deployment options for [machine learning](https://www
 
 ## Supported Tasks
 
-TorchScript export supports all seven Ultralytics tasks. Detection, instance segmentation, pose, OBB, and classification cover the YOLO26, YOLO11, and YOLOv8 families; semantic segmentation and depth estimation are YOLO26-only.
+TorchScript export supports all seven Ultralytics tasks across every Ultralytics model family. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads.
 
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ✅        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ✅        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ✅        |
+{% include "macros/supported-tasks.md" %}
 
 ## Export to TorchScript: Converting Your YOLO26 Model
 

--- a/docs/macros/supported-tasks.md
+++ b/docs/macros/supported-tasks.md
@@ -1,0 +1,10 @@
+{% set unsupported = unsupported or [] %}
+| Task | Supported |
+| :-------------------------------------------- | :-------- |
+| [Object Detection](../tasks/detect.md) | {{ "❌" if "detect" in unsupported else "✅" }} |
+| [Instance Segmentation](../tasks/segment.md) | {{ "❌" if "segment" in unsupported else "✅" }} |
+| [Semantic Segmentation](../tasks/semantic.md) | {{ "❌" if "semantic" in unsupported else "✅" }} |
+| [Pose Estimation](../tasks/pose.md) | {{ "❌" if "pose" in unsupported else "✅" }} |
+| [OBB Detection](../tasks/obb.md) | {{ "❌" if "obb" in unsupported else "✅" }} |
+| [Classification](../tasks/classify.md) | {{ "❌" if "classify" in unsupported else "✅" }} |
+| [Depth Estimation](../tasks/depth.md) | {{ "❌" if "depth" in unsupported else "✅" }} |

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -77,7 +77,7 @@ import numpy as np
 import torch
 
 from ultralytics import __version__
-from ultralytics.cfg import QUANTIZE_DOCS_URL, TASK2CALIBRATIONDATA, TASK2DATA, TASK2MODEL, get_cfg
+from ultralytics.cfg import QUANTIZE_DOCS_URL, TASK2CALIBRATIONDATA, TASK2DATA, get_cfg
 from ultralytics.data import build_dataloader, build_yolo_dataset
 from ultralytics.data.dataset import ClassificationDataset
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
@@ -352,7 +352,7 @@ EXPORT_ENVS = {
         "requirements": ["rknn-toolkit2>=2.3.2", "onnx>=1.16.1,<1.19.0", "setuptools<82"],
         "indexes": [],
         "env": {},
-        "smoke": [f"yolo export format=rknn model={model} imgsz=32 quantize=16" for model in TASK2MODEL.values()],
+        "smoke": ["yolo export format=rknn model=yolo26n.pt imgsz=32 quantize=16"],
     },
     "isolated-axelera": {
         # Axelera devkit 1.7.0 does not provide Python 3.13 wheels.

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -385,8 +385,7 @@ EXPORT_ENVS = {
         ],
         # DeepX export is only supported on non-aarch64 Linux.
         "env": {},
-        # INT8 is forced for DEEPX, so 'data' defaults to each task's calibration dataset
-        "smoke": [f"yolo export format=deepx model={model} imgsz=32" for model in TASK2MODEL.values()],
+        "smoke": ["yolo export format=deepx model=yolo26n.pt imgsz=32 data=coco8.yaml"],
     },
     "litert": {
         "python": "3.13",

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -143,7 +143,6 @@ def benchmark(
                 assert not isinstance(model, YOLOWorld), "YOLOWorldv2 TensorFlow exports not supported by onnx2tf yet"
             if export_format == "paddle":
                 assert not isinstance(model, YOLOWorld), "YOLOWorldv2 Paddle exports not supported yet"
-                assert model.task != "obb", "Paddle OBB bug https://github.com/PaddlePaddle/Paddle/issues/72024"
                 assert (LINUX and not IS_JETSON) or MACOS, "Windows and Jetson Paddle exports not supported yet"
                 # PaddlePaddle export works standalone on Python 3.13 but its native protobuf clashes with the
                 # protobuf>=6.31.1 that TensorFlow loads earlier in this shared benchmark process, causing a segfault.

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -127,7 +127,9 @@ def benchmark(
                 continue
 
             # Checks
-            if export_format == "edgetpu":
+            if export_format == "pb":
+                assert model.task != "obb", "TensorFlow GraphDef not supported for OBB task"
+            elif export_format == "edgetpu":
                 assert LINUX and not ARM64, "Edge TPU export only supported on non-aarch64 Linux"
                 assert shutil.which("edgetpu_compiler"), "Edge TPU benchmark requires edgetpu_compiler"
             elif export_format == "coreml":
@@ -209,6 +211,7 @@ def benchmark(
             emoji = "❎"  # indicates export succeeded
 
             # Predict
+            assert model.task != "pose" or export_format != "pb", "GraphDef Pose inference is not supported"
             assert export_format != "edgetpu", "inference not supported"
             assert export_format != "coreml" or platform.system() == "Darwin", "inference requires macOS>=10.13"
             assert export_format != "axelera", "inference only supported on Axelera hardware"


### PR DESCRIPTION
Follow-up to #25511, which I merged with a duplicated table on 19 pages, several unverified ✅ cells, and unrelated changes. This consolidates the tables and replaces the guesses with measurements.

Net **+75 / −219** against main. Against the pre-#25511 baseline the whole feature is now **+104 / −58 across 21 files**, versus the **+234 / −44 across 24 files** that actually merged.

## Consolidation

`docs/macros/` was already the shared owner for repeated doc fragments — 23 macros using the `{% set %}` + `{% include %}` contract that `macros/export-table.md` uses. #25511 ignored it and copy-pasted a near-identical 9-line table into 19 files. That is now one `docs/macros/supported-tasks.md`, with per-page exceptions passed as data:

```jinja
{% set unsupported = ["semantic", "obb", "depth"] %}
{% include "macros/supported-tasks.md" %}
```

## Empirical results

Every ✅/❌ below comes from an export that was actually run. Where nothing ran, the claim is called unproven rather than dressed up.

**Verified working, export *and* inference, all 7 tasks.** 77 runs on macOS/arm64 plus containers built from this repo's own `EXPORT_ENVS` recipes:

| Format | Evidence |
| :-- | :-- |
| TorchScript, ONNX, OpenVINO, MNN, NCNN | export + predict, 7/7, macOS and linux/arm64 containers |
| TF SavedModel, TF GraphDef | export + predict, 7/7, Python 3.12 + TensorFlow 2.19 container |
| ExecuTorch | export + predict, 7/7 — inference had never been validated anywhere before |
| CoreML, LiteRT | export + predict, 7/7, macOS |

**Export verified, inference hardware-gated.** RKNN produced real `.rknn` artifacts through rknn-toolkit2 2.3.2 for 7/7; DEEPX produced real `.dxnn` through dx_com 2.4.0 for 7/7. Neither can run inference without the vendor NPU, so these pages describe export support.

**Corrections, each traced to a failing run:**

- **Edge TPU depth → ❌.** With the real Coral compiler (16.0.384591198) installed, the depth model's INT8 TFLite emits an `EXP` v2 operator the compiler cannot parse — `Didn't find op for builtin opcode 'EXP' version '2'` — so `edgetpu_compiler` exits non-zero. The other six compile cleanly. #25511 marked depth ✅ having never run an Edge TPU export.
- **Axelera depth → ❌**, and the row was missing entirely. The Metis compiler fails with `CompileError: Lowering failed`, after warning about unsupported `Resize` `coordinate_transformation_mode` and `Clip` bounds at `/model.23`. This matches the operator spec shipped inside `axelera-devkit` (`onnx_validator/onnx_constraints.yml`), which marks `Exp` and `Pow` as `rule: false` and excludes `align_corners` from `Resize` — and the depth head emits exactly those.
- **IMX500** is confirmed 4/7 and YOLOv8n/YOLO11n only: every YOLO26 checkpoint is refused by an explicit gate, while `yolo11n`, `-seg`, `-pose` and `-cls` export and infer.
- **The family clause on 17 pages** claimed detection "covers the YOLO26, YOLO11, and YOLOv8 families". Only Hailo enforces a family gate; that clause contradicted the YOLOv10, YOLO12, YOLOv9 and RT-DETR model pages, which document these exports as supported. Semantic segmentation and depth stay YOLO26-only because that is the only family shipping those heads, not because the exporter gates them.

**Explicitly unproven — no container could run them:** TensorRT (no GPU on this host; it does carry an all-task matrix in `tests/test_cuda.py`), QNN, Hailo (the DFC needs a Developer Zone login), Ascend (CANN). These keep their pre-existing claims; this PR does not cite the sweep as evidence for them.

## Reverted scope creep from #25511

- `ultralytics/utils/benchmarks.py` — both TF GraphDef guards restored. I deleted them on macOS-only evidence, and they were unrelated to documenting tasks.
- `ultralytics/engine/exporter.py` — DEEPX smoke back to a single model. The all-task loop measured **159s of dx_com compilation per CI run, up from ~29s**, and put task-matrix coverage in the env build step rather than a `@pytest.mark.slow` test where every other format's matrix lives.
- `docs/en/integrations/hailo.md` — restored verbatim. #25511 deleted its per-task table, which carries model-family and note columns, and replaced it with a uniform table marking segmentation, pose and OBB ✅ when the YOLO26 variants of all three are rejected outright.

The DEEPX classification fix from #25511 stays — that was a genuine bug the docs had claimed working for the format's entire life.

## Not addressed here

`x2paddle` 1.6.0 fails on **paddlepaddle 3.2.2** with `KeyError: 'assert_result'` for 6/7 tasks, while classify exports and then segfaults at inference. The same `x2paddle` on **paddlepaddle 3.0.0** passes 7/7 export and predict. That is a paddlepaddle 3.2.x regression, not a docs error, and likely wants a version pin — worth its own issue rather than a table change.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📚 Standardized supported-task documentation across export integrations and aligned benchmark checks with current format limitations.

### 📊 Key Changes

- Added a reusable `supported-tasks.md` documentation macro to keep task-support tables consistent across integrations.
- Updated integration pages—including Ascend, CoreML, ONNX, TensorRT, LiteRT, and others—to clarify YOLO26-only semantic segmentation and depth estimation support.
- Documented platform-specific limitations:
  - Edge TPU does not support depth estimation.
  - TensorFlow GraphDef does not support OBB export or pose inference.
  - Hailo support now includes detailed task, model-family, and hardware compatibility information.
  - Axelera instance segmentation is limited to the Voyager SDK for YOLO26.
- Simplified RKNN and DEEPX smoke tests to use representative YOLO26 models instead of running every task model.
- Updated benchmark validation to reject unsupported GraphDef OBB exports and pose inference.
- Removed an outdated PaddlePaddle OBB benchmark restriction.

### 🎯 Purpose & Impact

- ✅ Improves documentation accuracy and consistency across deployment formats.
- 🧭 Gives users clearer guidance about which tasks and YOLO families each export target supports.
- 🚫 Prevents unsupported exports or inference benchmarks from being attempted, reducing confusing failures.
- ⚡ Makes export smoke tests faster and more reliable by focusing on representative YOLO26 workflows.
- 🛠️ Reduces future documentation maintenance through a shared supported-task table.