### PR TITLE
fix: handle odd column count in plot_results to prevent IndexError

### DIFF
--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -1082,8 +1082,8 @@ def plot_results(file: str = "path/to/results.csv", dir: str = "", on_plot: Call
                 columns = (
                     loss_keys[:loss_mid] + metric_keys[:metric_mid] + loss_keys[loss_mid:] + metric_keys[metric_mid:]
                 )
-                fig, ax = plt.subplots(2, len(columns) // 2, figsize=(len(columns) + 2, 6), tight_layout=True)
-                ax = ax.ravel()
+                fig, ax = plt.subplots(2, math.ceil(len(columns) / 2), figsize=(len(columns) + 2, 6), tight_layout=True)
+                ax = np.atleast_1d(ax).ravel()
             x = data.select(data.columns[0]).to_numpy().flatten()
             for i, j in enumerate(columns):
                 y = data.select(j).to_numpy().flatten().astype("float")


### PR DESCRIPTION
When the total number of loss + metric columns is odd, `plt.subplots(2, len(columns) // 2)` creates too few axes. The loop then crashes with `IndexError: index N is out of bounds`.

**Reproduction:** Train with an odd total of loss + metric keys, then call `plot_results()`.

**Fix:** Use `math.ceil(len(columns) / 2)` for correct grid sizing, and `np.atleast_1d(ax).ravel()` for consistent array shape.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fix `plot_results` handling of odd column counts to prevent `IndexError` during result visualization.

### 📊 Key Changes
- Use `math.ceil(len(columns) / 2)` when calculating the number of subplot columns.
- Normalize the subplot axes with `np.atleast_1d(...).ravel()` for consistent iteration.

### 🎯 Purpose & Impact
- Prevents indexing failures when plotting results with an odd number of columns.
- Improves robustness across different result file configurations without changing even-column behavior.