### PR TITLE
Fix `AttributeError` on `mask_threshold` in SAM3 semantic prediction

### DIFF
--- a/ultralytics/models/sam/sam3/sam3_image.py
+++ b/ultralytics/models/sam/sam3/sam3_image.py
@@ -30,6 +30,8 @@ def _update_out(out, out_name, out_value, auxiliary=True, update_aux=True):
 class SAM3SemanticModel(torch.nn.Module):
     """SAM3 model for semantic segmentation with vision-language backbone."""
 
+    mask_threshold: float = 0.0
+
     def __init__(
         self,
         backbone: SAM3VLBackbone,


### PR DESCRIPTION
Fixes #25557, reported by @stone-jr.

`SAM3SemanticPredictor.postprocess()` thresholds the masks at `self.model.mask_threshold` (`predict.py:2335`), and `inference_features()` does the same at `predict.py:2407`. But `get_model()` for that predictor returns `build_sam3_image_model()`, which builds a `SAM3SemanticModel` (`sam3/sam3_image.py:30`) — and that class inherits from `torch.nn.Module` directly, so it never gets the `mask_threshold` attribute that `SAMModel` (`modules/sam.py:53`) and `SAM2Model` (`modules/sam.py:161`) declare. There is no assignment of it anywhere else in the package either, so the lookup fails at runtime:

```
AttributeError: 'SAM3SemanticModel' object has no attribute 'mask_threshold'
```

The attribute lookup happens on every call that keeps at least one mask after NMS, which is the normal path for text and visual prompts. Both lines are on documented paths: `postprocess()` is the one the reporter hit, and `inference_features()` is what the SAM 3 page uses to share features between two predictors (`docs/en/models/sam-3.md:242`).

I checked the other three SAM 3 predictors instead of assuming they behave the same way:

- `SAM3VideoSemanticPredictor` inherits `get_model()`, so it ends up with the same `SAM3SemanticModel` and the `inference_features()` it inherits crashes as well. Its own `postprocess()` override (`predict.py:2642`) thresholds at a literal and never reads the attribute, so the video path itself is not affected.
- `SAM3VideoPredictor` is not affected. `SAM2VideoPredictor.get_model()` resolves through the MRO to `build_interactive_sam3()`, so `self.model` is a `SAM3Model` and the read at `predict.py:968` finds the attribute on `SAM2Model`.
- The interactive `SAM3Predictor` is not affected either, for the same reason.

This comes from #25386, which replaced the `> 0.5` literal by `> self.model.mask_threshold` on both lines. The intent of that PR is right — these are raw logits, so the equivalent of `sigmoid(logits) > 0.5` is `logits > 0`, and that is exactly the `0.0` the sibling classes declare. Only the attribute was missing. First affected release is v8.4.105 and it still reproduces on `main` (8.4.113), which is why the same snippet from the docs worked for the reporter a week earlier and stopped working after upgrading.

So the fix is the declaration the class was missing, in the same form the two sibling models use:

```python
mask_threshold: float = 0.0
```

Going back to a `> 0` literal on those two lines would also stop the crash, but `self.model.mask_threshold` is read from five other call sites in the same file (`Predictor` at `predict.py:400`, `405`, `521`, `684` and `SAM2VideoPredictor` at `968`), so the threshold already belongs to the model everywhere else and only this model was missing it.

Deleted: nothing. Net +2 lines, and no change of behaviour against the intent of #25386 — the threshold value is the same one the rest of the SAM family already applies.

## Reproduce

Ran end to end with the real `sam3.pt` checkpoint on `main` (8.4.113), one RTX 4060, `quantize=16`, on the `bus.jpg` asset of the repo. This is the text prompt block of the docs page, unchanged:

```python
from ultralytics.models.sam import SAM3SemanticPredictor

overrides = {"conf": 0.25, "task": "segment", "mode": "predict", "model": "sam3.pt", "quantize": 16}
predictor = SAM3SemanticPredictor(overrides=overrides)
predictor.set_image("ultralytics/assets/bus.jpg")
results = predictor(text=["person"])
```

```
before   AttributeError: 'SAM3SemanticModel' object has no attribute 'mask_threshold'
after    6 boxes, masks (6, 1080, 810), conf 0.972 0.970 0.966 0.943 0.762 0.302
```

The same run also shows why `0.0` is the right value and not just the value that stops the crash. `pred_masks` comes out in the range **-149.875 to +20.422**, so those are raw logits and not probabilities, and thresholding them at the old `0.5` literal trims every mask a bit:

```
object          1       2       3       4       5      6
area @ 0.0   32205   45736   21145   11438   2803   547     px
area @ 0.5   31804   45029   20828   11312   2757   536     px
lost          1.25%   1.55%   1.50%   1.10%   1.64%  2.01%
```

Same detections in both runs, 1608 pixels change class. It always trims and never grows, and the smallest object loses the most in relative terms, which is the silent accuracy loss #25386 was after.

The crash also reproduces without the checkpoint, by building a bare `SAM3SemanticModel` and calling the real `postprocess()` on synthetic predictions, if you want to check it without the gated weights. The attribute lookup does not depend on the tensors.

It is a class attribute in the siblings, so the class check shows the same:

```
SAMModel           0.0
SAM2Model          0.0
SAM3Model          0.0
SAM3SemanticModel  MISSING   ->  0.0 after this PR
```

## Validation

Every `self.model.<attr>` reached from `SAM3SemanticPredictor` and `SAM3VideoSemanticPredictor` resolves on `SAM3SemanticModel` after the change (`backbone`, `names`, `text_embeddings`, `set_classes`, `set_imgsz`, `forward_grounding`, `_encode_prompt`, `mask_threshold`), so no sibling attribute is left missing behind this one. `format`, `stride` and `fp16` are the ones `Predictor.setup_model()` assigns at runtime (`predict.py:472-474`), so they resolve too.

`pytest tests/test_cli.py` gives 45 passed, 1 skipped and 1 failure, `test_solutions[analytics]`, which dies with the same SIGSEGV on `main` without this patch, so it is a local matplotlib problem on my side and not related to SAM. The lazy-import guard on `ultralytics.models.sam.sam3.geometry_encoders` passes. `ruff format --check` and `ruff check` are clean on the touched file.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes an `AttributeError` encountered when using SAM3 semantic prediction with `mask_threshold`.

### 📊 Key Changes
- Adds a class-level `mask_threshold` float attribute to `SAM3SemanticModel`.
- Initializes the default threshold to `0.0` for reliable semantic mask processing.

### 🎯 Purpose & Impact
- Prevents SAM3 semantic prediction from failing when accessing `mask_threshold`.
- Improves compatibility and stability for users running SAM3 semantic segmentation workflows. 🛠️
