### PR TITLE
Reduce `Annotator.masks` in row bands to cut mask plotting time and memory

### DIFF
--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -489,11 +489,15 @@ class Annotator:
             device = self.im.device if tensor_image else masks.device
             masks = ops.scale_masks(masks[None].to(device).float(), self.im.shape[:2])[0] > 0.5
             colors = torch.tensor(colors, device=device, dtype=torch.float32) / 255.0  # shape(n,3)
-            colors = colors[:, None, None]  # shape(n,1,1,3)
+            colors = colors[:, None, None] * alpha  # shape(n,1,1,3), premultiplied by alpha
             masks = masks.unsqueeze(3)  # shape(n,h,w,1)
-            # prod/amax rather than cumprod[-1]/max().values: same result without the (n,h,w,*) intermediates
-            mcs = (masks * (colors * alpha)).amax(0)  # shape(h,w,3)
-            inv_alpha_masks = (1 - masks * alpha).prod(0)  # shape(h,w,1)
+            mcs = torch.empty((*masks.shape[1:3], 3), device=device, dtype=torch.float32)  # shape(h,w,3)
+            inv_alpha_masks = torch.empty((*masks.shape[1:3], 1), device=device, dtype=torch.float32)  # shape(h,w,1)
+            # Reduce in row bands so the (n,h,w,*) intermediates never span the full height
+            bands = max(1, masks.numel() * 12 // 2**23)  # 12 bytes per mask element downstream, 8 MB per band
+            for m, mcs_band, inv_band in zip(masks.chunk(bands, 1), mcs.chunk(bands), inv_alpha_masks.chunk(bands)):
+                torch.amax(m * colors, 0, out=mcs_band)
+                torch.prod(1 - m * alpha, 0, out=inv_band)
             im = (self.im if tensor_image else torch.from_numpy(self.im)).to(device).float() / 255.0
             im = ((im * inv_alpha_masks + mcs) * 255).byte()
             self.im[:] = im if tensor_image else im.cpu().numpy()


### PR DESCRIPTION
The tensor branch of `Annotator.masks` reduces over all instances at full frame height, so `masks * colors` and `1 - masks * alpha` still build `(n, h, w, 3)` and `(n, h, w, 1)` intermediates — 498 MB of transient float32 at 1080p with n=20. This runs once per frame under the default `save=True` of `yolo predict`, and `engine/results.py:557` is its only caller.

Reducing the same `amax`/`prod` over row bands keeps the reduction order untouched, so the output is bit-for-bit identical, but each intermediate stays under 8 MB and fits in cache.

Deleted: the two full-height reductions and their comment.

Net +4 lines: the band loop replaces two one-liners, and the added lines are the two output buffers plus the loop that keeps the intermediates bounded.

## Reproduce

```bash
yolo predict model=yolo11n-seg.pt source=<12 frames at 1920x1080> save=True device=cpu imgsz=1088
```

## Measured

Full `yolo predict` wall clock, 12 frames at 1080p, 22.4 instances per frame, medians of interleaved before/after runs:

```
                          before      after
CPU, 1 thread          891.8 ms    637.4 ms/frame   1.40x
CPU, 32 threads        259.2 ms    164.5 ms/frame   1.58x
CUDA                    47.0 ms     42.6 ms/frame   1.10x
```

The reduction on its own, n=27 at 1080p, median of 7 interleaved reps:

```
CPU     371.3 -> 121.4 ms   3.06x
CUDA     11.7 ->   5.4 ms   2.18x
```

Peak CUDA memory for the same block: n=20 658.9 -> 200.5 MB, n=50 1608.6 -> 438.8 MB.

## Identical output

sha256 of the raw bytes is identical in 336 configurations — cpu and cuda, n from 1 to 100, shapes from 1x1 to 17x4001 including empty height and empty width, alpha 0.0/0.31/0.5/1.0 — and the concatenated saved JPGs match in every end-to-end run above. The band loop does not change the reduction order, it is the same `torch.prod`/`torch.amax` over the same axis, so this holds on CUDA with a non-dyadic alpha too.

Band count is derived from `masks.numel()`, so a zero-width or zero-height image still takes the single-band path instead of dividing by zero.

`pytest tests/test_python.py -k "predict or plot or seg"` gives 28 passed, 2 skipped.

## Coverage

The numpy branch of `Annotator.masks` accumulates per mask into an `overlay` and never builds the stacked intermediates, and `Annotator.semantic_mask` uses a per-class loop with `addWeighted`, so neither carries this. A grep for `.amax(0)`/`.prod(0)` across `ultralytics/` returns no other reduction over a stacked mask tensor.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Reduces mask plotting memory usage and processing time by compositing masks in row bands instead of allocating full-height intermediate tensors.

### 📊 Key Changes
- Premultiplies mask colors by the alpha value before compositing.
- Allocates output tensors once for composited colors and inverse alpha masks.
- Processes masks in configurable row bands to limit intermediate memory consumption.
- Preserves the existing mask blending behavior while using in-place reductions.

### 🎯 Purpose & Impact
- 🧠 Lowers peak memory usage during mask plotting, especially for large images or many masks.
- ⚡ Can improve plotting performance by avoiding full-height intermediate tensors.
- ✅ Maintains compatibility for tensor and NumPy-backed images.
- 🔍 The updated memory strategy should be validated across different image sizes, mask counts, devices, and alpha values.