### PR TITLE
Update Raspberry Pi 5 benchmarks with Google LiteRT using multi-cores

### DIFF
--- a/docs/en/guides/raspberry-pi.md
+++ b/docs/en/guides/raspberry-pi.md
@@ -198,7 +198,7 @@ The below table represents the benchmark results for two different models (YOLO2
         | MNN           | ✅      | 9.4              | 0.4749      | 91.87                |
         | NCNN          | ✅      | 9.4              | 0.4784      | 67.03                 |
         | ExecuTorch    | ✅      | 9.4              | 0.4772      | 144.83                 |
-        | LiteRT        | ✅      | 9.8              | 0.4730      | 245.5                 |
+        | LiteRT        | ✅      | 9.8              | 0.4730      | 123.30                 |
 
     === "YOLO26s"
 
@@ -211,7 +211,7 @@ The below table represents the benchmark results for two different models (YOLO2
         | MNN           | ✅      | 36.4              | 0.5614      | 237.24                |
         | NCNN          | ✅      | 36.4              | 0.5684      | 172.88                |
         | ExecuTorch    | ✅      | 36.5              | 0.5670      | 376.48                |
-        | LiteRT        | ✅      | 36.8              | 0.5630      | 795.00                |
+        | LiteRT        | ✅      | 36.8              | 0.5630      | 360.00                |
 
     Benchmarked with Ultralytics 8.4.108
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated Raspberry Pi LiteRT benchmark results for YOLO26 models with corrected performance measurements. ⚡

### 📊 Key Changes

- Changed the LiteRT inference time for **YOLO26n** from **245.5 ms** to **123.30 ms**.
- Changed the LiteRT inference time for **YOLO26s** from **795.00 ms** to **360.00 ms**.
- Model accuracy and preprocessing metrics remain unchanged.
- Updated values apply to benchmarks run with **Ultralytics 8.4.108**.

### 🎯 Purpose & Impact

- Provides more accurate LiteRT performance data for Raspberry Pi deployments. 📈
- Helps users make better-informed decisions when selecting inference formats.
- Shows substantially improved LiteRT latency for both YOLO26 models, indicating faster edge inference than previously documented.