### PR TITLE
keep the mixed text order stable across processes

### DIFF
--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -382,6 +382,9 @@ rlatjdwls2528@gmail.com:
 ronald_eddy@yahoo.com:
   avatar: https://avatars.githubusercontent.com/u/10393491?v=4
   username: him2him2
+rudrachhaya700@gmail.com:
+  avatar: https://avatars.githubusercontent.com/u/226091897?v=4
+  username: rudrakumar07
 rulosanti@gmail.com:
   avatar: https://avatars.githubusercontent.com/u/20377209?v=4
   username: rulosant

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -422,8 +422,8 @@ class BaseMixTransform(BaseTransform):
             return labels
 
         mix_texts = [*labels["texts"], *(item for x in labels["mix_labels"] for item in x["texts"])]
-        mix_texts = list({tuple(x) for x in mix_texts})
-        text2id = {text: i for i, text in enumerate(mix_texts)}
+        mix_texts = [list(x) for x in dict.fromkeys(tuple(x) for x in mix_texts)]
+        text2id = {tuple(text): i for i, text in enumerate(mix_texts)}
 
         for label in [labels] + labels["mix_labels"]:
             for i, cls in enumerate(label["cls"].squeeze(-1).tolist()):


### PR DESCRIPTION
## Summary

`BaseMixTransform._update_label_text` deduplicates the combined positive/negative text list by building a `set` of tuples and converting it back with `list({...})`. Set iteration order for a set of tuples of strings depends on the string hashes, and CPython randomizes string hashing per process (`PYTHONHASHSEED`) unless it's pinned. So the same input label produces a differently-ordered `mix_texts` list, and therefore a differently-ordered `text2id` mapping, in different processes (e.g. different DataLoader workers or different DDP ranks).

Deduplication now goes through `dict.fromkeys`, which preserves first-appearance order and is not affected by hash randomization.

## Test plan

- [x] Verified with a fixed RNG seed across repeated process runs that `mix_texts` order is now stable, where it previously varied
- [x] Confirmed `RandomLoadText`'s negative-sample selection (downstream of this ordering) is also now reproducible under a fixed seed
- [x] `ruff check` / `ruff format --check` pass

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛠️ Preserves text-label ordering during data augmentation while adding a new GitHub author entry.

### 📊 Key Changes

- Replaced unordered set-based text deduplication with order-preserving deduplication in `ultralytics/data/augment.py`.
- Ensured text-to-class ID mappings remain consistent with the original text order.
- Added GitHub profile metadata for contributor @rudrakumar07.

### 🎯 Purpose & Impact

- ✅ Makes text label IDs deterministic and reproducible across runs.
- 🧩 Prevents unpredictable class ordering when combining labels through mix-based augmentations.
- 📈 Improves training consistency for tasks that use text labels, with no expected impact on users who do not use these augmentations.