### PR TITLE
fix: add eps to width in bbox_iou xyxy branch for symmetric handling

### DIFF
--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -139,8 +139,8 @@ def bbox_iou(
     else:  # x1, y1, x2, y2 = box1
         b1_x1, b1_y1, b1_x2, b1_y2 = box1.chunk(4, -1)
         b2_x1, b2_y1, b2_x2, b2_y2 = box2.chunk(4, -1)
-        w1, h1 = b1_x2 - b1_x1, b1_y2 - b1_y1 + eps
-        w2, h2 = b2_x2 - b2_x1, b2_y2 - b2_y1 + eps
+        w1, h1 = b1_x2 - b1_x1 + eps, b1_y2 - b1_y1 + eps
+        w2, h2 = b2_x2 - b2_x1 + eps, b2_y2 - b2_y1 + eps
 
     # Intersection area
     inter = (b1_x2.minimum(b2_x2) - b1_x1.maximum(b2_x1)).clamp_(0) * (


### PR DESCRIPTION
In the xyxy branch of `bbox_iou`, epsilon is added to height but not width due to Python tuple unpacking: `w1, h1 = b1_x2 - b1_x1, b1_y2 - b1_y1 + eps` applies `+ eps` only to `h1`. For zero-width boxes, this gives asymmetric area computation.

**Fix:** Add `+ eps` to both width and height. The change is numerically negligible for any real box (~1e-7 in a 100px box = 1e-9 relative change), but makes the degenerate case symmetric.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes `bbox_iou` width calculations in the `xyxy` branch by consistently adding `eps` to both box dimensions. ⚙️

### 📊 Key Changes
- Adds `eps` to the width calculation for both bounding boxes.
- Retains the existing `eps` adjustment for height calculations.
- Provides symmetric numerical handling across width and height dimensions.

### 🎯 Purpose & Impact
- Improves stability when calculating IoU for zero-width or very small bounding boxes.
- Ensures consistent behavior between the `xyxy` and other supported box formats.
- May slightly alter IoU results for degenerate or near-degenerate boxes while improving robustness. 🛠️