### PR TITLE
Restore the supported-tasks macro and drop the dead model_name sets

### DIFF
--- a/docs/en/integrations/edge-tpu.md
+++ b/docs/en/integrations/edge-tpu.md
@@ -47,15 +47,8 @@ TFLite Edge TPU offers various deployment options for machine learning models, i
 
 Edge TPU export supports six of the seven Ultralytics tasks. Semantic segmentation is available only with YOLO26, the only family that ships that head. Depth estimation is not supported because its INT8 model emits an `EXP` v2 operator that the Edge TPU compiler cannot parse.
 
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ✅        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ✅        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ❌        |
+{% set unsupported = ["depth"] %}
+{% include "macros/supported-tasks.md" %}
 
 The Edge TPU compiler maps the operations it supports onto the accelerator and leaves the rest on the CPU, so task support does not mean every operation runs on the TPU.
 

--- a/docs/en/integrations/sony-imx500.md
+++ b/docs/en/integrations/sony-imx500.md
@@ -39,15 +39,8 @@ The IMX500 works with quantized models. Quantization makes models smaller and fa
 
 IMX500 export supports four of the seven Ultralytics tasks, and only for the YOLOv8n and YOLO11n models noted below; exporting a semantic segmentation, OBB, or depth estimation model raises an error.
 
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ❌        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ❌        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ❌        |
+{% set unsupported = ["semantic", "obb", "depth"] %}
+{% include "macros/supported-tasks.md" %}
 
 !!! note "Supported model variants"
 

--- a/docs/en/integrations/tf-graphdef.md
+++ b/docs/en/integrations/tf-graphdef.md
@@ -55,15 +55,8 @@ Here's how you can deploy with TF GraphDef efficiently across various platforms.
 
 TF GraphDef export supports six of the seven Ultralytics tasks. Semantic segmentation and depth estimation are available only with YOLO26, the only family that ships those heads. Pose models can be exported, but Ultralytics GraphDef inference is not currently supported for them.
 
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ✅        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ❌        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ✅        |
+{% set unsupported = ["obb"] %}
+{% include "macros/supported-tasks.md" %}
 
 ## Exporting YOLO26 Models to TF GraphDef
 

--- a/docs/en/tasks/classify.md
+++ b/docs/en/tasks/classify.md
@@ -257,7 +257,6 @@ Export a YOLO26n-cls model to a different format like ONNX, CoreML, etc.
 
 Available YOLO26-cls export formats are in the table below. You can export to any format using the `format` argument, i.e., `format='onnx'` or `format='engine'`. You can predict or validate directly on exported models, i.e., `yolo predict model=yolo26n-cls.onnx`. Usage examples are shown for your model after export completes.
 
-{% set model_name = "yolo26n-cls" %}
 {% include "macros/export-table.md" %}
 
 See full `export` details in the [Export](../modes/export.md) page.

--- a/docs/en/tasks/depth.md
+++ b/docs/en/tasks/depth.md
@@ -371,7 +371,6 @@ Export a YOLO26n-depth model to a different format like ONNX, CoreML, etc.
 
 Available YOLO26 depth estimation export formats are in the table below. You can export to any format using the `format` argument, i.e., `format='onnx'` or `format='engine'`. You can predict or validate directly on exported models, i.e., `yolo predict model=yolo26n-depth.onnx`. Usage examples are shown for your model after export completes.
 
-{% set model_name = "yolo26n-depth" %}
 {% include "macros/export-table.md" %}
 
 See full `export` details in the [Export](../modes/export.md) page.

--- a/docs/en/tasks/obb.md
+++ b/docs/en/tasks/obb.md
@@ -226,7 +226,6 @@ Export a YOLO26n-obb model to a different format like ONNX, CoreML, etc.
 
 Available YOLO26-obb export formats are in the table below. You can export to any format using the `format` argument, i.e., `format='onnx'` or `format='engine'`. You can predict or validate directly on exported models, i.e., `yolo predict model=yolo26n-obb.onnx`. Usage examples are shown for your model after export completes.
 
-{% set model_name = "yolo26n-obb" %}
 {% include "macros/export-table.md" %}
 
 See full `export` details in the [Export](../modes/export.md) page.

--- a/docs/en/tasks/pose.md
+++ b/docs/en/tasks/pose.md
@@ -215,7 +215,6 @@ Export a YOLO26n Pose model to a different format like ONNX, CoreML, etc. This a
 
 Available YOLO26-pose export formats are in the table below. You can export to any format using the `format` argument, i.e., `format='onnx'` or `format='engine'`. You can predict or validate directly on exported models, i.e., `yolo predict model=yolo26n-pose.onnx`. Usage examples are shown for your model after export completes.
 
-{% set model_name = "yolo26n-pose" %}
 {% include "macros/export-table.md" %}
 
 See full `export` details in the [Export](../modes/export.md) page.

--- a/docs/en/tasks/segment.md
+++ b/docs/en/tasks/segment.md
@@ -203,7 +203,6 @@ Available YOLO26-seg export formats are in the table below. You can export to an
 
     CoreML embedded NMS pipelines (`nms=True`) only support object detection models. Segmentation exports to CoreML warn and force `nms=False`, producing a raw model without NMS.
 
-{% set model_name = "yolo26n-seg" %}
 {% include "macros/export-table.md" %}
 
 See full `export` details in the [Export](../modes/export.md) page.

--- a/docs/en/tasks/semantic.md
+++ b/docs/en/tasks/semantic.md
@@ -217,7 +217,6 @@ Export a YOLO26n-sem model to a different format like ONNX, CoreML, etc.
 
 Available YOLO26 semantic segmentation export formats are in the table below. You can export to any format using the `format` argument, i.e., `format='onnx'` or `format='engine'`. You can predict or validate directly on exported models, i.e., `yolo predict model=yolo26n-sem.onnx`. Usage examples are shown for your model after export completes.
 
-{% set model_name = "yolo26n-sem" %}
 {% include "macros/export-table.md" %}
 
 See full `export` details in the [Export](../modes/export.md) page.

--- a/docs/macros/supported-tasks.md
+++ b/docs/macros/supported-tasks.md
@@ -1,9 +1,9 @@
-| Task                                          | Supported |
-| :-------------------------------------------- | :-------- |
-| [Object Detection](../tasks/detect.md)        | ✅        |
-| [Instance Segmentation](../tasks/segment.md)  | ✅        |
-| [Semantic Segmentation](../tasks/semantic.md) | ✅        |
-| [Pose Estimation](../tasks/pose.md)           | ✅        |
-| [OBB Detection](../tasks/obb.md)              | ✅        |
-| [Classification](../tasks/classify.md)        | ✅        |
-| [Depth Estimation](../tasks/depth.md)         | ✅        |
+| Task                                          | Supported                                         |
+| :-------------------------------------------- | :------------------------------------------------ |
+| [Object Detection](../tasks/detect.md)        | {{ "❌" if "detect" in unsupported else "✅" }}   |
+| [Instance Segmentation](../tasks/segment.md)  | {{ "❌" if "segment" in unsupported else "✅" }}  |
+| [Semantic Segmentation](../tasks/semantic.md) | {{ "❌" if "semantic" in unsupported else "✅" }} |
+| [Pose Estimation](../tasks/pose.md)           | {{ "❌" if "pose" in unsupported else "✅" }}     |
+| [OBB Detection](../tasks/obb.md)              | {{ "❌" if "obb" in unsupported else "✅" }}      |
+| [Classification](../tasks/classify.md)        | {{ "❌" if "classify" in unsupported else "✅" }} |
+| [Depth Estimation](../tasks/depth.md)         | {{ "❌" if "depth" in unsupported else "✅" }}    |


### PR DESCRIPTION
## Background

#25544 replaced `{% include "macros/supported-tasks.md" %}` with literal inlined tables on three pages, because the portal was rendering the macro's conditional cells as raw text. That was the right call at the time — the pages were genuinely broken — but it treated the symptom. ultralytics/portal#3237 fixes the renderer itself, so the macro can own all nineteen pages again.

While reviewing #25544 I also asserted that its `{% set model_name %}` deletions would regress the task export tables, and pushed a commit restoring those six lines. **That was wrong**, and this PR undoes it.

## Changes

**`docs/macros/supported-tasks.md`** goes back to conditional cells. It needs no `{% set unsupported = unsupported or [] %}` default line — the fixed renderer treats an unset name as absent — so the macro is one line shorter than the original.

**edge-tpu / sony-imx500 / tf-graphdef** drop their inlined tables for `{% set unsupported = [...] %}` + the include. The other sixteen pages already include the macro and are unchanged.

**Six `docs/en/tasks/*.md`** lose their body-level `{% set model_name = "..." %}`. Those lines were dead:

```
context WITH model_name (frontmatter):     `yolo26n-seg.torchscript`
context WITHOUT model_name (frontmatter):  `yolo26n.torchscript`
```

Every one of those pages declares `model_name:` in **frontmatter**, and that is what populates the render context — `renderMacros` never parsed a body-level `{% set %}` into it. The body line only ever rendered as a visible `<p>{% set model_name = "yolo26n-cls" %}</p>` paragraph. Frontmatter stays the single source of truth.

Net **-27 lines**.

## Verification

Rendered the actual modified files through the fixed renderer:

| Page | Result |
| --- | --- |
| edge-tpu | depth ❌, rest ✅ |
| sony-imx500 | semantic ❌, obb ❌, depth ❌, rest ✅ |
| tf-graphdef | obb ❌, rest ✅ |
| onnx (plain include, unchanged) | all ✅ |
| tasks/segment | `yolo26n-seg.torchscript` |
| tasks/classify | `yolo26n-cls.torchscript` |
| tasks/detect (no frontmatter `model_name`) | `yolo26n.torchscript` |

No `{% set %}` or `{{ }}` survives into any rendered page. Formatted with `prettier@3.8.5 --tab-width 4 --print-width 120`.

## Merge order

**Do not merge before ultralytics/portal#3237 is deployed** — the macro's conditionals depend on that renderer fix. Merging this first would put the raw-template tables back on nineteen pages.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧩 Centralized task-support tables across integration and task documentation using a reusable macro.

### 📊 Key Changes

- Added configurable support status rendering to `docs/macros/supported-tasks.md`.
- Updated Edge TPU, Sony IMX500, and TF GraphDef integration pages to define unsupported tasks through a shared macro.
- Removed repeated `model_name` settings from task export documentation because the shared export table now handles them.
- Preserved existing support information, including:
  - Edge TPU: all tasks except depth estimation.
  - Sony IMX500: detection, instance segmentation, pose, and classification.
  - TF GraphDef: all tasks except OBB detection.

### 🎯 Purpose & Impact

- 📚 Reduces duplicated Markdown and makes documentation easier to maintain.
- ✅ Ensures task-support tables use a consistent format across pages.
- 🔄 Simplifies future updates when adding or removing export support.
- 👥 Improves documentation reliability for users selecting deployment targets and export formats.