### PR TITLE
Fix MuSGD head grouping for custom backbones

### DIFF
--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -382,6 +382,9 @@ rlatjdwls2528@gmail.com:
 ronald_eddy@yahoo.com:
   avatar: https://avatars.githubusercontent.com/u/10393491?v=4
   username: him2him2
+rudrachhaya700@gmail.com:
+  avatar: https://avatars.githubusercontent.com/u/226091897?v=4
+  username: rudrakumar07
 rulosanti@gmail.com:
   avatar: https://avatars.githubusercontent.com/u/20377209?v=4
   username: rulosant

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1157,16 +1157,16 @@ class BaseTrainer:
         if use_muon:
             num_params[0] = len(g[3])  # update number of params
             g[3] = {"params": g[3], **optim_args, "weight_decay": decay, "use_muon": True, "param_group": "muon"}
-            import re
-
-            # higher lr for certain parameters in MuSGD when finetuning
-            # proto.semseg is the checkpoint parameter name for YOLO26 semantic auxiliary heads.
-            pattern = re.compile(r"(?=.*23)(?=.*cv3)|proto\.semseg|SemanticSegment")
+            target = unwrap_model(model)
+            head = getattr(target, "student_model", target).model[-1]
+            heads = (getattr(head, "cv3", None), getattr(head, "one2one_cv3", None))
+            boosted = {id(p) for m in heads if m for p in m.parameters()}
             g_ = []  # new param groups
             for x in g:
                 p = x.pop("params")
-                p1 = [v for k, v in p.items() if pattern.search(k)]
-                p2 = [v for k, v in p.items() if not pattern.search(k)]
+                p1, p2 = [], []
+                for k, v in p.items():
+                    (p1 if id(v) in boosted or "proto.semseg" in k or "SemanticSegment" in k else p2).append(v)
                 g_.extend([{"params": p1, **x, "lr": lr * 3}, {"params": p2, **x}])
             g = g_
         optimizer = (partial(MuSGD, muon=muon, sgd=sgd) if use_muon else getattr(optim, name))(params=g)

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1157,6 +1157,7 @@ class BaseTrainer:
         if use_muon:
             num_params[0] = len(g[3])  # update number of params
             g[3] = {"params": g[3], **optim_args, "weight_decay": decay, "use_muon": True, "param_group": "muon"}
+            # higher lr for certain parameters in MuSGD when finetuning
             target = unwrap_model(model)
             head = getattr(target, "student_model", target).model[-1]
             heads = (getattr(head, "cv3", None), getattr(head, "one2one_cv3", None))


### PR DESCRIPTION
MuSGD assumes the detection head is always layer 23. Custom model YAMLs can place it elsewhere, so their classification head silently misses the intended 3x learning rate.

Run this on `main`, then on this PR:

```python
from ultralytics.engine.trainer import BaseTrainer
from ultralytics.nn.tasks import DetectionModel

cfg = {
    "nc": 2,
    "backbone": [
        [-1, 1, "Conv", [16, 3, 2]],
        [-1, 1, "Conv", [32, 3, 2]],
        [-1, 1, "Conv", [64, 3, 2]],
    ],
    "head": [[[0, 1, 2], 1, "Detect", ["nc"]]],
}
model = DetectionModel(cfg, verbose=False)
trainer = object.__new__(BaseTrainer)
optimizer = trainer.build_optimizer(model, name="MuSGD", lr=0.01)
head = model.model[-1]
head_params = {id(p) for p in head.cv3.parameters()}
head_lrs = {
    group["lr"]
    for group in optimizer.param_groups
    if any(id(p) in head_params for p in group["params"])
}
print(f"Detect layer: {head.i}")
print(f"Classification head LR: {head_lrs}")
```

Current `main`:

```text
Detect layer: 3
Classification head LR: {0.01}
```

This PR:

```text
Detect layer: 3
Classification head LR: {0.03}
```

- for distillation, boosts the student head and not the teacher
- Deleted: fixed layer-23 regex and local `re` import

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 Improves MuSGD fine-tuning by reliably assigning higher learning rates to detection and semantic-segmentation head parameters.

### 📊 Key Changes
- Replaced regex-based parameter matching with direct inspection of the model’s final head.
- Automatically identifies parameters in the `cv3` and `one2one_cv3` layers for boosted learning rates.
- Preserves special handling for semantic-segmentation parameters such as `proto.semseg` and `SemanticSegment`.
- Supports wrapped models and student-model architectures through safer model unwrapping.
- Added the contributor @rudrakumar07 to the documentation author registry.

### 🎯 Purpose & Impact
- 🎯 Makes MuSGD fine-tuning more robust across supported model architectures.
- ⚡ Applies the higher learning rate to the intended head parameters without relying on fragile parameter-name patterns.
- 🧠 May improve adaptation speed and fine-tuning results for detection and segmentation models.
- ✅ Reduces the risk of missing relevant parameters when model structures or naming conventions change.