### PR TITLE
Deploy docs when `ultralytics/cfg/default.yaml` changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -113,7 +113,7 @@ jobs:
             if [[ "$BEFORE_SHA" == "0000000000000000000000000000000000000000" ]]; then
               BEFORE_SHA=$(git rev-list --max-parents=0 "$CURRENT_SHA")
             fi
-            changed_files=$(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" -- docs/ mkdocs.yml mkdocs.yaml)
+            changed_files=$(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" -- docs/ mkdocs.yml mkdocs.yaml ultralytics/cfg/default.yaml)
             if [[ -z "$changed_files" ]]; then
               echo "No docs source changes."
               exit 0


### PR DESCRIPTION
## summary

the docs deploy hook only fires when a push touches `docs/`, `mkdocs.yml` or `mkdocs.yaml`, but the macro render context also loads `ultralytics/cfg/default.yaml` and interpolates 18 of its values into the augmentation argument table. a push that changes one of those defaults without touching `docs/` therefore changes the correct rendered page and never triggers a deployment, leaving production stale until the next unrelated docs push.

adding the file to the change-detection pathspec restores the filter's stated intent of firing on every docs source change. verified over real push ranges: `#24897` and `#25141` now deploy, while code-only and workflow-only pushes still do not.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the documentation workflow to detect changes in `ultralytics/cfg/default.yaml` and trigger documentation checks or builds accordingly.

### 📊 Key Changes
- Added `ultralytics/cfg/default.yaml` to the list of documentation-related files monitored by the GitHub Actions workflow.
- Documentation workflows now run when default configuration options change. ⚙️

### 🎯 Purpose & Impact
- Keeps generated or referenced documentation synchronized with the latest default settings.
- Prevents documentation updates from being missed when configuration changes occur.
- Improves reliability of documentation validation with minimal workflow overhead. ✅