### PR TITLE
Use every class as a negative when a multi-modal dataset has no labelled instance

### DIFF
--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -610,7 +610,8 @@ class YOLOMultiModalDataset(YOLODataset):
                 for t in text:
                     t = t.strip()
                     category_freq[t] += 1
-        return category_freq
+        # a background-only dataset sees no class, leaving every class an equally valid negative
+        return category_freq or dict.fromkeys((t.strip() for text in texts for t in text), 0)
 
 
 class GroundingDataset(YOLODataset):


### PR DESCRIPTION
## summary

a yolo-world or yoloe fine-tune on a dataset whose images are all background images dies with `ValueError: max() arg is an empty sequence`, because `YOLOMultiModalDataset.category_freq` counts label rows and comes back empty while the label list itself is non-empty, so nothing upstream stops the run. the class vocabulary is fully known in that case, since it is read from `data["names"]` rather than derived from the annotations, so every class is an equally valid negative and the property now returns each class at frequency zero instead of an empty table. a dataset with at least one labelled instance keeps today's frequency table, negatives and transforms unchanged.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ Improves category-frequency handling for background-only grounding datasets by preserving all class names with zero counts.

### 📊 Key Changes
- Updates `category_freq()` in `ultralytics/data/dataset.py`.
- Returns the calculated frequencies when classes are present.
- Adds a fallback that creates entries for all available text categories with a count of `0` when no classes are detected.

### 🎯 Purpose & Impact
- ✅ Prevents background-only datasets from returning an empty category-frequency mapping.
- 📚 Ensures every known category remains represented as a valid negative example.
- 🔧 Improves dataset processing reliability for grounding workflows without affecting datasets that contain labeled classes.