### PR TITLE
Threshold SAM3 video semantic masks at the model logit threshold

### DIFF
--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -2651,7 +2651,10 @@ class SAM3VideoSemanticPredictor(SAM3SemanticPredictor):
             pred_masks, pred_boxes = None, torch.zeros((0, 7), device=self.device)
         else:
             pred_masks = torch.cat([obj_id_to_mask[obj_id] for obj_id in curr_obj_ids], dim=0)
-            pred_masks = F.interpolate(pred_masks.float()[None], orig_imgs[0].shape[:2], mode="bilinear")[0] > 0.5
+            pred_masks = (
+                F.interpolate(pred_masks.float()[None], orig_imgs[0].shape[:2], mode="bilinear")[0]
+                > self.model.mask_threshold
+            )
             pred_ids = torch.tensor(curr_obj_ids, dtype=torch.int32, device=pred_masks.device)
             pred_scores = torch.tensor(
                 [preds["obj_id_to_score"][obj_id] for obj_id in curr_obj_ids], device=pred_masks.device
@@ -3368,9 +3371,9 @@ class SAM3VideoSemanticPredictor(SAM3SemanticPredictor):
 
         # Part 1: masks from previous SAM2 propagation
         existing_masklet_obj_ids = tracker_metadata_prev["obj_ids"]
-        existing_masklet_binary = tracker_low_res_masks_global.unsqueeze(1)
-        assert len(existing_masklet_obj_ids) == len(existing_masklet_binary)
-        for obj_id, mask in zip(existing_masklet_obj_ids, existing_masklet_binary):
+        existing_masklet_logits = tracker_low_res_masks_global.unsqueeze(1)
+        assert len(existing_masklet_obj_ids) == len(existing_masklet_logits)
+        for obj_id, mask in zip(existing_masklet_obj_ids, existing_masklet_logits):
             obj_id_to_mask[obj_id] = mask  # (1, H_video, W_video)
 
         # Part 2: masks from new detections


### PR DESCRIPTION
#25386 moved the SAM 3 semantic masks from the `> 0.5` literal to the model logit threshold, but only on the image path. `SAM3VideoSemanticPredictor.postprocess()` still has the old literal at `predict.py:2654`, and the tensors it cuts there are raw logits too.

Both sources of `obj_id_to_mask` are logits, and the rest of the file already treats them like that. `build_outputs()` (`predict.py:3357`) fills that dict from exactly two places:

- the propagated masklets, `tracker_low_res_masks_global`, which this same file binarises with `> 0` at `predict.py:3146` and `predict.py:3274`
- the new and reconditioned detections, `det_out["mask"]`, which is `sam3_image_out["pred_masks"][keep]` (`predict.py:2949`) — the same tensor the image path thresholds at `mask_threshold` since #25386

So `predict.py:2654` is the only line left in the file that compares those logits against 0.5. The variable they arrive in was called `existing_masklet_binary` (`predict.py:3371`), but it holds logits and not a binary mask. That is probably why the literal survived the earlier fix, so here it is renamed to `existing_masklet_logits`.

Deleted: the `> 0.5` literal on the video path, and the `existing_masklet_binary` name that was hiding it. Net +3 lines, which is the same wrapped expression the image path already uses at `predict.py:2333`.

## Siblings

`mask_threshold` is `0.0` on every SAM model (`sam3/sam3_image.py:33`, `modules/sam.py:53` and `:161`), so the `> 0` comparisons in this file are already at the model threshold and are left untouched — only the `0.5` was off. `SAM3VideoPredictor`, the non-semantic video path, is `SAM3VideoPredictor(SAM2VideoPredictor, SAM3Predictor)` (`predict.py:2432`), so its `postprocess()` resolves to the `SAM2VideoPredictor` override at `predict.py:972`. That one delegates to `super()`, that is `Predictor.postprocess()`, which thresholds at `self.model.mask_threshold` since always (`predict.py:521`), and then it only adds the optional `non_overlap_masks` pass on top. There is no literal in either step, so that path was never affected. The empty-object branch above the fix returns `None` masks and is untouched.

`fastsam/predict.py:101` and `utils/plotting.py:492` also have a `> 0.5`, but those run on masks that are already boolean, where 0.5 is the correct midpoint after a bilinear resize and not a cut on a logit. Those two are correct as they are, so I left them alone.

## Measured

Two clips from the repo's own CI assets, 12 frames each, `quantize=16`, one RTX 4060: `solutions_ci_demo.mp4` with `text=["person"]` (45 objects a frame, 59-1129 px each) and `solution_ci_parking_demo.mp4` with `text=["car"]` (41-42 objects, 352-2916 px). The videos download by themselves; `sam3.pt` has to come from Hugging Face as `docs/en/models/sam-3.md` describes.

Each clip runs **once** and every frame is post-processed twice on the same `preds` dict, once at `self.model.mask_threshold` and once at `0.5`. The patched line is the only place in `postprocess()` that reads that attribute, so setting it to `0.5` gives exactly the pre-fix code, and everything else (interpolation, `keep`, boxes, `_apply_object_wise_non_overlapping_constraints`) runs the same on both sides. Two separate runs would not isolate the threshold, because the video path is stateful and `PositionEmbeddingRandom.__init__` turns determinism off (`sam/modules/blocks.py:809-810`).

Masks are compared by `obj_id` (`boxes[:, 4]`) and not by index, because `keep` can drop a different object on each side: `keep` is `pred_masks.any(dim=(1, 2))` *after* the cut (`predict.py:2665`), so an object that `0.5` leaves empty goes out of the output completely. The script counts those (`on one side only` below) and they are zero on both clips, so the totals are the full output and not a part of it. Measuring right after the threshold would also give a bigger effect than the real one, since the non-overlap arbitration runs after the cut. These are the masks the predictor really returns:

```python
import torch
import torch.nn.functional as F

from ultralytics.models.sam import SAM3VideoSemanticPredictor
from ultralytics.utils import ASSETS_URL
from ultralytics.utils.downloads import safe_download

VIDEO, TEXT = "solutions_ci_demo.mp4", ["person"]  # and solution_ci_parking_demo.mp4 / ["car"]
safe_download(f"{ASSETS_URL}/{VIDEO}")  # sam3.pt is gated, see docs/en/models/sam-3.md

p = SAM3VideoSemanticPredictor(
    overrides={"model": "sam3.pt", "task": "segment", "mode": "predict", "imgsz": 640,
               "conf": 0.25, "quantize": 16, "save": False, "verbose": False}
)
orig, frames, lo, hi, ids, odd = type(p).postprocess, [], [], [], set(), 0


def by_id(res):  # {obj_id: bool mask}
    r = res[0]
    if r.masks is None or not len(r.masks):
        return {}
    return dict(zip(r.boxes.data[:, 4].int().tolist(), r.masks.data.bool()))


def paired(self, preds, img, orig_imgs):
    global odd, ids
    res = orig(self, preds, img, orig_imgs)  # at self.model.mask_threshold
    fixed, saved = by_id(res), self.model.mask_threshold
    self.model.mask_threshold = 0.5  # the pre-fix literal, same tensors
    legacy = by_id(orig(self, preds, img, orig_imgs))
    self.model.mask_threshold = saved
    odd += len(fixed.keys() ^ legacy.keys())  # `keep` drops a mask the other side empties out
    ids |= fixed.keys() | legacy.keys()
    row = []
    for i in sorted(fixed.keys() & legacy.keys()):
        f, l = fixed[i], legacy[i]
        eroded = -F.max_pool2d(-f[None, None].float(), 3, 1, 1)
        ring = f & ~eroded[0, 0].bool()  # the 1 px inner border of the mask
        cut = f & ~l
        row.append((int(f.sum()), int(l.sum()), int(cut.sum()), int((cut & ring).sum()), int(ring.sum())))
    frames.append(row)
    m = torch.cat([preds["obj_id_to_mask"][i] for i in sorted(preds["obj_id_to_mask"])])
    lo.append(m.min().item())
    hi.append(m.max().item())
    return res


type(p).postprocess = paired
for i, _ in enumerate(p(source=VIDEO, text=TEXT, stream=True)):
    if i == 11:
        break

print(f"\n{VIDEO} {TEXT}\nframe  objects   at mask_threshold   at 0.5   diff")
for k, fr in enumerate(frames):
    a, b = sum(x[0] for x in fr), sum(x[1] for x in fr)
    print(f"{k:>5} {len(fr):>8} {a:>19} {b:>8} {100 * (a - b) / a:>6.2f} %")

o = [x for fr in frames for x in fr]
ta, tb, cut, ring = (sum(x[i] for x in o) for i in range(4))
w = max(o, key=lambda x: (x[0] - x[1]) / x[0])
print(f"\ntotal        {ta} -> {tb} px, {100 * (ta - tb) / ta:.2f} % over {len(o)} masks, "
      f"{len(ids)} ids x {len(frames)} frames, {odd} on one side only")
print(f"per mask     {sum(x[1] < x[0] for x in o)} smaller at 0.5, "
      f"{sum(x[1] == x[0] for x in o)} equal, {sum(x[1] > x[0] for x in o)} larger")
print(f"worst        {w[0]} -> {w[1]} px, {w[2]} px cut, {w[3]} of them on the border")
print(f"cut pixels   {cut}, {ring} on the 1 px border ({100 * ring / cut:.2f} %), {cut - ring} interior")
print(f"logits       {min(lo):.3f} to {max(hi):.3f}")
s = sorted(o)
q = len(s) // 4
print("size bin (px)   n   area lost   border ring   ring cut")
for b in (s[:q], s[q : 2 * q], s[2 * q : 3 * q], s[3 * q :]):
    a, c, r = (sum(x[i] for x in b) for i in (0, 1, 4))
    print(f"{min(x[0] for x in b):>6}-{max(x[0] for x in b):<6} {len(b):>4} "
          f"{100 * (a - c) / a:>10.2f} % {100 * r / a:>12.1f} % {100 * sum(x[3] for x in b) / r:>9.2f} %")
```

```
solutions_ci_demo.mp4 ['person']
frame  objects   at mask_threshold   at 0.5   diff
    0       45               19825    19341   2.44 %
    1       45               19391    19211   0.93 %
    2       45               19711    19520   0.97 %
    3       45               19932    19731   1.01 %
    4       45               19881    19660   1.11 %
    5       45               20052    19834   1.09 %
    6       45               20090    19902   0.94 %
    7       45               20088    19881   1.03 %
    8       45               20076    19872   1.02 %
    9       45               20292    20064   1.12 %
   10       45               20246    19996   1.23 %
   11       45               19914    19709   1.03 %

total        239498 -> 236721 px, 1.16 % over 540 masks, 45 ids x 12 frames, 0 on one side only
per mask     510 smaller at 0.5, 23 equal, 7 larger
worst        329 -> 303 px, 26 px cut, 26 of them on the border
cut pixels   2846, 2843 on the 1 px border (99.89 %), 3 interior
logits       -166.750 to 73.750
size bin (px)   n   area lost   border ring   ring cut
    59-277     135       1.17 %         33.2 %      3.77 %
   277-409     135       1.27 %         30.2 %      4.26 %
   409-546     135       1.09 %         26.1 %      4.31 %
   546-1129    135       1.15 %         22.0 %      5.30 %
```

Same script with `VIDEO, TEXT = "solution_ci_parking_demo.mp4", ["car"]`, whose objects are three to five times bigger:

```
total        966759 -> 958500 px, 0.85 % over 501 masks, 42 ids x 12 frames, 0 on one side only
per mask     498 smaller at 0.5, 1 equal, 2 larger
worst        526 -> 504 px, 22 px cut, 22 of them on the border
cut pixels   8279, 8279 on the 1 px border (100.00 %), 0 interior
logits       -136.625 to 31.594
size bin (px)   n   area lost   border ring   ring cut
   352-1507    125       0.87 %         10.6 %      8.39 %
  1508-2106    125       0.78 %          9.7 %      8.02 %
  2107-2360    125       0.91 %          9.8 %      9.22 %
  2361-2916    126       0.85 %          9.1 %      9.38 %
```

I ran the script three times on each clip and the output is byte-identical, so the spread here is measured and not assumed.

The 540 and 501 rows are per frame, so they are 45 and 42 tracked objects seen over 12 frames each, and not 1041 different objects. The logits go from -166.750 to +73.750, so 0.5 is not a probability cut here, it is 0.5 of a logit. What it touches is the contour, and that is measured too: 2843 of the 2846 pixels it cuts on the first clip, and 8279 of 8279 on the second, fall in the one-pixel border ring of the mask — three interior pixels in the 1041 masks. The interior and the background are far from both thresholds, and that is why the aggregate is around 1 % of the area while 517 of 540 masks change on one clip and 500 of 501 on the other.

Object size does not change this on these clips. The loss per size quartile is 1.17 / 1.27 / 1.09 / 1.15 % for the persons and 0.87 / 0.78 / 0.91 / 0.85 % for the cars, flat over a 59-2916 px range. The idea that a small object is almost all contour is correct about the ring — 33.2 % of the area in the smallest quartile against 22.0 % in the largest — but the part of that ring that flips goes the other way, 3.77 % against 5.30 %, and the two cancel each other out. So it looks like a more or less constant slice of area at any object size, and not a small-object problem.

In aggregate the direction is always the same, so anything that measures area on these masks gets a lower value than it should. Per mask it is not strictly one-sided: 7 of the 540 person masks and 2 of the 501 car masks come out 1-2 px *larger* at `0.5`. That is the arbitration and not the threshold: `_apply_object_wise_non_overlapping_constraints` runs after the cut, so at `0.5` a neighbour with a higher tracker score stops claiming a border pixel and that pixel goes back to this object. All of them are inside 2 px, the trimming is what dominates.

I have to be honest about the limits here: two clips with one prompt each, and what this measures is how much mask area changes, not accuracy against ground truth, there is no annotated video on my side. The argument for the change is the unit mismatch and the inconsistency with the other three thresholds in the file. The numbers only give the size of the effect, they are not a mAP claim.

## Validation

`ruff format --check` and `ruff check` are clean. The image path is untouched, and `SAM3SemanticPredictor` keeps thresholding at `self.model.mask_threshold` exactly as #25386 left it.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates SAM3 video semantic mask postprocessing to apply the model-defined mask logit threshold instead of a hard-coded value.

### 📊 Key Changes
- Replaces the fixed `0.5` mask threshold with `self.model.mask_threshold` after mask upsampling.
- Renames propagated mask variables from binary masks to logits to accurately reflect their contents.
- Preserves SAM2 propagated mask logits through video output construction.

### 🎯 Purpose & Impact
- Aligns video semantic mask generation with the model's configured logit threshold.
- Improves consistency and configurability across SAM3 mask predictions.
- Helps prevent incorrect mask binarization when models use thresholds other than `0.5`.