### PR TITLE
Stream ONNX and QNN calibration data

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -114,41 +114,6 @@ def test_onnx_int8_quantize_excludes_non_weighted_ops(monkeypatch):
     assert calls["nodes_to_exclude"] == ["pool", "sigmoid"]
 
 
-def test_onnx_calibration_reader_iterates_lazily_and_rewinds():
-    """Check ONNX/QNN calibration transforms one batch at a time and recreates its iterator on rewind."""
-    import numpy as np
-
-    from ultralytics.utils.export.onnx import onnx_calibration_reader
-
-    class Dataset:
-        def __init__(self):
-            self.iterations = 0
-
-        def __iter__(self):
-            self.iterations += 1
-            return iter((1, 2))
-
-    transformed = []
-
-    def transform_fn(batch):
-        transformed.append(batch)
-        return np.full((1, 3, 2, 2), batch, dtype=np.float32)
-
-    dataset = Dataset()
-    reader = onnx_calibration_reader(dataset, transform_fn, batch=2)
-    assert transformed == []
-    assert dataset.iterations == 1
-
-    assert np.array_equal(reader.get_next()["images"], np.full((2, 3, 2, 2), 1, dtype=np.float32))
-    assert transformed == [1]
-    assert reader.get_next()["images"].shape == (2, 3, 2, 2)
-    assert reader.get_next() is None
-
-    reader.rewind()
-    assert dataset.iterations == 2
-    assert np.array_equal(reader.get_next()["images"], np.full((2, 3, 2, 2), 1, dtype=np.float32))
-
-
 def test_quantize_canonicalization():
     """Quantize accepts 8/16/32 (int or str) and w-notation, canonicalizing to the int form (unset stays None)."""
     for value, expected in [

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -114,6 +114,41 @@ def test_onnx_int8_quantize_excludes_non_weighted_ops(monkeypatch):
     assert calls["nodes_to_exclude"] == ["pool", "sigmoid"]
 
 
+def test_onnx_calibration_reader_iterates_lazily_and_rewinds():
+    """Check ONNX/QNN calibration transforms one batch at a time and recreates its iterator on rewind."""
+    import numpy as np
+
+    from ultralytics.utils.export.onnx import onnx_calibration_reader
+
+    class Dataset:
+        def __init__(self):
+            self.iterations = 0
+
+        def __iter__(self):
+            self.iterations += 1
+            return iter((1, 2))
+
+    transformed = []
+
+    def transform_fn(batch):
+        transformed.append(batch)
+        return np.full((1, 3, 2, 2), batch, dtype=np.float32)
+
+    dataset = Dataset()
+    reader = onnx_calibration_reader(dataset, transform_fn, batch=2)
+    assert transformed == []
+    assert dataset.iterations == 1
+
+    assert np.array_equal(reader.get_next()["images"], np.full((2, 3, 2, 2), 1, dtype=np.float32))
+    assert transformed == [1]
+    assert reader.get_next()["images"].shape == (2, 3, 2, 2)
+    assert reader.get_next() is None
+
+    reader.rewind()
+    assert dataset.iterations == 2
+    assert np.array_equal(reader.get_next()["images"], np.full((2, 3, 2, 2), 1, dtype=np.float32))
+
+
 def test_quantize_canonicalization():
     """Quantize accepts 8/16/32 (int or str) and w-notation, canonicalizing to the int form (unset stays None)."""
     for value, expected in [

--- a/ultralytics/utils/export/onnx.py
+++ b/ultralytics/utils/export/onnx.py
@@ -15,22 +15,21 @@ def onnx_calibration_reader(dataset, transform_fn, input_name: str = "images", b
 
     class _CalibrationReader(CalibrationDataReader):
         def __init__(self):
-            """Materialize calibration inputs as `{input_name: float32_NCHW}` dicts."""
-            self.samples = []
-            for b in dataset:
-                im = transform_fn(b)
-                if batch and im.shape[0] != batch:  # tile up to the static batch dimension
-                    im = np.tile(im, (-(-batch // im.shape[0]), 1, 1, 1))[:batch]
-                self.samples.append({input_name: im})
-            self.iterator = iter(self.samples)
+            """Initialize calibration dataset iteration."""
+            self.iterator = iter(dataset)
 
         def get_next(self):
             """Return the next calibration sample, or None when exhausted."""
-            return next(self.iterator, None)
+            if (b := next(self.iterator, None)) is None:
+                return None
+            im = transform_fn(b)
+            if batch and im.shape[0] != batch:  # tile up to the static batch dimension
+                im = np.tile(im, (-(-batch // im.shape[0]), 1, 1, 1))[:batch]
+            return {input_name: im}
 
         def rewind(self):
             """Reset the iterator for an additional calibration pass."""
-            self.iterator = iter(self.samples)
+            self.iterator = iter(dataset)
 
     return _CalibrationReader()
 


### PR DESCRIPTION
## Summary

- stream ONNX and QNN calibration batches instead of materializing every transformed batch
- recreate the source iterator on rewind and preserve static-batch tiling
- retain only the source dataset reference and current iterator, with no transformed calibration tensors cached

This removes `self.samples`, eager traversal, and cache-based rewind. With the default 5,000-image COCO validation set at 640 px, the previous reader could retain about 22.9 GiB of float32 image tensors at once; the streaming reader holds approximately one batch (75 MiB at batch 16).

## Validation

- verified lazy transformation, exhaustion, static-batch tiling, and rewind behavior with a focused local script
- confirmed both ONNX INT8 and QNN use the shared reader
- Ruff and formatting checks pass for `ultralytics/utils/export/onnx.py`