### PR TITLE
Clarify IoA wording in Copy-Paste augmentation documentation

### DIFF
--- a/docs/en/guides/yolo-data-augmentation.md
+++ b/docs/en/guides/yolo-data-augmentation.md
@@ -327,7 +327,7 @@ Then launch the training with the Python API:
 - **Ultralytics' implementation**: [CopyPaste](../reference/data/augment.md#ultralytics.data.augment.CopyPaste)
 - **Note**:
     - As pictured in the gif below, the `copy_paste` augmentation can be used to copy objects from one image to another.
-    - Once an object is copied, regardless of the `copy_paste_mode`, its Intersection over Area (IoA) is computed with all the object of the source image. If all the IoA are below `0.3` (30%), the object is pasted in the target image. If only one the IoA is above `0.3`, the object is not pasted in the target image.
+    - Once an object is copied, regardless of the `copy_paste_mode`, its Intersection over Area (IoA) is computed with all objects in the source image. If all IoA values are below `0.3` (30%), the object is pasted into the target image. If at least one IoA value is above `0.3`, the object is not pasted into the target image.
     - The IoA threshold cannot be changed with the current implementation and is set to `0.3` by default.
 
 |                                                               **`copy_paste` off**                                                               |                                               **`copy_paste` on with `copy_paste_mode=flip`**                                               |                                                       **Visualize the `copy_paste` process**                                                        |
@@ -342,7 +342,7 @@ Then launch the training with the Python API:
 - **Purpose**: Allows flexibility in how copied objects are integrated into target images.
 - **Ultralytics' implementation**: [CopyPaste](../reference/data/augment.md#ultralytics.data.augment.CopyPaste)
 - **Note**:
-    - The IoA principle is the same for both `copy_paste_mode`, but the way the objects are copied is different.
+    - The IoA principle is the same for both `copy_paste_mode` options, but the way the objects are copied is different.
     - Depending on the image size, objects may sometimes be copied partially or entirely outside the frame.
     - Depending on the quality of polygon annotations, copied objects may have slight shape variations compared to the originals.
 

--- a/docs/en/guides/yolo-data-augmentation.md
+++ b/docs/en/guides/yolo-data-augmentation.md
@@ -327,7 +327,7 @@ Then launch the training with the Python API:
 - **Ultralytics' implementation**: [CopyPaste](../reference/data/augment.md#ultralytics.data.augment.CopyPaste)
 - **Note**:
     - As pictured in the gif below, the `copy_paste` augmentation can be used to copy objects from one image to another.
-    - Once an object is copied, regardless of the `copy_paste_mode`, its Intersection over Area (IoA) is computed with all objects in the source image. If all IoA values are below `0.3` (30%), the object is pasted into the target image. If at least one IoA value is above `0.3`, the object is not pasted into the target image.
+    - Once an object is selected for copying, its IoA is computed against all objects already present in the target image, regardless of `copy_paste_mode`. The object is pasted only if all IoA values are below `0.3` (30%); it is not pasted if any IoA value is `0.3` or higher.
     - The IoA threshold cannot be changed with the current implementation and is set to `0.3` by default.
 
 |                                                               **`copy_paste` off**                                                               |                                               **`copy_paste` on with `copy_paste_mode=flip`**                                               |                                                       **Visualize the `copy_paste` process**                                                        |


### PR DESCRIPTION
## Description

This PR improves the wording in the Copy-Paste augmentation documentation by correcting grammatical issues and improving readability.

## Changes

- Fix grammatical issues and pluralization.
- Improve sentence clarity and readability.
- Make the IoA description easier to understand.

No functional changes were made.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Clarifies the IoA wording and grammar in the Copy-Paste augmentation documentation. ✨

### 📊 Key Changes
- Replaces ambiguous phrasing with clear references to all source-image objects and IoA values.
- Corrects the paste-condition wording for IoA values below or above the `0.3` threshold.
- Clarifies that the IoA principle applies to both `copy_paste_mode` options.

### 🎯 Purpose & Impact
- Improves documentation accuracy and readability for users configuring Copy-Paste augmentation.
- Makes the object-pasting behavior and threshold conditions easier to understand without changing implementation behavior.