### PR TITLE
Exclude out-of-range ground truth from depth calibration

### DIFF
--- a/docs/en/tasks/depth.md
+++ b/docs/en/tasks/depth.md
@@ -205,7 +205,7 @@ The depth head separates **shape** (relative scene structure) from **scale** (ab
         model.save("yolo26s-depth-calibrated.pt")
         ```
 
-Calibration needs ground-truth depth to fit against, so it runs on a labeled split — it is not something that can happen at blind inference. Use it when relative depth is already good and only the scale/range is wrong; if the relative structure itself needs to change for your domain, [fine-tune](#fine-tuning-on-your-own-data) instead.
+Calibration needs ground-truth depth to fit against, so it runs on a labeled split — it is not something that can happen at blind inference. It fits and scores on the same pixels the val metrics evaluate: GT at or beyond the dataset YAML's `max_depth` (default 100 m) is excluded. Use it when relative depth is already good and only the scale/range is wrong; if the relative structure itself needs to change for your domain, [fine-tune](#fine-tuning-on-your-own-data) instead.
 
 Training does this for you automatically: after `model.train(...)` completes, the best and last checkpoints are calibrated on the validation set so they output metric-scaled depth out of the box.
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1208,52 +1208,6 @@ def test_depth_calibration_checkpoint_provenance(tmp_path):
     assert float(head.cal_b) == provenance["b"]
 
 
-def test_depth_calibrate_excludes_gt_beyond_dataset_max_depth(monkeypatch):
-    """Model.calibrate() drops GT beyond the dataset max_depth so invalid far pixels cannot steer the fitted scale."""
-    import math
-
-    from ultralytics.models.yolo.depth.calibrate import _depth_head
-
-    # Half the GT sits at 2 m and needs a 1.5x correction; the other half sits at 60 m with the opposite error.
-    # The dataset YAML declares max_depth=42, so the 60 m pixels are invalid under the metrics' Eigen protocol —
-    # if they leak into the fit (no exclusion, or the 100 m default instead of the dataset value) the two errors
-    # cancel, the CV picks identity, and the checkpoint ships uncalibrated.
-    gt = torch.cat([torch.full((32,), 2.0), torch.full((32,), 60.0)]).reshape(8, 8)
-    pred = torch.where(gt < 42, gt / 1.5, gt * 1.5)
-
-    class _Net(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-            head = torch.nn.Module()
-            head.register_buffer("cal_a", torch.tensor(1.0))
-            head.register_buffer("cal_b", torch.tensor(0.0))
-            self.model = torch.nn.Sequential(head)
-
-        def forward(self, x):
-            return pred.expand(x.shape[0], -1, -1)
-
-    class _Validator:
-        def __init__(self, args=None, _callbacks=None):
-            self.dataloader = [{"img": torch.zeros(2, 3, 8, 8, dtype=torch.uint8), "depth": gt.expand(2, 8, 8)}] * 2
-            self.device = "cpu"
-            self.data = {"max_depth": 42.0}
-
-        def __call__(self, model=None):
-            pass
-
-    model = YOLO("yolo26n-depth.yaml", task="depth")
-    model.model = _Net()
-    monkeypatch.setattr(model, "_smart_load", lambda key: _Validator)
-
-    a, b = model.calibrate()
-
-    head = _depth_head(model.model)
-    assert a == 1.0
-    assert b == pytest.approx(math.log(1.5), abs=1e-5)
-    assert float(head.cal_a) == 1.0
-    assert float(head.cal_b) == pytest.approx(math.log(1.5), abs=1e-5)
-
-
 @pytest.mark.parametrize("external", [False, True])
 def test_depth_trainer_records_portable_calibration_split(tmp_path, monkeypatch, external):
     """Calibration provenance records local splits without rejecting external validation paths."""

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1208,6 +1208,52 @@ def test_depth_calibration_checkpoint_provenance(tmp_path):
     assert float(head.cal_b) == provenance["b"]
 
 
+def test_depth_calibrate_excludes_gt_beyond_dataset_max_depth(monkeypatch):
+    """Model.calibrate() drops GT beyond the dataset max_depth so invalid far pixels cannot steer the fitted scale."""
+    import math
+
+    from ultralytics.models.yolo.depth.calibrate import _depth_head
+
+    # Half the GT sits at 2 m and needs a 1.5x correction; the other half sits at 60 m with the opposite error.
+    # The dataset YAML declares max_depth=42, so the 60 m pixels are invalid under the metrics' Eigen protocol —
+    # if they leak into the fit (no exclusion, or the 100 m default instead of the dataset value) the two errors
+    # cancel, the CV picks identity, and the checkpoint ships uncalibrated.
+    gt = torch.cat([torch.full((32,), 2.0), torch.full((32,), 60.0)]).reshape(8, 8)
+    pred = torch.where(gt < 42, gt / 1.5, gt * 1.5)
+
+    class _Net(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            head = torch.nn.Module()
+            head.register_buffer("cal_a", torch.tensor(1.0))
+            head.register_buffer("cal_b", torch.tensor(0.0))
+            self.model = torch.nn.Sequential(head)
+
+        def forward(self, x):
+            return pred.expand(x.shape[0], -1, -1)
+
+    class _Validator:
+        def __init__(self, args=None, _callbacks=None):
+            self.dataloader = [{"img": torch.zeros(2, 3, 8, 8, dtype=torch.uint8), "depth": gt.expand(2, 8, 8)}] * 2
+            self.device = "cpu"
+            self.data = {"max_depth": 42.0}
+
+        def __call__(self, model=None):
+            pass
+
+    model = YOLO("yolo26n-depth.yaml", task="depth")
+    model.model = _Net()
+    monkeypatch.setattr(model, "_smart_load", lambda key: _Validator)
+
+    a, b = model.calibrate()
+
+    head = _depth_head(model.model)
+    assert a == 1.0
+    assert b == pytest.approx(math.log(1.5), abs=1e-5)
+    assert float(head.cal_a) == 1.0
+    assert float(head.cal_b) == pytest.approx(math.log(1.5), abs=1e-5)
+
+
 @pytest.mark.parametrize("external", [False, True])
 def test_depth_trainer_records_portable_calibration_split(tmp_path, monkeypatch, external):
     """Calibration provenance records local splits without rejecting external validation paths."""

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -624,7 +624,9 @@ class Model(torch.nn.Module):
             args["data"] = data
         validator = self._smart_load("validator")(args=args, _callbacks=self.callbacks)
         validator(model=self.model)  # builds the dataloader and reports metrics with the current calibration
-        res = fit_calibration_selective(self.model, validator.dataloader, validator.device)
+        res = fit_calibration_selective(
+            self.model, validator.dataloader, validator.device, max_depth=validator.data.get("max_depth") or 100.0
+        )
         if res is None:
             return None
         LOGGER.info("Call model.save(...) to persist the calibration.")

--- a/ultralytics/models/yolo/depth/calibrate.py
+++ b/ultralytics/models/yolo/depth/calibrate.py
@@ -300,8 +300,8 @@ def calibrate_checkpoint(
             | raw | calibrated) for the first val batches into this directory.
         dataset_hash (str, optional): Immutable dataset manifest identity used for calibration.
         validation_split (str, optional): Dataset-root-relative split used to collect calibration images.
-        max_depth (float): Maximum valid GT depth in meters; pixels beyond it are excluded from the fit and the
-            held-out δ1 scoring, matching the val metrics' Eigen protocol.
+        max_depth (float): Maximum valid GT depth in meters; pixels beyond it are excluded from the fit and the held-out
+            δ1 scoring, matching the val metrics' Eigen protocol.
     """
     from copy import deepcopy
 

--- a/ultralytics/models/yolo/depth/calibrate.py
+++ b/ultralytics/models/yolo/depth/calibrate.py
@@ -139,12 +139,14 @@ def select_calibration_cv(
 
 @smart_inference_mode()
 def _collect_logpairs(
-    model: torch.nn.Module, dataloader, device: torch.device | str, max_images: int
+    model: torch.nn.Module, dataloader, device: torch.device | str, max_images: int, max_depth: float = 100.0
 ) -> list[tuple[np.ndarray, np.ndarray]]:
     """Run the model over the loader and return a list of per-image ``(log_pred, log_gt)`` arrays.
 
     One entry per image (each subsampled to ≤20k valid pixels) so callers can split images into independent fit/score
-    sets. Calibration buffers are reset to identity for the duration so the fit sees the raw output, then restored.
+    sets. Only GT inside ``(0.001, max_depth)`` is collected — the same population ``DepthMetrics`` evaluates (Eigen
+    protocol), so invalid far GT cannot steer the fitted scale or the held-out δ1 the selection policy trusts.
+    Calibration buffers are reset to identity for the duration so the fit sees the raw output, then restored.
     """
     head = _depth_head(model)
     a0, b0 = float(head.cal_a), float(head.cal_b)
@@ -167,7 +169,7 @@ def _collect_logpairs(
             if pred.shape[-2:] != gt.shape[-2:]:
                 pred = F.interpolate(pred, size=gt.shape[-2:], mode="bilinear", align_corners=True)
             for pi, gi in zip(pred, gt):
-                valid = (gi > 1e-3) & (pi > 1e-3) & torch.isfinite(pi)
+                valid = (gi > 1e-3) & (gi < max_depth) & (pi > 1e-3) & torch.isfinite(pi)
                 if not valid.any():
                     continue
                 lp = torch.log(pi[valid]).detach().cpu().numpy()
@@ -192,6 +194,7 @@ def fit_calibration_selective(
     device: torch.device | str,
     max_images: int = 200,
     margin: float = 0.002,
+    max_depth: float = 100.0,
 ) -> dict[str, Any] | None:
     """Select and apply calibration via "calibrate only if it helps" (see :func:`select_calibration_cv`).
 
@@ -206,7 +209,7 @@ def fit_calibration_selective(
     if head is None:
         LOGGER.warning("calibrate: no Depth head with cal buffers found; skipping.")
         return None
-    pairs = _collect_logpairs(model, dataloader, device, max_images)
+    pairs = _collect_logpairs(model, dataloader, device, max_images, max_depth)
     if len(pairs) < 2:
         LOGGER.warning("calibrate: fewer than 2 valid images for fit/score split; calibration skipped.")
         return None
@@ -281,6 +284,7 @@ def calibrate_checkpoint(
     *,
     dataset_hash: str | None = None,
     validation_split: str | None = None,
+    max_depth: float = 100.0,
 ) -> dict | None:
     """Fit calibration for a saved checkpoint in place (used by automatic post-training calibration).
 
@@ -296,6 +300,8 @@ def calibrate_checkpoint(
             | raw | calibrated) for the first val batches into this directory.
         dataset_hash (str, optional): Immutable dataset manifest identity used for calibration.
         validation_split (str, optional): Dataset-root-relative split used to collect calibration images.
+        max_depth (float): Maximum valid GT depth in meters; pixels beyond it are excluded from the fit and the
+            held-out δ1 scoring, matching the val metrics' Eigen protocol.
     """
     from copy import deepcopy
 
@@ -306,7 +312,7 @@ def calibrate_checkpoint(
     if saved is None or _depth_head(saved) is None:
         return
     work = deepcopy(saved).float()
-    res = fit_calibration_selective(work, dataloader, device)
+    res = fit_calibration_selective(work, dataloader, device, max_depth=max_depth)
     if res is None:
         return None
     a, b = res["a"], res["b"]

--- a/ultralytics/models/yolo/depth/train.py
+++ b/ultralytics/models/yolo/depth/train.py
@@ -165,6 +165,7 @@ class DepthTrainer(DetectionTrainer):
                         plot_dir=plot_dir,
                         dataset_hash=self.data.get("hash"),
                         validation_split=validation_split,
+                        max_depth=self.data.get("max_depth") or 100.0,
                     )
                     if ckpt == plot_ckpt and provenance is not None:
                         self.depth_calibration = provenance


### PR DESCRIPTION
## Summary

Depth calibration accepted every ground-truth pixel above 0.001 m, while `DepthMetrics` evaluates only pixels inside the dataset's `(min_depth, max_depth)` range. Out-of-range far-depth values could therefore steer both the fitted scale and the held-out score used to decide whether calibration helps.

This change threads the dataset `max_depth` value through the existing calibration owner and adds it to the existing validity mask for both manual and post-training calibration. The default remains 100 m, matching `DepthMetrics`.

## Validation

A synthetic calibration case whose valid range requires a 1.5x scale selects identity on the previous implementation when invalid far pixels are included. With this change it selects scale-only at approximately 1.5x with held-out delta1 of 1.0. Existing depth checks and CI pass.