### PR TITLE
Declare the expected output in three docstring examples

### DIFF
--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -382,6 +382,9 @@ rlatjdwls2528@gmail.com:
 ronald_eddy@yahoo.com:
   avatar: https://avatars.githubusercontent.com/u/10393491?v=4
   username: him2him2
+rudrachhaya700@gmail.com:
+  avatar: https://avatars.githubusercontent.com/u/226091897?v=4
+  username: rudrakumar07
 rulosanti@gmail.com:
   avatar: https://avatars.githubusercontent.com/u/20377209?v=4
   username: rulosant

--- a/ultralytics/nn/modules/block.py
+++ b/ultralytics/nn/modules/block.py
@@ -1512,6 +1512,7 @@ class C2fPSA(C2f):
         >>> x = torch.randn(1, 64, 128, 128)
         >>> output = model(x)
         >>> print(output.shape)
+        torch.Size([1, 64, 128, 128])
     """
 
     def __init__(self, c1: int, c2: int, n: int = 1, e: float = 0.5):

--- a/ultralytics/solutions/config.py
+++ b/ultralytics/solutions/config.py
@@ -59,8 +59,10 @@ class SolutionConfig:
     Examples:
         >>> from ultralytics.solutions.config import SolutionConfig
         >>> cfg = SolutionConfig(model="yolo26n.pt", region=[(0, 0), (100, 0), (100, 100), (0, 100)])
-        >>> cfg.update(show=False, conf=0.3)
+        >>> cfg.update(show=False, conf=0.3).conf
+        0.3
         >>> print(cfg.model)
+        yolo26n.pt
     """
 
     source: str | None = None

--- a/ultralytics/utils/errors.py
+++ b/ultralytics/utils/errors.py
@@ -20,7 +20,8 @@ class HUBModelError(Exception):
         ...     # Code that might fail to find a model
         ...     raise HUBModelError("Custom model not found message")
         ... except HUBModelError as e:
-        ...     print(e)  # Displays the emoji-enhanced error message
+        ...     print(e)
+        Custom model not found message
     """
 
     def __init__(self, message: str = "Model not found. Please check model URL and try again."):


### PR DESCRIPTION
## summary

`pytest --doctest-modules ultralytics/utils/errors.py ultralytics/solutions/config.py ultralytics/nn/modules/block.py` reported `3 failed, 7 passed`. Each of the three Examples is self-contained, runs without raising, and produces output that the docstring never declared, so doctest compared the real output against "expected nothing".

- `HUBModelError` — `print(e)` emits `Custom model not found message`. The trailing comment is redundant once the output is declared on its own line.
- `C2fPSA` — `print(output.shape)` emits `torch.Size([1, 64, 128, 128])`.
- `SolutionConfig` — `update()` returns `self`, so the bare call echoed the full 40-field dataclass repr and the Example never reached `print(cfg.model)`. Reading `.conf` off the chained return declares a stable scalar instead of a repr that every newly added config field would invalidate.

The three files now report `10 passed`, with no `# doctest: +SKIP` directive added and no Example step removed. Package doctests are not exercised in CI: `pyproject.toml` `addopts` carries `--doctest-modules`, but `ci.yml` points pytest at `tests/` only.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improved documentation examples and contributor metadata without changing core functionality. ✨

### 📊 Key Changes

- Added the GitHub profile for contributor @rudrakumar07 to the documentation authors list.
- Updated the `C2fPSA` example to show its expected output shape.
- Clarified `SolutionConfig.update()` usage by demonstrating method chaining and returned configuration values.
- Improved the `HUBModelError` example to show the actual printed error message.

### 🎯 Purpose & Impact

- Makes API and module documentation more explicit and easier to follow. 📚
- Helps users understand expected outputs and configuration behavior through runnable examples.
- Provides clearer error-handling guidance for HUB model lookup failures.
- No functional behavior or model performance changes are introduced.