### PR TITLE
fix: guard zero height in STrack.tlwh_to_xyah to prevent Kalman corruption

### DIFF
--- a/ultralytics/trackers/byte_tracker.py
+++ b/ultralytics/trackers/byte_tracker.py
@@ -181,7 +181,7 @@ class STrack(BaseTrack):
         """Convert bounding box from tlwh format to center-x-center-y-aspect-height (xyah) format."""
         ret = np.asarray(tlwh).copy()
         ret[:2] += ret[2:] / 2
-        ret[2] /= ret[3]
+        ret[2] /= max(ret[3], 1e-6)
         return ret
 
     @property

--- a/ultralytics/trackers/byte_tracker.py
+++ b/ultralytics/trackers/byte_tracker.py
@@ -181,7 +181,8 @@ class STrack(BaseTrack):
         """Convert bounding box from tlwh format to center-x-center-y-aspect-height (xyah) format."""
         ret = np.asarray(tlwh).copy()
         ret[:2] += ret[2:] / 2
-        ret[2] /= max(ret[3], 1e-6)
+        ret[3] = max(ret[3], 1e-6)
+        ret[2] /= ret[3]
         return ret
 
     @property


### PR DESCRIPTION
When a detection has height=0, `ret[2] /= ret[3]` produces `inf`, which propagates into the Kalman filter and corrupts all subsequent tracking predictions for that track.

**Reproduction:** Degenerate detection with h=0 → inf → Kalman state diverges → garbage tracking.

**Fix:** `ret[2] /= max(ret[3], 1e-6)` — floors height to a negligible epsilon. No behavioral change for valid (non-zero) heights.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Prevents zero-height bounding boxes from corrupting STrack Kalman filter state during tracking. 🛡️

### 📊 Key Changes
- Updates `STrack.tlwh_to_xyah` in `ultralytics/trackers/byte_tracker.py` to clamp height to a small positive minimum before division.
- Preserves existing bounding-box conversion behavior for valid heights while safely handling zero-height inputs.

### 🎯 Purpose & Impact
- Prevents division-by-zero and invalid aspect-ratio values from propagating into the Kalman filter.
- Improves tracker stability and robustness when degenerate detections are encountered. ✅