### PR TITLE
Bump eviden-actions/clean-self-hosted-runner from v1.4.34 to v1.4.35 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -461,7 +461,7 @@ jobs:
     runs-on: raspberry-pi
     steps:
       - name: Clean up runner
-        uses: eviden-actions/clean-self-hosted-runner@v1.4.34
+        uses: eviden-actions/clean-self-hosted-runner@v1.4.35
       - uses: actions/checkout@v7
       - name: Activate Virtual Environment for Tests
         run: |
@@ -530,7 +530,7 @@ jobs:
           cat benchmarks.log
           echo "$(cat benchmarks.log)" >> $GITHUB_STEP_SUMMARY
       - name: Clean up runner
-        uses: eviden-actions/clean-self-hosted-runner@v1.4.34
+        uses: eviden-actions/clean-self-hosted-runner@v1.4.35
       # The below is fixed in: https://github.com/ultralytics/ultralytics/pull/15987
       # - name: Reboot # run a reboot command in the background to free resources for next run and not crash main thread
       #   run: sudo bash -c "sleep 10; reboot" &
@@ -560,7 +560,7 @@ jobs:
             onnxruntime_whl: "https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.16.3-cp38-cp38-linux_aarch64.whl"
     steps:
       - name: Clean up runner
-        uses: eviden-actions/clean-self-hosted-runner@v1.4.34
+        uses: eviden-actions/clean-self-hosted-runner@v1.4.35
       - uses: actions/checkout@v7
       - uses: ultralytics/actions/setup-uv@main
       - name: Activate virtual environment
@@ -586,7 +586,7 @@ jobs:
       - name: Pytest tests
         run: pytest --slow tests/test_cuda.py
       - name: Clean up runner
-        uses: eviden-actions/clean-self-hosted-runner@v1.4.34
+        uses: eviden-actions/clean-self-hosted-runner@v1.4.35
 
   Conda:
     if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.conda == 'true')


### PR DESCRIPTION
Bump eviden-actions/clean-self-hosted-runner from v1.4.34 to v1.4.35 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the self-hosted runner cleanup action in CI workflows from `v1.4.34` to `v1.4.35`. 🧹

### 📊 Key Changes

- Updated `eviden-actions/clean-self-hosted-runner` to `v1.4.35`.
- Applied the update across Raspberry Pi, benchmark, CUDA, and related test jobs.
- No changes were made to application code, tests, or model functionality.

### 🎯 Purpose & Impact

- 🛠️ Keeps CI runner cleanup aligned with the latest action version.
- 🚀 May improve reliability and resource cleanup between jobs on self-hosted runners.
- ✅ Helps reduce interference between workflow runs without affecting end users or model behavior.