### PR TITLE
Fix IndexError in class_activation_map with out-of-range classes

### DIFF
--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -1375,7 +1375,7 @@ def class_activation_map(
         s = torch.cat(scores, 2)  # (B, nc, predictions) class logits
         if classes is not None:
             cls = torch.as_tensor(classes, dtype=torch.long, device=s.device).flatten()
-            cls = cls[cls < s.shape[1]]  # drop ids beyond this model's output channels, e.g. depth/single-class heads
+            cls = cls[(cls >= 0) & (cls < s.shape[1])]  # drop ids outside this model's output channels
             if len(cls):
                 s = s[:, cls]  # heatmap for the requested classes only
         s = s.amax(1)  # (B, predictions) best class logit of each prediction

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -1374,8 +1374,10 @@ def class_activation_map(
                 handle.remove()
         s = torch.cat(scores, 2)  # (B, nc, predictions) class logits
         if classes is not None:
-            cls = torch.as_tensor(classes, dtype=torch.long, device=s.device)
-            s = s[:, cls.flatten()]  # heatmap for the requested classes only
+            cls = torch.as_tensor(classes, dtype=torch.long, device=s.device).flatten()
+            cls = cls[cls < s.shape[1]]  # drop ids beyond this model's output channels, e.g. depth/single-class heads
+            if len(cls):
+                s = s[:, cls]  # heatmap for the requested classes only
         s = s.amax(1)  # (B, predictions) best class logit of each prediction
         keep = (s.sigmoid() >= conf) | (s == s.amax(1, keepdim=True))  # top prediction alone if none above conf
         n = min(int(keep.sum(1).amax()), topk)  # predictions to explain, one backward pass each


### PR DESCRIPTION
## Summary
- Fixes #25571: `visualize=True` combined with `classes=[...]` raised `IndexError` when a requested class id exceeded the model's output channel count (e.g. depth or single-class heads), since `class_activation_map` indexed the score tensor with unfiltered class ids.
- Requested class ids are now filtered to those within the model's channel range before indexing; if none remain valid, the CAM falls back to all channels instead of crashing.

## Test plan
- [x] Reproduced the crash on `main` with `yolo predict depth model=yolo26n-depth.pt source=ultralytics/assets/bus.jpg 'classes=[0,2]' save_txt=True save_conf=True save_crop=True visualize=True line_width=1 show_labels=False show_conf=False imgsz=64`
- [x] Verified the same command completes successfully with the fix applied, producing the CAM overlay and depth prediction
- [x] `ruff check` / `ruff format --check` on the changed file show no new issues

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes an `IndexError` in `class_activation_map` when requested class IDs exceed the model's available output channels.

### 📊 Key Changes
- Flattens the requested class IDs before indexing class logits.
- Filters out class IDs beyond the model's output channel count.
- Preserves heatmap generation when all requested classes are out of range by skipping class-specific indexing.

### 🎯 Purpose & Impact
- Prevents crashes for depth, single-class, and other models with fewer output channels than requested class IDs.
- Improves the robustness of class activation map generation without changing behavior for valid class IDs.
- Keeps the change focused and localized to the affected plotting logic.