### PR TITLE
Fix `Annotator.kpts()` dropping keypoints and limbs on image borders

### DIFF
--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -603,6 +603,7 @@ class Results(SimpleClass, DataExportMixin):
             for i, k in enumerate(reversed(self.keypoints.cpu().numpy().data)):  # one host transfer, no per-kpt syncs
                 annotator.kpts(
                     k,
+                    self.orig_shape,
                     radius=kpt_radius,
                     kpt_line=kpt_line,
                     kpt_color=colors(i, True) if color_mode == "instance" else None,

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -603,7 +603,6 @@ class Results(SimpleClass, DataExportMixin):
             for i, k in enumerate(reversed(self.keypoints.cpu().numpy().data)):  # one host transfer, no per-kpt syncs
                 annotator.kpts(
                     k,
-                    self.orig_shape,
                     radius=kpt_radius,
                     kpt_line=kpt_line,
                     kpt_color=colors(i, True) if color_mode == "instance" else None,

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -604,7 +604,7 @@ class Annotator:
                     conf2 = kpts[(sk[1] - 1), 2]
                     if conf1 < conf_thres or conf2 < conf_thres:
                         continue
-                elif pos1 == (0, 0) or pos2 == (0, 0):  # (0, 0) marks a missing keypoint without a confidence channel
+                elif not (kpts[sk[0] - 1, :2].any() and kpts[sk[1] - 1, :2].any()):  # (0, 0) marks a missing keypoint
                     continue
                 if min(pos1 + pos2) < 0:
                     continue

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -557,6 +557,7 @@ class Annotator:
     def kpts(
         self,
         kpts,
+        shape: tuple = (640, 640),
         radius: int | None = None,
         kpt_line: bool = True,
         conf_thres: float = 0.25,
@@ -566,6 +567,7 @@ class Annotator:
 
         Args:
             kpts (torch.Tensor): Keypoints, shape [17, 3] (x, y, confidence).
+            shape (tuple, optional): Image shape (h, w).
             radius (int, optional): Keypoint radius.
             kpt_line (bool, optional): Draw lines between keypoints.
             conf_thres (float, optional): Confidence threshold.

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -557,7 +557,6 @@ class Annotator:
     def kpts(
         self,
         kpts,
-        shape: tuple = (640, 640),
         radius: int | None = None,
         kpt_line: bool = True,
         conf_thres: float = 0.25,
@@ -567,7 +566,6 @@ class Annotator:
 
         Args:
             kpts (torch.Tensor): Keypoints, shape [17, 3] (x, y, confidence).
-            shape (tuple, optional): Image shape (h, w).
             radius (int, optional): Keypoint radius.
             kpt_line (bool, optional): Draw lines between keypoints.
             conf_thres (float, optional): Confidence threshold.
@@ -589,12 +587,12 @@ class Annotator:
         for i, k in enumerate(kpts):
             color_k = kpt_color or (self.kpt_color[i].tolist() if is_pose else colors(i))
             x_coord, y_coord = k[0], k[1]
-            if x_coord % shape[1] != 0 and y_coord % shape[0] != 0:
-                if len(k) == 3:
-                    conf = k[2]
-                    if conf < conf_thres:
-                        continue
-                cv2.circle(self.im, (int(x_coord), int(y_coord)), radius, color_k, -1, lineType=cv2.LINE_AA)
+            if len(k) == 3:
+                if k[2] < conf_thres:
+                    continue
+            elif x_coord == 0 and y_coord == 0:  # (0, 0) marks a missing keypoint when there is no confidence channel
+                continue
+            cv2.circle(self.im, (int(x_coord), int(y_coord)), radius, color_k, -1, lineType=cv2.LINE_AA)
 
         if kpt_line:
             ndim = kpts.shape[-1]
@@ -606,9 +604,9 @@ class Annotator:
                     conf2 = kpts[(sk[1] - 1), 2]
                     if conf1 < conf_thres or conf2 < conf_thres:
                         continue
-                if pos1[0] % shape[1] == 0 or pos1[1] % shape[0] == 0 or pos1[0] < 0 or pos1[1] < 0:
+                elif pos1 == (0, 0) or pos2 == (0, 0):  # (0, 0) marks a missing keypoint without a confidence channel
                     continue
-                if pos2[0] % shape[1] == 0 or pos2[1] % shape[0] == 0 or pos2[0] < 0 or pos2[1] < 0:
+                if min(pos1 + pos2) < 0:
                     continue
                 cv2.line(
                     self.im,


### PR DESCRIPTION
`Annotator.kpts()` guards every keypoint with a modulo (`plotting.py:592`):

```python
if x_coord % shape[1] != 0 and y_coord % shape[0] != 0:
```

A modulo is not a bounds check, and the pose pipeline sends it exactly the values it rejects. `scale_coords()` ends in `clip_coords()` (`ops.py:220-227`), which does `clamp_(0, w)` / `clamp_(0, h)`, so every keypoint predicted outside the frame lands on **0, W or H exactly**. For those the modulo is 0, the condition is False, and `cv2.circle` never runs. No warning, and the confidence is not even read. Lines 609-611 do the same with the limbs.

So the keypoints that get dropped are the ones the clamp just created: a person walking out of view, an ankle below the bottom edge, a hand past the right edge.

`zidane.jpg`, one of the repo's own assets, with `yolo predict model=yolo11n-pose.pt` and nothing else:

```
kpt 11 (left hip)   x=1034.46  y=720.00  conf=0.477   y == H  -> dropped
kpt 12 (right hip)  x= 900.29  y=720.00  conf=0.655   y == H  -> dropped
```

Both hips, and the three limbs that depend on them. The image is 720 px tall, the hips are at y=720.0, and they are thrown away for being divisible by the height.

Deleted: the modulo guard, the `shape` argument it was the only user of, and the `(0, 0)` coordinate test on the path where a confidence column already answers the same question. +8/-11 across two files.

## Reproduce

```python
from ultralytics import YOLO

r = YOLO("yolo11n-pose.pt").predict("ultralytics/assets/zidane.jpg")[0]
h, w = r.orig_shape
for person in r.keypoints.cpu().numpy().data:
    for i, (x, y, conf) in enumerate(person):
        if conf >= 0.25 and (x % w == 0 or y % h == 0):
            print(f"kpt {i:>2}  x={x:8.2f} y={y:8.2f} conf={conf:.3f}  -> not drawn")
```

## Measured

`yolo predict model=yolo11n-pose.pt` with default settings over coco8-pose plus coco128 (136 images, 180 people):

```
images with at least one keypoint lost    16 / 136   11.8 %
people with at least one keypoint lost    18 / 180   10.0 %
keypoints at conf >= 0.25 lost            26 / 2200   1.18 %
```

Limbs are on top of that count, and they are lost earlier: a limb needs both of its endpoints to survive the guard.

What changes and what does not, by sha256 of the rendered array:

```
zidane.jpg      4111 px change, all inside y[326,719] x[851,1050]  (the two hips and their limbs)
bus.jpg         one limb reappears at the left edge, no new circles
(0, 0) with visibility 0, ndim=2 and ndim=3   identical
(0, 0) with confidence 0.90, ndim=3           now drawn (see the last section)
keypoints under conf_thres                    identical
negative coordinates                          identical
coordinates that are interior multiples       identical
val_batch0_labels and val_batch0_pred         identical
```

That last row needs its mechanism explained, because it does not hold for every case. I replayed the exact arrays that `yolo pose val` passes to `plot_images()` — the 14-person label batch and the 197-person prediction batch of coco8-pose — and both mosaics come out byte-for-byte identical. This happens because neither batch has a keypoint at exactly `(0, 0)` with visibility at or above the threshold: COCO-style labels write a missing keypoint as `0 0 0`, and it is the visibility column that drops it, not the coordinates.

When such a keypoint does exist the mosaic changes, and it should. `plot_images()` never passed `shape`, so it checked every mosaic against the `(640, 640)` default no matter how large the tiles really were, and whether a border keypoint survived depended on where it landed. Put the same keypoint on the left edge of all 16 tiles of a mosaic and it was drawn in 12 of them and dropped in the 4 of the first column, the ones whose absolute x is 0 .. same defect, same fix, and now the 16 tiles agree (184 px change).

`pytest tests/test_python.py -k "pose or plot or result or annotat"` gives 23 passed. `ruff format --check` and `ruff check` are clean.

## The `shape` argument

After the fix nothing reads it, so it goes out. `Results.plot()` was passing `self.orig_shape` positionally (`results.py:606`) and the patch drops that argument; the other caller, `plot_images()` at `plotting.py:981`, never passed it and needs no edit. This is a deliberate signature change on a public class, so third-party code calling `annotator.kpts(k, im.shape)` positionally would now pass a tuple to `radius` and raise in `cv2.circle` — it fails loudly instead of silently. If you prefer it the other way, I can leave the parameter in place and ignored ..

## What the guard still does, and what it does not

The `(0, 0)` test stays only where it is the only signal available. With three columns the confidence already says if a keypoint exists, so that is what decides, and a real keypoint clamped to the top-left corner is now drawn like any other — same reason the hips above are drawn. With two columns there is no third value to check, so `(0, 0)` still means "missing", which is the convention the original code assumed and I am not changing it. In both cases the negative check stays.

The two-column path is reached by a model trained on a `kpt_shape: [K, 2]` dataset — tiger-pose is the one in the repo. Its predictions arrive at `Results.plot()` with `has_visible=False`, so there is no confidence column and `(0, 0)` is all we have. I checked that path through `Results.plot()` and not just through `Annotator` on its own: the `(0, 0)` placeholder renders identically before and after, and a keypoint clamped to `y == H` or `x == W` is drawn now and was not before, which is the same fix as everywhere else.

Labels are the other direction and they never reach plotting with two columns: `verify_image_label()` appends the visibility column first (`data/utils.py:321-323`). One consequence worth stating, since that column is built from the coordinates: a two-column dataset that writes a missing keypoint as `0 0` gets visibility 1.0, so it would now be drawn in the corner. The mask only zeroes negative coordinates. tiger-pose has 0 of its 3156 keypoints at `(0, 0)`, so nothing in the repo hits it.

`SolutionAnnotator.draw_specific_kpts()` (`solutions.py:509-513`) already filters on confidence alone with no coordinate guard, so with this both keypoint drawing paths in the repo follow the same rule. `Annotator.kpts` has no overrides, and the modulo idiom does not appear anywhere else in the repo.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes `Annotator.kpts()` so keypoints and connecting limbs located on image borders are rendered correctly.

### 📊 Key Changes
- Removes the image-shape argument from `Annotator.kpts()` and its call site.
- Replaces border-coordinate filtering with confidence checks and explicit handling of missing `(0, 0)` keypoints.
- Preserves rejection of negative coordinates when drawing limbs.

### 🎯 Purpose & Impact
- Prevents valid keypoints and limbs at coordinate zero or on image edges from being incorrectly dropped.
- Improves pose visualization accuracy for detections touching image borders.
- Simplifies the keypoint drawing API while maintaining support for confidence- and non-confidence-based keypoint data.