### PR TITLE
Make augmentation probability guards exact at p=0

### DIFF
--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -335,7 +335,7 @@ class BaseMixTransform(BaseTransform):
             >>> transform = BaseMixTransform(dataset, pre_transform=None, p=0.5)
             >>> result = transform({"image": img, "bboxes": boxes, "cls": classes})
         """
-        if random.uniform(0, 1) > self.p:
+        if random.random() >= self.p:
             return labels
 
         params = self.get_params(labels)
@@ -2214,7 +2214,7 @@ class Albumentations(BaseTransform):
             - Spatial transforms update bounding boxes, while non-spatial transforms only modify the image.
             - Requires the Albumentations library to be installed.
         """
-        if self.transform is None or random.random() > self.p:
+        if self.transform is None or random.random() >= self.p:
             return labels
 
         im = labels["img"]
@@ -2444,7 +2444,7 @@ class Format(BaseTransform):
         if len(img.shape) < 3:
             img = img[..., None]
         img = img.transpose(2, 0, 1)
-        img = np.ascontiguousarray(img[::-1] if random.uniform(0, 1) > self.bgr and img.shape[0] == 3 else img)
+        img = np.ascontiguousarray(img[::-1] if random.random() >= self.bgr and img.shape[0] == 3 else img)
         img = torch.from_numpy(img)
         return img
 


### PR DESCRIPTION
## summary

`ultralytics/data/augment.py` gates four augmentations on a draw from `random`, which returns values in `[0.0, 1.0)`. `RandomFlip` applies its flip on `r < p`, exact at both ends: never at `p=0`, always at `p=1`. The three early-return guards used `r > p`, which leaves the `p=0` end open — a draw of exactly `0.0` makes `0.0 > 0.0` false, so the guard falls through and the transform runs at `p=0`.

This switches those three to `r >= p`, the exact negation of the `RandomFlip` form:

| site | before | after |
| --- | --- | --- |
| `BaseMixTransform.__call__` | `random.uniform(0, 1) > self.p` | `random.random() >= self.p` |
| `Albumentations.__call__` | `random.random() > self.p` | `random.random() >= self.p` |
| `Format._format_img` | `random.uniform(0, 1) > self.bgr` | `random.random() >= self.bgr` |

`random.uniform(0, 1)` is `0 + (1 - 0) * random.random()`, so it draws the same value from the same stream and never returns `1.0`. `>=` is therefore exact at `p=1` as well as at `p=0`, and calling `random.random()` directly drops a layer of indirection from a per-sample path.

Where `p=0` is load-bearing:

- `DepthDataset.build_transforms` disables `Mosaic`, `MixUp` and `CutMix` with `p=0.0` because none of them override `apply_depth`; running one would mix the image and leave the depth map untouched.
- `bgr` defaults to `0.0` and validation forces `0.0` (`dataset.py:329`), so channel order on those paths is now deterministic.

Verified with a seeded `YOLODataset` over coco8 (`augment=True`, `mosaic=1.0`, `mixup=0.3`, `cutmix=0.3`, `bgr=0.0`, so all three lines execute): `img`, `cls` and `bboxes` are byte-identical before and after across 3 seeds x 4 images. Over 2,000,000 draws, `(r > p) != (r >= p)` holds 0 times for every `p` in `{0.0, 0.05, 0.1, 0.3, 0.5, 0.9, 1.0}` — the only inputs that move are draws where `r == p` exactly.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🎲 Standardizes augmentation probability checks by using `random.random()` with consistent boundary handling.

### 📊 Key Changes
- Replaced `random.uniform(0, 1)` with Python’s simpler `random.random()` in mix transforms and image formatting.
- Updated probability conditions from `>` to `>=` for mix augmentation, Albumentations, and BGR channel reversal.
- Preserved the configured augmentation behavior while making threshold handling consistent across preprocessing paths.

### 🎯 Purpose & Impact
- ✅ Improves code clarity and consistency across data augmentation utilities.
- 🎯 Ensures transformations are applied according to the intended probability boundary.
- 🚀 Has negligible practical impact for users, with changes only affecting the extremely rare case where the random value exactly matches the configured probability.