### PR TITLE
Write one label format per file in convert_coco with use_segments

### DIFF
--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -319,7 +319,9 @@ def convert_coco(
                     if use_segments:
                         seg = ann.get("segmentation")
                         if seg is None or len(seg) == 0:
-                            segments.append([])
+                            cx, cy, bw, bh = box[1:]
+                            x1, y1, x2, y2 = cx - bw / 2, cy - bh / 2, cx + bw / 2, cy + bh / 2
+                            segments.append([cls, x1, y1, x2, y1, x2, y2, x1, y2])
                         elif len(seg) > 1:
                             s = merge_multi_segment(seg)
                             s = (np.concatenate(s, axis=0) / np.array([w, h])).reshape(-1).tolist()
@@ -335,9 +337,7 @@ def convert_coco(
                     if use_keypoints:
                         line = (*(keypoints[i]),)  # cls, box, keypoints
                     else:
-                        line = (
-                            *(segments[i] if use_segments and len(segments[i]) > 0 else bboxes[i]),
-                        )  # cls, box or segments
+                        line = (*(segments[i] if use_segments else bboxes[i]),)  # cls, box or segments
                     file.write(("%g " * len(line)).rstrip() % line + "\n")
 
         if lvis:


### PR DESCRIPTION
## summary

convert_coco picked polygon or box per annotation, so a COCO json whose annotations are not uniformly segmented produced a label file with 9-token polygon rows next to 5-token box rows, which is not a valid label file for either task. annotations with no usable segmentation now become box-shaped polygons, the same conversion GroundingDataset.cache_labels already uses, so the writer no longer needs its per-row fork.

conversions where every annotation carries a segmentation are byte-identical, as are use_segments=False and use_keypoints=True. an all-box-only json converted with use_segments=True now yields polygon rows; detect labels built from it are unchanged, and segment training on the old output raised ValueError before.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ Improved COCO-to-YOLO segmentation conversion by generating rectangular polygons when segmentation data is missing.

### 📊 Key Changes
- 📦 Converts annotations without segmentation data into a four-corner polygon based on the bounding box.
- 📝 Ensures segmentation exports consistently use polygon data whenever `use_segments=True`.
- 🧹 Removes the previous fallback that could write bounding-box annotations or empty segments in segmentation mode.

### 🎯 Purpose & Impact
- ✅ Prevents missing or malformed labels when preparing COCO datasets for segmentation tasks.
- 🎯 Allows objects with bounding boxes but no segmentation masks to remain usable as rectangular approximations.
- 🚀 Improves compatibility and reliability for downstream YOLO segmentation training and dataset conversion.