### PR TITLE
fix: handle empty stats in DetMetrics.process to prevent ValueError

### DIFF
--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -1156,7 +1156,7 @@ class DetMetrics(SimpleClass, DataExportMixin):
             (dict[str, np.ndarray]): Dictionary containing concatenated statistics arrays.
         """
         stats = {k: np.concatenate(v, 0) if v else np.empty((0,)) for k, v in self.stats.items()}  # to numpy
-        if not stats:
+        if not any(v.size for v in stats.values()):
             return stats
         results = ap_per_class(
             stats["tp"],

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -1155,7 +1155,7 @@ class DetMetrics(SimpleClass, DataExportMixin):
         Returns:
             (dict[str, np.ndarray]): Dictionary containing concatenated statistics arrays.
         """
-        stats = {k: np.concatenate(v, 0) for k, v in self.stats.items()}  # to numpy
+        stats = {k: np.concatenate(v, 0) if v else np.empty((0,)) for k, v in self.stats.items()}  # to numpy
         if not stats:
             return stats
         results = ap_per_class(


### PR DESCRIPTION
When validation processes zero images (empty dataset or class filter excluding all classes), all stat lists are empty. `np.concatenate([], 0)` raises `ValueError: need at least one array to concatenate`.

The existing `if not stats` guard on line 1159 is dead code — the dict always has 5 keys, so it's never empty.

**Fix:** Use `np.concatenate(v, 0) if v else np.empty((0,))` in the dict comprehension.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fix empty-statistics handling in `DetMetrics.process` to prevent `ValueError` when no metric data is available.

### 📊 Key Changes
- Safely creates an empty NumPy array when a statistics list is empty instead of calling `np.concatenate` on it.
- Preserves the existing early return when no statistics are present.
- Limits the change to a single line in `ultralytics/utils/metrics.py`.

### 🎯 Purpose & Impact
- Prevents metric processing from failing on empty predictions or datasets.
- Improves robustness for evaluation workflows with no collected statistics.
- Has minimal impact on existing behavior when statistics are available.