### PR TITLE
Count the region-text matmuls open-vocabulary heads run functionally

### DIFF
--- a/docs/en/reference/utils/torch_utils.md
+++ b/docs/en/reference/utils/torch_utils.md
@@ -84,6 +84,18 @@ keywords: Ultralytics, torch utils, model optimization, device selection, infere
 
 <br><br><hr><br>
 
+## ::: ultralytics.utils.torch_utils._contrastive_ops
+
+<br><br><hr><br>
+
+## ::: ultralytics.utils.torch_utils._max_sigmoid_ops
+
+<br><br><hr><br>
+
+## ::: ultralytics.utils.torch_utils._image_pool_ops
+
+<br><br><hr><br>
+
 ## ::: ultralytics.utils.torch_utils.get_flops
 
 <br><br><hr><br>

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -516,6 +516,39 @@ def _attention_ops(m, x, y):
     m.total_ops += b * area * m.num_heads * tokens * tokens * (key_dim + m.head_dim)
 
 
+def _contrastive_ops(m, x, y):
+    """Count the region-text similarity einsum of a contrastive head for THOP.
+
+    It pairs every spatial position with every text embedding over the channel axis functionally, so no child-module
+    hook observes it. A YOLOE head whose text embeddings have been fused into its classify branch keeps the module but
+    drops the einsum, and is charged nothing.
+    """
+    if not hasattr(m, "logit_scale"):
+        return  # reparameterized head: forward_fuse passes the features straight through
+    b, c, h, w = x[0].shape
+    m.total_ops += b * x[1].shape[1] * c * h * w
+
+
+def _max_sigmoid_ops(m, x, y):
+    """Count the guide-embedding einsum of a max-sigmoid attention block for THOP.
+
+    Same functional pairing as a contrastive head, but over the `nh * hc` channels the block re-projects its input to
+    rather than the channels it receives.
+    """
+    b, _, h, w = x[0].shape
+    m.total_ops += b * x[1].shape[1] * m.nh * m.hc * h * w
+
+
+def _image_pool_ops(m, x, y):
+    """Count the query-key and attention-value matmuls of image-pooling attention for THOP.
+
+    Both products run functionally between the text embeddings and the `nf` feature maps pooled to `k**2` patches each,
+    contracting `nh * hc` channels per output element.
+    """
+    text = x[1]
+    m.total_ops += 2 * text.shape[0] * m.nh * m.hc * text.shape[1] * m.k**2 * m.nf
+
+
 def get_flops(model, imgsz=640):
     """Calculate FLOPs (floating point operations) for a model in GFLOPs.
 
@@ -538,7 +571,15 @@ def get_flops(model, imgsz=640):
         return 0.0  # if not installed return 0.0 GFLOPs
 
     try:
-        from ultralytics.nn.modules.block import AAttn, Attention  # imported here: block.py imports this module
+        # imported here: block.py imports this module
+        from ultralytics.nn.modules.block import (
+            AAttn,
+            Attention,
+            BNContrastiveHead,
+            ContrastiveHead,
+            ImagePoolingAttn,
+            MaxSigmoidAttnBlock,
+        )
 
         model = unwrap_model(model)
         p = next(model.parameters())
@@ -547,9 +588,17 @@ def get_flops(model, imgsz=640):
         attn = tuple(m for m in model.modules() if isinstance(m, (Attention, AAttn)))
         # attention costs scale with the square of the image area, so a model carrying one is measured at full size;
         # stride= extrapolates from a stride-sized sample, which is affine in area and would land ~97% low on it.
+        # The open-vocabulary rules below stay affine in area, so they extrapolate correctly and need no full size.
         stride = None if attn else max(int(model.stride.max()), 32) if hasattr(model, "stride") else 32  # max stride
         im = torch.empty((1, p.shape[1], *imgsz), device=p.device, dtype=p.dtype)  # input image in BCHW format
-        custom_ops = {Attention: _attention_ops, AAttn: _attention_ops} if attn else None
+        custom_ops = {
+            Attention: _attention_ops,
+            AAttn: _attention_ops,
+            ContrastiveHead: _contrastive_ops,
+            BNContrastiveHead: _contrastive_ops,
+            MaxSigmoidAttnBlock: _max_sigmoid_ops,
+            ImagePoolingAttn: _image_pool_ops,
+        }
         return thop.profile(model, inputs=[im], stride=stride, custom_ops=custom_ops, verbose=False)[0] / 1e9 * 2
     except Exception:
         return 0.0


### PR DESCRIPTION
## summary

`ContrastiveHead` / `BNContrastiveHead` (`block.py:754`/`:780`), `MaxSigmoidAttnBlock` (`:611`) and `ImagePoolingAttn` (`:745`/`:749`) compute their region-text products with `torch.einsum` on reshaped tensors. THOP counts MACs through forward hooks, so no child-module hook observes those products and the blocks are charged only for their conv and linear children. `cv4` of `WorldDetect` and `YOLOEDetect` is a `ModuleList` of contrastive heads, so every YOLO-World and YOLOE model reports a GFLOPs figure short by that term.

`get_flops()` registers three more `custom_ops` rules next to the existing `_attention_ops`, each charging one multiply-add per output element over the axis its einsum contracts:

- `ContrastiveHead` / `BNContrastiveHead` — `tokens * c` per spatial position
- `MaxSigmoidAttnBlock` — the same pairing over the `nh * hc` channels the block re-projects its input to
- `ImagePoolingAttn` — two products between the text embeddings and the `nf` feature maps pooled to `k**2` patches each

### Numbers

Validated against `torch.utils.flop_counter.FlopCounterMode`, which counts `aten.bmm` at the dispatcher level and never sees this code. "rule adds" is `get_flops` minus a rule-less profile through the same path:

| model | before | after | rule adds | `aten.bmm` | |
| -- | -- | -- | -- | -- | -- |
| yolov8-world | 10.341 | **11.105** | 0.7641 | 0.7641 | match |
| yolov8-worldv2 | 9.959 | **10.721** | 0.7619 | 0.7619 | match |
| yoloe-v8 | 9.359 | **10.047** | 0.6881 | 0.6881 | match |
| yoloe-11 | 7.158 | **7.846** | 0.7496 | 0.7496 | match |
| yoloe-26 | 6.095 | **6.783** | 0.8110 | 0.8110 | match |
| yoloe-11-seg | 10.416 | **11.104** | 0.7496 | 0.7496 | match |

The missing term scales with `nc * embed * spatial` rather than with backbone width, so the relative error was largest on the smallest models: YOLOE-26 was 9.7% low.

Sweeping all 66 YAMLs under `cfg/models/**` on both revisions: **58 unchanged bit-for-bit, 8 moved**, and the 8 are exactly the open-vocabulary family (the six above plus `yoloe-26-seg` 9.865 to 10.553 and `yoloe-v8-seg` 12.618 to 13.306). No model outside it is touched.

### Reparameterized heads are charged nothing

`YOLOEDetect.fuse(txt_feats)` folds the text embeddings into the classify branch and calls `BNContrastiveHead.fuse()`, which drops `logit_scale` and rebinds `forward` to a pass-through that runs no einsum. The module stays in `model.modules()`, so the hook still fires. `_contrastive_ops` returns early in that state, keeping the figure equal to the closed-set equivalent — measured 6.673 for a reparameterized `yoloe-11`, matching `yolo11n`, which is what the docs describe. The state is reachable: `YOLOEPELinearTrainer.get_model` returns a reparameterized model as `trainer.model`, and `model_info_for_loggers()` profiles it at epoch 0.

`logit_scale` is the discriminator because it is set in both heads' `__init__` and removed only by that same `fuse()`, together with the einsum. `trainer.py:1132` already keys on it to identify these two classes.

### Stride

The `stride=` decision still keys only on `Attention`/`AAttn`. All three new costs are affine in image area — the first two linear in `h * w`, the image-pooling term constant because adaptive pooling fixes `nf * k**2` tokens — so THOP's affine extrapolation stays valid and these models keep the fast path. Verified at `imgsz=[640, 320]`, `[512, 928]`, `320` and `1280`, and at `nc` of 1, 7, 80 and 200; every case matches `aten.bmm` exactly.

### Docs

No published figure changes, and the two tables on `docs/en/models/yoloe.md` show why:

| | published | params measured | before | after |
| -- | -- | -- | -- | -- |
| `yoloe-26n-seg` (Text/Visual) | 4.8M / 6.0B | 5.10M | 9.865 | 10.553 |
| `yoloe-26n-seg-pf` (Prompt-free) | 6.5M / 15.8B | 6.45M | 15.960 | 15.960 |

The prompt-free row is measurement-consistent and does not move, because its heads are already reparameterized. The text/visual row's params disagree by 6% before any FLOPs question, so that table is paper-sourced rather than a `model.info()` render — the same test that left the YOLOv8/YOLO11/YOLO26 tables alone in #25545. Putting a measured number in one of its five rows would misalign it with the other four. `docs/en/models/yolo-world.md` publishes no FLOPs column at all.

### Validation

- Counts match `FlopCounterMode`'s `aten.bmm` exactly on all eight affected models, with yolov8/yolo11/yolo26 as zero-change controls.
- A reparameterized `yoloe-11` is charged nothing for its fused heads.
- `tests/test_python.py::test_model_profile` and `::test_model_methods` pass; `ruff check` and `ruff format --check` clean.
- Doctest failures in `torch_utils.py` (`select_device`, `attempt_compile`, `profile_ops`) are present identically on the parent commit and are host-dependent.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

⚡️ Improved FLOPs reporting for YOLO open-vocabulary and attention-based components.

### 📊 Key Changes

- Added THOP operation counters for:
  - Contrastive heads
  - Max-sigmoid attention blocks
  - Image-pooling attention
- Registered these custom operation handlers in `get_flops()`.
- Preserved existing attention FLOPs handling and clarified how image-size scaling is applied.
- Added the new utility functions to the Torch utilities reference documentation.

### 🎯 Purpose & Impact

- 📈 Produces more accurate FLOPs estimates for models using open-vocabulary and multimodal modules.
- 🔍 Ensures functional operations such as einsum and matrix multiplications are included even when they are not represented by child modules.
- 🧮 Improves model profiling and comparison for YOLOE-style architectures without changing model inference behavior.
- 📚 Makes the new FLOPs-counting utilities discoverable in the Ultralytics documentation.