### PR TITLE
return a bool from is_triton_model

### DIFF
--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -382,6 +382,9 @@ rlatjdwls2528@gmail.com:
 ronald_eddy@yahoo.com:
   avatar: https://avatars.githubusercontent.com/u/10393491?v=4
   username: him2him2
+rudrachhaya700@gmail.com:
+  avatar: https://avatars.githubusercontent.com/u/226091897?v=4
+  username: rudrakumar07
 rulosanti@gmail.com:
   avatar: https://avatars.githubusercontent.com/u/20377209?v=4
   username: rulosant

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -200,7 +200,7 @@ class Model(torch.nn.Module):
         from urllib.parse import urlsplit
 
         url = urlsplit(model)
-        return url.netloc and url.path and url.scheme in {"http", "grpc"}
+        return bool(url.netloc and url.path and url.scheme in {"http", "grpc"})
 
     @staticmethod
     def is_hub_model(model: str) -> bool:


### PR DESCRIPTION
## Summary

`Model.is_triton_model` is annotated `-> bool` but its body returns `url.netloc and url.path and url.scheme in {"http", "grpc"}` — a bare `and` chain, which returns the first falsy operand instead of `True`/`False`. For a non-Triton model path this returns `''` rather than `False`.

Wraps the expression in `bool(...)` so the function always returns an actual boolean, matching its declared return type.

## Test plan

- [x] Verified with both matching and non-matching Triton URLs that the function now returns `True`/`False` rather than a truthy/falsy string
- [x] `ruff check` / `ruff format --check` pass

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
✅ Improved Triton model URL detection by ensuring the check returns a proper Boolean value.

### 📊 Key Changes
- Updated `is_triton_model()` in `ultralytics/engine/model.py` to explicitly return `True` or `False`.
- Added GitHub author metadata for @rudrakumar07.

### 🎯 Purpose & Impact
- 🛠️ Makes Triton model validation more predictable and type-consistent.
- 🔍 Prevents the function from returning non-Boolean URL components in edge cases.
- 📚 Updates documentation contributor information without affecting runtime behavior.