### PR TITLE
Reorder Models nav newest-first and add YOLO12 to the models index

### DIFF
--- a/docs/en/models/index.md
+++ b/docs/en/models/index.md
@@ -1,7 +1,7 @@
 ---
 comments: true
-description: Discover a variety of models supported by Ultralytics, including YOLOv3 to YOLO26, NAS, SAM, and RT-DETR for detection, segmentation, semantic segmentation, depth estimation, and more.
-keywords: Ultralytics, supported models, YOLOv3, YOLOv4, YOLOv5, YOLOv6, YOLOv7, YOLOv8, YOLOv9, YOLOv10, YOLO11, SAM, SAM2, SAM3, MobileSAM, FastSAM, YOLO-NAS, RT-DETR, YOLO-World, object detection, image segmentation, semantic segmentation, depth estimation, classification, pose estimation, multi-object tracking
+description: Discover a variety of models supported by Ultralytics, including YOLO26 back to YOLOv3, NAS, SAM, and RT-DETR for detection, segmentation, semantic segmentation, depth estimation, and more.
+keywords: Ultralytics, supported models, YOLO26, YOLO12, YOLO11, YOLOv10, YOLOv9, YOLOv8, YOLOv7, YOLOv6, YOLOv5, YOLOv4, YOLOv3, SAM3, SAM2, SAM, MobileSAM, FastSAM, YOLO-NAS, RT-DETR, YOLO-World, YOLOE, object detection, image segmentation, semantic segmentation, depth estimation, classification, pose estimation, multi-object tracking
 ---
 
 # Models Supported by Ultralytics
@@ -14,25 +14,26 @@ Welcome to Ultralytics' model documentation! We offer support for a wide range o
 
 Here are some of the key models supported:
 
-1. **[YOLOv3](yolov3.md)**: The third iteration of the YOLO model family, originally by Joseph Redmon, known for its efficient real-time object detection capabilities.
-2. **[YOLOv4](yolov4.md)**: A darknet-native update to YOLOv3, released by Alexey Bochkovskiy in 2020.
-3. **[YOLOv5](yolov5.md)**: An improved version of the YOLO architecture by Ultralytics, offering better performance and speed trade-offs compared to previous versions.
-4. **[YOLOv6](yolov6.md)**: Released by [Meituan](https://www.meituan.com/) in 2022, and in use in many of the company's autonomous delivery robots.
-5. **[YOLOv7](yolov7.md)**: Updated YOLO models released in 2022 by the authors of YOLOv4. Only inference is supported.
+1. **[YOLO26](yolo26.md) 🚀 NEW**: Ultralytics' **latest** next-generation YOLO model optimized for edge deployment with end-to-end NMS-free inference.
+2. **[YOLO12](yolo12.md)**: A community-driven release with an attention-centric architecture, maintained primarily for benchmarking and research.
+3. **[YOLO11](yolo11.md)**: Ultralytics' YOLO models delivering high performance across multiple tasks including detection, segmentation, pose estimation, tracking, and classification.
+4. **[YOLOv10](yolov10.md)**: By Tsinghua University, featuring NMS-free training and efficiency-accuracy driven architecture, delivering state-of-the-art performance and latency.
+5. **[YOLOv9](yolov9.md)**: An experimental model trained on the Ultralytics [YOLOv5](yolov5.md) codebase implementing Programmable Gradient Information (PGI).
 6. **[YOLOv8](yolov8.md)**: A versatile model featuring enhanced capabilities such as [instance segmentation](https://www.ultralytics.com/glossary/instance-segmentation), pose/keypoints estimation, and classification.
-7. **[YOLOv9](yolov9.md)**: An experimental model trained on the Ultralytics [YOLOv5](yolov5.md) codebase implementing Programmable Gradient Information (PGI).
-8. **[YOLOv10](yolov10.md)**: By Tsinghua University, featuring NMS-free training and efficiency-accuracy driven architecture, delivering state-of-the-art performance and latency.
-9. **[YOLO11](yolo11.md)**: Ultralytics' YOLO models delivering high performance across multiple tasks including detection, segmentation, pose estimation, tracking, and classification.
-10. **[YOLO26](yolo26.md) 🚀 NEW**: Ultralytics' **latest** next-generation YOLO model optimized for edge deployment with end-to-end NMS-free inference.
-11. **[Segment Anything Model (SAM)](sam.md)**: Meta's original Segment Anything Model (SAM).
-12. **[Segment Anything Model 2 (SAM2)](sam-2.md)**: The next generation of Meta's Segment Anything Model for videos and images.
-13. **[Segment Anything Model 3 (SAM3)](sam-3.md) 🚀 NEW**: Meta's third generation Segment Anything Model with Promptable Concept Segmentation for text and image exemplar-based segmentation.
-14. **[Mobile Segment Anything Model (MobileSAM)](mobile-sam.md)**: MobileSAM for mobile applications, by Kyung Hee University.
-15. **[Fast Segment Anything Model (FastSAM)](fast-sam.md)**: FastSAM by Image & Video Analysis Group, Institute of Automation, Chinese Academy of Sciences.
-16. **[YOLO-NAS](yolo-nas.md)**: YOLO [Neural Architecture Search](https://www.ultralytics.com/glossary/neural-architecture-search-nas) (NAS) Models.
-17. **[Real-Time Detection Transformers (RT-DETR)](rtdetr.md)**: Baidu's PaddlePaddle real-time Detection [Transformer](https://www.ultralytics.com/glossary/transformer) (RT-DETR) models.
-18. **[YOLO-World](yolo-world.md)**: Real-time Open Vocabulary Object Detection models from Tencent AI Lab.
-19. **[YOLOE](yoloe.md)**: An improved open-vocabulary object detector that maintains YOLO's real-time performance while detecting arbitrary classes beyond its training data.
+7. **[YOLOv7](yolov7.md)**: Updated YOLO models released in 2022 by the authors of YOLOv4. Only inference is supported.
+8. **[YOLOv6](yolov6.md)**: Released by [Meituan](https://www.meituan.com/) in 2022, and in use in many of the company's autonomous delivery robots.
+9. **[YOLOv5](yolov5.md)**: An improved version of the YOLO architecture by Ultralytics, offering better performance and speed trade-offs compared to previous versions.
+10. **[YOLOv4](yolov4.md)**: A darknet-native update to YOLOv3, released by Alexey Bochkovskiy in 2020.
+11. **[YOLOv3](yolov3.md)**: The third iteration of the YOLO model family, originally by Joseph Redmon, known for its efficient real-time object detection capabilities.
+12. **[Segment Anything Model 3 (SAM3)](sam-3.md) 🚀 NEW**: Meta's third generation Segment Anything Model with Promptable Concept Segmentation for text and image exemplar-based segmentation.
+13. **[Segment Anything Model 2 (SAM2)](sam-2.md)**: The next generation of Meta's Segment Anything Model for videos and images.
+14. **[Segment Anything Model (SAM)](sam.md)**: Meta's original Segment Anything Model (SAM).
+15. **[Mobile Segment Anything Model (MobileSAM)](mobile-sam.md)**: MobileSAM for mobile applications, by Kyung Hee University.
+16. **[Fast Segment Anything Model (FastSAM)](fast-sam.md)**: FastSAM by Image & Video Analysis Group, Institute of Automation, Chinese Academy of Sciences.
+17. **[YOLO-NAS](yolo-nas.md)**: YOLO [Neural Architecture Search](https://www.ultralytics.com/glossary/neural-architecture-search-nas) (NAS) Models.
+18. **[Real-Time Detection Transformers (RT-DETR)](rtdetr.md)**: Baidu's PaddlePaddle real-time Detection [Transformer](https://www.ultralytics.com/glossary/transformer) (RT-DETR) models.
+19. **[YOLO-World](yolo-world.md)**: Real-time Open Vocabulary Object Detection models from Tencent AI Lab.
+20. **[YOLOE](yoloe.md)**: An improved open-vocabulary object detector that maintains YOLO's real-time performance while detecting arbitrary classes beyond its training data.
 
 <p align="center">
   <br>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -242,20 +242,20 @@ nav:
       - OBB: tasks/obb.md
   - Models:
       - models/index.md
-      - YOLOv3: models/yolov3.md
-      - YOLOv4: models/yolov4.md
-      - YOLOv5: models/yolov5.md
-      - YOLOv6: models/yolov6.md
-      - YOLOv7: models/yolov7.md
-      - YOLOv8: models/yolov8.md
-      - YOLOv9: models/yolov9.md
-      - YOLOv10: models/yolov10.md
-      - YOLO11: models/yolo11.md
-      - YOLO12: models/yolo12.md
       - YOLO26 🚀: models/yolo26.md
-      - SAM (Segment Anything Model): models/sam.md
-      - SAM 2 (Segment Anything Model 2): models/sam-2.md
+      - YOLO12: models/yolo12.md
+      - YOLO11: models/yolo11.md
+      - YOLOv10: models/yolov10.md
+      - YOLOv9: models/yolov9.md
+      - YOLOv8: models/yolov8.md
+      - YOLOv7: models/yolov7.md
+      - YOLOv6: models/yolov6.md
+      - YOLOv5: models/yolov5.md
+      - YOLOv4: models/yolov4.md
+      - YOLOv3: models/yolov3.md
       - SAM 3 (Segment Anything Model 3): models/sam-3.md
+      - SAM 2 (Segment Anything Model 2): models/sam-2.md
+      - SAM (Segment Anything Model): models/sam.md
       - MobileSAM (Mobile Segment Anything Model): models/mobile-sam.md
       - FastSAM (Fast Segment Anything Model): models/fast-sam.md
       - YOLO-NAS (Neural Architecture Search): models/yolo-nas.md


### PR DESCRIPTION
## summary

the models section lists generations oldest-first, so yolo26 and yolo11 sit at the bottom of a 20-item sidebar. this reorders the numbered yolo and sam generations newest-first in the nav and mirrors the same order in the featured models list on the models index page.

yolo12 is in the nav but was missing from that list entirely, so it is added along with the matching keywords. mobilesam, fastsam, yolo-nas, rt-detr, yolo-world and yoloe keep their existing order.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Reorganized the model documentation to highlight YOLO26 and newer models first, while ordering legacy YOLO and SAM models from newest to oldest. 🚀

### 📊 Key Changes

- Updated the models page metadata to prioritize YOLO26, YOLO12, YOLO11, and related supported models.
- Reordered the model listings from YOLO26 back to YOLOv3.
- Reordered the SAM family from SAM3 back to the original SAM.
- Updated the MkDocs navigation to match the new model hierarchy.
- Added YOLOE to the supported-model keywords.

### 🎯 Purpose & Impact

- Makes YOLO26—the latest recommended Ultralytics model—more visible to new users.
- Helps users find newer model documentation and capabilities faster.
- Provides a more consistent, chronological browsing experience across YOLO and SAM model families.
- Improves documentation discoverability through refreshed search metadata without changing model functionality.