### PR TITLE
Fix dynamic CoreML anchor export

### DIFF
--- a/ultralytics/utils/tal.py
+++ b/ultralytics/utils/tal.py
@@ -398,8 +398,8 @@ def make_anchors(feats, strides, grid_cell_offset=0.5):
         stride = strides[i]
         h, w = feats[i].shape[2:] if isinstance(feats, list) else (int(feats[i][0]), int(feats[i][1]))
         # new_* factories inherit the device at runtime, unlike torch.arange which bakes it into traced graphs
-        sx = feats[0].new_ones(w, dtype=dtype).cumsum(0) - (1 - grid_cell_offset)  # shift x
-        sy = feats[0].new_ones(h, dtype=dtype).cumsum(0) - (1 - grid_cell_offset)  # shift y
+        sx = feats[0].new_full((w,), 1, dtype=dtype).cumsum(0) - (1 - grid_cell_offset)  # shift x
+        sy = feats[0].new_full((h,), 1, dtype=dtype).cumsum(0) - (1 - grid_cell_offset)  # shift y
         sy, sx = torch.meshgrid(sy, sx, indexing="ij") if TORCH_1_11 else torch.meshgrid(sy, sx)
         anchor_points.append(torch.stack((sx, sy), -1).view(-1, 2))
         stride_tensor.append(feats[0].new_full((h * w, 1), stride, dtype=dtype))


### PR DESCRIPTION
## Summary

Replace unsupported `Tensor.new_ones()` anchor factories with the equivalent `Tensor.new_full()` operation already used in `make_anchors()`. This keeps runtime device inheritance for dynamic TorchScript graphs while allowing CoreML Tools to convert dynamic end-to-end exports.

Fixes #25616.

## Validation

- `ruff check ultralytics/utils/tal.py`
- `ruff format --check ultralytics/utils/tal.py`
- exact fuzz reproduction passed 3/3: `python .github/scripts/fuzz.py repro "export segment model=yolo26n-seg.pt imgsz=32 format=coreml end2end=True max_det=10 dynamic=True batch=2"`
- verified anchor values, shapes, and device are unchanged
- verified the traced graph uses `aten::new_full` without an explicit device argument

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛠️ Updated anchor-grid creation to use more trace-friendly PyTorch tensor factories.

### 📊 Key Changes

- Replaced `new_ones()` with `new_full()` when generating x- and y-axis anchor coordinates in `ultralytics/utils/tal.py`.
- Preserved existing anchor values, device placement, data type, and grid behavior.
- No changes to the public API or model configuration.

### 🎯 Purpose & Impact

- ✅ Improves compatibility with PyTorch tracing and graph export by avoiding tensor factory behavior that may embed device information.
- 🚀 Supports more reliable model conversion and deployment across devices and runtimes.
- 🔒 Expected to maintain existing training and inference results while improving backend compatibility.