### PR TITLE
Vectorize the Deep OC-SORT GMC warp and drop a redundant mean copy

### DIFF
--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -382,6 +382,9 @@ rlatjdwls2528@gmail.com:
 ronald_eddy@yahoo.com:
   avatar: https://avatars.githubusercontent.com/u/10393491?v=4
   username: him2him2
+rudrachhaya700@gmail.com:
+  avatar: https://avatars.githubusercontent.com/u/226091897?v=4
+  username: rudrakumar07
 rulosanti@gmail.com:
   avatar: https://avatars.githubusercontent.com/u/20377209?v=4
   username: rulosant

--- a/ultralytics/trackers/deep_oc_sort.py
+++ b/ultralytics/trackers/deep_oc_sort.py
@@ -116,7 +116,7 @@ class DeepOCSortTrack(OCSortTrack):
         """
         if not stracks:
             return
-        multi_mean = np.asarray([st.mean.copy() for st in stracks])
+        multi_mean = np.asarray([st.mean for st in stracks])
         multi_covariance = np.asarray([st.covariance for st in stracks])
 
         R = H[:2, :2]
@@ -128,10 +128,13 @@ class DeepOCSortTrack(OCSortTrack):
         R8x8[4:6, 4:6] = R  # rotate velocity (vx, vy)
         # indices 2,3 (a,h) and 6,7 (va,vh) remain identity
 
+        multi_mean = np.matmul(R8x8, multi_mean[..., None])[..., 0]
+        multi_mean[:, :2] += t
+        # Keep the right operand C-contiguous, as the `utils.stracks` sibling does: an F-contiguous one sends matmul
+        # into BLAS's transposed-gemm kernel, which on macOS Accelerate leaves FP-exception flags set even for finite
+        # inputs, and numpy then reports spurious divide-by-zero RuntimeWarnings.
+        multi_covariance = np.matmul(np.matmul(R8x8, multi_covariance), np.ascontiguousarray(R8x8.T))
         for i, (mean, cov) in enumerate(zip(multi_mean, multi_covariance)):
-            mean = R8x8.dot(mean)
-            mean[:2] += t
-            cov = R8x8.dot(cov).dot(R8x8.transpose())
             stracks[i].mean = mean
             stracks[i].covariance = cov
 


### PR DESCRIPTION
`DeepOCSortTrack.multi_gmc` warped each track's Kalman mean and covariance in a per-track Python loop. The `utils.stracks` sibling was batched in #25343, but this override was not part of that change and still ran the earlier shape.

The mean and covariance warps become two batched `np.matmul` calls. The remaining loop only writes the results back and performs the `last_observation` warp, which is per-track and conditional. The per-track `.copy()` is dropped: `np.asarray([...])` already allocates a new 2-D array and the warp allocates its result again, so each mean was copied twice.

`R8x8` stays `np.eye(8)` float64, keeping the homography precision from #25504. The right operand of the covariance product is wrapped in `np.ascontiguousarray` for the same reason as #25473: an F-contiguous right operand sends `matmul` into BLAS's transposed-gemm kernel, which on macOS Accelerate leaves FP-exception flags set even for finite inputs. The previous code used `.dot`, which is not a ufunc and never inspected those flags, so the wrap is what keeps the batched form silent. Without it, `np.errstate(all="raise")` turns the covariance product into `FloatingPointError: divide by zero encountered in matmul`.

Measured by capturing the real inputs the function receives during a live `model.track` run with `gmc_method: sparseOptFlow` (median 21 concurrent tracks, max 27, two calls per frame): 165 us to 95 us at N=27, a 1.70x to 1.75x gain over three interleaved rounds. 1.63x to 1.80x at N=13, 1.68x to 1.74x at N=50, 1.22x to 1.43x at N=2, and a wash at N=1.

Means and warped observations are bit-identical to the previous code. The covariance differs by at most one float64 ULP of the matrix magnitude (2.184e-16 relative, 9.095e-13 absolute worst case), because `a.dot(b).dot(c)` and `np.matmul(np.matmul(a, b), c)` select different BLAS kernels. That does not reach the output on either clip tested: 958 rows over 29 distinct track ids, and 22 rows over 2 ids, both come out byte-identical with an identical track-id sequence, and neither revision emits a warning under `-W error::RuntimeWarning`.

`pytest tests/test_python.py -k "track"` passes.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Optimizes Deep OC-SORT global motion compensation with batched NumPy operations and prevents spurious macOS warnings.

### 📊 Key Changes

- Replaced per-track matrix operations with batched `numpy.matmul` processing for track means and covariance matrices.
- Removed an unnecessary copy when collecting track means.
- Ensured the covariance transformation uses a C-contiguous transpose to avoid issues with macOS Accelerate.
- Added the contributor `@rudrakumar07` to the documentation authors mapping.

### 🎯 Purpose & Impact

- ⚡ Improves the efficiency of Deep OC-SORT tracking by processing multiple tracks at once.
- 🛡️ Prevents misleading divide-by-zero `RuntimeWarning` messages on macOS, even when inputs are valid.
- ✅ Preserves tracking behavior while making global motion compensation more robust across platforms.
- 🙌 Credits the new contributor in the project documentation.