### PR TITLE
Fix analytics pie chart percentage labels

### DIFF
--- a/ultralytics/solutions/analytics.py
+++ b/ultralytics/solutions/analytics.py
@@ -248,7 +248,7 @@ class Analytics(BaseSolution):
         self.ax.set_ylabel(self.y_label, color=self.fg_color, fontsize=self.fontsize - 3)
 
         # Add and format legend (skip for pie charts which manage their own legend)
-        if self.type != "pie":
+        if plot != "pie":
             legend = self.ax.legend(loc="upper left", fontsize=13, facecolor=self.bg_color, edgecolor=self.bg_color)
             for text in legend.get_texts():
                 text.set_color(self.fg_color)

--- a/ultralytics/solutions/analytics.py
+++ b/ultralytics/solutions/analytics.py
@@ -223,7 +223,6 @@ class Analytics(BaseSolution):
                 # Create the legend using labels from the bars
                 for bar, label in zip(bars, labels):
                     bar.set_label(label)  # Assign label to each bar
-                self.ax.legend(loc="upper left", fontsize=13, facecolor=self.fg_color, edgecolor=self.fg_color)
             elif plot == "pie":
                 total = sum(counts)
                 percentages = [size / total * 100 for size in counts]
@@ -247,11 +246,12 @@ class Analytics(BaseSolution):
         self.ax.set_xlabel(self.x_label, color=self.fg_color, fontsize=self.fontsize - 3)
         self.ax.set_ylabel(self.y_label, color=self.fg_color, fontsize=self.fontsize - 3)
 
-        # Add and format legend (skip for pie charts which manage their own legend)
-        if plot != "pie":
-            legend = self.ax.legend(loc="upper left", fontsize=13, facecolor=self.bg_color, edgecolor=self.bg_color)
-            for text in legend.get_texts():
-                text.set_color(self.fg_color)
+        # Add and format legend
+        legend = self.ax.get_legend() or self.ax.legend(
+            loc="upper left", fontsize=13, facecolor=self.bg_color, edgecolor=self.bg_color
+        )
+        for text in legend.get_texts():
+            text.set_color(self.fg_color)
 
         # Redraw graph, update view, capture, and display the updated plot
         self.ax.relim()

--- a/ultralytics/solutions/analytics.py
+++ b/ultralytics/solutions/analytics.py
@@ -247,10 +247,11 @@ class Analytics(BaseSolution):
         self.ax.set_xlabel(self.x_label, color=self.fg_color, fontsize=self.fontsize - 3)
         self.ax.set_ylabel(self.y_label, color=self.fg_color, fontsize=self.fontsize - 3)
 
-        # Add and format legend
-        legend = self.ax.legend(loc="upper left", fontsize=13, facecolor=self.bg_color, edgecolor=self.bg_color)
-        for text in legend.get_texts():
-            text.set_color(self.fg_color)
+        # Add and format legend (skip for pie charts which manage their own legend)
+        if self.type != "pie":
+            legend = self.ax.legend(loc="upper left", fontsize=13, facecolor=self.bg_color, edgecolor=self.bg_color)
+            for text in legend.get_texts():
+                text.set_color(self.fg_color)
 
         # Redraw graph, update view, capture, and display the updated plot
         self.ax.relim()


### PR DESCRIPTION
Pie charts set a custom legend with percentage labels at line 240, but the generic legend at line 251 unconditionally overwrites it with a legend showing only class names.

**Reproduction:** `yolo solutions analytics analytics_type="pie"` → percentage labels disappear.

**Fix:** Skip the generic legend when `self.type == "pie"`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Skip the generic Matplotlib legend for pie charts so their percentage labels remain visible and unobstructed.

### 📊 Key Changes
- Updated `ultralytics/solutions/analytics.py` to conditionally create and format the generic legend only when the chart type is not `pie`.
- Preserved existing legend behavior for all non-pie chart types.

### 🎯 Purpose & Impact
- Prevents the generic legend from interfering with pie-chart percentage labels.
- Improves pie-chart readability while maintaining existing behavior for other analytics charts.