### PR TITLE
Assert the discarded coordinate round-trip checks in test_utils_ops

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1427,15 +1427,17 @@ def test_utils_ops():
 
     make_divisible(17, torch.tensor([8]))
 
-    boxes = torch.rand(10, 4)  # xywh
-    torch.allclose(boxes, xyxy2xywh(xywh2xyxy(boxes)))
-    torch.allclose(boxes, xyxy2xywhn(xywhn2xyxy(boxes)))
-    torch.allclose(boxes, ltwh2xywh(xywh2ltwh(boxes)))
-    torch.allclose(boxes, xyxy2ltwh(ltwh2xyxy(boxes)))
+    # xywh, offset off zero where a relative comparison degenerates, plus one exact zero center held to atol
+    boxes = torch.cat((torch.rand(9, 4) + 1, torch.tensor([[0.0, 0.0, 1.0, 1.0]])))
+    assert torch.allclose(boxes, xyxy2xywh(xywh2xyxy(boxes)))
+    assert torch.allclose(boxes, xyxy2xywhn(xywhn2xyxy(boxes)))
+    assert torch.allclose(boxes, ltwh2xywh(xywh2ltwh(boxes)))
+    assert torch.allclose(boxes, xyxy2ltwh(ltwh2xyxy(boxes)))
 
-    boxes = torch.rand(10, 5)  # xywhr for OBB
-    boxes[:, 4] = torch.randn(10) * 30
-    torch.allclose(boxes, xyxyxyxy2xywhr(xywhr2xyxyxyxy(boxes)), rtol=1e-3)
+    boxes = torch.rand(10, 5) + 1  # xywhr for OBB
+    boxes[:, 2] += 1  # xyxyxyxy2xywhr canonicalizes w < h into w > h, so the fixture must start there
+    boxes[:, 4] = torch.rand(10) * np.pi - np.pi / 4  # and inside its documented [-pi/4, 3pi/4) angle range
+    assert torch.allclose(boxes, xyxyxyxy2xywhr(xywhr2xyxyxyxy(boxes)), rtol=1e-3, atol=1e-5)  # angle spans 0
 
     # segment2box must not drop a polygon lying on the left image edge (all x == 0) to a zero box
     assert segment2box(np.array([[0, 100], [0, 150], [0, 200]]), 640, 640).tolist() == [0, 100, 0, 200]


### PR DESCRIPTION
the five coordinate-converter round-trip checks in `test_utils_ops` were bare `torch.allclose` expression statements. `torch.allclose` returns a bool, so a false result was discarded and the test passed regardless, leaving the eight converters they name without round-trip coverage.

asserting them made two fixture problems visible:

- the obb fixture could never round-trip. `xyxyxyxy2xywhr` canonicalizes `w < h` by swapping w and h and adding pi/2 to the angle, while `xywhr2xyxyxyxy` does not canonicalize, so `torch.rand(10, 5)` failed on roughly half its rows. the fixture also used `torch.randn(10) * 30` radians, far outside the `[-pi/4, 3pi/4)` input range `xywhr2xyxyxyxy` documents. each violation fails the check on its own.
- `torch.rand` reaches values near zero, where a relative comparison of a float32 round-trip degenerates. over 10000 seeds the `xyxy2xywh` and `xyxy2xywhn` checks failed 2.4% and 3.5% of runs at torch's default tolerance, and `xyxy2ltwh` came within 10% of the failure threshold.

changes in `tests/test_python.py`:

- prefix all five checks with `assert`
- build the xywh fixture off zero and append one exact zero center, so the four checks catch an injected error of 1e-6
- start the obb fixture inside the canonical domain, and give its assert `atol=1e-5` alongside the existing `rtol=1e-3`, since the angle legitimately passes through zero

0 failures over 20000 seeds; each of the five checks fails when its round-trip is perturbed.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧪 Strengthens geometry utility tests by using valid edge cases and explicit assertions for bounding box conversions.

### 📊 Key Changes

- Added `assert` statements to ensure all box conversion round trips actually pass.
- Updated axis-aligned box fixtures to include:
  - Coordinates offset from zero for reliable relative comparisons.
  - An exact zero-center case validated with absolute tolerance.
- Updated oriented bounding box fixtures to:
  - Use canonical width/height ordering.
  - Generate angles within the documented supported range.
  - Apply explicit relative and absolute tolerances for angle wraparound.
- Preserved coverage for polygons positioned on the image’s left edge.

### 🎯 Purpose & Impact

- ✅ Makes geometry tests meaningful by preventing silently ignored comparison results.
- 🛡️ Reduces false failures caused by invalid or numerically sensitive test inputs.
- 📐 Improves validation of axis-aligned and oriented bounding box conversions.
- 🔍 Helps detect regressions in coordinate transformations and OBB angle handling more reliably.