### PR TITLE
fix: release VideoWriter in solutions to prevent corrupted output

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -869,6 +869,8 @@ def handle_yolo_solutions(args: list[str]) -> None:
                     break
         finally:
             cap.release()
+            if solution_name != "crop":
+                vw.release()
 
 
 def parse_key_value_pair(pair: str = "key=value") -> tuple:


### PR DESCRIPTION
The solutions VideoWriter (`vw`) is never released. The `finally` block only calls `cap.release()`, leaving the AVI file unflushed and potentially corrupted.

**Reproduction:** `yolo solutions count source="video.mp4"` → output video may be truncated or unplayable.

**Fix:** Add `vw.release()` in the `finally` block, guarded by `solution_name != "crop"` (since `vw` is only created for non-crop solutions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Ensures solution video writers are properly released to prevent corrupted output files. 🎥

### 📊 Key Changes
- Releases `VideoWriter` instances in `handle_yolo_solutions` during cleanup.
- Skips writer release for the `crop` solution, which does not use the video writer.
- Keeps camera capture cleanup in the existing `finally` block.

### 🎯 Purpose & Impact
- Prevents incomplete or corrupted solution-generated video files.
- Ensures video resources are flushed and released reliably, including when processing exits unexpectedly.
- Improves output reliability without changing crop-solution behavior. ✅