### PR TITLE
Fix RKNN export by pinning package versions

### DIFF
--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -382,6 +382,9 @@ rlatjdwls2528@gmail.com:
 ronald_eddy@yahoo.com:
   avatar: https://avatars.githubusercontent.com/u/10393491?v=4
   username: him2him2
+rudrachhaya700@gmail.com:
+  avatar: https://avatars.githubusercontent.com/u/226091897?v=4
+  username: rudrakumar07
 rulosanti@gmail.com:
   avatar: https://avatars.githubusercontent.com/u/20377209?v=4
   username: rulosant

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1026,7 +1026,7 @@ class Exporter:
     @try_export
     def export_onnx(self, prefix=colorstr("ONNX:")):  # noqa: B008
         """Export YOLO model to ONNX format."""
-        requirements = ["onnx>=1.12.0,<2.0.0"]
+        requirements = ["onnx>=1.16.1,<1.19.0" if self.args.format == "rknn" else "onnx>=1.12.0,<2.0.0"]
         if self.args.simplify or (self.args.format == "onnx" and self.args.quantize == 8):
             # Pass onnxruntime variants as interchangeable candidates so AutoUpdate keeps an installed build
             # (e.g. onnxruntime-qnn for QNN export) instead of reinstalling stable onnxruntime and breaking its ABI.

--- a/ultralytics/utils/export/rknn.py
+++ b/ultralytics/utils/export/rknn.py
@@ -58,7 +58,7 @@ def onnx2rknn(
     LOGGER.info(f"\n{prefix} starting export with rknn-toolkit2...")
     # onnx<1.19.0 fixes AttributeError: module 'onnx' has no attribute 'mapping'
     # setuptools<82 retains pkg_resources, which rknn-toolkit2 depends on and setuptools 82 removed
-    check_requirements(["rknn-toolkit2>=2.3.2", "onnx<1.19.0", "setuptools<82"])
+    check_requirements(["rknn-toolkit2>=2.3.2", "onnx>=1.16.1,<1.19.0", "setuptools<82"])
 
     if IS_COLAB:
         # Prevent 'exit' from closing the notebook https://github.com/airockchip/rknn-toolkit2/issues/259

--- a/ultralytics/utils/export/rknn.py
+++ b/ultralytics/utils/export/rknn.py
@@ -56,8 +56,9 @@ def onnx2rknn(
     from ultralytics.utils.checks import check_requirements
 
     LOGGER.info(f"\n{prefix} starting export with rknn-toolkit2...")
-    check_requirements("rknn-toolkit2>=2.3.2")
-    check_requirements("onnx<1.19.0")  # fix AttributeError: module 'onnx' has no attribute 'mapping'
+    # onnx<1.19.0 fixes AttributeError: module 'onnx' has no attribute 'mapping'
+    # setuptools<82 retains pkg_resources, which rknn-toolkit2 depends on and setuptools 82 removed
+    check_requirements(["rknn-toolkit2>=2.3.2", "onnx<1.19.0", "setuptools<82"])
 
     if IS_COLAB:
         # Prevent 'exit' from closing the notebook https://github.com/airockchip/rknn-toolkit2/issues/259

--- a/ultralytics/utils/export/rknn.py
+++ b/ultralytics/utils/export/rknn.py
@@ -56,9 +56,8 @@ def onnx2rknn(
     from ultralytics.utils.checks import check_requirements
 
     LOGGER.info(f"\n{prefix} starting export with rknn-toolkit2...")
-    # onnx<1.19.0 fixes AttributeError: module 'onnx' has no attribute 'mapping'
     # setuptools<82 retains pkg_resources, which rknn-toolkit2 depends on and setuptools 82 removed
-    check_requirements(["rknn-toolkit2>=2.3.2", "onnx>=1.16.1,<1.19.0", "setuptools<82"])
+    check_requirements(["rknn-toolkit2>=2.3.2", "setuptools<82"])
 
     if IS_COLAB:
         # Prevent 'exit' from closing the notebook https://github.com/airockchip/rknn-toolkit2/issues/259


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves RKNN export compatibility by pinning compatible ONNX and setuptools versions. 🛠️

### 📊 Key Changes

- Uses `onnx>=1.16.1,<1.19.0` specifically for RKNN exports while preserving the broader ONNX range for other formats.
- Adds a `setuptools<82` requirement for RKNN exports because newer setuptools versions removed `pkg_resources`, which `rknn-toolkit2` depends on.
- Removes the separate ONNX compatibility check from the RKNN conversion utility, centralizing version handling during export.
- Adds the contributor @rudrakumar07 to the documentation author mappings.

### 🎯 Purpose & Impact

- Makes RKNN model exports more reliable by installing versions compatible with `rknn-toolkit2`. ✅
- Prevents export failures caused by missing `pkg_resources` or incompatible ONNX versions.
- Keeps existing ONNX export behavior unchanged for non-RKNN workflows.
- Improves the experience for users deploying YOLO models to Rockchip hardware. 🚀