### PR TITLE
Revert "Replace pytube/pafy with `yt-dlp` for YouTube streams"

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -406,7 +406,7 @@ def test_predict_all_image_formats():
 
 @pytest.mark.slow
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")
-@pytest.mark.skipif(is_github_action_running(), reason="YouTube blocks GitHub Actions runner IPs")
+@pytest.mark.skipif(is_github_action_running(), reason="No auth https://github.com/JuanBindez/pytubefix/issues/166")
 def test_youtube():
     """Test YOLO model on a YouTube video stream, handling potential network-related errors."""
     model = YOLO(MODEL)

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -663,11 +663,12 @@ def autocast_list(source: list[Any]) -> list[Image.Image | np.ndarray]:
     return files
 
 
-def get_best_youtube_url(url: str) -> str | None:
+def get_best_youtube_url(url: str, method: str = "pytube") -> str | None:
     """Retrieve the URL of the best quality MP4 video stream from a given YouTube video.
 
     Args:
         url (str): The URL of the YouTube video.
+        method (str): The method to use for extracting video info. Options are "pytube", "pafy", and "yt-dlp".
 
     Returns:
         (str | None): The URL of the best quality MP4 video stream, or None if no suitable stream is found.
@@ -679,19 +680,38 @@ def get_best_youtube_url(url: str) -> str | None:
         https://rr4---sn-q4flrnek.googlevideo.com/videoplayback?expire=...
 
     Notes:
-        - Requires the yt-dlp package, which is installed automatically on first use.
-        - Looks for formats with a video codec, no audio, and *.mp4 extension at 1080p or above.
+        - Requires additional libraries based on the chosen method: pytubefix, pafy, or yt-dlp.
+        - The function prioritizes streams with at least 1080p resolution when available.
+        - For the "yt-dlp" method, it looks for formats with video codec, no audio, and *.mp4 extension.
     """
-    check_requirements("yt-dlp")
-    import yt_dlp
+    if method == "pytube":
+        # Switched from pytube to pytubefix to resolve https://github.com/pytube/pytube/issues/1954
+        check_requirements("pytubefix>=6.5.2")
+        from pytubefix import YouTube
 
-    with yt_dlp.YoutubeDL({"quiet": True}) as ydl:
-        info_dict = ydl.extract_info(url, download=False)  # extract info
-    for f in reversed(info_dict.get("formats", [])):  # reversed because best is usually last
-        # Find a format with video codec, no audio, *.mp4 extension at least 1920x1080 size
-        good_size = (f.get("width") or 0) >= 1920 or (f.get("height") or 0) >= 1080
-        if good_size and f["vcodec"] != "none" and f["acodec"] == "none" and f["ext"] == "mp4":
-            return f.get("url")
+        streams = YouTube(url).streams.filter(file_extension="mp4", only_video=True)
+        streams = sorted(streams, key=lambda s: s.resolution, reverse=True)  # sort streams by resolution
+        for stream in streams:
+            if stream.resolution and int(stream.resolution[:-1]) >= 1080:  # check if resolution is at least 1080p
+                return stream.url
+
+    elif method == "pafy":
+        check_requirements(("pafy", "youtube_dl==2020.12.2"))
+        import pafy
+
+        return pafy.new(url).getbestvideo(preftype="mp4").url
+
+    elif method == "yt-dlp":
+        check_requirements("yt-dlp")
+        import yt_dlp
+
+        with yt_dlp.YoutubeDL({"quiet": True}) as ydl:
+            info_dict = ydl.extract_info(url, download=False)  # extract info
+        for f in reversed(info_dict.get("formats", [])):  # reversed because best is usually last
+            # Find a format with video codec, no audio, *.mp4 extension at least 1920x1080 size
+            good_size = (f.get("width") or 0) >= 1920 or (f.get("height") or 0) >= 1080
+            if good_size and f["vcodec"] != "none" and f["acodec"] == "none" and f["ext"] == "mp4":
+                return f.get("url")
 
 
 # Define constants


### PR DESCRIPTION
Reverts ultralytics/ultralytics#16336

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🎥 Expanded YouTube video stream support by adding multiple extraction methods and replacing the outdated `pytube` dependency with `pytubefix`.

### 📊 Key Changes
- Added a `method` argument to `get_best_youtube_url()` with support for:
  - `pytubefix` (default)
  - `pafy`
  - `yt-dlp`
- Updated dependency handling to install and validate the required library for each method.
- Added `pytubefix` support for selecting high-quality MP4 video-only streams, prioritizing 1080p or higher.
- Preserved the existing `yt-dlp` stream-selection behavior.
- Updated the YouTube test skip message to reference an authentication limitation and its related [GitHub issue](https://github.com/JuanBindez/pytubefix/issues/166).

### 🎯 Purpose & Impact
- ✅ Improves compatibility with YouTube by moving from the outdated `pytube` package to `pytubefix`.
- 🔄 Gives users flexibility to choose among three YouTube extraction backends.
- 📺 Enables reliable selection of high-resolution MP4 streams for video inference.
- ⚠️ YouTube access may still require authentication or be affected by service restrictions, particularly in automated environments such as GitHub Actions.