### PR TITLE
Remove the unmatchable printed output from the Kalman filter docstring examples

### DIFF
--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -382,6 +382,9 @@ rlatjdwls2528@gmail.com:
 ronald_eddy@yahoo.com:
   avatar: https://avatars.githubusercontent.com/u/10393491?v=4
   username: him2him2
+rudrachhaya700@gmail.com:
+  avatar: https://avatars.githubusercontent.com/u/226091897?v=4
+  username: rudrakumar07
 rulosanti@gmail.com:
   avatar: https://avatars.githubusercontent.com/u/20377209?v=4
   username: rulosant

--- a/ultralytics/trackers/utils/kalman_filter.py
+++ b/ultralytics/trackers/utils/kalman_filter.py
@@ -32,8 +32,6 @@ class KalmanFilterXYAH:
         >>> kf = KalmanFilterXYAH()
         >>> measurement = np.array([100, 200, 1.5, 50])
         >>> mean, covariance = kf.initiate(measurement)
-        >>> print(mean)
-        >>> print(covariance)
     """
 
     def __init__(self):
@@ -310,8 +308,6 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
         >>> kf = KalmanFilterXYWH()
         >>> measurement = np.array([100, 50, 20, 40])
         >>> mean, covariance = kf.initiate(measurement)
-        >>> print(mean)
-        >>> print(covariance)
     """
 
     def initiate(self, measurement: np.ndarray):
@@ -329,17 +325,6 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
             >>> kf = KalmanFilterXYWH()
             >>> measurement = np.array([100, 50, 20, 40])
             >>> mean, covariance = kf.initiate(measurement)
-            >>> print(mean)
-            [100.  50.  20.  40.   0.   0.   0.   0.]
-            >>> print(covariance)
-            [[ 4.      0.      0.      0.      0.      0.      0.      0.    ]
-             [ 0.     16.      0.      0.      0.      0.      0.      0.    ]
-             [ 0.      0.      4.      0.      0.      0.      0.      0.    ]
-             [ 0.      0.      0.     16.      0.      0.      0.      0.    ]
-             [ 0.      0.      0.      0.      1.5625  0.      0.      0.    ]
-             [ 0.      0.      0.      0.      0.      6.25    0.      0.    ]
-             [ 0.      0.      0.      0.      0.      0.      1.5625  0.    ]
-             [ 0.      0.      0.      0.      0.      0.      0.      6.25  ]]
         """
         measurement = np.asarray(measurement, dtype=np.float64)
         mean_pos = measurement


### PR DESCRIPTION
## summary

`pytest --doctest-modules ultralytics/trackers/utils/kalman_filter.py` reports `3 failed, 10 passed` on a clean checkout. `pyproject.toml` carries `--doctest-modules` in pytest `addopts`, but `ci.yml` points pytest at `tests/` only, so package doctests never run in CI.

Two of the three are the `KalmanFilterXYAH` and `KalmanFilterXYWH` class docstrings, which end in `>>> print(mean)` / `>>> print(covariance)` with no declared output — a doctest with an empty `want` asserts _empty_ output, so any print fails.

The third is `KalmanFilterXYWH.initiate`, whose expected block was written for numpy's default printoptions:

```
[100.  50.  20.  40.   0.   0.   0.   0.]
```

`ultralytics/utils/__init__.py:165` installs `np.set_printoptions(linewidth=320, formatter={"float_kind": "{:11.5g}".format})` at import time, so the real output is `[        100          50          20          40           0           0           0           0]` and that block can never match. The torch override on the line above sets `precision` only, which is why the package's `tensor([...])` expected blocks are unaffected — a numpy float array in a docstring is the only shape this reaches, and it is the only one in the package.

The prints are removed rather than rewritten to the `%11.5g` text: all ten Examples in this file that already pass end on an assignment line and print nothing, including `KalmanFilterXYAH.initiate`, the direct sibling of the failing method. Each Example still shows how to obtain both return values.

`pytest --doctest-modules ultralytics/trackers/utils/kalman_filter.py` is now `13 passed`; across `ultralytics/trackers/` the count goes from `19 failed, 22 passed` to `16 failed, 25 passed`, with the remaining failures pre-existing and unrelated. `python docs/build_reference.py` produces no diff — the generated reference page carries one directive per class and renders the docstrings live.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧹 Simplified Kalman filter documentation and added a new GitHub contributor entry.

### 📊 Key Changes

- Removed verbose printed output and covariance matrices from Kalman filter docstrings in `kalman_filter.py`.
- Kept the usage examples focused on initialization without showing generated console output.
- Added GitHub author metadata for @rudrakumar07.

### 🎯 Purpose & Impact

- 📖 Makes the Kalman filter documentation shorter, cleaner, and easier to read.
- 🛠️ Does not change tracking behavior or Kalman filter functionality.
- 👤 Ensures the new contributor is correctly recognized in project documentation.