### PR TITLE
fix: check first_conv exists in checkpoint before accessing in load()

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -327,7 +327,7 @@ class BaseModel(torch.nn.Module):
         first_conv = "model.0.conv.weight"  # hard-coded to yolo models for now
         # mostly used to boost multi-channel training
         state_dict = self.state_dict()
-        if first_conv not in updated_csd and first_conv in state_dict:
+        if first_conv not in updated_csd and first_conv in state_dict and first_conv in csd:
             c1, c2, h, w = state_dict[first_conv].shape
             cc1, cc2, ch, cw = csd[first_conv].shape
             if ch == h and cw == w:


### PR DESCRIPTION
In `BaseModel.load`, the condition checks `first_conv not in updated_csd and first_conv in state_dict` but doesn't check `first_conv in csd` (the checkpoint). Line 332 then does `csd[first_conv].shape`, which crashes with `KeyError` when the checkpoint uses a different naming convention.

**Reproduction:** Load a pretrained checkpoint from a model with different first-layer naming → KeyError.

**Fix:** Add `and first_conv in csd` to the condition.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Safely handles checkpoints without the expected first convolution layer during model weight loading. 🛠️

### 📊 Key Changes
- Adds a check that `first_conv` exists in the checkpoint state dictionary before accessing its shape.
- Preserves the existing channel-adaptation logic for compatible checkpoints.

### 🎯 Purpose & Impact
- Prevents a potential `KeyError` when loading checkpoints with different model structures or missing initial convolution weights.
- Improves robustness of model loading without changing behavior for standard YOLO checkpoints. ✅