### PR TITLE
Fix `Heatmap` overlay disappearing on frames without tracks

### DIFF
--- a/ultralytics/solutions/heatmap.py
+++ b/ultralytics/solutions/heatmap.py
@@ -113,7 +113,7 @@ class Heatmap(ObjectCounter):
             self.display_counts(plot_im)  # Display the counts on the frame
 
         # Normalize, apply colormap to heatmap and combine with original image
-        if self.track_data.is_track:
+        if self.heatmap.any():
             normalized_heatmap = cv2.normalize(self.heatmap, None, 0, 255, cv2.NORM_MINMAX).astype(np.uint8)
             colored_heatmap = cv2.applyColorMap(normalized_heatmap, self.colormap)
             plot_im = cv2.addWeighted(plot_im, 0.5, colored_heatmap, 0.5, 0)


### PR DESCRIPTION
`self.heatmap` is an accumulator built once (heatmap.py:88) and it only grows, so by frame 300 it holds the history of the whole clip. The overlay that draws it is gated on `self.track_data.is_track` (heatmap.py:116), which only checks if **this** frame returned track IDs. That is a property of the current frame, not of the accumulator.

The two stop agreeing as soon as the tracker returns nothing for one frame: the object leaves the view, gets occluded, or comes back and its new ID is not confirmed yet. On that frame the whole accumulated heatmap disappears from the output, and it comes back on the next one. There is no error and no warning, the overlay just flickers.

The check the code really needs is `self.heatmap.any()`: is there anything to draw.

Deleted: the `is_track` guard on the overlay. +1/-1, no new state, no flag, no branch — the condition is replaced in the same place that checks it.

## Reproduce

Default settings, no high `conf`. An object that leaves the view for 5 frames:

```python
import cv2, numpy as np
from ultralytics import solutions

bus = cv2.resize(cv2.imread("ultralytics/assets/bus.jpg"), (240, 400))
hm = solutions.Heatmap(model="yolo11n.pt", show=False, verbose=False)
for i in range(24):
    f = np.full((640, 960, 3), 128, np.uint8)
    if not 10 <= i < 15:                      # the object is out of view on 10..14
        f[150:550, 100 + i * 20 : 340 + i * 20] = bus
    hm.process(f)
    print(i, "drawn today:", bool(hm.track_data.is_track), " has history:", bool(hm.heatmap.any()))
```

```
frames 0-9    drawn, has history
frames 10-14  NOT drawn, has history   <- the accumulated heatmap disappears
frame  15     NOT drawn, has history   <- object is back, but the track is not confirmed yet
frames 16-23  drawn, has history
```

6 of 24 frames lose the overlay at `conf=0.25`.

## Measured

`solutions_ci_demo.mp4` with `yolo11n`, counting frames where the accumulator is non-empty but the guard hides it:

```
conf=0.25 (default)    0 / 62 frames
conf=0.5               0 / 62
conf=0.8              27 / 62   in runs of 5, 1 and 21 frames
```

The clip is 62 frames of large, always-present objects, so at the default the detector never misses and the bug never appears. Raising `conf` is only one way to produce a frame without tracks — the repro above produces them at the default by moving the object out of view.

Frames that draw the overlay today are byte-for-byte unchanged: md5 of `plot_im.tobytes()` is identical on all of them across conf 0.25 and 0.8 and colormaps DEEPGREEN (the default) and JET. The only frames whose bytes change are the ones that were losing the overlay.

`pytest tests/test_solutions.py` gives 51 passed, 1 skipped.

## Why not just drop the guard

`cv2.normalize` of an all-zero accumulator stays all zero, and `applyColorMap(0)` is not transparent: it is `[0,0,0]` in DEEPGREEN, `[135,42,53]` in PARULA (the example in cfg/__init__.py:112) and `[128,0,0]` in JET. With the 0.5 `addWeighted` that turns a `[200,200,200]` pixel into `[100,100,100]` — every frame before the first detection would get tinted, or halved in brightness on the default colormap. `.any()` leaves those frames untouched.

The same reasoning discards `is_track or self.heatmap.any()`: the only case where it differs from `.any()` alone is a confirmed track whose boxes are all degenerate (sub-pixel width or height, or fully outside the frame), and there the accumulator is still empty, so it would apply that same flat tint over a clean frame.

`Heatmap` is the only solution holding an accumulator across frames, and after this change `is_track` keeps its one correct use in `solutions.py:175`, where it checks if there are boxes to iterate.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes Heatmap overlay rendering so it remains visible on frames without active tracks.

### 📊 Key Changes
- Changes the overlay condition from checking whether tracking is active to checking whether the heatmap contains data.
- Continues normalizing, colorizing, and blending the accumulated heatmap whenever it is non-empty.

### 🎯 Purpose & Impact
- Prevents the heatmap overlay from disappearing during frames where no objects are currently tracked.
- Provides more consistent visualization across video sequences while preserving existing behavior for empty heatmaps.