### PR TITLE
Fix ECC global motion compensation warping against the first frame

### DIFF
--- a/ultralytics/trackers/utils/gmc.py
+++ b/ultralytics/trackers/utils/gmc.py
@@ -152,9 +152,7 @@ class GMC:
         except Exception as e:
             LOGGER.warning(f"findTransformECC failed; using identity warp. {e}")
 
-        # Store current frame data for next iteration
         self.prevFrame = frame.copy()
-
         return H
 
     def apply_features(self, raw_frame: np.ndarray, detections: list | None = None) -> np.ndarray:

--- a/ultralytics/trackers/utils/gmc.py
+++ b/ultralytics/trackers/utils/gmc.py
@@ -152,6 +152,9 @@ class GMC:
         except Exception as e:
             LOGGER.warning(f"findTransformECC failed; using identity warp. {e}")
 
+        # Store current frame data for next iteration
+        self.prevFrame = frame.copy()
+
         return H
 
     def apply_features(self, raw_frame: np.ndarray, detections: list | None = None) -> np.ndarray:


### PR DESCRIPTION
`GMC.apply_ecc()` only assigns `self.prevFrame` during first-frame initialisation (gmc.py:144), so from the second frame on every `findTransformECC` call aligns the current frame against frame 0 instead of the previous one. The warp it returns is cumulative, but `multi_gmc` (`utils/stracks.py:144`, reached from `byte_tracker.py:358`, `track_tracker.py:440` and `deep_oc_sort.py:241`) applies it as a per-frame delta to the position and velocity of every track. `findTransformECC` does not raise here, it converges to a local optimum, so nothing warns the user until the drift is large enough to stop converging at all.

`apply_features()` ends with `self.prevFrame = frame.copy()` at gmc.py:267 and `apply_sparseoptflow()` does the same at gmc.py:327, both under the comment "Store current frame data for next iteration". `apply_ecc()` is the only one of the three that never updates it.

Deleted: nothing. Net +3 lines, which are the missing half of a per-frame state update the two sibling methods already do, plus the same comment they already have.

## Reproduce

A fixed texture panning 4 px per frame. No download, no model:

```python
import cv2, numpy as np
from ultralytics.trackers.utils.gmc import GMC

rng = np.random.default_rng(0)
scene = cv2.GaussianBlur(rng.integers(0, 255, (400, 900, 3), dtype=np.uint8), (0, 0), 4)
gmc = GMC(method="ecc")
for i in range(6):
    print(i, round(float(gmc.apply(np.roll(scene, -4 * i, axis=1))[0, 2]), 3))
```

```
frame    before     after     true dx
  1      -4.007    -4.007      -4.0
  2      -8.007    -3.982      -4.0
  3     -12.034    -3.995      -4.0
  4    -109.664    -3.990      -4.0
  5      +0.000    -3.999      -4.0     <- ECC stops converging and falls back to identity
```

## Measured

`yolo11n` on CPU over `solutions_ci_demo.mp4` (the asset the CI already uses), same botsort config except `gmc_method`:

```
                        boxes   unique IDs   mean track length
ecc, before               736       33            22.30
ecc, after               1229       25            49.16
sparseOptFlow            1019       17            59.94
```

Before this PR, `ecc` emits 33 identities on a clip where `sparseOptFlow` ends at 17, and it keeps only 736 boxes from the same detections. Anything counting unique IDs reports roughly twice the real number, with no warning. After the fix `ecc` moves towards the other method rather than away from it, though it does not match it — the residual gap is the accuracy of ECC itself, not the accumulation.

`sparseOptFlow` is unchanged, 1019 boxes and 17 IDs before and after, since the diff only touches `apply_ecc`.

This is not an accuracy claim in the MOT sense. There is no ground truth here, what is measured is the number of identities the tracker emits and the warp against a known camera motion.

`pytest tests/test_python.py -k track` gives 14 passed. `ecc` is not the default in any tracker YAML — botsort and tracktrack ship `sparseOptFlow`, deepocsort ships `none` — but the three offer it in the arg comment, and `tests/test_python.py:510` exercises it.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes ECC global motion compensation so each processed frame is correctly retained as the reference for the next iteration. 🛠️

### 📊 Key Changes
- Stores a copy of the current grayscale frame in `self.prevFrame` after ECC processing.
- Ensures the updated reference frame is available on subsequent iterations.

### 🎯 Purpose & Impact
- Prevents ECC warping from incorrectly using the first frame as the reference throughout tracking.
- Improves global motion compensation accuracy and tracking stability across video sequences. 📈