### PR TITLE
Ignore grounding segmentations that are not polygon point lists

### DIFF
--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -48,7 +48,7 @@ from .utils import (
 )
 
 # Ultralytics dataset *.cache version, >= 1.0.0 for Ultralytics YOLO models
-DATASET_CACHE_VERSION = "1.0.5"
+DATASET_CACHE_VERSION = "1.0.6"
 
 
 class YOLODataset(BaseDataset):
@@ -708,6 +708,7 @@ class GroundingDataset(YOLODataset):
         img_to_anns = defaultdict(list)
         for ann in annotations["annotations"]:
             img_to_anns[ann["image_id"]].append(ann)
+        dropped = False
         for img_id, anns in TQDM(img_to_anns.items(), desc=f"Reading annotations {self.json_file}"):
             img = images[f"{img_id:d}"]
             h, w, f = img["height"], img["width"], img["file_name"]
@@ -744,16 +745,35 @@ class GroundingDataset(YOLODataset):
                     bboxes.append(box)
                     seg = ann.get("segmentation")
                     segmented |= seg is not None
-                    if not seg:  # keep one segment per box so an image mixing the two kinds stays aligned
+                    if not isinstance(seg, list):
+                        seg = [seg]  # an RLE dict is one non-polygon entry
+                    elif seg and all(isinstance(x, list) and len(x) == 2 for x in seg):
+                        seg = [seg]  # the value is itself a single polygon in [[x, y], ...] form
+                    seg = [  # [[x, y], ...] is a polygon form too, flatten it to [x, y, x, y, ...]
+                        [c for x in p for c in x]
+                        if isinstance(p, list) and all(isinstance(x, list) and len(x) == 2 for x in p)
+                        else p
+                        for p in seg
+                    ]
+                    polygons = [
+                        p
+                        for p in seg
+                        if isinstance(p, list)
+                        and len(p) >= 6
+                        and not len(p) % 2
+                        and all(isinstance(c, (int, float)) for c in p)
+                    ]
+                    dropped |= len(polygons) < sum(bool(p) or p == 0 for p in seg)  # 0 is a coordinate
+                    if not polygons:  # keep one segment per box so an image mixing the two kinds stays aligned
                         cx, cy, bw, bh = box[1:]
                         x1, y1, x2, y2 = cx - bw / 2, cy - bh / 2, cx + bw / 2, cy + bh / 2
                         segments.append([cls, x1, y1, x2, y1, x2, y2, x1, y2])  # segments2boxes returns the box
                         continue
-                    elif len(seg) > 1:
-                        s = merge_multi_segment(seg)
+                    elif len(polygons) > 1:
+                        s = merge_multi_segment(polygons)
                         s = (np.concatenate(s, axis=0) / np.array([w, h], dtype=np.float32)).reshape(-1).tolist()
                     else:
-                        s = [j for i in seg for j in i]  # all segments concatenated
+                        s = [j for i in polygons for j in i]  # all segments concatenated
                         s = (
                             (np.array(s, dtype=np.float32).reshape(-1, 2) / np.array([w, h], dtype=np.float32))
                             .reshape(-1)
@@ -779,6 +799,11 @@ class GroundingDataset(YOLODataset):
                     "bbox_format": "xywh",
                     "texts": texts,
                 }
+            )
+        if dropped:
+            LOGGER.warning(
+                f"{self.json_file}: ignored segmentations that are not polygon point lists, such as RLE masks. "
+                "Annotations left without a polygon use a segment shaped like their bounding box."
             )
         x["hash"] = get_hash(self.json_file)
         save_dataset_cache_file(self.prefix, path, x, DATASET_CACHE_VERSION)

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -746,7 +746,7 @@ class GroundingDataset(YOLODataset):
                     seg = ann.get("segmentation")
                     segmented |= seg is not None
                     if not isinstance(seg, list):
-                        seg = [seg]  # an RLE dict is one non-polygon entry
+                        seg = [seg]  # a non-list value, such as an RLE dict, is one non-polygon entry
                     elif seg and all(isinstance(x, list) and len(x) == 2 for x in seg):
                         seg = [seg]  # the value is itself a single polygon in [[x, y], ...] form
                     seg = [  # [[x, y], ...] is a polygon form too, flatten it to [x, y, x, y, ...]
@@ -763,7 +763,7 @@ class GroundingDataset(YOLODataset):
                         and not len(p) % 2
                         and all(isinstance(c, (int, float)) for c in p)
                     ]
-                    dropped |= len(polygons) < sum(bool(p) or p == 0 for p in seg)  # 0 is a coordinate
+                    dropped |= len(polygons) < sum(bool(p) or p == 0 for p in seg)  # empty entries carry no mask
                     if not polygons:  # keep one segment per box so an image mixing the two kinds stays aligned
                         cx, cy, bw, bh = box[1:]
                         x1, y1, x2, y2 = cx - bw / 2, cy - bh / 2, cx + bw / 2, cy + bh / 2


### PR DESCRIPTION
## summary

`GroundingDataset.cache_labels` decided the COCO `segmentation` format by `len()`, so an RLE mask `{"counts": ..., "size": ...}` measured 2 and entered the multi-polygon branch, where `merge_multi_segment` reshaped the dict's string keys and aborted the whole label scan. The polygon branches now receive only entries that are flat numeric coordinate lists holding at least three pairs, and anything else falls back to the bounding-box-shaped polygon that empty segmentations already used, reported once per annotation file.

Eight shapes that raised now cache, and the one- and two-point shapes that used to cache silently as a zero-size box or a pseudo-segment take the fallback instead. An annotation keeps whichever polygons survive rather than discarding them all, so a real polygon beside an RLE entry is preserved. The nested `[[x, y], ...]` point-list form that `Results.masks.xy[i].tolist()` produces is now read as one polygon instead of being stitched into a retraced contour with duplicated vertices, which is the one input whose output changes while already succeeding.

The cache version moves to `1.0.6` because the silent shapes could leave a cache behind: a `1.0.5` cache written before this change was otherwise reloaded unchanged and the fix never reached anyone who already had one.

This mirrors the same fix for `convert_coco` in #25672 and is stacked on #25660, which rewrites the same block.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ Improved COCO segmentation annotation handling and refreshed the dataset cache version for more reliable dataset loading.

### 📊 Key Changes
- 🔄 Updated `DATASET_CACHE_VERSION` from `1.0.5` to `1.0.6` so existing caches are rebuilt with the new logic.
- 🧩 Added support for different segmentation formats, including single polygons and nested polygon point lists.
- 🚫 Detects and ignores unsupported or invalid segmentations, such as RLE mask dictionaries or empty entries.
- 📦 Combines multiple valid polygons correctly while preserving alignment between bounding boxes and segments.
- 🟦 Uses a bounding-box-shaped fallback segment when an annotation has no usable polygon.
- ⚠️ Logs a warning when non-polygon segmentations are dropped.

### 🎯 Purpose & Impact
- ✅ Makes COCO dataset caching more robust across varied annotation formats.
- 🧠 Reduces failures and malformed labels during segmentation dataset preparation.
- 🎯 Allows training to continue when annotations contain unsupported RLE masks, while clearly notifying users.
- 🔁 Automatically invalidates outdated dataset caches so the corrected processing is applied.