### PR TITLE
Fix RKNN INT8 exports returning all-zero class scores

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1065,16 +1065,14 @@ class Exporter:
             self.args.simplify = True  # fix OBB runtime error related to topk
 
         model = NMSModel(self.model, self.args) if self.args.nms else self.model
-        # rknn-toolkit2 quantizes output0 with one per-tensor scale, which the pixel-space box channels set: every
-        # score <= 1.0 then rounds to zero. Reuse the LiteRT normalizer so the whole tensor is unit-range
-        # (RKNNBackend denormalizes at runtime). Floating-point RKNN builds keep pixel coordinates.
+        # Normalize coordinates by input size so RKNN's per-tensor INT8 scale preserves class scores.
         if (
             self.args.format == "rknn"
             and self.args.quantize == 8
             and self.model.task in {"detect", "segment", "pose", "obb"}
             and not self.metadata["end2end"]
         ):
-            from ultralytics.utils.export.litert import _NormalizeCoords
+            from ultralytics.utils.export.engine import _NormalizeCoords
 
             model = _NormalizeCoords(
                 model,

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1064,9 +1064,30 @@ class Exporter:
             self.args.opset = opset  # for NMSModel
             self.args.simplify = True  # fix OBB runtime error related to topk
 
+        model = NMSModel(self.model, self.args) if self.args.nms else self.model
+        # rknn-toolkit2 quantizes output0 with one per-tensor scale, which the pixel-space box channels set: every
+        # score <= 1.0 then rounds to zero. Reuse the LiteRT normalizer so the whole tensor is unit-range
+        # (RKNNBackend denormalizes at runtime). Floating-point RKNN builds keep pixel coordinates.
+        if (
+            self.args.format == "rknn"
+            and self.args.quantize == 8
+            and self.model.task in {"detect", "segment", "pose", "obb"}
+            and not self.metadata["end2end"]
+        ):
+            from ultralytics.utils.export.litert import _NormalizeCoords
+
+            model = _NormalizeCoords(
+                model,
+                int(self.im.shape[2]),
+                int(self.im.shape[3]),
+                self.model.task,
+                len(self.metadata["names"]),
+                self.metadata.get("kpt_shape"),
+            )
+
         with arange_patch(dynamic=bool(dynamic), quantize=self.args.quantize, fmt=self.args.format):
             torch2onnx(
-                NMSModel(self.model, self.args) if self.args.nms else self.model,
+                model,
                 self.im,
                 f,
                 opset=opset,
@@ -1480,16 +1501,19 @@ class Exporter:
             output_dir.mkdir(parents=True, exist_ok=True)
             rknn_dataset = output_dir / "dataset.txt"
             rknn_dataset.write_text("\n".join(str(Path(x).resolve()) for x in image_paths) + "\n")
-        return onnx2rknn(
-            onnx_file=f_onnx,
-            output_dir=output_dir,
-            name=self.args.name,
-            quantize=self.args.quantize,
-            batch=self.args.batch,
-            dataset=rknn_dataset,
-            metadata=self.metadata,
-            prefix=prefix,
-        )
+        try:
+            return onnx2rknn(
+                onnx_file=f_onnx,
+                output_dir=output_dir,
+                name=self.args.name,
+                quantize=self.args.quantize,
+                batch=self.args.batch,
+                dataset=rknn_dataset,
+                metadata=self.metadata,
+                prefix=prefix,
+            )
+        finally:
+            Path(f_onnx).unlink(missing_ok=True)  # INT8 graphs hold normalized coordinates, so they are not reusable
 
     @try_export
     def export_ascend(self, prefix=colorstr("Ascend:")):  # noqa: B008

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1513,7 +1513,8 @@ class Exporter:
                 prefix=prefix,
             )
         finally:
-            Path(f_onnx).unlink(missing_ok=True)  # INT8 graphs hold normalized coordinates, so they are not reusable
+            if self.args.quantize == 8:  # INT8 graphs hold normalized coordinates, so they are not reusable
+                Path(f_onnx).unlink(missing_ok=True)
 
     @try_export
     def export_ascend(self, prefix=colorstr("Ascend:")):  # noqa: B008

--- a/ultralytics/nn/backends/rknn.py
+++ b/ultralytics/nn/backends/rknn.py
@@ -60,17 +60,16 @@ class RKNNBackend(BaseBackend):
         """Run inference on the Rockchip NPU.
 
         Args:
-            im (torch.Tensor): Input image tensor in BCHW format, normalized to [0, 1].
+            im (torch.Tensor): Input image tensor in BHWC format, normalized to [0, 1].
 
         Returns:
             (list): Model predictions as a list of output arrays.
         """
-        h, w = im.shape[2:4]
+        h, w = im.shape[1:3]
         im = (im.cpu().numpy() * 255).astype("uint8")
         im = im if isinstance(im, (list, tuple)) else [im]
         y = self.model.inference(inputs=im)
-        # INT8 exports normalize box (and pose keypoint) coordinates to [0, 1] so a single per-tensor scale does not
-        # collapse the class scores (see _NormalizeCoords); undo it here. Floating-point builds are already in pixels.
+        # INT8 exports use input-relative coordinates so a single per-tensor scale preserves class scores.
         if (
             self.metadata.get("args", {}).get("quantize") == 8
             and self.task in {"detect", "segment", "pose", "obb"}

--- a/ultralytics/nn/backends/rknn.py
+++ b/ultralytics/nn/backends/rknn.py
@@ -65,6 +65,23 @@ class RKNNBackend(BaseBackend):
         Returns:
             (list): Model predictions as a list of output arrays.
         """
+        h, w = im.shape[2:4]
         im = (im.cpu().numpy() * 255).astype("uint8")
         im = im if isinstance(im, (list, tuple)) else [im]
-        return self.model.inference(inputs=im)
+        y = self.model.inference(inputs=im)
+        # INT8 exports normalize box (and pose keypoint) coordinates to [0, 1] so a single per-tensor scale does not
+        # collapse the class scores (see _NormalizeCoords); undo it here. Floating-point builds are already in pixels.
+        if (
+            self.metadata.get("args", {}).get("quantize") == 8
+            and self.task in {"detect", "segment", "pose", "obb"}
+            and not self.end2end
+        ):
+            kpt_start = 4 + len(self.names)  # pose keypoints follow the box (4) and class-score (nc) channels
+            for x in y:
+                if x.ndim == 3:
+                    x[:, [0, 2]] *= w
+                    x[:, [1, 3]] *= h
+                    if self.task == "pose":
+                        x[:, kpt_start::3] *= w
+                        x[:, kpt_start + 1 :: 3] *= h
+        return y

--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -13,6 +13,40 @@ from ultralytics.utils.checks import check_requirements, check_tensorrt, check_v
 from ultralytics.utils.torch_utils import TORCH_2_4, TORCH_2_9
 
 
+class _NormalizeCoords(torch.nn.Module):
+    """Wrap a model with input-relative box and pose coordinates for per-tensor quantization."""
+
+    def __init__(self, model: torch.nn.Module, h: int, w: int, task: str, nc: int, kpt_shape: tuple | None):
+        """Initialize with the wrapped model and prediction metadata."""
+        super().__init__()
+        self.model = model
+        self.h = h
+        self.w = w
+        self.task = task
+        self.nc = nc
+        self.kpt_shape = kpt_shape
+
+    def forward(self, x: torch.Tensor):
+        """Run the wrapped model and normalize its coordinate channels by input size."""
+        y = self.model(x)
+        det = y[0] if isinstance(y, (tuple, list)) else y
+        box_wh = torch.tensor([self.w, self.h, self.w, self.h], dtype=det.dtype, device=det.device).view(1, 4, 1)
+        parts = [det[:, :4] / box_wh]
+        if self.task == "pose" and self.kpt_shape:
+            parts.append(det[:, 4 : 4 + self.nc])
+            b, _, a = det.shape
+            kpts = det[:, 4 + self.nc :].view(b, self.kpt_shape[0], self.kpt_shape[1], a)
+            kpt_wh = torch.tensor([self.w, self.h], dtype=det.dtype, device=det.device).view(1, 1, 2, 1)
+            kpts = torch.cat([kpts[:, :, :2] / kpt_wh, kpts[:, :, 2:]], dim=2)
+            parts.append(kpts.reshape(b, -1, a))
+        else:
+            parts.append(det[:, 4 : 4 + self.nc])
+            if det.shape[1] > 4 + self.nc:
+                parts.append(det[:, 4 + self.nc :])
+        det = torch.cat(parts, dim=1)
+        return (det, *y[1:]) if isinstance(y, (tuple, list)) else det
+
+
 def best_onnx_opset(onnx: types.ModuleType, cuda: bool = False, quantize: int | str | None = None) -> int:
     """Return max ONNX opset for this torch version with ONNX fallback."""
     if TORCH_2_4:  # _constants.ONNX_MAX_OPSET first defined in torch 1.13

--- a/ultralytics/utils/export/litert.py
+++ b/ultralytics/utils/export/litert.py
@@ -14,15 +14,20 @@ from ultralytics.utils import LOGGER
 class _NormalizeCoords(torch.nn.Module):
     """Wrap a model so box (and pose keypoint) coordinates are output normalized to [0, 1].
 
-    LiteRT exports trace the raw PyTorch model, whose detection output concatenates pixel-space box coordinates
-    (0-imgsz) with [0, 1] class scores in a single tensor. A single per-tensor INT8 scale cannot represent both ranges,
-    so the scores collapse to zero. Normalizing coordinates to [0, 1] keeps the whole tensor in a unit range so
-    quantization preserves score resolution; ``LiteRTBackend`` denormalizes by image size at runtime.
+    LiteRT and INT8 RKNN exports trace the raw PyTorch model, whose detection output concatenates pixel-space box
+    coordinates (0-imgsz) with [0, 1] class scores in a single tensor. A single per-tensor INT8 scale cannot represent
+    both ranges, so the scores collapse to zero. Normalizing coordinates to [0, 1] keeps the whole tensor in a unit
+    range so quantization preserves score resolution; ``LiteRTBackend`` and ``RKNNBackend`` denormalize by image size at
+    runtime.
 
     Only the coordinate channels are divided — x/width and y/height — so the divisor is uniform-magnitude and quantizes
     cleanly to a single per-tensor scale. (Multiplying the whole tensor by a mixed-magnitude per-channel vector instead
     would round the small coordinate factors to zero and destroy box accuracy.) Per-axis division also supports
-    non-square ``imgsz``; ``LiteRTBackend`` denormalizes by width/height to match.
+    non-square ``imgsz``; the backends denormalize by width/height to match.
+
+    Slices follow the head's own concatenation boundaries (box | class scores | mask coefficients or angle) instead of
+    one ``4:`` tail slice: rknn-toolkit2 gives each concat input its own scale only while every slice maps 1:1 onto one
+    of them, and a slice straddling two inputs inherits the pixel-range scale this wrapper exists to avoid.
     """
 
     def __init__(self, model: torch.nn.Module, h: int, w: int, task: str, nc: int, kpt_shape: tuple | None):
@@ -49,7 +54,9 @@ class _NormalizeCoords(torch.nn.Module):
             kpts = torch.cat([kpts[:, :, :2] / kpt_wh, kpts[:, :, 2:]], dim=2)  # normalize x, y; keep conf
             parts.append(kpts.reshape(b, -1, a))
         else:
-            parts.append(det[:, 4:])  # class scores (+ mask coefficients / angle)
+            parts.append(det[:, 4 : 4 + self.nc])  # class scores
+            if det.shape[1] > 4 + self.nc:
+                parts.append(det[:, 4 + self.nc :])  # segment mask coefficients / obb angle
         det = torch.cat(parts, dim=1)
         return (det, *y[1:]) if isinstance(y, (tuple, list)) else det
 

--- a/ultralytics/utils/export/litert.py
+++ b/ultralytics/utils/export/litert.py
@@ -9,56 +9,7 @@ from pathlib import Path
 import torch
 
 from ultralytics.utils import LOGGER
-
-
-class _NormalizeCoords(torch.nn.Module):
-    """Wrap a model so box (and pose keypoint) coordinates are output normalized to [0, 1].
-
-    LiteRT and INT8 RKNN exports trace the raw PyTorch model, whose detection output concatenates pixel-space box
-    coordinates (0-imgsz) with [0, 1] class scores in a single tensor. A single per-tensor INT8 scale cannot represent
-    both ranges, so the scores collapse to zero. Normalizing coordinates to [0, 1] keeps the whole tensor in a unit
-    range so quantization preserves score resolution; ``LiteRTBackend`` and ``RKNNBackend`` denormalize by image size at
-    runtime.
-
-    Only the coordinate channels are divided — x/width and y/height — so the divisor is uniform-magnitude and quantizes
-    cleanly to a single per-tensor scale. (Multiplying the whole tensor by a mixed-magnitude per-channel vector instead
-    would round the small coordinate factors to zero and destroy box accuracy.) Per-axis division also supports
-    non-square ``imgsz``; the backends denormalize by width/height to match.
-
-    Slices follow the head's own concatenation boundaries (box | class scores | mask coefficients or angle) instead of
-    one ``4:`` tail slice: rknn-toolkit2 gives each concat input its own scale only while every slice maps 1:1 onto one
-    of them, and a slice straddling two inputs inherits the pixel-range scale this wrapper exists to avoid.
-    """
-
-    def __init__(self, model: torch.nn.Module, h: int, w: int, task: str, nc: int, kpt_shape: tuple | None):
-        """Initialize with the wrapped model, input height/width, task, class count and optional keypoint shape."""
-        super().__init__()
-        self.model = model
-        self.h = h
-        self.w = w
-        self.task = task
-        self.nc = nc
-        self.kpt_shape = kpt_shape
-
-    def forward(self, x: torch.Tensor):
-        """Run the wrapped model and normalize coordinate channels of the detection output to [0, 1]."""
-        y = self.model(x)
-        det = y[0] if isinstance(y, (tuple, list)) else y  # segment returns (detections, protos)
-        box_wh = torch.tensor([self.w, self.h, self.w, self.h], dtype=det.dtype, device=det.device).view(1, 4, 1)
-        parts = [det[:, :4] / box_wh]  # box xywh: x,w by width; y,h by height
-        if self.task == "pose" and self.kpt_shape:
-            parts.append(det[:, 4 : 4 + self.nc])  # class scores
-            b, _, a = det.shape
-            kpts = det[:, 4 + self.nc :].view(b, self.kpt_shape[0], self.kpt_shape[1], a)
-            kpt_wh = torch.tensor([self.w, self.h], dtype=det.dtype, device=det.device).view(1, 1, 2, 1)
-            kpts = torch.cat([kpts[:, :, :2] / kpt_wh, kpts[:, :, 2:]], dim=2)  # normalize x, y; keep conf
-            parts.append(kpts.reshape(b, -1, a))
-        else:
-            parts.append(det[:, 4 : 4 + self.nc])  # class scores
-            if det.shape[1] > 4 + self.nc:
-                parts.append(det[:, 4 + self.nc :])  # segment mask coefficients / obb angle
-        det = torch.cat(parts, dim=1)
-        return (det, *y[1:]) if isinstance(y, (tuple, list)) else det
+from ultralytics.utils.export.engine import _NormalizeCoords
 
 
 def torch2litert(
@@ -104,7 +55,7 @@ def torch2litert(
     file = Path(file)
     quant_tag = "_int8" if static_int8 else "_w8a16" if static_int16 else "_w8a32" if dynamic_int8 else ""
 
-    # Normalize coordinate channels to [0, 1] so INT8 quantization preserves scores (denormalized in LiteRTBackend).
+    # Normalize coordinate channels by input size so INT8 quantization preserves scores (denormalized in LiteRTBackend).
     # End-to-end models output post-NMS pixel coordinates in FP32 (no scale collapse), so they are left as-is.
     meta = metadata or {}
     task = meta.get("task")


### PR DESCRIPTION
`yolo export format=rknn quantize=8` produces models whose class scores are all exactly zero. Measured on 8.4.110 with the rknn-toolkit2 2.3.2 simulator (`init_runtime()` with no target), yolo26n at 640, counting non-zero values in the score block of `output0`:

| task | score channels non-zero, before | after | cosine vs FP32 ONNX, after |
|---|---|---|---|
| detect | **0** / 672000 | 558 | 0.9969 |
| segment | **0** / 672000 | 67 | 0.9890 |
| pose | **0** / 8400 | 102 | 0.9986 |
| obb | **0** / 126000 | 100 | 0.9984 |
| obb angle | **0** / 8400 | 8198 | 0.9876 |
| segment mask coefficients | 42784 / 268800 | 258592 | 0.8360 → 0.9967 |

Box coordinates keep their accuracy: cosine 0.9997 for detect and pose on both sides, 0.9990 for segment and 0.9999 for obb after the change (the small segment cost is spelled out below). The obb rows are on a DOTA val image; on `bus.jpg` the FP32 reference itself is weak for obb (max score 0.074), so it is a poor place to read the number. classify, depth and semantic are healthy today (cosine 0.9955 / 0.8574 / 0.9985) and this PR does not touch them. The task table added in #25511 lists all seven as supported, which holds for the FP16 path; under `quantize=8` four of them return nothing.

The head ends in a `Concat` that puts box coordinates in pixels (675 here) next to class scores in [0, 1] inside a single `output0`, and rknn-toolkit2 quantizes that tensor with one per-tensor scale. The box range sets the step, so every score below 1.0 rounds into the zero bucket. The exact scale comes from the calibration set, so the step value is not something I measured directly — what I measured is the outcome, zero scores on the default export path.

### Changes

The repo already owns this problem: `_NormalizeCoords` in `ultralytics/utils/export/litert.py`, whose docstring describes it word for word ("A single per-tensor INT8 scale cannot represent both ranges, so the scores collapse to zero"), applied to the same four tasks and undone at runtime in `LiteRTBackend.forward`. So this PR extends that owner instead of adding a parallel path: the wrapper is now also applied on the INT8 RKNN export, and `RKNNBackend.forward` denormalises the same way `LiteRTBackend` does.

`export_rknn` also drops the intermediate ONNX on INT8 exports, the way `export_hailo` already does. Without that, an INT8 export leaves a `.onnx` holding normalised coordinates next to the model, and loading it directly gives boxes squashed into [0, 1] with no warning. FP16 exports keep theirs, since those coordinates stay in pixels and the file is still usable.

One detail is what separates the four tasks, and it is the reason this is not a two-line change. `_NormalizeCoords` slices the output *after* the concat. For detect the slices `0:4` and `4:4+nc` land 1:1 on the `Concat` inputs, rknn then keeps a separate scale per branch and the wrapper works verbatim — detect scores 0.9969, pose 0.9986. For segment the tail slice `4:116` straddles two inputs ([4], [80], [32]), and for obb `4:20` straddles ([4], [15], [1]); rknn materialises the concat at the 675 range and the slice inherits that scale, so with the wrapper as it stands today segment scores, obb scores and the obb angle stay at zero. Cutting the tail at the head's own boundaries (`4 : 4+nc`, then the remainder) recovers both. That is a re-association of `cat` and nothing else — I checked the patched `forward` against a literal reimplementation of the current one on the same tensors and it is bit-identical (`torch.equal`, max_abs_diff 0.0) for detect/segment/pose/obb at 640×640 and at 480×640.

### LiteRT is untouched, and I ran it

The slice change lives in a LiteRT file, so I exported LiteRT INT8 before and after with the same harness, same calibration, same `bus.jpg`, same frozen FP32 ONNX as reference:

| task | FP32 max score | before: INT8 max | non-zero | cos | after: INT8 max | non-zero | cos |
|---|---|---|---|---|---|---|---|
| detect | 0.896046 | 0.759079 | 524 / 672000 | 0.992081 | 0.759079 | 524 | 0.992081 |
| segment | 0.874480 | 0.781160 | 80 / 672000 | 0.987920 | 0.781160 | 80 | 0.987920 |
| obb | 0.074005 | 0.013216 | 13 / 126000 | 0.791774 | 0.013216 | 13 | 0.791774 |

The `.tflite` files come out byte-identical (sha over the flatbuffer, cutting the appended metadata that carries the export date): detect `8d19b0a616356e57`, segment `5b8d5f0cb16d0484`, obb `ed4376928f903585`. Tensor tables match one to one (697 / 791 / 760 tensors), interpreter `output0` matches with max_abs_diff 0, and inference through `AutoBackend` returns the same boxes in pixels on both sides. ai-edge's quantizer handles the straddling slice differently from rknn's, so LiteRT was not broken and this change is justified by RKNN alone.

### The `quantize == 8` gate

Both the wrap and the runtime denormalisation are gated on `quantize == 8`, and that gate is the compatibility decision of this PR. Any `.rknn` already exported holds boxes in pixels; an unconditional denormalisation in the backend multiplies them a second time. I fed the FP16 output through the patched backend with the gate forced open and detect goes from 675 to **432000**, pose from 655 to 419200 — a factor of 640, silently. `quantize=16` is the documented default (`docs/en/integrations/rockchip-rknn.md`), so those files are not an edge case, they are the common one. The LiteRT precedent does not cover this: onnx2tf already emitted normalised `.tflite`, so there was no pixel-space artefact to protect. `quantize` travels in `metadata["args"]` for RKNN, so the backend reads it without a version gate. The gate keys on precision, not on version, so an INT8 `.rknn` exported before this PR is denormalised too. That one is fine: those files are the bug — every score in them is zero, so they return no detections at all and there is nothing working to protect. The files the gate does protect are the FP16 ones, which work today.

With the gate in, `quantize=16` is bit-identical to main on all seven tasks (max_abs_diff = 0, 0 differing elements), and the FP16 boxes come back at 675.0 and 655.0 exactly as the raw model holds them.

### Validation

- rknn-toolkit2 2.3.2 host simulator, ultralytics 8.4.110, yolo26n, imgsz 640. Reference is a frozen FP32 ONNX per task, checked to be in pixels before use.
- `quantize=8`, all seven tasks export on both sides. Calibration file sha identical on both sides; the ONNX graph sha differs on the four affected tasks only, which is the patch.
- classify / depth / semantic: ONNX graph sha identical and backend output bit-identical (0/1000, 0/409600, 0/7782400 differing).
- After `format=rknn`, no `.onnx` is left behind and the `.rknn` is written, checked for `quantize=8` and `quantize=16`.
- `pytest tests/test_exports.py -k rknn --slow` → 4 passed.
- `ruff check ultralytics/` clean, `ruff format --check` clean on the three touched files.

Honest about what gets slightly worse: putting the whole tensor in unit range costs segment a little box precision, cosine 0.999789 → 0.998953 with 2161 of 33600 box values dropping to zero, and obb 0.999892 → 0.999881. detect and pose are unchanged on the box block.

Why CI does not catch this: `test_export_rknn` ends at `assert next(Path(file).rglob("*.rknn"), None)`. It never runs inference, so a model that exports cleanly and returns zero scores passes.

### Relation to #24703

#24703 attacks the same zero-detection symptom by moving the whole decode to the CPU and restricting INT8 to detect. What I measured says the collapse is narrower than that: it is a range problem in the final `Concat`, not in the decode. Normalizing the coordinate channels — the mechanism the repo already ships for LiteRT — keeps the decode on the NPU, adds no new decode path and no output-shape dispatch (the backend reads `quantize` from the exported metadata), and recovers all four tasks, including the segment/pose/obb INT8 exports that #24703 rejects. And the failure itself is not board-only: it reproduces on any x86 Linux host with rknn-toolkit2 through `init_runtime()` with no target, which is how every number above was produced, so anyone can re-run the repro without Rockchip hardware.

### Scope

This does not close #25497. That issue asks for validation on real RK3588/RK3588S and its acceptance criteria rule out conversion-based checking as a substitute, while everything here is the host-side simulator. `RKNNBackend.forward` only loads on Rockchip, so I could not run it on a board — I ran the real `forward`, including reading `args.quantize` from the written `metadata.yaml`, with `self.model.inference` replaced by the simulator output. There is no mAP either, only per-block cosine on two images.

Deleted: the single `det[:, 4:]` tail slice in `_NormalizeCoords` (replaced by slices on the head's own boundaries) and the intermediate `.onnx` that `format=rknn` used to leave next to the model. The net +48 is the wrapper hookup plus the runtime denormalisation — there was no existing RKNN INT8 handling to remove, and no decode path is added.

let me know what you think ..
