### PR TITLE
fix: guard empty input in smooth() to prevent IndexError

### DIFF
--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -658,6 +658,8 @@ class ConfusionMatrix(DataExportMixin):
 
 def smooth(y: np.ndarray, f: float = 0.05) -> np.ndarray:
     """Box filter of fraction f."""
+    if len(y) == 0:
+        return y
     nf = round(len(y) * f * 2) // 2 + 1  # number of filter elements (must be odd)
     p = np.ones(nf // 2)  # ones padding
     yp = np.concatenate((p * y[0], y, p * y[-1]), 0)  # y padded


### PR DESCRIPTION
`smooth()` accesses `y[0]` and `y[-1]` without checking length, crashing on empty input.

**Reproduction:** `smooth(np.array([]))` → IndexError.

**Fix:** Early return for empty input: `if len(y) == 0: return y`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Guards `smooth()` against empty NumPy inputs to prevent an `IndexError`.

### 📊 Key Changes
- Adds an early return when the input array is empty.
- Leaves existing smoothing behavior unchanged for non-empty inputs.

### 🎯 Purpose & Impact
- Prevents failures when metric smoothing receives empty data.
- Improves robustness of the metrics utility with a minimal, backward-compatible fix.