### PR TITLE
Update docs landing new banner to depth estimation

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -48,11 +48,11 @@ Explore the Ultralytics Docs, a comprehensive resource covering the YOLO package
 
 Request an Enterprise License for commercial use at [Ultralytics Licensing](https://www.ultralytics.com/license?utm_source=docs.ultralytics.com&utm_medium=referral&utm_content=license_inline_link).
 
-!!! tip "🚀 New: Knowledge Distillation"
+!!! tip "🚀 New: Depth Estimation"
 
-    Train smaller YOLO models with guidance from a larger teacher model — no extra inference cost, just better accuracy.
+    Predict a per-pixel depth map in meters from a single RGB image with the YOLO26 depth models.
 
-    [:octicons-arrow-right-24: Learn more](guides/knowledge-distillation.md)
+    [:octicons-arrow-right-24: Learn more](tasks/depth.md)
 
 ## Get Started in Two Commands
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -50,7 +50,7 @@ Request an Enterprise License for commercial use at [Ultralytics Licensing](http
 
 !!! tip "🚀 New: Depth Estimation"
 
-    Predict a per-pixel depth map in meters from a single RGB image with the YOLO26 depth models.
+    Turn a single photo into a depth map — a distance in meters for every pixel.
 
     [:octicons-arrow-right-24: Learn more](tasks/depth.md)
 


### PR DESCRIPTION
## summary

the "new" callout on the docs landing page pointed at knowledge distillation. it now points at monocular depth estimation, the newer task, with a one-line description of what the depth models output.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the documentation homepage to highlight the new **Depth Estimation** capability instead of **Knowledge Distillation**. 📏

### 📊 Key Changes

- Replaced the “New: Knowledge Distillation” homepage tip with “New: Depth Estimation.”
- Updated the description to explain depth maps and per-pixel distance measurements.
- Linked users to the new [Depth Estimation documentation](https://docs.ultralytics.com/tasks/depth/).

### 🎯 Purpose & Impact

- Makes users more aware of Ultralytics’ depth estimation functionality. 👁️
- Improves homepage discoverability for depth estimation workflows and guidance.
- Removes the knowledge distillation feature from the homepage spotlight, though its documentation remains available elsewhere.