### PR TITLE
Report the unmatched image directory when a grounding scan finds nothing

### DIFF
--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -803,6 +803,8 @@ class GroundingDataset(YOLODataset):
         cache, _ = self._load_or_scan_cache(cache_path, self.get_cache_hash())
         [cache.pop(k) for k in ("hash", "version")]  # remove items
         labels = cache["labels"]
+        if not labels:
+            raise RuntimeError(f"No images from {self.json_file} found in {self.img_path}. {HELP_URL}")
         self._verify_instance_counts(labels)
         self.im_files = [str(label["im_file"]) for label in labels]
         if LOCAL_RANK in {-1, 0}:


### PR DESCRIPTION
## summary

when none of the images a grounding json references are found under `img_path` — a wrong path, an unextracted archive, the wrong split — `GroundingDataset` returned an empty label list that flowed on until `build_transforms` asked for negative texts, where `min(max(category_freq.values()), 100)` raised `ValueError: max() arg is an empty sequence`, naming neither images nor paths.

`get_labels` now raises the same no-valid-images guard its sibling `YOLODataset.get_labels` already carries, naming the annotation file and the directory that was searched. it sits in `get_labels` rather than `cache_labels` so it also covers a cache that was written holding zero labels, which `cache_labels` never re-enters. a grounding dataset that does find its images is unaffected in both tasks.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Adds a clear error when a JSON-based dataset contains no matching images. 🚨

### 📊 Key Changes

- Checks whether the loaded dataset labels list is empty.
- Raises a `RuntimeError` with the JSON file, image path, and Ultralytics help link when no images are found.
- Prevents later processing from continuing with an invalid or empty dataset.

### 🎯 Purpose & Impact

- 🛠️ Provides an immediate, actionable error instead of allowing confusing downstream failures.
- 🔍 Helps users identify incorrect image paths, missing files, or dataset configuration issues faster.
- ✅ Improves dataset validation reliability without affecting valid datasets.