### PR TITLE
Refactor Ultralytics Platform integration

### DIFF
--- a/docs/en/guides/model-deployment-practices.md
+++ b/docs/en/guides/model-deployment-practices.md
@@ -28,7 +28,7 @@ It's also important to follow best practices when deploying a model because depl
 
 Oftentimes, once a model is [trained](./model-training-tips.md), [evaluated](./model-evaluation-insights.md), and [tested](./model-testing.md), it needs to be converted into specific formats to be deployed effectively in various environments, such as cloud, edge, or local devices.
 
-With YOLO26, you can [export your model to various formats](../modes/export.md) depending on your deployment needs. For instance, [exporting YOLO26 to ONNX](../integrations/onnx.md) is straightforward and ideal for transferring models between frameworks. To explore more integration options and ensure a smooth deployment across different environments, visit our [model integration hub](../integrations/index.md).
+With YOLO26, you can [export your model to various formats](../modes/export.md) depending on your deployment needs. For instance, [exporting YOLO26 to ONNX](../integrations/onnx.md) is straightforward and ideal for transferring models between frameworks. To explore more integration options and ensure a smooth deployment across different environments, visit our [model integration catalog](../integrations/index.md).
 
 ### Choosing a Deployment Environment
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -44,7 +44,7 @@ keywords: Ultralytics, YOLO, YOLO26, YOLO11, object detection, image segmentatio
 
 [Ultralytics](https://www.ultralytics.com) YOLO is a family of real-time computer vision models for object detection, instance segmentation, semantic segmentation, depth estimation, classification, pose estimation, oriented bounding boxes, and tracking, available through one Python package and CLI. YOLO26 is built on deep learning and computer vision advancements, featuring end-to-end NMS-free inference and optimized edge deployment. Its streamlined design makes it suitable for various applications and easily adaptable to different hardware platforms, from edge devices to cloud APIs. For stable production workloads, both [YOLO26](models/yolo26.md) and [YOLO11](models/yolo11.md) are recommended.
 
-Explore the Ultralytics Docs, a comprehensive resource covering the YOLO package and CLI as well as the [Ultralytics Platform](platform/index.md), which adds data annotation, cloud training, and deployment on top of the same models. Whether you are a seasoned machine learning practitioner or new to the field, this hub aims to help you get the most out of YOLO in your projects.
+Explore the Ultralytics Docs, a comprehensive resource covering the YOLO package and CLI as well as the [Ultralytics Platform](platform/index.md), which adds data annotation, cloud training, and deployment on top of the same models. Whether you are a seasoned machine learning practitioner or new to the field, these resources help you get the most out of YOLO in your projects.
 
 Request an Enterprise License for commercial use at [Ultralytics Licensing](https://www.ultralytics.com/license?utm_source=docs.ultralytics.com&utm_medium=referral&utm_content=license_inline_link).
 

--- a/docs/en/models/index.md
+++ b/docs/en/models/index.md
@@ -141,7 +141,7 @@ Ultralytics supports a comprehensive range of YOLO (You Only Look Once) versions
 
 ### Why should I use Ultralytics Platform for [machine learning](https://www.ultralytics.com/glossary/machine-learning-ml) projects?
 
-[Ultralytics Platform](../platform/index.md) provides a no-code, end-to-end platform for training, deploying, and managing YOLO models. It simplifies complex workflows, enabling users to focus on model performance and application. The HUB also offers [cloud training capabilities](../platform/train/cloud-training.md), comprehensive dataset management, and user-friendly interfaces for both beginners and experienced developers.
+[Ultralytics Platform](../platform/index.md) provides a no-code, end-to-end platform for training, deploying, and managing YOLO models. It simplifies complex workflows, enabling users to focus on model performance and application. It also offers [cloud training capabilities](../platform/train/cloud-training.md), comprehensive dataset management, and user-friendly interfaces for both beginners and experienced developers.
 
 ### What types of tasks can Ultralytics YOLO models perform?
 

--- a/docs/en/platform/account/activity.md
+++ b/docs/en/platform/account/activity.md
@@ -14,7 +14,7 @@ keywords: Ultralytics Platform, activity feed, audit log, notifications, event t
 
 ## Overview
 
-The Activity Feed serves as your central hub for:
+The Activity Feed provides one place for:
 
 - **Training updates**: Job started, completed, failed, or cancelled
 - **Data changes**: Datasets created, modified, or deleted

--- a/docs/en/reference/utils/callbacks/platform.md
+++ b/docs/en/reference/utils/callbacks/platform.md
@@ -16,10 +16,6 @@ keywords: platform callbacks, training callbacks, console logging, YOLO11 traini
 
 <br><br><hr><br>
 
-## ::: ultralytics.utils.callbacks.platform.resolve_platform_uri
-
-<br><br><hr><br>
-
 ## ::: ultralytics.utils.callbacks.platform._interp_plot
 
 <br><br><hr><br>
@@ -33,10 +29,6 @@ keywords: platform callbacks, training callbacks, console logging, YOLO11 traini
 <br><br><hr><br>
 
 ## ::: ultralytics.utils.callbacks.platform._send
-
-<br><br><hr><br>
-
-## ::: ultralytics.utils.callbacks.platform._send_async
 
 <br><br><hr><br>
 
@@ -73,17 +65,5 @@ keywords: platform callbacks, training callbacks, console logging, YOLO11 traini
 <br><br><hr><br>
 
 ## ::: ultralytics.utils.callbacks.platform.on_train_end
-
-<br><br><hr><br>
-
-## ::: ultralytics.utils.callbacks.platform.on_val_start
-
-<br><br><hr><br>
-
-## ::: ultralytics.utils.callbacks.platform.on_predict_end
-
-<br><br><hr><br>
-
-## ::: ultralytics.utils.callbacks.platform.on_export_start
 
 <br><br>

--- a/docs/en/reference/utils/checks.md
+++ b/docs/en/reference/utils/checks.md
@@ -16,6 +16,10 @@ keywords: Ultralytics, YOLO, utility functions, version checks, requirements, im
 
 <br><br><hr><br>
 
+## ::: ultralytics.utils.checks.resolve_platform_uri
+
+<br><br><hr><br>
+
 ## ::: ultralytics.utils.checks.parse_requirements
 
 <br><br><hr><br>

--- a/docs/en/reference/utils/events.md
+++ b/docs/en/reference/utils/events.md
@@ -22,4 +22,20 @@ keywords: Ultralytics, YOLO, utils, telemetry, analytics, events, anonymization,
 
 ## ::: ultralytics.utils.events._arch
 
+<br><br><hr><br>
+
+## ::: ultralytics.utils.events.on_train_end
+
+<br><br><hr><br>
+
+## ::: ultralytics.utils.events.on_val_start
+
+<br><br><hr><br>
+
+## ::: ultralytics.utils.events.on_predict_end
+
+<br><br><hr><br>
+
+## ::: ultralytics.utils.events.on_export_start
+
 <br><br>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,7 +29,7 @@ def test_special_modes() -> None:
     run("yolo cfg")
 
 
-@pytest.mark.parametrize("api_key", ["legacy_hub_key", "ul_" + "a" * 40])
+@pytest.mark.parametrize("api_key", ["legacy_api_key", "ul_" + "a" * 40])
 def test_settings_migration(tmp_path: Path, api_key: str) -> None:
     """Verify schema migration preserves user settings and only retains Platform API keys."""
     from ultralytics.utils import SettingsManager

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -755,7 +755,7 @@ def test_platform_job_transport(monkeypatch, tmp_path):
         captured.update(url=url, **kwargs)
         return SimpleNamespace(status_code=200, json=lambda: {"received": True}, raise_for_status=lambda: None)
 
-    monkeypatch.setattr(platform, "requests", SimpleNamespace(post=post), raising=False)
+    monkeypatch.setattr("requests.post", post)
     monkeypatch.setattr(platform, "_api_key", "api-key")
     monkeypatch.setattr(platform, "PLATFORM_API_URL", "https://example.test/api/webhooks")
     assert platform._send("epoch_end", {"epoch": 0}, "user/project", "model") == {"received": True}

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -64,6 +64,7 @@ ASSETS = ROOT / "assets"  # default images
 ASSETS_URL = "https://github.com/ultralytics/assets/releases/download/v0.0.0"  # assets GitHub URL
 # Configurable Platform URL for debugging (e.g. ULTRALYTICS_PLATFORM_URL=http://localhost:3000)
 PLATFORM_URL = os.getenv("ULTRALYTICS_PLATFORM_URL", "https://platform.ultralytics.com").rstrip("/")
+PLATFORM_API_URL = os.getenv("PLATFORM_API_URL", f"{PLATFORM_URL}/api/webhooks")
 DEFAULT_CFG_PATH = ROOT / "cfg/default.yaml"
 NUM_THREADS = min(8, max(1, os.cpu_count() - 1))  # number of YOLO multiprocessing threads
 AUTOINSTALL = env_bool("YOLO_AUTOINSTALL", True)  # global auto-install mode
@@ -1442,10 +1443,10 @@ class SettingsManager(JSONDict):
             if not re.fullmatch(r"ul_[0-9a-f]{40}", valid.get("api_key", "")):
                 if valid.get("api_key"):
                     LOGGER.warning(
-                        f"Legacy HUB API key removed. Get a Platform API key from {PLATFORM_URL}/settings?tab=api-keys "
+                        f"Legacy API key removed. Get a Platform API key from {PLATFORM_URL}/settings?tab=api-keys "
                         "and run 'yolo login API_KEY'."
                     )
-                valid["api_key"] = ""  # discard legacy HUB keys, which cannot authenticate with Platform
+                valid["api_key"] = ""  # discard legacy keys, which cannot authenticate with Platform
             valid["settings_version"] = self.version
             self.clear()
             self.update({**self.defaults, **valid})

--- a/ultralytics/utils/callbacks/base.py
+++ b/ultralytics/utils/callbacks/base.py
@@ -170,10 +170,8 @@ def get_default_callbacks():
 def add_integration_callbacks(instance):
     """Add integration callbacks to the instance's callbacks dictionary.
 
-    This function loads and adds various integration callbacks to the provided instance. The specific callbacks added
-    depend on the type of instance provided. All instances receive Ultralytics Platform callbacks, while Trainer
-    instances also receive additional callbacks for various integrations like ClearML, Comet, DVC, MLflow, Neptune, Ray
-    Tune, TensorBoard, and Weights & Biases.
+    This function loads and adds analytics callbacks to every instance. Trainer instances also receive Platform and
+    experiment logger callbacks for ClearML, Comet, DVC, MLflow, Neptune, Ray Tune, TensorBoard, and Weights & Biases.
 
     Args:
         instance (Trainer | Predictor | Validator | Exporter): The object instance to which callbacks will be added. The
@@ -184,10 +182,9 @@ def add_integration_callbacks(instance):
         >>> trainer = BaseTrainer()
         >>> add_integration_callbacks(trainer)
     """
-    from .platform import callbacks as platform_cb
+    from ultralytics.utils.events import callbacks as events_cb
 
-    # Load Ultralytics callbacks
-    callbacks_list = [platform_cb]
+    callbacks_list = [events_cb]
 
     # Load training callbacks
     if "Trainer" in instance.__class__.__name__:
@@ -196,11 +193,12 @@ def add_integration_callbacks(instance):
         from .dvc import callbacks as dvc_cb
         from .mlflow import callbacks as mlflow_cb
         from .neptune import callbacks as neptune_cb
+        from .platform import callbacks as platform_cb
         from .raytune import callbacks as tune_cb
         from .tensorboard import callbacks as tb_cb
         from .wb import callbacks as wb_cb
 
-        callbacks_list.extend([clear_cb, comet_cb, dvc_cb, mlflow_cb, neptune_cb, tune_cb, tb_cb, wb_cb])
+        callbacks_list.extend([platform_cb, clear_cb, comet_cb, dvc_cb, mlflow_cb, neptune_cb, tune_cb, tb_cb, wb_cb])
 
     # Add the callbacks to the callbacks dictionary
     for callbacks in callbacks_list:

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -8,24 +8,24 @@ import sys
 from concurrent.futures import ThreadPoolExecutor
 from math import isfinite
 from pathlib import Path
-from time import sleep, time
+from time import time
 
 from ultralytics.utils import (
     ENVIRONMENT,
     GIT,
     LOGGER,
+    PLATFORM_API_URL,
     PLATFORM_URL,
     PYTHON_VERSION,
-    RANK,
     SETTINGS,
     TESTS_RUNNING,
     Retry,
     colorstr,
 )
-from ultralytics.utils.events import events
 
 PREFIX = colorstr("Platform: ")
-PLATFORM_API_URL = os.getenv("PLATFORM_API_URL", f"{PLATFORM_URL}/api/webhooks")
+_api_key = None
+_executor = ThreadPoolExecutor(max_workers=10)
 
 
 def slugify(text):
@@ -33,122 +33,6 @@ def slugify(text):
     if not text:
         return text
     return re.sub(r"-+", "-", re.sub(r"[^a-z0-9\s-]", "", str(text).lower()).replace(" ", "-")).strip("-")[:128]
-
-
-try:
-    assert not TESTS_RUNNING  # do not log pytest
-    _api_key = os.getenv("ULTRALYTICS_API_KEY") or SETTINGS.get("api_key")
-    assert _api_key  # verify API key is present
-
-    import requests
-
-    from ultralytics.utils.logger import ConsoleLogger, SystemLogger
-    from ultralytics.utils.torch_utils import model_info_for_loggers
-
-    _executor = ThreadPoolExecutor(max_workers=10)  # Bounded thread pool for async operations
-
-except (AssertionError, ImportError):
-    _api_key = None
-
-
-def resolve_platform_uri(uri, hard=True):
-    """Resolve ul:// URIs to signed URLs by authenticating with Ultralytics Platform.
-
-    Formats:
-        ul://username/datasets/slug  -> Returns signed URL to NDJSON file
-        ul://username/project/model  -> Returns signed URL to .pt file
-
-    Args:
-        uri (str): Platform URI starting with "ul://".
-        hard (bool): Whether to raise an error if resolution fails.
-
-    Returns:
-        (str | None): Signed URL on success, None if not found and hard=False.
-
-    Raises:
-        ValueError: If API key is missing/invalid or URI format is wrong.
-        PermissionError: If access is denied.
-        RuntimeError: If resource is not ready (e.g., dataset still processing).
-        FileNotFoundError: If resource not found and hard=True.
-        ConnectionError: If network request fails and hard=True.
-    """
-    import requests
-
-    path = uri[5:]  # Remove "ul://"
-    parts = path.split("/")
-
-    api_key = os.getenv("ULTRALYTICS_API_KEY") or SETTINGS.get("api_key")
-    if not api_key:
-        raise ValueError(f"ULTRALYTICS_API_KEY required for '{uri}'. Get key at {PLATFORM_URL}/settings")
-
-    base = PLATFORM_API_URL
-    headers = {"Authorization": f"Bearer {api_key}"}
-
-    # ul://username/datasets/slug
-    if len(parts) == 3 and parts[1] == "datasets":
-        username, _, slug = parts
-        url = f"{base}/datasets/{username}/{slug}/export"
-
-    # ul://username/project/model
-    elif len(parts) == 3:
-        username, project, model = parts
-        url = f"{base}/models/{username}/{project}/{model}/download"
-
-    else:
-        raise ValueError(f"Invalid platform URI: {uri}. Use ul://user/datasets/name or ul://user/project/model")
-
-    # (connect_timeout, read_timeout) — short connect so retries are fast, long read for server-side generation
-    timeout = (10, 3600) if "/datasets/" in url else (10, 90)
-
-    try:
-        for attempt in range(5):
-            try:
-                # GET not HEAD: a HEAD response carries no body, so every platform error message was lost.
-                r = requests.get(url, headers=headers, allow_redirects=False, timeout=timeout)
-                if r.status_code in {408, 429} or r.status_code >= 500:
-                    raise requests.exceptions.HTTPError(f"HTTP {r.status_code}", response=r)
-                break
-            except (
-                requests.exceptions.ConnectionError,
-                requests.exceptions.ReadTimeout,
-                requests.exceptions.HTTPError,
-            ) as e:
-                if attempt >= 4:
-                    raise
-                delay = 2 * (2**attempt)  # 2s, 4s, 8s, 16s backoff
-                LOGGER.warning(f"Retry {attempt + 1}/5 for {uri} in {delay}s: {e}")
-                sleep(delay)
-    except Exception as e:
-        if hard:
-            raise ConnectionError(f"Failed to resolve {uri}: {e}") from e
-        LOGGER.warning(f"Failed to resolve {uri}: {e}")
-        return None
-
-    # Handle redirect responses (301, 302, 303, 307, 308)
-    if 300 <= r.status_code < 400 and "location" in r.headers:
-        return r.headers["location"]  # Return signed URL
-
-    # Echo only the platform's own JSON `error`: a proxy or WAF error page can quote our Authorization
-    # header, and it would land in the user's console.
-    try:
-        detail = str(r.json().get("error", "")).strip()
-    except Exception:
-        detail = ""
-    detail = f" {detail[:500]}" if detail else ""
-
-    if r.status_code == 401:
-        raise ValueError(f"Invalid ULTRALYTICS_API_KEY for '{uri}'.{detail}")
-    if r.status_code == 403:
-        raise PermissionError(f"Access denied for '{uri}'. Check dataset/model visibility settings.{detail}")
-    if r.status_code == 404:
-        if hard:
-            raise FileNotFoundError(f"Not found on platform: {uri}.{detail}")
-        LOGGER.warning(f"Not found on platform: {uri}.{detail}")
-        return None
-    if r.status_code == 409:
-        raise RuntimeError(f"Resource not ready: {uri}. Dataset may still be processing.{detail}")
-
-    raise RuntimeError(f"Platform error for '{uri}' (HTTP {r.status_code}).{detail or f' {r.reason}'}")
 
 
 def _interp_plot(plot, n=101):
@@ -213,6 +97,8 @@ def _send(event, data, project, name, model_id=None, retry=2, timeout=30):
     """Send event to Platform endpoint with retry logic."""
     if not _api_key:
         return None
+    import requests  # scoped as slow import
+
     payload = {"event": event, "project": project, "name": name, "data": _sanitize_json_value(data)}
     if model_id:
         payload["modelId"] = model_id
@@ -252,11 +138,6 @@ def _send(event, data, project, name, model_id=None, retry=2, timeout=30):
         return None
 
 
-def _send_async(event, data, project, name, model_id=None):
-    """Send event asynchronously using bounded thread pool."""
-    _executor.submit(_send, event, data, project, name, model_id)
-
-
 def _handle_control_response(trainer, ctx, response):
     """Apply centralized stop signals returned by Platform webhook responses.
 
@@ -284,6 +165,7 @@ def _upload_model(model_path, project, name, progress=False, retry=1, model_id=N
     model_size = model_path.stat().st_size
     if os.getenv("PLATFORM_API_URL"):
         return {"modelPath": str(model_path.resolve()), "modelSize": model_size}
+    import requests  # scoped as slow import
 
     # Get signed upload URL from Platform (server sanitizes filename for storage safety)
     @Retry(times=3, delay=2)
@@ -392,11 +274,17 @@ def _get_project_name(trainer):
 
 def on_pretrain_routine_start(trainer):
     """Initialize Platform logging at training start."""
-    if RANK not in {-1, 0} or not trainer.args.project:
+    global _api_key
+    if TESTS_RUNNING or not trainer.args.project:
+        return
+    _api_key = os.getenv("ULTRALYTICS_API_KEY") or SETTINGS.get("api_key")
+    if not _api_key:
         return
 
     project, name = _get_project_name(trainer)
     LOGGER.info(f"{PREFIX}Streaming training metrics to Platform")
+
+    from ultralytics.utils.logger import ConsoleLogger
 
     # Single dict for all platform callback state
     ctx = {
@@ -413,7 +301,8 @@ def on_pretrain_routine_start(trainer):
     # Create callback to send console output to Platform
     def send_console_output(content, line_count, chunk_id):
         """Send batched console output to Platform webhook."""
-        _send_async(
+        _executor.submit(
+            _send,
             "console_output",
             {"chunkId": chunk_id, "content": content, "lineCount": line_count},
             project,
@@ -474,7 +363,7 @@ def on_pretrain_routine_end(trainer):
 def on_fit_epoch_end(trainer):
     """Log training and system metrics at epoch end."""
     ctx = getattr(trainer, "platform", None)
-    if not ctx or RANK not in {-1, 0} or not trainer.args.project:
+    if not ctx:
         return
 
     project, name = _get_project_name(trainer)
@@ -487,6 +376,8 @@ def on_fit_epoch_end(trainer):
     model_info = None
     if trainer.epoch == 0:
         try:
+            from ultralytics.utils.torch_utils import model_info_for_loggers
+
             info = model_info_for_loggers(trainer)
             model_info = {
                 "parameters": info.get("model/parameters", 0),
@@ -500,6 +391,8 @@ def on_fit_epoch_end(trainer):
     system = {}
     try:
         if not ctx["system_logger"]:
+            from ultralytics.utils.logger import SystemLogger
+
             ctx["system_logger"] = SystemLogger(all_drives=True)
         system = ctx["system_logger"].get_metrics(rates=True)
     except Exception:
@@ -526,7 +419,7 @@ def on_fit_epoch_end(trainer):
 def on_model_save(trainer):
     """Upload model checkpoint (rate limited to every 15 min)."""
     ctx = getattr(trainer, "platform", None)
-    if not ctx or RANK not in {-1, 0} or not trainer.args.project:
+    if not ctx:
         return
     # Rate limit to every 15 minutes (900 seconds)
     if time() - ctx["last_upload"] < 900:
@@ -546,10 +439,9 @@ def on_model_save(trainer):
 
 
 def on_train_end(trainer):
-    """Run events on train end once fitness and duration are known, then log final results and upload best model."""
-    events(trainer.args, trainer.device, trainer)
+    """Log final training results and upload the best model to Platform."""
     ctx = getattr(trainer, "platform", None)  # set only by on_pretrain_routine_start, so unset without an API key
-    if not ctx or RANK not in {-1, 0} or not trainer.args.project:
+    if not ctx:
         return
 
     project, name = _get_project_name(trainer)
@@ -622,40 +514,10 @@ def on_train_end(trainer):
     LOGGER.info(f"{PREFIX}View results at {url}")
 
 
-def on_val_start(validator):
-    """Run events on validation start, when the user asked for validation.
-
-    A trainer runs its own final validation on a copy of the trainer's args, whose mode is still 'train'. Since an event
-    is named for its mode, firing here would send a second 'train' event indistinguishable from the training one.
-    """
-    if validator.args.mode == "val":
-        events(validator.args, validator.device)
-
-
-def on_predict_end(predictor):
-    """Run events on predict end, once per-image speeds are known."""
-    events(predictor.args, predictor.device, predictor)
-
-
-def on_export_start(exporter):
-    """Run events on export start."""
-    events(exporter.args, exporter.device)
-
-
 callbacks = {
-    # Anonymous analytics, gated only by the documented sync setting inside Events
-    "on_val_start": on_val_start,
-    "on_predict_end": on_predict_end,
-    "on_export_start": on_export_start,
-    "on_train_end": on_train_end,  # sends the train event, then uploads results if a Platform run is in flight
-    **(
-        {
-            "on_pretrain_routine_start": on_pretrain_routine_start,
-            "on_pretrain_routine_end": on_pretrain_routine_end,
-            "on_fit_epoch_end": on_fit_epoch_end,
-            "on_model_save": on_model_save,
-        }
-        if _api_key
-        else {}
-    ),
+    "on_pretrain_routine_start": on_pretrain_routine_start,
+    "on_pretrain_routine_end": on_pretrain_routine_end,
+    "on_fit_epoch_end": on_fit_epoch_end,
+    "on_model_save": on_model_save,
+    "on_train_end": on_train_end,
 }

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -37,6 +37,7 @@ from ultralytics.utils import (
     LOGGER,
     MACOS,
     ONLINE,
+    PLATFORM_API_URL,
     PLATFORM_URL,
     PYTHON_VERSION,
     RKNN_CHIPS,
@@ -70,6 +71,99 @@ def normalize_platform_uri(uri):
     """
     s = str(uri)
     return f"ul://{s[len(PLATFORM_URL) + 1 :].strip('/')}" if s.startswith(f"{PLATFORM_URL}/") else uri
+
+
+def resolve_platform_uri(uri, hard=True):
+    """Resolve ul:// URIs to signed URLs by authenticating with Ultralytics Platform.
+
+    Formats:
+        ul://username/datasets/slug  -> Returns signed URL to NDJSON file
+        ul://username/project/model  -> Returns signed URL to .pt file
+
+    Args:
+        uri (str): Platform URI starting with "ul://".
+        hard (bool): Whether to raise an error if resolution fails.
+
+    Returns:
+        (str | None): Signed URL on success, None if not found and hard=False.
+
+    Raises:
+        ValueError: If the API key or URI is invalid.
+        PermissionError: If access is denied.
+        RuntimeError: If the resource is not ready or Platform returns another error.
+        FileNotFoundError: If the resource is not found and hard=True.
+        ConnectionError: If the request fails and hard=True.
+    """
+    import requests  # scoped as slow import
+
+    # Scoped: SettingsManager imports torch_utils, which imports checks before SETTINGS is assigned.
+    from ultralytics.utils import SETTINGS
+
+    path = str(uri)[5:]
+    parts = path.split("/")
+    api_key = os.getenv("ULTRALYTICS_API_KEY") or SETTINGS.get("api_key")
+    if not api_key:
+        raise ValueError(f"ULTRALYTICS_API_KEY required for '{uri}'. Get a key at {PLATFORM_URL}/settings")
+
+    if len(parts) == 3 and parts[1] == "datasets":
+        username, _, slug = parts
+        endpoint = f"datasets/{username}/{slug}/export"
+    elif len(parts) == 3:
+        username, project, model = parts
+        endpoint = f"models/{username}/{project}/{model}/download"
+    else:
+        raise ValueError(f"Invalid Platform URI: {uri}. Use ul://user/datasets/name or ul://user/project/model")
+
+    url = f"{PLATFORM_API_URL}/{endpoint}"
+    # Short connect so retries are fast; long read for server-side generation.
+    timeout = (10, 3600) if "/datasets/" in url else (10, 90)
+    headers = {"Authorization": f"Bearer {api_key}"}
+
+    try:
+        for attempt in range(5):
+            try:
+                # GET preserves Platform error bodies, unlike HEAD.
+                response = requests.get(url, headers=headers, allow_redirects=False, timeout=timeout)
+                if response.status_code in {408, 429} or response.status_code >= 500:
+                    raise requests.exceptions.HTTPError(f"HTTP {response.status_code}", response=response)
+                break
+            except (
+                requests.exceptions.ConnectionError,
+                requests.exceptions.ReadTimeout,
+                requests.exceptions.HTTPError,
+            ) as error:
+                if attempt >= 4:
+                    raise
+                delay = 2 * (2**attempt)  # 2s, 4s, 8s, 16s backoff
+                LOGGER.warning(f"Retry {attempt + 1}/5 for {uri} in {delay}s: {error}")
+                time.sleep(delay)
+    except Exception as error:
+        if hard:
+            raise ConnectionError(f"Failed to resolve {uri}: {error}") from error
+        LOGGER.warning(f"Failed to resolve {uri}: {error}")
+        return None
+
+    if 300 <= response.status_code < 400 and "location" in response.headers:
+        return response.headers["location"]
+
+    # Echo only Platform's bounded JSON error: proxy/WAF pages may quote the Authorization header.
+    try:
+        detail = str(response.json().get("error", "")).strip()
+    except (AttributeError, TypeError, ValueError):
+        detail = ""
+    detail = f" {detail[:500]}" if detail else ""
+    if response.status_code == 401:
+        raise ValueError(f"Invalid ULTRALYTICS_API_KEY for '{uri}'.{detail}")
+    if response.status_code == 403:
+        raise PermissionError(f"Access denied for '{uri}'. Check dataset/model visibility settings.{detail}")
+    if response.status_code == 404:
+        if hard:
+            raise FileNotFoundError(f"Not found on Platform: {uri}.{detail}")
+        LOGGER.warning(f"Not found on Platform: {uri}.{detail}")
+        return None
+    if response.status_code == 409:
+        raise RuntimeError(f"Resource not ready: {uri}. Dataset may still be processing.{detail}")
+    raise RuntimeError(f"Platform error for '{uri}' (HTTP {response.status_code}).{detail or f' {response.reason}'}")
 
 
 def parse_requirements(file_path=ROOT.parent / "requirements.txt", package=""):
@@ -685,8 +779,6 @@ def check_file(file, suffix="", download=True, download_dir=".", hard=True):
     ):  # file exists or gRPC Triton images
         return file
     elif download and file.lower().startswith("ul://"):  # Ultralytics Platform URI
-        from ultralytics.utils.callbacks.platform import resolve_platform_uri
-
         url = resolve_platform_uri(file, hard=hard)  # Convert to signed HTTPS URL
         if url is None:
             return []  # Not found, soft fail (consistent with file search behavior)

--- a/ultralytics/utils/events.py
+++ b/ultralytics/utils/events.py
@@ -203,3 +203,35 @@ class Events:
 
 
 events = Events()
+
+
+def on_train_end(trainer):
+    """Record an anonymous training event after final metrics are available."""
+    events(trainer.args, trainer.device, trainer)
+
+
+def on_val_start(validator):
+    """Record an anonymous standalone validation event.
+
+    A trainer's final validation retains mode=train, so the guard prevents a duplicate train event.
+    """
+    if validator.args.mode == "val":
+        events(validator.args, validator.device)
+
+
+def on_predict_end(predictor):
+    """Record an anonymous prediction event after per-image speeds are available."""
+    events(predictor.args, predictor.device, predictor)
+
+
+def on_export_start(exporter):
+    """Record an anonymous export event."""
+    events(exporter.args, exporter.device)
+
+
+callbacks = {
+    "on_train_end": on_train_end,
+    "on_val_start": on_val_start,
+    "on_predict_end": on_predict_end,
+    "on_export_start": on_export_start,
+}


### PR DESCRIPTION
## Summary

- move Platform URI resolution and anonymous analytics callbacks to their existing owners
- register training-only Platform callbacks only for trainers, preserving rank-zero DDP behavior and avoiding Platform imports in predict, val, and export paths
- resolve authentication per training run so login changes do not require a process restart, while continuing to send every training argument and share `project`, `name`, and `exist_ok` across local outputs and experiment loggers
- centralize the Platform API URL and remove remaining ambiguous HUB wording without changing third-party Hub references or historical URLs

## Validation

- `ruff format --check ultralytics/utils/__init__.py ultralytics/utils/checks.py ultralytics/utils/events.py ultralytics/utils/callbacks/base.py ultralytics/utils/callbacks/platform.py tests/test_cli.py tests/test_python.py`
- `pytest -q tests/test_cli.py::test_settings_migration tests/test_cli.py::test_platform_login tests/test_python.py::test_normalize_platform_uri tests/test_python.py::test_platform_job_transport tests/test_python.py::test_events`
- `python docs/build_reference.py`
- cold full-diff Claude Opus review: LGTM

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Refactors Platform integration and anonymous analytics callbacks, improves `ul://` resource resolution, and updates related documentation and tests. 🚀

### 📊 Key Changes

- Moved `resolve_platform_uri` from Platform callbacks to `ultralytics.utils.checks`, making it a general-purpose utility for dataset and model downloads.
- Centralized the `PLATFORM_API_URL` configuration in `ultralytics.utils`.
- Separated anonymous analytics callbacks into `ultralytics.utils.events`, while Platform callbacks now focus on authenticated training integrations.
- Adjusted callback registration so analytics run across model workflows, while Platform logging is attached specifically to trainers.
- Added scoped imports and lazy initialization for `requests`, logging utilities, and model information helpers to reduce import overhead and improve initialization reliability.
- Simplified Platform callback behavior and removed duplicate or obsolete helper functions.
- Updated API-key migration handling and related tests to use clearer “legacy API key” terminology.
- Refreshed documentation wording and corrected API reference pages to reflect the callback and utility moves. 📚

### 🎯 Purpose & Impact

- Makes Platform URI handling available independently of Platform training callbacks, improving reuse and maintainability. 🔗
- Preserves support for downloading Platform-hosted datasets and models through `ul://` paths with retries, signed URLs, and clearer error handling.
- Prevents anonymous analytics and authenticated Platform logging from being unnecessarily coupled.
- Reduces startup dependencies and avoids importing slower components until they are needed.
- Improves callback documentation accuracy and helps users better understand the current Ultralytics Platform workflow.
- Existing users should see minimal behavioral change, while developers benefit from cleaner callback organization and more reliable testing. ✅