### PR TITLE
Enable multi-core Google LiteRT CPU inference

### DIFF
--- a/ultralytics/nn/backends/litert.py
+++ b/ultralytics/nn/backends/litert.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import numpy as np
 import torch
 
-from ultralytics.utils import LOGGER
+from ultralytics.utils import LOGGER, NUM_THREADS
 from ultralytics.utils.checks import check_requirements
 
 from .base import BaseBackend, read_tflite_metadata
@@ -34,7 +34,7 @@ class LiteRTBackend(BaseBackend):
         tflite_file = Path(weight)
 
         LOGGER.info(f"Loading {tflite_file} for LiteRT inference...")
-        self.interpreter = Interpreter(str(tflite_file))
+        self.interpreter = Interpreter(str(tflite_file), num_threads=NUM_THREADS) # Enable multi-core inference
         self.interpreter.allocate_tensors()
         self.input_details = self.interpreter.get_input_details()
         self.output_details = self.interpreter.get_output_details()

--- a/ultralytics/nn/backends/litert.py
+++ b/ultralytics/nn/backends/litert.py
@@ -34,7 +34,7 @@ class LiteRTBackend(BaseBackend):
         tflite_file = Path(weight)
 
         LOGGER.info(f"Loading {tflite_file} for LiteRT inference...")
-        self.interpreter = Interpreter(str(tflite_file), num_threads=NUM_THREADS) # Enable multi-core inference
+        self.interpreter = Interpreter(str(tflite_file), num_threads=NUM_THREADS)  # Enable multi-core inference
         self.interpreter.allocate_tensors()
         self.input_details = self.interpreter.get_input_details()
         self.output_details = self.interpreter.get_output_details()


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

LiteRT inference now uses the configured number of CPU threads for faster multi-core model execution. ⚡

### 📊 Key Changes

- Imports the global `NUM_THREADS` setting.
- Passes `NUM_THREADS` to the LiteRT `Interpreter` during model loading.
- Enables multi-core inference while preserving existing LiteRT behavior.

### 🎯 Purpose & Impact

- 🚀 May improve LiteRT inference speed, especially on multi-core CPUs.
- ⚙️ Ensures LiteRT follows the project-wide thread configuration.
- ✅ No changes to model outputs or user-facing inference APIs.