### PR TITLE
Remove tests added alongside small bug-fix PRs

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -415,25 +415,3 @@ def test_setup_model_respects_pretrained_arg_for_pt_models(monkeypatch, pretrain
 
     assert captured["cfg"] == checkpoint_model.yaml, "Checkpoint config was not used"
     assert captured["weights"] is (checkpoint_model if uses_weights else None), "Unexpected weights loaded"
-
-
-@pytest.mark.parametrize("end2end", [False, True])
-def test_pose_model_init_criterion_selects_loss_by_head(end2end):
-    """Pose (non-Pose26 head) must use v8PoseLoss and Pose26 must use PoseLoss26, regardless of end2end."""
-    from ultralytics.nn.tasks import PoseModel, yaml_model_load
-    from ultralytics.utils.loss import PoseLoss26, v8PoseLoss
-
-    def build(yaml_name):
-        cfg = yaml_model_load(yaml_name)
-        cfg["end2end"] = end2end
-        model = PoseModel(cfg, nc=2, data_kpt_shape=[17, 3], verbose=False)
-        model.args = get_cfg()
-        return model
-
-    pose_criterion = build("yolov8n-pose.yaml").init_criterion()
-    pose26_criterion = build("yolo26n-pose.yaml").init_criterion()
-    pose_loss = pose_criterion.one2many if end2end else pose_criterion
-    pose26_loss = pose26_criterion.one2many if end2end else pose26_criterion
-
-    assert type(pose_loss) is v8PoseLoss, f"Pose head with end2end={end2end} must use v8PoseLoss"
-    assert type(pose26_loss) is PoseLoss26, f"Pose26 head with end2end={end2end} must use PoseLoss26"

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -187,16 +187,6 @@ def test_int8_calibration_validates_split():
         exporter.get_int8_calibration_dataloader()
 
 
-def test_int8_calibration_classify_fraction():
-    """Check classification INT8 calibration respects fraction (#25469)."""
-    exporter = object.__new__(Exporter)
-    exporter.model = SimpleNamespace(task="classify")
-    exporter.args = get_cfg(overrides={"data": "imagenet10", "fraction": 0.5, "batch": 1})
-    exporter.imgsz = [32]
-    dataloader = exporter.get_int8_calibration_dataloader()
-    assert len(dataloader.dataset) == 6  # imagenet10 val has 12 images, fraction=0.5 keeps 6
-
-
 def test_export_rknn_batch_expansion(monkeypatch, tmp_path):
     """Check RKNN calibrates batch 1 before Toolkit expands to the requested batch."""
     calls = {}

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -22,7 +22,6 @@ from ultralytics import RTDETR, YOLO
 from ultralytics.cfg import get_cfg
 from ultralytics.data.build import build_dataloader, load_inference_source
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
-from ultralytics.optim.muon import muon_update
 from ultralytics.utils import (
     ARM64,
     ASSETS,
@@ -44,20 +43,6 @@ from ultralytics.utils import (
 )
 from ultralytics.utils.downloads import download, safe_download
 from ultralytics.utils.torch_utils import TORCH_1_11, TORCH_1_13
-
-
-def test_muon_update_batches_higher_rank_tensors():
-    """Test batched Muon updates flatten tensors with more than two dimensions before stacking."""
-    gradients = [torch.randn(2, 4), torch.randn(2, 2, 1, 1, 4)]
-    updates = muon_update(gradients, [torch.zeros_like(gradient) for gradient in gradients])
-
-    assert [update.shape for update in updates] == [gradient.shape for gradient in gradients]
-    assert all(torch.isfinite(update).all() for update in updates)
-
-    gradient = torch.randn(2, 2, 4)
-    update = muon_update(gradient, torch.zeros_like(gradient))
-    assert update.shape == gradient.shape
-    assert torch.isfinite(update).all()
 
 
 def test_dataloader_caps_workers_to_batches():


### PR DESCRIPTION
Removes the regression tests merged with three small bug-fix PRs:

- `test_pose_model_init_criterion_selects_loss_by_head` (#25261)
- `test_muon_update_batches_higher_rank_tensors` (#25317) — plus its now-unused `muon_update` import
- `test_int8_calibration_classify_fraction` (#25469)

Net -47 lines, tests-only change. All three files collect cleanly (672 tests).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧹 Removes several targeted regression tests that are no longer needed from the Ultralytics test suite.

### 📊 Key Changes

- Deleted the pose model criterion-selection test covering standard Pose and Pose26 loss behavior.
- Removed the INT8 classification calibration fraction test.
- Removed the Muon optimizer update test for higher-rank tensors.
- Cleaned up the now-unused `muon_update` import from `tests/test_python.py`.

### 🎯 Purpose & Impact

- 🛠️ Simplifies and reduces maintenance overhead in the test suite.
- ⚡ Shortens test execution by removing three focused test cases.
- ⚠️ Reduces automated coverage for pose loss selection, classification INT8 calibration fractions, and Muon tensor updates, so regressions in these areas may be less likely to be detected automatically.