### PR TITLE
Skip the GMC warp when a tracker sets `gmc_method: none`

### DIFF
--- a/ultralytics/trackers/byte_tracker.py
+++ b/ultralytics/trackers/byte_tracker.py
@@ -353,7 +353,7 @@ class BYTETracker:
         self, strack_pool: list[STrack], unconfirmed: list[STrack], img: np.ndarray | None, results_high: Any
     ) -> None:
         """Hook called after Kalman predict, before first-stage assignment. Default: GMC if available."""
-        if hasattr(self, "gmc") and img is not None:
+        if hasattr(self, "gmc") and self.gmc.method is not None and img is not None:
             try:
                 warp = self.gmc.apply(img, results_high.xyxy)
             except Exception as e:

--- a/ultralytics/trackers/deep_oc_sort.py
+++ b/ultralytics/trackers/deep_oc_sort.py
@@ -235,7 +235,7 @@ class DeepOCSORT(OCSORT):
         results_high: Any,
     ) -> None:
         """Apply GMC warp to Kalman state before first-stage association."""
-        if img is None:
+        if img is None or self.gmc.method is None:
             return
         try:
             warp = self.gmc.apply(img, results_high.xyxy if len(results_high) else np.empty((0, 4)))

--- a/ultralytics/trackers/track_tracker.py
+++ b/ultralytics/trackers/track_tracker.py
@@ -489,7 +489,7 @@ class TRACKTRACK:
             (unconfirmed if not track.is_activated else tracked).append(track)
         pool = joint_stracks(tracked, self.lost_stracks)
 
-        if img is not None:
+        if img is not None and self.gmc.method is not None:
             self._apply_gmc(img, dets_high, [pool, unconfirmed])
         TTSTrack.multi_predict(pool)
 


### PR DESCRIPTION
## Summary

`deepocsort.yaml` ships `gmc_method: none`, but the warp still ran on every frame. `GMC.__init__` normalizes `none` to `self.method = None` and `GMC.apply` then returns `np.eye(2, 3)`, so each frame built an 8x8 identity, pushed every track mean and covariance through it, added a zero translation, and rebuilt every stored observation, twice per frame.

`docs/en/modes/track.md` already documents `none` as the way to disable camera motion compensation, so this makes the code match the documented behaviour.

Each of the three call sites already had a condition deciding whether to warp, so this extends that condition to consult `gmc.method`. Net zero added lines. `botsort.yaml` and `tracktrack.yaml` ship `sparseOptFlow`, so those sites only skip when a user selects `none` explicitly.

The guard keys on `method is None`, not on "the warp happens to be identity", so the `except Exception -> np.eye(2, 3)` fallback for an enabled method that fails on a frame keeps behaving exactly as before.

## Behaviour

The identity warp was not a strict no-op. `DeepOCSortTrack.multi_gmc` rebuilds `last_observation` through a center and width round trip, and in float32 that does not return the original corners: over 2000 synthetic boxes, 83.5% change, by up to 1.220703e-04 px. It reaches a fixed point after one pass, so it does not accumulate across frames, and it never moved a track id or an output box on any clip measured here. Removing it is therefore a small correctness gain as well as a saving, but the byte identical result below is measured rather than structural.

`GMC.apply` keeps its `else: return np.eye(2, 3)` branch. `GMC.__init__` raises on an unknown method, so `self.method` is one of `orb`, `sift`, `ecc`, `sparseOptFlow` or `None`, which means that branch is now reachable only through a direct call by a user, not through any call site in the package. It stays because `GMC.apply` is published on the reference site.

## Verification

Full matrix of 6 trackers x 3 `gmc_method` settings x {cpu, cuda:0}, 200 frames of a 1080p clip with `yolo11n.pt`, dumping every output row as (frame, track id, class, confidence, xyxy) at float64 and comparing digests against `main`:

| | result |
| -- | -- |
| cells compared | 36 |
| differing cells | 0 |
| track id changes | 0 |
| max box delta | 0 |
| final track state dtype changes | 0 |

GMC work actually performed over those 200 frames, counted by wrapping `GMC.apply`:

| config | `gmc_method` | `gmc.apply` calls before | after |
| -- | -- | -- | -- |
| `deepocsort.yaml` (shipped) | `none` | 201 | 0 |
| `botsort.yaml` | `none` | 201 | 0 |
| `tracktrack.yaml` | `none` | 201 | 0 |
| `botsort.yaml` (shipped) | `sparseOptFlow` | 201 | 201 |
| `tracktrack.yaml` (shipped) | `sparseOptFlow` | 201 | 201 |
| `bytetrack.yaml`, `fasttrack.yaml`, `ocsort.yaml` | no GMC | 0 | 0 |

`bytetrack`, `fasttrack` and `ocsort` never construct a `gmc` attribute, so the `hasattr` guard short circuits and they are unaffected on every revision.

## Cost

The removed work measures 92.1 us per call at 21 concurrent tracks, called twice per frame. Tracker only CPU, detector excluded, pinned to physical cores, three interleaved rounds, minimum of N:

| tracker | `gmc_method` | 25 objects | 100 objects | 300 objects |
| -- | -- | -- | -- | -- |
| `deepocsort` | `none` | -8.8% | -6.9% | -6.5% |
| `botsort` | `none` | -6.4% | -3.3% | -2.9% |
| `tracktrack` | `none` | -3.1% | -1.0% | +2.8% |

In absolute terms that is 0.14 ms per frame at 25 tracks and 1.49 ms per frame at 300. Rows for `sparseOptFlow`, where no code changed, drift by up to 4% across the same runs, which sets the noise floor for this measurement.

This does not touch the dominant tracker cost. `sparseOptFlow` itself is about 11 ms per frame at 1080p and about 43 ms at 4K, and it runs on `orig_img` rather than the `imgsz` resized input, so `botsort` and `tracktrack` on shipped defaults are unaffected by this change.

`pytest tests/test_python.py -k track` passes, 14 tests.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves tracker stability by skipping Global Motion Compensation (GMC) when no GMC method is configured. 🛠️

### 📊 Key Changes

- Added checks for `self.gmc.method is not None` before applying GMC in:
  - ByteTrack
  - Deep OC-SORT
  - TrackTracker
- Prevented GMC processing when no image or detection data is available where applicable.
- Preserved existing GMC behavior when a valid method is configured.

### 🎯 Purpose & Impact

- ✅ Avoids unnecessary GMC calls and potential runtime errors when GMC is disabled.
- 📈 Improves reliability across supported tracking workflows.
- 🔧 Makes tracker behavior more consistent for users who do not configure camera-motion compensation.
- 🚀 Has no expected impact on tracking when GMC is enabled.