### PR TITLE
Preserve YOLOE one-to-one classifiers during linear probing

### DIFF
--- a/ultralytics/models/yolo/yoloe/train.py
+++ b/ultralytics/models/yolo/yoloe/train.py
@@ -146,9 +146,9 @@ class YOLOEPETrainer(DetectionTrainer):
         model.model[-1].cv3[2][2] = deepcopy(model.model[-1].cv3[2][2]).requires_grad_(True)
 
         if getattr(model.model[-1], "one2one_cv3", None) is not None:
-            model.model[-1].one2one_cv3[0][2] = deepcopy(model.model[-1].cv3[0][2]).requires_grad_(True)
-            model.model[-1].one2one_cv3[1][2] = deepcopy(model.model[-1].cv3[1][2]).requires_grad_(True)
-            model.model[-1].one2one_cv3[2][2] = deepcopy(model.model[-1].cv3[2][2]).requires_grad_(True)
+            model.model[-1].one2one_cv3[0][2] = deepcopy(model.model[-1].one2one_cv3[0][2]).requires_grad_(True)
+            model.model[-1].one2one_cv3[1][2] = deepcopy(model.model[-1].one2one_cv3[1][2]).requires_grad_(True)
+            model.model[-1].one2one_cv3[2][2] = deepcopy(model.model[-1].one2one_cv3[2][2]).requires_grad_(True)
 
         model.train()
 

--- a/ultralytics/models/yolo/yoloe/train_seg.py
+++ b/ultralytics/models/yolo/yoloe/train_seg.py
@@ -103,9 +103,9 @@ class YOLOEPESegTrainer(SegmentationTrainer):
         model.model[-1].cv3[2][2] = deepcopy(model.model[-1].cv3[2][2]).requires_grad_(True)
 
         if getattr(model.model[-1], "one2one_cv3", None) is not None:
-            model.model[-1].one2one_cv3[0][2] = deepcopy(model.model[-1].cv3[0][2]).requires_grad_(True)
-            model.model[-1].one2one_cv3[1][2] = deepcopy(model.model[-1].cv3[1][2]).requires_grad_(True)
-            model.model[-1].one2one_cv3[2][2] = deepcopy(model.model[-1].cv3[2][2]).requires_grad_(True)
+            model.model[-1].one2one_cv3[0][2] = deepcopy(model.model[-1].one2one_cv3[0][2]).requires_grad_(True)
+            model.model[-1].one2one_cv3[1][2] = deepcopy(model.model[-1].one2one_cv3[1][2]).requires_grad_(True)
+            model.model[-1].one2one_cv3[2][2] = deepcopy(model.model[-1].one2one_cv3[2][2]).requires_grad_(True)
 
         model.train()
 


### PR DESCRIPTION
In `YOLOEPETrainer.get_model`, the three `one2one_cv3` assignments copy from `cv3` instead of `one2one_cv3`:

```python
model.model[-1].one2one_cv3[0][2] = deepcopy(model.model[-1].cv3[0][2]).requires_grad_(True)
```

The two branches have their own `cv3` feature layers, so pairing the one2one features with the one2many final projection destroys the head. For end-to-end models like YOLO26, inference and validation run the one2one branch, so linear probing starts from near-zero mAP instead of the pretrained level.

The `deepcopy` is only there to drop the `requires_grad_(False)` set by `_fuse_tp`, so copying each branch its own conv keeps the pretrained weights.

Validation on COCO128 with `yoloe-26s-seg.pt`, `YOLOEPETrainer`, 1 epoch:

| one2one_cv3 source | mAP50 | mAP50-95 |
| --- | --- | --- |
| `cv3` (before) | 0.018 | 0.012 |
| `one2one_cv3` (after) | 0.546 | 0.403 |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes YOLOEPETrainer initialization so the one2one classifier retains its own weights instead of being overwritten by one2many classifier weights.

### 📊 Key Changes
- Updates `one2one_cv3` layers to deep-copy their existing classifier modules.
- Preserves independent one2one and one2many classifier weights during model setup.
- Keeps the modified classifier layers trainable with `requires_grad_(True)`.

### 🎯 Purpose & Impact
- Prevents unintended weight sharing or overwriting in YOLOE pose-free training.
- Improves correctness and stability for models using separate one2one and one2many detection heads.
- Limits the fix to the affected initialization logic without changing other training behavior. 🌟