### PR TITLE
Describe what emojis() does to the HUBModelError message

### DIFF
--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -382,6 +382,9 @@ rlatjdwls2528@gmail.com:
 ronald_eddy@yahoo.com:
   avatar: https://avatars.githubusercontent.com/u/10393491?v=4
   username: him2him2
+rudrachhaya700@gmail.com:
+  avatar: https://avatars.githubusercontent.com/u/226091897?v=4
+  username: rudrakumar07
 rulosanti@gmail.com:
   avatar: https://avatars.githubusercontent.com/u/20377209?v=4
   username: rulosant

--- a/ultralytics/utils/errors.py
+++ b/ultralytics/utils/errors.py
@@ -7,7 +7,7 @@ class HUBModelError(Exception):
     """Exception raised when a model cannot be found or retrieved from Ultralytics HUB.
 
     This custom exception is used specifically for handling errors related to model fetching in Ultralytics YOLO. The
-    error message is processed to include emojis for better user experience.
+    message is passed through `emojis()`, which strips non-ASCII characters on Windows so the text stays printable.
 
     Attributes:
         message (str): The error message displayed when the exception is raised.
@@ -25,9 +25,6 @@ class HUBModelError(Exception):
 
     def __init__(self, message: str = "Model not found. Please check model URL and try again."):
         """Initialize a HUBModelError exception.
-
-        This exception is raised when a requested model is not found or cannot be retrieved from Ultralytics HUB. The
-        message is processed to include emojis for better user experience.
 
         Args:
             message (str, optional): The error message to display when the exception is raised.


### PR DESCRIPTION
## summary

The `HUBModelError` class docstring and its `__init__` docstring both stated that the error message "is processed to include emojis for better user experience". `emojis()` never adds anything:

```python
def emojis(string=""):
    return string.encode().decode("ascii", "ignore") if WINDOWS else string
```

Off Windows it returns the string unchanged; on Windows it strips every non-ASCII character, emojis included. The two real raise sites in `ultralytics/hub/session.py` do pass emoji-carrying messages, so the wrapper keeps them printable on a Windows console rather than enriching them.

The class docstring now says that, and the duplicated sentence is deleted from `__init__` instead of restated. Docstring text only.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛠️ Clarifies `HUBModelError` message handling for Windows compatibility and adds a new GitHub author profile.

### 📊 Key Changes

- Updated `HUBModelError` documentation to explain that messages pass through `emojis()`, which removes non-ASCII characters on Windows.
- Removed redundant exception documentation from the constructor.
- Added GitHub author metadata for @rudrakumar07.

### 🎯 Purpose & Impact

- 🪟 Improves clarity around how error messages remain printable on Windows.
- 📖 Makes the exception documentation more concise and accurate.
- 👤 Ensures contributions from @rudrakumar07 are correctly attributed in the documentation.