### PR TITLE
Speed up bare Ultralytics imports

### DIFF
--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -1,5 +1,4 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
-
 """Monte Carlo fuzzing of the `yolo` CLI to find bugs outside the finite test matrix.
 
 Runs randomized/mutated `yolo` commands in subprocesses, classifies every outcome (pass, expected cfg error,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ dependencies = [
     "torch>=1.8.0",
     "torch>=1.8.0,!=2.4.0; sys_platform == 'win32'", # Windows CPU errors w/ 2.4.0 https://github.com/ultralytics/ultralytics/issues/15049
     "torchvision>=0.9.0",
+    "ultralytics-autoimport>=0.1.0",
     "psutil>=5.8.0", # system utilization
     "polars>=0.20.0",
     "nvidia-ml-py>=12.0.0", # NVIDIA GPU monitoring https://pypi.org/project/nvidia-ml-py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ dependencies = [
     "torch>=1.8.0",
     "torch>=1.8.0,!=2.4.0; sys_platform == 'win32'", # Windows CPU errors w/ 2.4.0 https://github.com/ultralytics/ultralytics/issues/15049
     "torchvision>=0.9.0",
-    "ultralytics-autoimport>=0.1.0",
     "psutil>=5.8.0", # system utilization
     "polars>=0.20.0",
     "nvidia-ml-py>=12.0.0", # NVIDIA GPU monitoring https://pypi.org/project/nvidia-ml-py

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,9 +73,11 @@ def test_platform_login(monkeypatch) -> None:
 
 
 def test_cli_imports_defer_torchvision() -> None:
-    """Verify startup imports do not load torchvision or SAM3 geometry."""
+    """Verify startup imports defer heavyweight dependencies, torchvision, and SAM3 geometry."""
     code = (
         "import sys; "
+        "import ultralytics; "
+        "assert not {'cv2', 'numpy', 'torch'} & sys.modules.keys(); "
         "from ultralytics import YOLO; "
         "from ultralytics.models.sam import Predictor; "
         "assert 'torchvision' not in sys.modules; "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -78,6 +78,8 @@ def test_cli_imports_defer_torchvision() -> None:
         "import sys; "
         "import ultralytics; "
         "assert not {'cv2', 'numpy', 'torch'} & sys.modules.keys(); "
+        "import ultralytics.utils.patches; "
+        "assert ultralytics.utils.imread is ultralytics.utils.patches.imread; "
         "from ultralytics import YOLO; "
         "from ultralytics.models.sam import Predictor; "
         "assert 'torchvision' not in sys.modules; "

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -6,15 +6,13 @@ import importlib
 import os
 from typing import TYPE_CHECKING
 
+from autoimport import lazy_import
+
 # Set ENV variables (place before imports)
 if not os.environ.get("OMP_NUM_THREADS"):
     os.environ["OMP_NUM_THREADS"] = "1"  # default for reduced CPU utilization during training
 
-from ultralytics.utils import ASSETS, SETTINGS
-from ultralytics.utils.checks import check_yolo as checks
-from ultralytics.utils.downloads import download
-
-settings = SETTINGS
+_utils = lazy_import("ultralytics.utils")
 
 MODELS = ("YOLO", "YOLOWorld", "YOLOE", "NAS", "SAM", "FastSAM", "RTDETR")
 
@@ -30,18 +28,31 @@ __all__ = (  # noqa: PLE0604
 if TYPE_CHECKING:
     # Enable hints for type checkers
     from ultralytics.models import YOLO, YOLOWorld, YOLOE, NAS, SAM, FastSAM, RTDETR  # noqa
+    from ultralytics.utils import ASSETS, SETTINGS
+    from ultralytics.utils.checks import check_yolo as checks
+    from ultralytics.utils.downloads import download
+
+    settings = SETTINGS
 
 
 def __getattr__(name: str):
-    """Lazy-import model classes on first access."""
+    """Lazy-import public attributes on first access."""
     if name in MODELS:
         return getattr(importlib.import_module("ultralytics.models"), name)
+    if name in {"ASSETS", "SETTINGS"}:
+        return getattr(_utils, name)
+    if name == "settings":
+        return _utils.SETTINGS
+    if name == "checks":
+        return importlib.import_module("ultralytics.utils.checks").check_yolo
+    if name == "download":
+        return importlib.import_module("ultralytics.utils.downloads").download
     raise AttributeError(f"module {__name__} has no attribute {name}")
 
 
 def __dir__():
-    """Extend dir() to include lazily available model names for IDE autocompletion."""
-    return sorted(set(globals()) | set(MODELS))
+    """Extend dir() with lazily available public names for IDE autocompletion."""
+    return sorted(set(globals()) | set(__all__) | {"SETTINGS"})
 
 
 if __name__ == "__main__":

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -6,13 +6,9 @@ import importlib
 import os
 from typing import TYPE_CHECKING
 
-from autoimport import lazy_import
-
 # Set ENV variables (place before imports)
 if not os.environ.get("OMP_NUM_THREADS"):
     os.environ["OMP_NUM_THREADS"] = "1"  # default for reduced CPU utilization during training
-
-_utils = lazy_import("ultralytics.utils")
 
 MODELS = ("YOLO", "YOLOWorld", "YOLOE", "NAS", "SAM", "FastSAM", "RTDETR")
 
@@ -40,9 +36,11 @@ def __getattr__(name: str):
     if name in MODELS:
         return getattr(importlib.import_module("ultralytics.models"), name)
     if name in {"ASSETS", "SETTINGS"}:
-        return getattr(_utils, name)
+        return getattr(importlib.import_module("ultralytics.utils"), name)
     if name == "settings":
-        return _utils.SETTINGS
+        return importlib.import_module("ultralytics.utils").SETTINGS
+    if name == "utils":
+        return importlib.import_module("ultralytics.utils")
     if name == "checks":
         return importlib.import_module("ultralytics.utils.checks").check_yolo
     if name == "download":


### PR DESCRIPTION
## Summary
- extend Ultralytics' existing PEP 562 `__getattr__` owner to defer heavyweight utility imports
- preserve the existing `ASSETS`, `SETTINGS`, `settings`, `checks`, `download`, and model APIs
- extend the startup regression to cover heavy dependencies and direct utility-submodule imports

## Cold-import benchmark
Python 3.13.9 on Apple M5 Pro with torch 2.13.0. Each result is the median of 12 fresh Python subprocesses against exact base `1ca0fa168` and this PR.

| Operation | Before | After | Change |
| --- | ---: | ---: | ---: |
| `import ultralytics` | 610.0 ms | 18.0 ms | -97.0% |
| access `ultralytics.ASSETS` | 601.9 ms | 598.3 ms | -0.6% |
| access `ultralytics.checks` | 596.6 ms | 596.4 ms | 0.0% |
| access `ultralytics.download` | 599.5 ms | 602.5 ms | +0.5% |
| access `ultralytics.YOLO` | 805.5 ms | 782.8 ms | -2.8% |

This defers initialization cost rather than removing it: first use of utility or model APIs remains approximately unchanged.

Exploratory combinations confirmed that lazily exposing only `checks` and `download` left bare import at 564.1 ms, while lazy utility state with eager helpers left it at 587.6 ms. All eagerly exported utility paths must be deferred to preserve the bare-import win.

## Design review
An initial implementation used `ultralytics-autoimport`, but cold review found two blockers: pre-seeding a package proxy could conflict with direct child-module imports, and its top-level `autoimport` package name collides with an existing PyPI project. This revision removes that dependency and uses Ultralytics' existing standard-library PEP 562 mechanism instead.

## Validation
- Ruff format and lint
- focused startup-import and Platform SETTINGS tests
- Python 3.8 bare import with no added dependency
- top-level aliases, star imports, `SETTINGS`, and `dir()` compatibility probes
- direct `ultralytics.utils.patches` import identity regression
- YOLO26n model construction and CPU image prediction

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves Ultralytics startup performance by lazily importing heavyweight dependencies and public utilities only when they are needed. ⚡

### 📊 Key Changes

- Removed eager imports of utilities, settings, download helpers, and checks from `ultralytics/__init__.py`.
- Added lazy loading for:
  - Model classes such as `YOLO`, `SAM`, and `RTDETR`
  - `ASSETS`, `SETTINGS`, and `settings`
  - `checks`, `download`, and the `utils` module
- Updated `__dir__()` and type-checking imports to preserve developer experience and autocomplete support.
- Expanded CLI import tests to confirm that `cv2`, NumPy, PyTorch, TorchVision, and SAM3 geometry are not loaded unnecessarily.
- Cleaned up the fuzzing script header formatting.

### 🎯 Purpose & Impact

- 🚀 Reduces initial import time and memory usage for lightweight use cases.
- 🧩 Avoids loading heavy dependencies until model or utility functionality actually requires them.
- ✅ Preserves the existing public API while improving startup behavior.
- 🛡️ Adds regression coverage to prevent accidental eager imports in future changes.