### PR TITLE
Fix CoreML export NotImplementedError for new_ones op

### DIFF
--- a/ultralytics/utils/export/coreml.py
+++ b/ultralytics/utils/export/coreml.py
@@ -17,9 +17,9 @@ from ultralytics.utils.checks import check_requirements
 def _new_ones_coreml_patch():
     """Temporarily replace Tensor.new_ones with an equivalent coremltools can convert.
 
-    coremltools has no registered conversion for 'new_ones', which breaks CoreML export for
-    models using dynamic anchor generation (see ultralytics/utils/tal.py make_anchors()).
-    This substitutes a mathematically identical torch.ones() call, active only during tracing.
+    coremltools has no registered conversion for 'new_ones', which breaks CoreML export for models using dynamic anchor
+    generation (see ultralytics/utils/tal.py make_anchors()). This substitutes a mathematically identical torch.ones()
+    call, active only during tracing.
     """
     original = torch.Tensor.new_ones
 

--- a/ultralytics/utils/export/coreml.py
+++ b/ultralytics/utils/export/coreml.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -13,6 +14,9 @@ from ultralytics.utils import LOGGER
 from ultralytics.utils.checks import check_requirements
 
 
+_new_ones_patch_lock = threading.RLock()
+
+
 @contextlib.contextmanager
 def _new_ones_coreml_patch():
     """Temporarily replace Tensor.new_ones with an equivalent coremltools can convert.
@@ -20,23 +24,27 @@ def _new_ones_coreml_patch():
     coremltools has no registered conversion for 'new_ones', which breaks CoreML export for
     models using dynamic anchor generation (see ultralytics/utils/tal.py make_anchors()).
     This substitutes a mathematically identical torch.ones() call, active only during tracing.
+
+    Guarded by a lock since this mutates the global Tensor.new_ones method; without it,
+    concurrent exports could save/restore each other's patched state.
     """
-    original = torch.Tensor.new_ones
+    with _new_ones_patch_lock:
+        original = torch.Tensor.new_ones
 
-    def patched(self, size, dtype=None, **kwargs):
-        if isinstance(size, torch.Tensor):
-            shape = (int(size),) if size.dim() == 0 else tuple(int(s) for s in size)
-        elif isinstance(size, int):
-            shape = (size,)
-        else:
-            shape = tuple(size)
-        return torch.ones(shape, dtype=dtype or self.dtype, device=self.device)
+        def patched(self, size, dtype=None, **kwargs):
+            if isinstance(size, torch.Tensor):
+                shape = (int(size),) if size.dim() == 0 else tuple(int(s) for s in size)
+            elif isinstance(size, int):
+                shape = (size,)
+            else:
+                shape = tuple(size)
+            return torch.ones(shape, dtype=dtype or self.dtype, device=self.device)
 
-    torch.Tensor.new_ones = patched
-    try:
-        yield
-    finally:
-        torch.Tensor.new_ones = original
+        torch.Tensor.new_ones = patched
+        try:
+            yield
+        finally:
+            torch.Tensor.new_ones = original
 
 
 class IOSDetectModel(nn.Module):

--- a/ultralytics/utils/export/coreml.py
+++ b/ultralytics/utils/export/coreml.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
 from typing import Any
 
@@ -10,6 +11,32 @@ from torch import nn
 
 from ultralytics.utils import LOGGER
 from ultralytics.utils.checks import check_requirements
+
+
+@contextlib.contextmanager
+def _new_ones_coreml_patch():
+    """Temporarily replace Tensor.new_ones with an equivalent coremltools can convert.
+
+    coremltools has no registered conversion for 'new_ones', which breaks CoreML export for
+    models using dynamic anchor generation (see ultralytics/utils/tal.py make_anchors()).
+    This substitutes a mathematically identical torch.ones() call, active only during tracing.
+    """
+    original = torch.Tensor.new_ones
+
+    def patched(self, size, dtype=None, **kwargs):
+        if isinstance(size, torch.Tensor):
+            shape = (int(size),) if size.dim() == 0 else tuple(int(s) for s in size)
+        elif isinstance(size, int):
+            shape = (size,)
+        else:
+            shape = tuple(size)
+        return torch.ones(shape, dtype=dtype or self.dtype, device=self.device)
+
+    torch.Tensor.new_ones = patched
+    try:
+        yield
+    finally:
+        torch.Tensor.new_ones = original
 
 
 class IOSDetectModel(nn.Module):
@@ -195,7 +222,8 @@ def torch2coreml(
     import coremltools as ct
 
     LOGGER.info(f"\n{prefix} starting export with coremltools {ct.__version__}...")
-    ts = torch.jit.trace(model.eval(), im, strict=False)  # TorchScript model
+    with _new_ones_coreml_patch():
+        ts = torch.jit.trace(model.eval(), im, strict=False)  # TorchScript model
     fp16 = quantize == 16
     weight_int8 = quantize in {8, "w8a16"}
 

--- a/ultralytics/utils/export/coreml.py
+++ b/ultralytics/utils/export/coreml.py
@@ -13,7 +13,6 @@ from torch import nn
 from ultralytics.utils import LOGGER
 from ultralytics.utils.checks import check_requirements
 
-
 _new_ones_patch_lock = threading.RLock()
 
 


### PR DESCRIPTION
Fixes #25616

CoreML export crashes when dynamic=True is set, on models that use make_anchors() in tal.py. That function calls Tensor.new_ones() to build the anchor grid coordinates, and coremltools doesn't know how to convert that op, so it fails with:

NotImplementedError: PyTorch convert function for op 'new_ones' not implemented.

I first thought about just swapping new_ones() for torch.arange() in tal.py directly, but that would break something else - new_ones() is used there on purpose so exported models pick up whatever device they're actually running on later, instead of the device baked in at export time. Changing that in tal.py would affect every other export format, not just CoreML.

So instead I patch Tensor.new_ones with an equivalent torch.ones() call, but only while CoreML is tracing the model. Everything else stays untouched.

Tested with:
yolo export segment model=yolo26n-seg.pt imgsz=32 format=coreml end2end=True max_det=10 dynamic=True batch=2

Before: failed with NotImplementedError
After: exports successfully, saved as yolo26n-seg.mlpackage (10.6 MB)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes CoreML export failures caused by the unsupported `new_ones` operation during TorchScript tracing.

### 📊 Key Changes
- Adds a temporary context manager that replaces `Tensor.new_ones` with a CoreML-compatible `torch.ones` implementation.
- Handles tensor, integer, and iterable shape inputs while preserving dtype and device.
- Applies the patch only during CoreML tracing and reliably restores the original method afterward.

### 🎯 Purpose & Impact
- Enables CoreML export for models that use dynamic anchor generation.
- Avoids the `NotImplementedError` raised by coremltools for the `new_ones` operation.
- Limits the change to the export tracing scope, minimizing impact on other PyTorch workflows.