### PR TITLE
fix: guard empty args in handle_yolo_hub to prevent IndexError

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -710,6 +710,9 @@ def handle_yolo_hub(args: list[str]) -> None:
     """
     from ultralytics import hub
 
+    if not args:
+        LOGGER.warning("No hub command provided. Usage: yolo hub login [API_KEY] or yolo hub logout")
+        return
     if args[0] == "login":
         key = args[1] if len(args) > 1 else ""
         # Log in to Ultralytics HUB using the provided API key


### PR DESCRIPTION
Running `yolo hub` with no subcommand passes an empty list to `handle_yolo_hub`, which immediately accesses `args[0]` → IndexError.

**Reproduction:** `yolo hub` → IndexError: list index out of range.

**Fix:** Add `if not args: LOGGER.warning(...); return` guard, consistent with the existing pattern in `handle_yolo_solutions`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Prevent `yolo hub` from raising an `IndexError` when invoked without arguments.

### 📊 Key Changes
- Added an early guard in `handle_yolo_hub` for empty argument lists.
- Logs a warning with valid `login` and `logout` usage instructions.
- Returns safely before attempting to access the first argument.

### 🎯 Purpose & Impact
- 🛡️ Improves CLI robustness for incomplete HUB commands.
- ✅ Replaces an unexpected exception with a clear, actionable warning.
- 🚀 Has minimal impact on existing `yolo hub login` and `yolo hub logout` behavior.