### PR TITLE
Remove stale reproduce command from Chinese depth notes

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -198,7 +198,7 @@ Ultralytics 支持广泛的 YOLO 模型，从早期的版本如 [YOLOv3](https:/
 - **abs_rel** 是预测深度与真实深度之间的平均绝对相对误差。
 - **rmse** 是均方根误差（单位为米）。
 - **速度** 为纯推理延迟（不含前/后处理），在 `imgsz=768`、`batch=1` 下测得，经预热后取多次计时运行的均值 ± 标准差。**CPU ONNX** 为在 32 核 Intel Xeon (Skylake) 上以 ONNX Runtime fp32 运行；**T4 TensorRT10** 为在 Tesla T4 上以 TensorRT fp16 运行。
-- **参数** 和 **FLOPs** 在 768×768 下测量。<br>使用 `yolo depth val data=nyu-depth.yaml device=0 imgsz=768` 复现结果。
+- **参数** 和 **FLOPs** 在 768×768（已发布权重的训练分辨率）下测量。
 
 </details>
 

--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -172,6 +172,9 @@
 62214284+Burhan-Q@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/62214284?v=4
   username: Burhan-Q
+62426699+zgh2022@users.noreply.github.com:
+  avatar: https://avatars.githubusercontent.com/u/62426699?v=4
+  username: zgh2022
 62523663+sokrisba@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/62523663?v=4
   username: sokrisba


### PR DESCRIPTION
`README.zh-CN.md` line 201 carried a leftover reproduce command with no counterpart in `README.md`:

```
- **参数** 和 **FLOPs** 在 768×768 下测量。<br>使用 `yolo depth val data=nyu-depth.yaml device=0 imgsz=768` 复现结果。
```

Three problems:

- It is attached to the params/FLOPs bullet, but `yolo depth val` does not reproduce params or FLOPs.
- It omits `model=`, so it cannot run as written.
- It conflicts with the correct single-scale command already given four lines above at line 197, which does include `model=yolo26n-depth.pt`.

It was also the only `yolo` command in `README.zh-CN.md` with no match in `README.md`. Replaced the bullet with a translation of the English one, which additionally carries the "training resolution of the released weights" detail the Chinese version had dropped.

After this change the two READMEs contain identical `yolo` command sets and remain at matching line and heading counts. No other divergence was found: all seven task tables are byte-identical, and the URL sets match.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Clarifies Chinese README evaluation notes and adds a missing GitHub contributor profile to the documentation configuration. 📝

### 📊 Key Changes

- Updated `README.zh-CN.md` to state that parameter and FLOPs measurements use the published model weights’ training resolution of 768×768.
- Removed the outdated command previously provided for reproducing those measurements.
- Added the GitHub author profile for @zgh2022 to `docs/mkdocs_github_authors.yaml`.

### 🎯 Purpose & Impact

- Makes the Chinese documentation more accurate and better aligned with the reported model metrics. ✅
- Prevents confusion about how parameter and FLOPs values were measured.
- Ensures @zgh2022 is correctly recognized and displayed as a contributor in generated documentation. 🌟