### PR TITLE
Fix: Always run GC and CUDA cache cleanup before validation, regardless of GPU memory threshold

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -593,10 +593,7 @@ class BaseTrainer:
             # Validation
             final_epoch = epoch + 1 >= self.epochs
             if self.args.val or final_epoch or self.stopper.possible_stop or self.stop:
-                gc.collect()  # always collect CPU-side garbage before validation
-                if self.device.type == "cuda":
-                    torch.cuda.empty_cache()  # release PyTorch CUDA allocator cache
-                self._clear_memory(None if self.device.type == "mps" else 0.5)  # prevent VRAM spike
+                self._clear_memory()  # unconditional cpu + accelerator cleanup before validation
                 self.metrics, self.fitness = self.validate()
 
             # NaN recovery

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -593,6 +593,9 @@ class BaseTrainer:
             # Validation
             final_epoch = epoch + 1 >= self.epochs
             if self.args.val or final_epoch or self.stopper.possible_stop or self.stop:
+                gc.collect()  # always collect CPU-side garbage before validation
+                if self.device.type == "cuda":
+                    torch.cuda.empty_cache()  # release PyTorch CUDA allocator cache
                 self._clear_memory(None if self.device.type == "mps" else 0.5)  # prevent VRAM spike
                 self.metrics, self.fitness = self.validate()
 


### PR DESCRIPTION
## Fix validation memory cleanup being skipped on low-utilization devices

### Summary

Fix an issue where validation memory cleanup could be skipped due to the `_clear_memory(0.5)` threshold condition, preventing garbage collection and accelerator cache cleanup in low-utilization scenarios.

### Problem

`_do_train` currently calls `_clear_memory()` with a memory threshold before validation:

```python
self._clear_memory(None if self.device.type == "mps" else 0.5)
````

However, `_clear_memory()` returns early when memory usage is below the threshold:

```python
def _clear_memory(self, threshold=None):
    if threshold:
        if self._get_memory(fraction=True) <= threshold:
            return
    gc.collect()
    self.accelerator.empty_cache()
```

This means `gc.collect()` and accelerator cache cleanup are skipped when the device memory utilization is below 50%.

For systems with large VRAM GPUs (16GB+) running lightweight models (e.g. YOLO11s using only 3-5GB VRAM), memory usage often remains below this threshold throughout training. As a result, validation may start without performing any memory cleanup.

### Impact

#### CPU memory accumulation

Validation metric calculation (`np.concatenate`, `ap_per_class`, etc.) creates temporary NumPy arrays.

Some objects may require Python garbage collection to be released. When cleanup is skipped, temporary objects can accumulate across epochs and eventually trigger:

```
numpy._ArrayMemoryError
```

on systems with limited system RAM.

#### Accelerator memory fragmentation

Accelerator allocators keep released memory blocks cached for reuse.

When cache cleanup is skipped before validation, cached blocks may accumulate and become fragmented. During validation, where inference batch size can be larger than training batch size, memory allocation may fail with errors such as:

```
RuntimeError: bad allocation
```

This issue is less visible on systems with larger memory capacity because additional resources can mask the underlying fragmentation.

### Solution

Make `_clear_memory()` support unconditional cleanup when called without a threshold.

The validation path now uses:

```python
self._clear_memory()
```

instead of:

```python
self._clear_memory(None if self.device.type == "mps" else 0.5)
```

This keeps `_clear_memory()` as the centralized memory cleanup entry point while ensuring validation always performs backend-aware cleanup.

The existing threshold behavior is preserved for cases where conditional cleanup is still desired.

### Why keep `_clear_memory()`

`_clear_memory()` remains responsible for all memory cleanup operations.

When called with a threshold, it keeps the existing behavior and allows cleanup to be skipped when appropriate.

When called without a threshold, it performs unconditional cleanup.

This approach avoids duplicated cleanup logic and preserves accelerator-specific handling through the existing backend abstraction.

### Performance impact

The additional cleanup occurs only at validation boundaries.

Approximate overhead:

* `gc.collect()`: 5-15 ms
* accelerator cache cleanup: 1-5 ms

For a 500 epoch training run, the total overhead is only a few seconds and is negligible compared with overall training time.

Released accelerator cache is automatically rebuilt by the framework when required, so training throughput is not affected.

### Validation

Environment:

* OS: Windows 11
* GPU: RTX 4060 Ti 16GB
* RAM: 32GB
* PyTorch 2.x
* NumPy 2.4.6
* Model: YOLO11s detection
* Batch size: 8
* Image size: 640

Before this fix:

* Training consistently failed during validation around epoch 2 due to CPU or accelerator memory allocation errors.

After this fix:

* Completed a full 500 epoch training run without memory-related failures.

### Checklist

* [x] I have checked existing PRs and issues for similar fixes.
* [x] This change does not introduce breaking behavior.
* [x] The fix has been tested on a real training workload.

I have read the CLA Document and I sign the CLA

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices for contributing, refer to our ✅ Contributing Guide.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Ensure validation always performs centralized, backend-aware memory cleanup.

### 📊 Key Changes

* Allows `_clear_memory()` to perform unconditional cleanup when no threshold is provided.
* Replaces threshold-based validation cleanup with an unconditional `_clear_memory()` call.
* Preserves accelerator-specific cache cleanup through the existing backend abstraction.

### 🎯 Purpose & Impact

* Prevents skipped memory cleanup in low-utilization scenarios.
* Reduces CPU memory accumulation and accelerator cache fragmentation during repeated validation.
* Avoids duplicated cleanup logic while maintaining minimal overhead.
