### PR TITLE
Fix NCNN and Paddle export of prompt-free YOLOE models

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -1042,6 +1042,9 @@ class LRPCHead(nn.Module):
     def forward(self, cls_feat: torch.Tensor, loc_feat: torch.Tensor, conf: float) -> tuple[tuple, torch.Tensor]:
         """Process classification and localization features to generate detection proposals."""
         if self.enabled:
+            if not conf:  # static export, every anchor passes the proposal filter
+                cls_feat = self.vocab(cls_feat.flatten(2).transpose(-1, -2))
+                return self.loc(loc_feat), cls_feat.transpose(-1, -2), None
             pf_score = self.pf(cls_feat)[0, 0].flatten(0)
             mask = pf_score.sigmoid() > conf
             cls_feat = cls_feat.flatten(2).transpose(-1, -2)
@@ -1209,19 +1212,21 @@ class YOLOEDetect(Detect):
         # Prompt-free fusion removes the one-to-many heads.
         cv2 = self.one2one_cv2 if self.end2end or self.cv2 is None else self.cv2
         cv3 = self.one2one_cv3 if self.end2end or self.cv3 is None else self.cv3
+        conf = 0 if self.export and not self.dynamic else getattr(self, "conf", 0.001)
         for i in range(self.nl):
             cls_feat = cv3[i](x[i])
             loc_feat = cv2[i](x[i])
             assert isinstance(self.lrpc[i], LRPCHead)
-            box, score, idx = self.lrpc[i](
-                cls_feat,
-                loc_feat,
-                0 if self.export and not self.dynamic else getattr(self, "conf", 0.001),
-            )
+            box, score, idx = self.lrpc[i](cls_feat, loc_feat, conf)
             boxes.append(box.view(bs, self.reg_max * 4, -1))
             scores.append(score)
             index.append(idx)
-        preds = {"boxes": torch.cat(boxes, 2), "scores": torch.cat(scores, 2), "feats": x, "index": torch.cat(index)}
+        preds = {
+            "boxes": torch.cat(boxes, 2),
+            "scores": torch.cat(scores, 2),
+            "feats": x,
+            "index": torch.cat(index) if conf else None,
+        }
         y = self._inference(preds)
         if self.end2end:
             y = self.postprocess(y.permute(0, 2, 1))
@@ -1231,7 +1236,7 @@ class YOLOEDetect(Detect):
         """Decode predicted bounding boxes for inference."""
         dbox = super()._get_decode_boxes(x)
         if hasattr(self, "lrpc"):
-            dbox = dbox if self.export and not self.dynamic else dbox[..., x["index"]]
+            dbox = dbox if x["index"] is None else dbox[..., x["index"]]
         return dbox
 
     @property
@@ -1353,26 +1358,23 @@ class YOLOESegment(YOLOEDetect):
         cv2 = self.one2one_cv2 if self.end2end or self.cv2 is None else self.cv2
         cv3 = self.one2one_cv3 if self.end2end or self.cv3 is None else self.cv3
         cv5 = self.one2one_cv5 if self.end2end or self.cv5 is None else self.cv5
+        conf = 0 if self.export and not self.dynamic else getattr(self, "conf", 0.001)
         for i in range(self.nl):
             cls_feat = cv3[i](x[i])
             loc_feat = cv2[i](x[i])
             assert isinstance(self.lrpc[i], LRPCHead)
-            box, score, idx = self.lrpc[i](
-                cls_feat,
-                loc_feat,
-                0 if self.export and not self.dynamic else getattr(self, "conf", 0.001),
-            )
+            box, score, idx = self.lrpc[i](cls_feat, loc_feat, conf)
             boxes.append(box.view(bs, self.reg_max * 4, -1))
             scores.append(score)
             index.append(idx)
         mc = torch.cat([cv5[i](x[i]).view(bs, self.nm, -1) for i in range(self.nl)], 2)
-        index = torch.cat(index)
+        index = torch.cat(index) if conf else None
         preds = {
             "boxes": torch.cat(boxes, 2),
             "scores": torch.cat(scores, 2),
             "feats": x,
             "index": index,
-            "mask_coefficient": mc * index.int() if self.export and not self.dynamic else mc[..., index],
+            "mask_coefficient": mc if index is None else mc[..., index],
         }
         y = self._inference(preds)
         if self.end2end:

--- a/ultralytics/utils/export/paddle.py
+++ b/ultralytics/utils/export/paddle.py
@@ -49,6 +49,11 @@ def torch2paddle(
 
     import x2paddle
     from x2paddle.convert import pytorch2paddle
+    from x2paddle.op_mapper.pytorch2paddle import prim2code
+
+    # x2paddle 1.6.0 codegen for pooling asserts reads exec() results from locals(), which PEP 667 broke in Python
+    # 3.13. The assert only re-checks pooling args that torch already validated during tracing, so skip emitting it.
+    prim2code.prim_assert = lambda layer, **kwargs: None
 
     LOGGER.info(f"\n{prefix} starting export with X2Paddle {x2paddle.__version__}...")
 

--- a/ultralytics/utils/export/paddle.py
+++ b/ultralytics/utils/export/paddle.py
@@ -53,11 +53,15 @@ def torch2paddle(
 
     # x2paddle 1.6.0 codegen for pooling asserts reads exec() results from locals(), which PEP 667 broke in Python
     # 3.13. The assert only re-checks pooling args that torch already validated during tracing, so skip emitting it.
+    prim_assert = prim2code.prim_assert
     prim2code.prim_assert = lambda layer, **kwargs: None
 
     LOGGER.info(f"\n{prefix} starting export with X2Paddle {x2paddle.__version__}...")
 
-    pytorch2paddle(module=model, save_dir=output_dir, jit_type="trace", input_examples=[im])  # export
+    try:
+        pytorch2paddle(module=model, save_dir=output_dir, jit_type="trace", input_examples=[im])  # export
+    finally:
+        prim2code.prim_assert = prim_assert
     if metadata:
         YAML.save(Path(output_dir) / "metadata.yaml", metadata)  # add metadata.yaml
     return str(output_dir)


### PR DESCRIPTION
Static export of `YOLOE("yoloe-26n-seg-pf.pt")` failed for NCNN and Paddle.

Static export passes `conf=0` into `LRPCHead`, so the proposal filter mask is all-ones and every use of it is a no-op multiply. Those dead ops broke both exporters:

1. **NCNN**: PNNX has no `torch.gt` layer, so the exported graph loaded with `layer torch.gt not exists or registered` and `network graph not ready`, then inference raised `IndexError: list index out of range`.
2. **Paddle**: `mc * index.int()` mixed dtypes and x2paddle raised `TypeError: (InvalidType) Type promotion only support calculations between floating-point numbers and between complex and real numbers. But got different data type x: float32, y: int32`.

Two changes:

1. `LRPCHead.forward` returns early when `conf` is 0: run `vocab` and `loc` on all anchors and return `None` for the mask. The callers now key off that `None` instead of re-deriving the export condition, and drop the no-op mask multiplies.
2. `torch2paddle` skips x2paddle's pooling-assert codegen. x2paddle 1.6.0 reads an `exec()` result back from `locals()`, which PEP 667 broke in Python 3.13, so **every** Paddle export on 3.13 died with `KeyError: 'assert_result'`. The assert only re-checks pooling args that torch already validated while tracing.

Verified on `yoloe-26n-seg-pf.pt` at `imgsz=640`: NCNN, Paddle, and static ONNX now export, load, and agree with each other; dynamic ONNX still matches PyTorch. Paddle export of `yolo26n-seg.pt`, `yolo11n-seg.pt`, and `yolo26n.pt` also works again on Python 3.13.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Improved static export handling for LRPC-based detection and segmentation models, while fixing Paddle export compatibility with Python 3.13.

### 📊 Key Changes

- Added a static-export path that keeps all anchors instead of applying confidence-based proposal filtering.
- Updated detection and segmentation heads to handle missing proposal indices safely during export.
- Simplified confidence-threshold handling across LRPC forward passes.
- Ensured segmentation mask coefficients remain correctly aligned when no anchor filtering is performed.
- Patched X2Paddle export to temporarily skip an unnecessary pooling assertion that is incompatible with Python 3.13.
- Restored the original X2Paddle behavior after export completes, including when errors occur.

### 🎯 Purpose & Impact

- ✅ Improves reliability of static model exports, where dynamic proposal filtering is unavailable.
- 📦 Helps exported detection and segmentation models preserve complete anchor data for downstream decoding.
- 🐍 Enables Paddle exports to work with Python 3.13 and X2Paddle 1.6.0.
- 🛡️ Limits the X2Paddle workaround to the export operation, reducing side effects on other functionality.
- ⚡ Supports more robust deployment workflows across static export formats and Paddle-based environments.