### PR TITLE
fix: handle missing rate-limit headers in 429 responses

### DIFF
--- a/ultralytics/hub/session.py
+++ b/ultralytics/hub/session.py
@@ -347,8 +347,8 @@ class HUBTrainingSession:
         elif response.status_code == HTTPStatus.TOO_MANY_REQUESTS:  # rate limit
             headers = response.headers
             return (
-                f"Rate limit reached ({headers['X-RateLimit-Remaining']}/{headers['X-RateLimit-Limit']}). "
-                f"Please retry after {headers['Retry-After']}s."
+                f"Rate limit reached ({headers.get('X-RateLimit-Remaining', '?')}/{headers.get('X-RateLimit-Limit', '?')}). "
+                f"Please retry after {headers.get('Retry-After', '?')}s."
             )
         else:
             try:

--- a/ultralytics/hub/utils.py
+++ b/ultralytics/hub/utils.py
@@ -156,8 +156,8 @@ def smart_request(
                 elif r.status_code == 429:  # rate limit
                     h = r.headers  # response headers
                     m = (
-                        f"Rate limit reached ({h['X-RateLimit-Remaining']}/{h['X-RateLimit-Limit']}). "
-                        f"Please retry after {h['Retry-After']}s."
+                        f"Rate limit reached ({h.get('X-RateLimit-Remaining', '?')}/{h.get('X-RateLimit-Limit', '?')}). "
+                        f"Please retry after {h.get('Retry-After', '?')}s."
                     )
                 if verbose:
                     LOGGER.warning(f"{PREFIX}{m} {HELP_MSG} ({r.status_code} #{code})")


### PR DESCRIPTION
Both `hub/session.py` and `hub/utils.py` access `headers['X-RateLimit-Remaining']`, `headers['X-RateLimit-Limit']`, and `headers['Retry-After']` on 429 responses. Proxies and non-standard servers commonly strip these headers, causing `KeyError`.

**Reproduction:** 429 response without rate-limit headers → KeyError.

**Fix:** Use `.get('header', '?')` for all three headers in both files.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Handle missing rate-limit headers gracefully when processing HTTP 429 responses.

### 📊 Key Changes
- Replaced direct rate-limit header lookups with safe `.get()` calls in `ultralytics/hub/session.py` and `ultralytics/hub/utils.py`.
- Displays `?` when remaining-limit, limit, or retry-after headers are unavailable.

### 🎯 Purpose & Impact
- Prevents additional header-related exceptions when services return incomplete 429 responses.
- Provides users with a clear rate-limit message while preserving existing behavior when headers are present.