### PR TITLE
Fix FP16 end-to-end segmentation with class-agnostic NMS

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -251,7 +251,7 @@ class Detect(nn.Module):
             scores, labels = scores.max(dim=-1, keepdim=True)
             scores, indices = scores.topk(k, dim=1)
             labels = labels.gather(1, indices)
-            return scores, labels, indices
+            return scores, labels.float(), indices
         ori_index = scores.max(dim=-1)[0].topk(k)[1].unsqueeze(-1)
         scores = scores.gather(dim=1, index=ori_index.expand(-1, -1, nc))
         scores, index = scores.flatten(1).topk(k)


### PR DESCRIPTION
Running an end-to-end segmentation model in FP16 with class-agnostic top-k crashes:

```python
from ultralytics import YOLO

model = YOLO("yolo26n-seg.pt")
model.predict("bus.jpg", device=0, quantize=16, agnostic_nms=True)
# RuntimeError: expected mat1 and mat2 to have the same dtype, but got: c10::Half != float
```

The cause is a dtype asymmetry between the two branches of `Detect.get_topk_index`. The regular branch returns the class labels already cast to float, so the `torch.cat` in `Segment.postprocess` promotes the whole prediction tensor to float32 and the mask coefficients reach `process_mask` in the same dtype as `protos.float()`. The agnostic branch returns them as int64, `torch.cat` promotes int64 with half to float16, and the coefficients arrive as `Half` to the `masks_in @ protos.float()` matmul in `ops.py`, which raises.

Detect is not affected because nothing downstream multiplies the predictions, the crash only shows up in segment. Also, `agnostic_nms=True` is not always an explicit opt-in: YOLOE sets it as default on every predict call, so an end-to-end YOLOE segmentation model in FP16 hits the same crash with the model defaults.

The fix casts the labels in the agnostic branch to match what the regular branch already returns, so both branches keep the same output contract. `get_topk_index` is defined once in `Detect` and the `postprocess` overrides of `Segment`, `Pose`, `OBB` and the YOLOE heads all inherit it, so the single cast covers every end-to-end task. `RTDETRDecoder` builds its own top-k and already returns float labels, not affected.

Deleted: nothing — the fix is a single in-place cast on the existing return line, +1/−1.

Validated on a RTX 4060 (torch 2.12.1, CUDA) with `yolo26n-seg.pt` on `bus.jpg`:

- The full 2x2 matrix `quantize={None,16} x agnostic_nms={False,True}` now runs, before the fix only the FP16 + agnostic cell crashed.
- FP32 + agnostic is bit-identical before and after the fix, boxes and masks compared with `torch.equal`.
- FP16 + agnostic vs FP32 + agnostic: same 5 detections and classes, max confidence delta 0.0003, mask IoU 0.9989 .. the expected FP16 noise.
- Detect end-to-end with the same combination keeps working.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes an FP16 segmentation crash when `agnostic_nms` is enabled for end-to-end models.

### 📊 Key Changes
- Converts gathered class labels to floating-point values in `get_topk_index`.
- Applies the fix specifically to the single-class-per-detection top-k path.

### 🎯 Purpose & Impact
- Prevents dtype-related failures during FP16 segmentation inference.
- Improves compatibility of end-to-end models with agnostic NMS.
- Keeps existing top-k selection behavior unchanged while ensuring labels use a compatible dtype.