### PR TITLE
Convert RLE segmentations to bounding-box polygons in convert_coco

### DIFF
--- a/docs/en/guides/coco-to-yolo.md
+++ b/docs/en/guides/coco-to-yolo.md
@@ -307,6 +307,12 @@ If conversion completes but `.txt` files are empty or missing, all annotations m
 
 **Solution**: Inspect your JSON annotations for `iscrowd` values. If using SAM masks, preprocess the JSON to set `iscrowd: 0`.
 
+### Box-Shaped Polygons From Mask Annotations
+
+If `use_segments=True` logs `RLE and other non-polygon segmentations converted to bounding-box polygons`, some annotations carry a `segmentation` value that is not a list of polygon points. The usual cause is COCO run-length encoding (`{"counts": ..., "size": ...}`), which bitmask exporters such as [SAM](../models/sam.md) write; a malformed value triggers the same fallback. Segment rows for those annotations are written from the bounding box, so the labels stay valid but carry no mask detail.
+
+**Solution**: Re-export the annotations with polygon segmentations, decode the RLE masks to polygons before running `convert_coco()`, or correct any malformed `segmentation` values.
+
 ### Class ID Gaps in Converted Labels
 
 If class IDs in label files are non-contiguous (e.g., 0, 4, 9 instead of 0, 1, 2), your annotation tool uses non-contiguous `category_id` values.

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -284,6 +284,7 @@ def convert_coco(
             annotations[ann["image_id"]].append(ann)
 
         image_txt = []
+        rle = False
         # Write labels file
         for img_id, anns in TQDM(annotations.items(), desc=f"Annotations {json_file}"):
             img = images[f"{img_id:d}"]
@@ -318,7 +319,8 @@ def convert_coco(
                     bboxes.append(box)
                     if use_segments:
                         seg = ann.get("segmentation")
-                        if seg is None or len(seg) == 0:
+                        if not isinstance(seg, list) or len(seg) == 0:  # RLE dict, or no polygon list
+                            rle |= bool(seg) and not isinstance(seg, list)  # had content, but not polygons
                             cx, cy, bw, bh = box[1:]
                             x1, y1, x2, y2 = cx - bw / 2, cy - bh / 2, cx + bw / 2, cy + bh / 2
                             segments.append([cls, x1, y1, x2, y1, x2, y2, x1, y2])
@@ -339,6 +341,9 @@ def convert_coco(
                     else:
                         line = (*(segments[i] if use_segments else bboxes[i]),)  # cls, box or segments
                     file.write(("%g " * len(line)).rstrip() % line + "\n")
+
+        if rle and not use_keypoints:  # segments are unused when keypoints own the output
+            LOGGER.warning(f"{json_file}: RLE and other non-polygon segmentations converted to bounding-box polygons.")
 
         if lvis:
             filename = Path(save_dir) / json_file.name.replace("lvis_v1_", "").replace(".json", ".txt")


### PR DESCRIPTION
## summary

convert_coco used len(segmentation) to tell a polygon list from an RLE dict, so a non-crowd annotation carrying {"counts": ..., "size": ...} took the multi-polygon branch and merge_multi_segment iterated the dict's keys, aborting the whole conversion with a reshape error. the format is now decided by type, so any non-polygon value falls back to the bounding-box polygon the empty-segmentation branch already writes, and one warning per json file reports the lost mask detail.

polygon, empty and missing segmentation conversions stay byte-identical, iscrowd annotations are still skipped earlier, and the warning is suppressed when use_keypoints owns the written rows. this is stacked on the convert_coco label-format branch and retargets to main once that merges.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛠️ Improved COCO-to-YOLO conversion handling for RLE and malformed mask annotations by falling back to valid bounding-box polygons with a clear warning.

### 📊 Key Changes

- Detects segmentation values that are not polygon lists, including COCO RLE dictionaries and malformed data.
- Converts unsupported segmentations into box-shaped polygons so generated labels remain valid.
- Adds a warning when RLE or other non-polygon segmentations are encountered.
- Documents the issue and recommended solutions in the COCO-to-YOLO conversion guide.
- Avoids the warning when keypoints are the output format, since segments are not used in that case.

### 🎯 Purpose & Impact

- ✅ Prevents conversion failures or invalid labels when mask annotations use RLE instead of polygon points.
- 🔍 Makes users aware that fallback polygons preserve bounding boxes but do not retain mask details.
- 📚 Helps users resolve the issue by re-exporting polygon annotations, decoding RLE masks, or correcting malformed data.
- 🚀 Improves reliability when preparing segmentation datasets for YOLO training.