### PR TITLE
Reject label files that mix segment and detection rows

### DIFF
--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -279,6 +279,7 @@ def verify_image_label(args: tuple) -> list:
             with open(lb_file, encoding="utf-8") as f:
                 lb = [x.split() for x in f.read().strip().splitlines() if len(x)]
                 if any(len(x) > 6 for x in lb) and (not keypoint):  # is segment
+                    assert all(len(x) > 6 for x in lb), "labels mix segment and non-segment rows"
                     classes = np.array([x[0] for x in lb], dtype=np.float32)
                     segments = [np.array(x[1:], dtype=np.float32).reshape(-1, 2) for x in lb]  # (cls, xy1...)
                     lb = np.concatenate((classes.reshape(-1, 1), segments2boxes(segments)), 1)  # (cls, xywh)


### PR DESCRIPTION
## summary

verify_image_label treated a label file as a segmentation file as soon as a single row had more than 6 tokens, so a 5-token detection row in the same file was reshaped into a 2-point polygon and reduced to a wrong but well-formed box, with no warning and no corrupt counter. a file mixing the two row shapes is now reported through the existing corrupt-label path and the image is skipped.

pure detection, pure segment, empty, keypoint and obb label files scan exactly as before; the parsed labels for coco8, coco8-seg, coco8-pose and dota8 are unchanged.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛡️ Added validation to detect mixed segmentation and detection labels within the same annotation file.

### 📊 Key Changes

- Checks that all label rows are segmentation annotations when any row contains more than six values.
- Raises a clear error—`"labels mix segment and non-segment rows"`—if segmentation and non-segmentation rows are mixed.
- Applies to standard object detection/segmentation labels, excluding keypoint annotations.

### 🎯 Purpose & Impact

- 🚨 Prevents malformed label files from being processed incorrectly.
- 🔍 Provides an immediate, actionable error during dataset verification.
- ✅ Helps users identify and fix inconsistent annotations before training, improving dataset reliability.