### PR TITLE
fix: use correct shape for empty Bboxes/Instances concatenation

### DIFF
--- a/ultralytics/utils/instance.py
+++ b/ultralytics/utils/instance.py
@@ -152,7 +152,7 @@ class Bboxes:
         """
         assert isinstance(boxes_list, (list, tuple))
         if not boxes_list:
-            return cls(np.empty(0))
+            return cls(np.empty((0, 4)))
         assert all(isinstance(box, Bboxes) for box in boxes_list)
 
         if len(boxes_list) == 1:
@@ -451,7 +451,7 @@ class Instances:
         """
         assert isinstance(instances_list, (list, tuple))
         if not instances_list:
-            return cls(np.empty(0))
+            return cls(np.empty((0, 4)))
         assert all(isinstance(instance, Instances) for instance in instances_list)
 
         if len(instances_list) == 1:


### PR DESCRIPTION
Both `Bboxes.concatenate([])` and `Instances.concatenate([])` return `cls(np.empty(0))`. The 1D array of shape `(0,)\) gets reshaped to `(1, 0)` in `Bboxes.__init__`, then fails the `assert shape[1] == 4` check.

**Reproduction:** `Bboxes.concatenate([])` → AssertionError.

**Fix:** Use `np.empty((0, 4))` — correctly represents zero bounding boxes with the expected 2D shape.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes empty `Bboxes` and `Instances` concatenation to return arrays with the correct shape.

### 📊 Key Changes
- Updates both `concatenate` methods to initialize empty bounding-box data with shape `(0, 4)`.
- Applies the fix in `Bboxes.concatenate` and `Instances.concatenate`.

### 🎯 Purpose & Impact
- Prevents shape-related errors when concatenating empty bounding boxes or instances.
- Improves robustness and consistency for downstream detection and instance-processing workflows.