### PR TITLE
fix: prevent Attention NaN when key_dim truncates to 0

### DIFF
--- a/ultralytics/nn/modules/block.py
+++ b/ultralytics/nn/modules/block.py
@@ -1298,7 +1298,7 @@ class Attention(nn.Module):
         super().__init__()
         self.num_heads = num_heads
         self.head_dim = dim // num_heads
-        self.key_dim = int(self.head_dim * attn_ratio)
+        self.key_dim = max(int(self.head_dim * attn_ratio), 1)
         self.scale = self.key_dim**-0.5
         nh_kd = self.key_dim * num_heads
         h = dim + nh_kd * 2


### PR DESCRIPTION
When `dim // num_heads * attn_ratio < 0.5`, `key_dim` truncates to 0, making `scale = 0**-0.5 = inf`. This silently produces NaN in attention output.

**Reproduction:** `Attention(dim=8, num_heads=8, attn_ratio=0.5)` → head_dim=1, key_dim=0, scale=inf → q/k empty → NaN.

**Fix:** Floor `key_dim` to 1: `max(int(self.head_dim * attn_ratio), 1)`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Prevents Attention from producing NaN values when the computed key dimension truncates to zero. 🔧

### 📊 Key Changes
- Ensures `key_dim` is always at least 1 using `max(..., 1)`.
- Preserves valid attention scaling and projection dimensions for small attention configurations.

### 🎯 Purpose & Impact
- Fixes a numerical stability issue caused by a zero key dimension.
- Improves robustness for models using small head dimensions or attention ratios.
- Limits the change to the Attention module without affecting normal configurations. ✅