### PR TITLE
fix: handle os.cpu_count() returning None in restricted environments

### DIFF
--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -359,7 +359,7 @@ def build_dataloader(
     nd = get_torch_device_backend(device).device_count() if device_type not in {"cpu", "mps"} else 0
     # Do not create more worker processes than final loader batches. Single-batch loaders run in-process to avoid
     # persistent DataLoader worker pools that add overhead and can stall tiny datasets while holding CUDA context.
-    nw = min(os.cpu_count() // max(nd, 1), workers, 0 if batches <= 1 else batches)  # number of workers
+    nw = min((os.cpu_count() or 1) // max(nd, 1), workers, 0 if batches <= 1 else batches)  # number of workers
     generator = torch.Generator()
     generator.manual_seed(6148914691236517205 + RANK)
     pin_memory = nd > 0 and pin_memory


### PR DESCRIPTION
Python docs state `os.cpu_count()` returns `None` when the count cannot be determined. This occurs in some Docker containers, embedded systems, and sandboxed environments. The current code `os.cpu_count() // max(nd, 1)` raises `TypeError` in these cases.

**Reproduction:** Run training in a Docker container with restricted CPU detection → `TypeError: unsupported operand type(s) for //: 'NoneType' and 'int'`.

**Fix:** `os.cpu_count() or 1` — falls back to 1 worker when undetectable.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Handles environments where `os.cpu_count()` returns `None` when calculating DataLoader worker counts.

### 📊 Key Changes
- Uses `os.cpu_count() or 1` to provide a safe fallback CPU count.
- Preserves existing worker-limit logic for device count, configured workers, and batch count.

### 🎯 Purpose & Impact
- 🛠️ Prevents a `TypeError` when building dataloaders in restricted or containerized environments.
- ✅ Allows training and inference to continue with at least one available CPU worker for eligible multi-batch loaders.
- 🔒 Keeps behavior unchanged on systems where `os.cpu_count()` returns a valid value.