### PR TITLE
fix: use kwargs in Ensemble.forward to prevent augment/profile swap

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1528,7 +1528,7 @@ class Ensemble(torch.nn.ModuleList):
             (torch.Tensor): Concatenated predictions from all models.
             (None): Always None for ensemble inference.
         """
-        y = [module(x, augment, profile)[0] for module in self]
+        y = [module(x, augment=augment, profile=profile)[0] for module in self]
         # y = torch.stack(y).max(0)[0]  # max ensemble
         # y = torch.stack(y).mean(0)  # mean ensemble
         y = torch.cat(y, 2)  # nms ensemble, y shape(B, HW, C*num_models)


### PR DESCRIPTION
Ensemble.forward calls `module(x, augment, profile)` with positional args, but `BaseModel.predict` has `predict(self, x, profile=False, augment=False)` — so the values are swapped: augment=True activates profiling, profile=True activates augmentation.

**Reproduction:** `ensemble(x, augment=True)` → predict receives profile=True, augment=False → augmentation silently ignored.

**Fix:** Use keyword arguments: `module(x, augment=augment, profile=profile)`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes ensemble inference argument handling by passing `augment` and `profile` as keyword arguments.

### 📊 Key Changes
- Updated `Ensemble.forward` in `ultralytics/nn/tasks.py` to call each module with explicit `augment=augment` and `profile=profile` keywords.
- Prevents positional argument misinterpretation and avoids swapping augmentation and profiling settings.

### 🎯 Purpose & Impact
- 🐛 Ensures ensemble models receive inference options reliably and as intended.
- ✅ Improves correctness for augmented and profiled inference without changing the ensemble prediction aggregation behavior.
- 🔧 Limits the fix to a focused Python code change.