### PR TITLE
Upgrade CI runner images to Node 24

### DIFF
--- a/docker/Dockerfile-runner
+++ b/docker/Dockerfile-runner
@@ -5,7 +5,8 @@
 
 # Start FROM Ultralytics GPU image
 FROM ultralytics/ultralytics:latest
-COPY --from=node:24-bookworm-slim /usr/local/ /usr/local/
+COPY --from=node:24-bookworm-slim /usr/local/bin/node /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/
+COPY --from=node:24-bookworm-slim /usr/local/lib/node_modules/ /usr/local/lib/node_modules/
 
 # Set additional environment variables for runner (no "v" on the version)
 ARG RUNNER_VERSION=2.334.0

--- a/docker/Dockerfile-runner
+++ b/docker/Dockerfile-runner
@@ -22,7 +22,7 @@ RUN FILENAME=actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz && \
     rm "$FILENAME" && \
     uv pip install --system --no-cache pytest-cov "tensorrt-cu12>=7.0.0,!=10.2.0" && \
     ./bin/installdependencies.sh && \
-    curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - && \
+    curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" -o /tmp/nodesource-setup.sh && bash /tmp/nodesource-setup.sh && rm /tmp/nodesource-setup.sh && \
     apt-get install -y --no-install-recommends libicu-dev nodejs sudo && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile-runner
+++ b/docker/Dockerfile-runner
@@ -8,6 +8,7 @@ FROM ultralytics/ultralytics:latest
 
 # Set additional environment variables for runner (no "v" on the version)
 ARG RUNNER_VERSION=2.334.0
+ARG NODE_MAJOR=24
 ENV RUNNER_ALLOW_RUNASROOT=1 \
     DEBIAN_FRONTEND=noninteractive
 
@@ -22,7 +23,9 @@ RUN FILENAME=actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz && \
     uv pip install --system --no-cache pytest-cov "tensorrt-cu12>=7.0.0,!=10.2.0" && \
     ./bin/installdependencies.sh && \
     apt-get update && \
-    apt-get install -y --no-install-recommends libicu-dev sudo nodejs npm && \
+    apt-get install -y --no-install-recommends libicu-dev sudo && \
+    curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile-runner
+++ b/docker/Dockerfile-runner
@@ -6,7 +6,7 @@
 # Start FROM Ultralytics GPU image
 FROM ultralytics/ultralytics:latest
 COPY --from=node:24-bookworm-slim /usr/local/bin/node /usr/local/bin/node
-COPY --from=node:24-bookworm-slim /usr/local/lib/node_modules/ /usr/local/lib/node_modules/
+COPY --from=node:24-bookworm-slim /usr/local/lib/node_modules/npm/ /usr/local/lib/node_modules/npm/
 
 # Set additional environment variables for runner (no "v" on the version)
 ARG RUNNER_VERSION=2.334.0

--- a/docker/Dockerfile-runner
+++ b/docker/Dockerfile-runner
@@ -5,7 +5,7 @@
 
 # Start FROM Ultralytics GPU image
 FROM ultralytics/ultralytics:latest
-COPY --from=node:24-bookworm-slim /usr/local/bin/node /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/
+COPY --from=node:24-bookworm-slim /usr/local/bin/node /usr/local/bin/node
 COPY --from=node:24-bookworm-slim /usr/local/lib/node_modules/ /usr/local/lib/node_modules/
 
 # Set additional environment variables for runner (no "v" on the version)
@@ -18,6 +18,8 @@ WORKDIR /actions-runner
 
 # Download and unpack the runner from https://github.com/actions/runner and install dependencies
 RUN FILENAME=actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz && \
+    ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
+    ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx && \
     curl -fLso "$FILENAME" "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${FILENAME}" && \
     tar xzf "$FILENAME" && \
     rm "$FILENAME" && \

--- a/docker/Dockerfile-runner
+++ b/docker/Dockerfile-runner
@@ -22,10 +22,8 @@ RUN FILENAME=actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz && \
     rm "$FILENAME" && \
     uv pip install --system --no-cache pytest-cov "tensorrt-cu12>=7.0.0,!=10.2.0" && \
     ./bin/installdependencies.sh && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends libicu-dev sudo && \
     curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - && \
-    apt-get install -y --no-install-recommends nodejs && \
+    apt-get install -y --no-install-recommends libicu-dev nodejs sudo && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile-runner
+++ b/docker/Dockerfile-runner
@@ -5,10 +5,10 @@
 
 # Start FROM Ultralytics GPU image
 FROM ultralytics/ultralytics:latest
+COPY --from=node:24-bookworm-slim /usr/local/ /usr/local/
 
 # Set additional environment variables for runner (no "v" on the version)
 ARG RUNNER_VERSION=2.334.0
-ARG NODE_MAJOR=24
 ENV RUNNER_ALLOW_RUNASROOT=1 \
     DEBIAN_FRONTEND=noninteractive
 
@@ -22,8 +22,7 @@ RUN FILENAME=actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz && \
     rm "$FILENAME" && \
     uv pip install --system --no-cache pytest-cov "tensorrt-cu12>=7.0.0,!=10.2.0" && \
     ./bin/installdependencies.sh && \
-    curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" -o /tmp/nodesource-setup.sh && bash /tmp/nodesource-setup.sh && rm /tmp/nodesource-setup.sh && \
-    apt-get install -y --no-install-recommends libicu-dev nodejs sudo && \
+    apt-get install -y --no-install-recommends libicu-dev sudo && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile-runner-cpu
+++ b/docker/Dockerfile-runner-cpu
@@ -8,6 +8,7 @@ FROM ultralytics/ultralytics:latest-cpu
 
 # Set additional environment variables for runner (no "v" on the version)
 ARG RUNNER_VERSION=2.334.0
+ARG NODE_MAJOR=24
 ENV RUNNER_ALLOW_RUNASROOT=1 \
     DEBIAN_FRONTEND=noninteractive
 
@@ -23,7 +24,9 @@ RUN FILENAME=actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz && \
     uv pip install --system pytest-cov && \
     ./bin/installdependencies.sh && \
     apt-get update && \
-    apt-get install -y --no-install-recommends libicu-dev sudo nodejs npm gpg && \
+    apt-get install -y --no-install-recommends libicu-dev sudo && \
+    curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile-runner-cpu
+++ b/docker/Dockerfile-runner-cpu
@@ -5,10 +5,10 @@
 
 # Start FROM Ultralytics CPU image
 FROM ultralytics/ultralytics:latest-cpu
+COPY --from=node:24-bookworm-slim /usr/local/ /usr/local/
 
 # Set additional environment variables for runner (no "v" on the version)
 ARG RUNNER_VERSION=2.334.0
-ARG NODE_MAJOR=24
 ENV RUNNER_ALLOW_RUNASROOT=1 \
     DEBIAN_FRONTEND=noninteractive
 
@@ -23,8 +23,7 @@ RUN FILENAME=actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz && \
     # Install runner dependencies \
     uv pip install --system pytest-cov && \
     ./bin/installdependencies.sh && \
-    curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" -o /tmp/nodesource-setup.sh && bash /tmp/nodesource-setup.sh && rm /tmp/nodesource-setup.sh && \
-    apt-get install -y --no-install-recommends libicu-dev nodejs sudo && \
+    apt-get install -y --no-install-recommends libicu-dev sudo && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile-runner-cpu
+++ b/docker/Dockerfile-runner-cpu
@@ -5,7 +5,8 @@
 
 # Start FROM Ultralytics CPU image
 FROM ultralytics/ultralytics:latest-cpu
-COPY --from=node:24-bookworm-slim /usr/local/ /usr/local/
+COPY --from=node:24-bookworm-slim /usr/local/bin/node /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/
+COPY --from=node:24-bookworm-slim /usr/local/lib/node_modules/ /usr/local/lib/node_modules/
 
 # Set additional environment variables for runner (no "v" on the version)
 ARG RUNNER_VERSION=2.334.0

--- a/docker/Dockerfile-runner-cpu
+++ b/docker/Dockerfile-runner-cpu
@@ -23,10 +23,8 @@ RUN FILENAME=actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz && \
     # Install runner dependencies \
     uv pip install --system pytest-cov && \
     ./bin/installdependencies.sh && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends libicu-dev sudo && \
     curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - && \
-    apt-get install -y --no-install-recommends nodejs && \
+    apt-get install -y --no-install-recommends libicu-dev nodejs sudo && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile-runner-cpu
+++ b/docker/Dockerfile-runner-cpu
@@ -23,7 +23,7 @@ RUN FILENAME=actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz && \
     # Install runner dependencies \
     uv pip install --system pytest-cov && \
     ./bin/installdependencies.sh && \
-    curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - && \
+    curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" -o /tmp/nodesource-setup.sh && bash /tmp/nodesource-setup.sh && rm /tmp/nodesource-setup.sh && \
     apt-get install -y --no-install-recommends libicu-dev nodejs sudo && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile-runner-cpu
+++ b/docker/Dockerfile-runner-cpu
@@ -6,7 +6,7 @@
 # Start FROM Ultralytics CPU image
 FROM ultralytics/ultralytics:latest-cpu
 COPY --from=node:24-bookworm-slim /usr/local/bin/node /usr/local/bin/node
-COPY --from=node:24-bookworm-slim /usr/local/lib/node_modules/ /usr/local/lib/node_modules/
+COPY --from=node:24-bookworm-slim /usr/local/lib/node_modules/npm/ /usr/local/lib/node_modules/npm/
 
 # Set additional environment variables for runner (no "v" on the version)
 ARG RUNNER_VERSION=2.334.0

--- a/docker/Dockerfile-runner-cpu
+++ b/docker/Dockerfile-runner-cpu
@@ -26,7 +26,7 @@ RUN FILENAME=actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz && \
     # Install runner dependencies \
     uv pip install --system pytest-cov && \
     ./bin/installdependencies.sh && \
-    apt-get install -y --no-install-recommends libicu-dev sudo && \
+    apt-get install -y --no-install-recommends gpg libicu-dev sudo && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile-runner-cpu
+++ b/docker/Dockerfile-runner-cpu
@@ -5,7 +5,7 @@
 
 # Start FROM Ultralytics CPU image
 FROM ultralytics/ultralytics:latest-cpu
-COPY --from=node:24-bookworm-slim /usr/local/bin/node /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/
+COPY --from=node:24-bookworm-slim /usr/local/bin/node /usr/local/bin/node
 COPY --from=node:24-bookworm-slim /usr/local/lib/node_modules/ /usr/local/lib/node_modules/
 
 # Set additional environment variables for runner (no "v" on the version)
@@ -18,6 +18,8 @@ WORKDIR /actions-runner
 
 # Download and unpack the runner from https://github.com/actions/runner and install dependencies
 RUN FILENAME=actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz && \
+    ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
+    ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx && \
     curl -fLso "$FILENAME" "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${FILENAME}" && \
     tar xzf "$FILENAME" && \
     rm "$FILENAME" && \


### PR DESCRIPTION
## Summary

- source Node 24 from the official rolling Node image in CPU and GPU GitHub runners
- replace the distro's stale Node.js 18 and redundant standalone npm packages
- copy only Node, npm, and npx so unrelated Node-image tools are not exposed

## Validation

- `git diff --check`
- built the complete AMD64 CPU runner image from `docker/Dockerfile-runner-cpu`
- verified Node `v24.19.0`, npm/npx `11.17.0`, Python `3.13.14`, uv `0.11.28`, and runner `2.334.0`
- verified Yarn and yarnpkg are absent

Required by Next.js 16.3 builds, which reject the Node.js 18 runtime currently present on `cpu-latest`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🐳 Runner images now bundle Node.js 24 and npm directly, replacing distribution-installed Node.js packages for more consistent GitHub Actions environments.

### 📊 Key Changes
- Added Node.js 24 from the `node:24-bookworm-slim` image to both GPU and CPU runner Dockerfiles.
- Added `npm` and `npx` command symlinks for the copied Node.js installation.
- Removed `nodejs` and `npm` from `apt` installation.
- Kept other required dependencies, including `libicu-dev`, `sudo`, and CPU-image `gpg`.

### 🎯 Purpose & Impact
- ✅ Provides a newer, standardized Node.js runtime across runner images.
- 🔒 Improves build reproducibility by avoiding host distribution package versions.
- 🧹 Simplifies package installation and may reduce dependency-management overhead.
- ⚙️ Ensures GitHub Actions workloads can use Node.js, npm, and npx consistently in both GPU and CPU environments.