### PR TITLE
Prevent concurrent download cache corruption

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -20,6 +20,7 @@ SOLUTION_ASSETS = {
     "pose_video": "solution_ci_pose_demo.mp4",
     "parking_video": "solution_ci_parking_demo.mp4",
     "vertical_video": "solution_vertical_demo.mp4",
+    "track_video": "decelera_portrait_min.mov",
     "parking_areas": "solution_ci_parking_areas.json",
     "parking_model": "solutions_ci_parking_model.pt",
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,7 +132,7 @@ def pytest_sessionfinish(session, exitstatus):
 
     # Remove files
     models = [path for x in ("*.onnx", "*.torchscript") for path in WEIGHTS_DIR.rglob(x)]
-    for file in ["decelera_portrait_min.mov", "bus.jpg", "yolo26n.onnx", "yolo26n.torchscript", *models]:
+    for file in ["bus.jpg", "yolo26n.onnx", "yolo26n.torchscript", *models]:
         Path(file).unlink(missing_ok=True)
 
     # Remove directories

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -470,7 +470,7 @@ def test_reid_invalid_crops():
 
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")
 @pytest.mark.parametrize("model", MODELS)
-def test_track_stream(model, tmp_path):
+def test_track_stream(model, tmp_path, solution_assets):
     """Test streaming tracking on a short video with all built-in trackers and various GMC/ReID configurations.
 
     Note imgsz=160 required for tracking for higher confidence and better matches.
@@ -483,7 +483,7 @@ def test_track_stream(model, tmp_path):
         return
     from ultralytics.trackers.track import TRACKER_MAP
 
-    video_url = f"{ASSETS_URL}/decelera_portrait_min.mov"
+    video_url = solution_assets("track_video")
     model = YOLO(model)
 
     # Default end-to-end run for all built-in trackers

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -10,6 +10,7 @@ from itertools import repeat
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from urllib import parse
+from uuid import uuid4
 
 from ultralytics.utils import ASSETS_URL, LOGGER, TQDM, checks, clean_url, emojis, is_online, url2file
 
@@ -343,6 +344,8 @@ def safe_download(
             uri = (url if gdrive else clean_url(url)).replace(ASSETS_URL, "https://ultralytics.com/assets")  # clean
             desc = f"Downloading {uri} to '{f}'"
             f.parent.mkdir(parents=True, exist_ok=True)  # make directory if missing
+            target = f
+            f = target.with_name(f".{target.name}.{uuid4().hex}.part")  # publish only after size validation
             curl_installed = shutil.which("curl")
             expected_size = None  # set from Content-Length; reused to validate curl retries
             for i in range(retry + 1):
@@ -386,6 +389,8 @@ def safe_download(
                                     f"Partial download: {file_size}/{expected_size} bytes ({file_size / expected_size * 100:.1f}%)"
                                 )
                             else:
+                                f.replace(target)
+                                f = target
                                 break  # success
                         f.unlink()  # remove partial downloads
                 except MemoryError:


### PR DESCRIPTION
## Summary

- publish downloads atomically only after existing size validation succeeds
- route the tracking video through the shared solution asset cache before xdist starts
- remove obsolete working-directory cleanup for that video

## Motivation

Parallel tracking tests could observe `decelera_portrait_min.mov` while another worker was still writing it, producing `moov atom not found` and five downstream `FileNotFoundError` failures. `safe_download()` validated the completed transfer but wrote directly to the final cache path, so concurrent callers could treat an in-progress file as a cache hit.

## Validation

- `ruff format --check ultralytics/utils/downloads.py tests/__init__.py tests/conftest.py tests/test_python.py`
- `ruff check ultralytics/utils/downloads.py tests/__init__.py tests/conftest.py tests/test_python.py`
- `pytest tests/test_python.py -k safe_download -q`
- `pytest "tests/test_python.py::test_track_stream[yolo26n.pt]" -q`
- five concurrent downloads against a throttled local HTTP server; final path remained absent until full size
- forced curl download against a local HTTP server; complete content published with no partial file left behind

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛡️ Improve download reliability by writing files to temporary paths and publishing them only after validation, while updating tracking tests to use shared solution assets.

### 📊 Key Changes

- Added a unique temporary `.part` filename for downloads using `uuid4`.
- Validated downloaded file size before replacing the final target file.
- Atomically moved validated downloads into place with `Path.replace()`.
- Updated tracking tests to retrieve the video through the shared `solution_assets` fixture.
- Registered the tracking video as a test asset and adjusted cleanup logic to preserve it.

### 🎯 Purpose & Impact

- ✅ Prevents incomplete or corrupted downloads from appearing as valid files.
- 🔄 Reduces the risk of concurrent processes reading partially downloaded assets.
- 🧪 Makes tracking tests more consistent by using the standard test-asset workflow.
- 📦 Improves download behavior for models, datasets, and other files across the Ultralytics package.