### PR TITLE
fix `Python` syntax error in `similarity-search` solution

### DIFF
--- a/docs/en/guides/similarity-search.md
+++ b/docs/en/guides/similarity-search.md
@@ -60,7 +60,7 @@ The `SearchApp` class launches the full Flask interface. On first run it downloa
     from ultralytics import solutions
 
     app = solutions.SearchApp(
-        # data = "path/to/img/directory" # Optional, build search engine with your own images
+        # data = "path/to/img/directory", # Optional, build search engine with your own images
         device="cpu"  # configure the device for processing, e.g., "cpu" or "cuda"
     )
 
@@ -83,7 +83,7 @@ Call the searcher with a natural language query to get back a list of matching i
     from ultralytics import solutions
 
     searcher = solutions.VisualAISearch(
-        # data = "path/to/img/directory" # Optional, build search engine with your own images
+        # data = "path/to/img/directory", # Optional, build search engine with your own images
         device="cpu"  # configure the device for processing, e.g., "cpu" or "cuda"
     )
 
@@ -138,7 +138,7 @@ While CLIP is developed by OpenAI, the [Ultralytics Python package](https://pypi
     from ultralytics import solutions
 
     searcher = solutions.VisualAISearch(
-        # data = "path/to/img/directory" # Optional, build search engine with your own images
+        # data = "path/to/img/directory", # Optional, build search engine with your own images
         device="cpu"  # configure the device for processing, e.g., "cpu" or "cuda"
     )
 

--- a/docs/en/guides/similarity-search.md
+++ b/docs/en/guides/similarity-search.md
@@ -60,7 +60,7 @@ The `SearchApp` class launches the full Flask interface. On first run it downloa
     from ultralytics import solutions
 
     app = solutions.SearchApp(
-        # data = "path/to/img/directory", # Optional, build search engine with your own images
+        data="images",  # replace with a path to build the search engine with your own images
         device="cpu"  # configure the device for processing, e.g., "cpu" or "cuda"
     )
 
@@ -83,7 +83,7 @@ Call the searcher with a natural language query to get back a list of matching i
     from ultralytics import solutions
 
     searcher = solutions.VisualAISearch(
-        # data = "path/to/img/directory", # Optional, build search engine with your own images
+        data="images",  # replace with a path to build the search engine with your own images
         device="cpu"  # configure the device for processing, e.g., "cpu" or "cuda"
     )
 
@@ -138,7 +138,7 @@ While CLIP is developed by OpenAI, the [Ultralytics Python package](https://pypi
     from ultralytics import solutions
 
     searcher = solutions.VisualAISearch(
-        # data = "path/to/img/directory", # Optional, build search engine with your own images
+        data="images",  # replace with a path to build the search engine with your own images
         device="cpu"  # configure the device for processing, e.g., "cpu" or "cuda"
     )
 

--- a/docs/en/guides/similarity-search.md
+++ b/docs/en/guides/similarity-search.md
@@ -61,7 +61,7 @@ The `SearchApp` class launches the full Flask interface. On first run it downloa
 
     app = solutions.SearchApp(
         data="images",  # replace with a path to build the search engine with your own images
-        device="cpu"  # configure the device for processing, e.g., "cpu" or "cuda"
+        device="cpu",  # configure the device for processing, e.g., "cpu" or "cuda"
     )
 
     app.run(debug=False)  # You can also use `debug=True` argument for testing
@@ -84,7 +84,7 @@ Call the searcher with a natural language query to get back a list of matching i
 
     searcher = solutions.VisualAISearch(
         data="images",  # replace with a path to build the search engine with your own images
-        device="cpu"  # configure the device for processing, e.g., "cpu" or "cuda"
+        device="cpu",  # configure the device for processing, e.g., "cpu" or "cuda"
     )
 
     results = searcher("a dog sitting on a bench")
@@ -139,7 +139,7 @@ While CLIP is developed by OpenAI, the [Ultralytics Python package](https://pypi
 
     searcher = solutions.VisualAISearch(
         data="images",  # replace with a path to build the search engine with your own images
-        device="cpu"  # configure the device for processing, e.g., "cpu" or "cuda"
+        device="cpu",  # configure the device for processing, e.g., "cpu" or "cuda"
     )
 
     results = searcher("a dog sitting on a bench")


### PR DESCRIPTION
Added the missing comma after the data argument in the SearchApp initialization example. This fixes the Python syntax error and ensures the example runs correctly when users uncomment the data argument to build a custom semantic search engine.

@glenn-jocher @Laughing-q FYI. Thanks!

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes invalid Python syntax in the similarity-search documentation examples. 🔧

### 📊 Key Changes
- Added missing commas to commented `data` arguments in three `SearchApp` and `VisualAISearch` examples.
- Updated examples in `docs/en/guides/similarity-search.md` without changing runtime code.

### 🎯 Purpose & Impact
- Ensures users can copy and run the documented Python examples without syntax errors. ✅
- Improves documentation accuracy and reduces confusion when configuring custom image directories.