### PR TITLE
Stop seven docstring examples echoing values no literal can match

### DIFF
--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -382,6 +382,9 @@ rlatjdwls2528@gmail.com:
 ronald_eddy@yahoo.com:
   avatar: https://avatars.githubusercontent.com/u/10393491?v=4
   username: him2him2
+rudrachhaya700@gmail.com:
+  avatar: https://avatars.githubusercontent.com/u/226091897?v=4
+  username: rudrakumar07
 rulosanti@gmail.com:
   avatar: https://avatars.githubusercontent.com/u/20377209?v=4
   username: rulosant

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -936,10 +936,14 @@ class Boxes(BaseTensor):
         >>> boxes_data = torch.tensor([[100, 50, 150, 100, 0.9, 0], [200, 150, 300, 250, 0.8, 1]])
         >>> orig_shape = (480, 640)  # height, width
         >>> boxes = Boxes(boxes_data, orig_shape)
-        >>> print(boxes.xyxy)
-        >>> print(boxes.conf)
-        >>> print(boxes.cls)
-        >>> print(boxes.xywhn)
+        >>> print(boxes.xyxy.shape)
+        torch.Size([2, 4])
+        >>> print(boxes.conf.shape)
+        torch.Size([2])
+        >>> print(boxes.cls.shape)
+        torch.Size([2])
+        >>> print(boxes.xywhn.shape)
+        torch.Size([2, 4])
     """
 
     def __init__(self, boxes: torch.Tensor | np.ndarray, orig_shape: tuple[int, int]) -> None:
@@ -1211,7 +1215,9 @@ class Keypoints(BaseTensor):
         >>> orig_shape = (480, 640)  # Original image shape (height, width)
         >>> keypoints = Keypoints(keypoints_data, orig_shape)
         >>> print(keypoints.xy.shape)  # Access xy coordinates
-        >>> print(keypoints.conf)  # Access confidence values
+        torch.Size([1, 17, 2])
+        >>> print(keypoints.conf.shape)  # Access confidence values
+        torch.Size([1, 17])
         >>> keypoints_cpu = keypoints.cpu()  # Move keypoints to CPU
     """
 
@@ -1429,9 +1435,12 @@ class OBB(BaseTensor):
     Examples:
         >>> boxes = torch.tensor([[100, 50, 150, 100, 30, 0.9, 0]])  # xywhr, conf, cls
         >>> obb = OBB(boxes, orig_shape=(480, 640))
-        >>> print(obb.xyxyxyxy)
-        >>> print(obb.conf)
-        >>> print(obb.cls)
+        >>> print(obb.xyxyxyxy.shape)
+        torch.Size([1, 4, 2])
+        >>> print(obb.conf.shape)
+        torch.Size([1])
+        >>> print(obb.cls.shape)
+        torch.Size([1])
     """
 
     def __init__(self, boxes: torch.Tensor | np.ndarray, orig_shape: tuple[int, int]) -> None:

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -459,9 +459,7 @@ def set_logging(name="LOGGING_NAME", verbose=True):
         (logging.Logger): Configured logger object.
 
     Examples:
-        >>> set_logging(name="ultralytics", verbose=True)
-        >>> logger = logging.getLogger("ultralytics")
-        >>> logger.info("This is an info message")
+        >>> logger = set_logging(name="ultralytics", verbose=True)
 
     Notes:
         - On Windows, this function attempts to reconfigure stdout to use UTF-8 encoding if possible.

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -450,7 +450,7 @@ def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=()
         >>> from ultralytics.utils.checks import check_requirements
 
         Check a requirements.txt file
-        >>> met = check_requirements("path/to/requirements.txt")
+        >>> met = check_requirements(Path("path/to/requirements.txt"))
 
         Check a single package
         >>> met = check_requirements("ultralytics>=8.3.200", cmds="--index-url https://download.pytorch.org/whl/cpu")

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -85,7 +85,7 @@ def parse_requirements(file_path=ROOT.parent / "requirements.txt", package=""):
 
     Examples:
         >>> from ultralytics.utils.checks import parse_requirements
-        >>> parse_requirements(package="ultralytics")
+        >>> requirements = parse_requirements(package="ultralytics")
     """
     if package:
         requires = [x for x in metadata.distribution(package).requires if "extra == " not in x]
@@ -450,16 +450,16 @@ def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=()
         >>> from ultralytics.utils.checks import check_requirements
 
         Check a requirements.txt file
-        >>> check_requirements("path/to/requirements.txt")
+        >>> met = check_requirements("path/to/requirements.txt")
 
         Check a single package
-        >>> check_requirements("ultralytics>=8.3.200", cmds="--index-url https://download.pytorch.org/whl/cpu")
+        >>> met = check_requirements("ultralytics>=8.3.200", cmds="--index-url https://download.pytorch.org/whl/cpu")
 
         Check multiple packages
-        >>> check_requirements(["numpy", "ultralytics"])
+        >>> met = check_requirements(["numpy", "ultralytics"])
 
         Check with interchangeable packages
-        >>> check_requirements([("onnxruntime", "onnxruntime-gpu"), "numpy"])
+        >>> met = check_requirements([("onnxruntime", "onnxruntime-gpu"), "numpy"])
     """
     prefix = colorstr("red", "bold", "requirements:")
 

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -541,8 +541,8 @@ class SystemLogger:
 
         Examples:
             >>> logger = SystemLogger()
-            >>> logger.get_metrics()["cpu"]  # CPU percentage
-            >>> logger.get_metrics(rates=True)["network"]["recv_mbs"]  # MB/s download rate
+            >>> cpu_percent = logger.get_metrics()["cpu"]
+            >>> download_rate = logger.get_metrics(rates=True)["network"]["recv_mbs"]  # MB/s
         """
         import psutil  # scoped as slow import
 


### PR DESCRIPTION
## summary

Seven docstring examples printed a value that no doctest expected-output line can ever match, so `pytest --doctest-modules` reported `Expected nothing` against output that changes between machines and runs:

- `engine.results.Boxes`, `Keypoints` and `OBB` printed float tensors. A hand-written float literal cannot survive the global print-formatter override installed in `ultralytics/utils/__init__.py`, so these now print `.shape` with the value declared, the form `Keypoints.xyn` already uses in the same file.
- `utils.set_logging` echoed a `Logger` repr whose level depends on the process `RANK`, then logged a message into the captured stream. It now binds the returned logger, which is what the function's Returns section documents.
- `utils.logger.SystemLogger.get_metrics` echoed a host CPU percentage and a live network rate, and `utils.checks.parse_requirements` echoed the installed distribution's requirement list. Both now bind their results.
- `utils.checks.check_requirements` echoed a bool that depends on which packages are installed, at all four calls in its example.

Only docstring lines change; no executable line is touched. Verified per site with `pytest --doctest-modules`: 7 failed before, 7 passed after, and passed again on a repeat run.

Six sites in the same sweep are deliberately not touched here, because suppressing their output would not remove their defect: `hub/google/__init__.py` (three sites) pings live GCP endpoints, `utils/autodevice.py` calls `print_status()` whose whole purpose is printing a host-dependent table, `utils/logger.py`'s `SystemLogger` class example ends in `for epoch in range(epochs)` with `epochs` undefined so it cannot pass regardless, and `utils/tqdm.py` renders a progress bar.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📚 Updates documentation examples to show clearer return values and tensor shapes across the Ultralytics API.

### 📊 Key Changes
- 🧮 Improved `Boxes`, `Keypoints`, and `OBB` examples to display tensor shapes instead of full tensor contents.
- 📝 Clarified utility examples for:
  - `set_logging()`
  - `parse_requirements()`
  - `check_requirements()`
  - `SystemLogger.get_metrics()`
- 👤 Added GitHub author metadata for @rudrakumar07.

### 🎯 Purpose & Impact
- ✅ Makes documentation examples more concise, predictable, and easier to understand.
- 🔍 Helps users verify API output dimensions without relying on variable tensor values.
- 🛠️ Demonstrates how to capture and reuse function return values in practical code.
- 🚀 No functional behavior changes are introduced; this PR primarily improves documentation clarity and contributor attribution.