### PR TITLE
Report a zero-class dataset instead of crashing in max()

### DIFF
--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -54,6 +54,8 @@ def check_class_names(names: list | dict) -> dict[int, str]:
         # Convert 1) string keys to int, i.e. '0' to 0, and non-string values to strings, i.e. True to 'True'
         names = {int(k): str(v) for k, v in names.items()}
         n = len(names)
+        if not n:
+            raise KeyError("0-class dataset, at least one class name is required in your dataset YAML.")
         if max(names.keys()) >= n:
             raise KeyError(
                 f"{n}-class dataset requires class indices 0-{n - 1}, but you have invalid class indices "


### PR DESCRIPTION
## summary

`check_class_names` validates class indices with `max(names.keys()) >= n`, which raises `ValueError: max() arg is an empty sequence` on an empty mapping before the guard it belongs to can run. a data yaml carrying `names: {}`, `names: []` or `nc: 0` now reports the zero-class condition through the same `KeyError` the adjacent invalid-index branch raises. every non-empty mapping, including the invalid-index case, the imagenet code remap and a plain list, is unchanged.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚫 Adds validation to reject datasets with no defined classes.

### 📊 Key Changes

- Updated `check_class_names()` in `ultralytics/nn/autobackend.py`.
- Raises a clear `KeyError` when a dataset YAML contains an empty class-name mapping.
- Prevents invalid class indices from being processed for zero-class datasets.

### 🎯 Purpose & Impact

- 🛡️ Provides earlier, more understandable feedback for incorrectly configured datasets.
- ✅ Helps users fix missing class definitions before training or inference begins.
- 🔧 Reduces potential downstream errors caused by datasets without class names.