### PR TITLE
Fix TorchScript GPU inference device mismatch

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -931,10 +931,6 @@ class Exporter:
             f"output shape(s) {self.output_shape} ({file_size(file):.1f} MB)"
         )
         self.run_callbacks("on_export_start")
-        if fmt in {"torchscript", "onnx", "openvino"}:
-            for m in model.modules():
-                if isinstance(m, Detect):
-                    m.shape = None
 
         # Export
         if is_tf_format:

--- a/ultralytics/utils/tal.py
+++ b/ultralytics/utils/tal.py
@@ -393,15 +393,16 @@ def make_anchors(feats, strides, grid_cell_offset=0.5):
     """Generate anchors from features."""
     anchor_points, stride_tensor = [], []
     assert feats is not None
-    dtype, device = feats[0].dtype, feats[0].device
+    dtype = feats[0].dtype
     for i in range(len(feats)):  # use len(feats) to avoid TracerWarning from iterating over strides tensor
         stride = strides[i]
         h, w = feats[i].shape[2:] if isinstance(feats, list) else (int(feats[i][0]), int(feats[i][1]))
-        sx = torch.arange(end=w, device=device, dtype=dtype) + grid_cell_offset  # shift x
-        sy = torch.arange(end=h, device=device, dtype=dtype) + grid_cell_offset  # shift y
+        # new_* factories inherit the device at runtime, unlike torch.arange which bakes it into traced graphs
+        sx = feats[0].new_ones(w, dtype=dtype).cumsum(0) - (1 - grid_cell_offset)  # shift x
+        sy = feats[0].new_ones(h, dtype=dtype).cumsum(0) - (1 - grid_cell_offset)  # shift y
         sy, sx = torch.meshgrid(sy, sx, indexing="ij") if TORCH_1_11 else torch.meshgrid(sy, sx)
         anchor_points.append(torch.stack((sx, sy), -1).view(-1, 2))
-        stride_tensor.append(torch.full((h * w, 1), stride, dtype=dtype, device=device))
+        stride_tensor.append(feats[0].new_full((h * w, 1), stride, dtype=dtype))
     return torch.cat(anchor_points), torch.cat(stride_tensor)
 
 


### PR DESCRIPTION
Predicting with a TorchScript model on GPU crashes for every task:

```
yolo predict model=yolo11n-seg.torchscript imgsz=640 device=0
```

```
RuntimeError: The following operation failed in the TorchScript interpreter.
  File "code/__torch__/ultralytics/nn/modules/head.py", line 114, in forward
    x1y1 = torch.sub(anchor_points, lt)
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

**Cause.** #25525 added a second `m.shape = None` reset after the export dry runs. `Detect._get_decode_boxes` then rebuilds anchors *inside* the trace, so `make_anchors` records `torch.arange(..., device=cpu)` with the trace device frozen into the op. `torch.jit.load(map_location=...)` moves parameters, buffers, and tensor constants, but it cannot change a device argument baked into a traced op, so the anchors stay on CPU while the input follows the requested device.

Before that commit the anchors came from the dry run and were baked in as a plain tensor constant, which `map_location` does move. Bisect confirms 018f8857a as the first bad commit.

**Fix.** Two changes:

1. Delete the second reset. Line 872 already clears `m.shape` before the dry runs, so the dry run recomputes anchors for the export `imgsz` and the trace sees a ready cache. Exported outputs are unchanged.
2. Build the anchor grids in `make_anchors` with `new_ones().cumsum()` and `new_full()` instead of `torch.arange` and `torch.full`. The `new_*` factories take their device from the feature tensor at runtime, while `torch.arange(device=...)` records the device as a constant. This covers `dynamic=True` TorchScript, which always rebuilds anchors inside the trace and failed the same way before and after #25525.

Verified in Docker:

1. Static and dynamic TorchScript GPU predict work for `yolo11n-seg`, `yolo26n-seg`, `yolo26n`, `yolo11n-pose`, and `yolo11n-obb`.
2. Repeated exports of one model object at `imgsz=640`, then `320`, then `640` give identical results for the two 640 runs, for TorchScript, ONNX, and OpenVINO, so no stale anchors return.
3. ONNX outputs match main bit for bit at both sizes.
4. `make_anchors` returns identical values for both input forms, list features and the IMX shape tensor.
5. One-epoch `coco8` train on GPU passes, since the loss shares `make_anchors`.
6. `pytest tests/test_exports.py --export-env base`: 29 passed, 17 skipped.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves model export reliability by making anchor generation preserve runtime device placement in traced graphs. 🚀

### 📊 Key Changes
- Removed export-time logic that reset `Detect` layer shapes for TorchScript, ONNX, and OpenVINO exports.
- Updated anchor generation in `tal.py` to create tensors with device-aware factory methods.
- Replaced `torch.arange` and explicit device assignments with `new_ones` and `new_full`, which inherit the input tensor’s device at runtime.
- Preserved existing anchor coordinates, strides, and data types while improving tracing behavior.

### 🎯 Purpose & Impact
- ✅ Helps exported models run correctly when moved between devices, such as CPU and GPU.
- 📦 Reduces the risk of traced graphs embedding an incorrect device from the export environment.
- 🔧 Simplifies export code by removing special-case `Detect` shape handling.
- 🌐 Improves compatibility across TorchScript, ONNX, OpenVINO, and related deployment workflows.