### PR TITLE
Report empty class lists and empty visual prompt batches instead of crashing

### DIFF
--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -476,9 +476,9 @@ class YOLOE(Model):
             assert "bboxes" in visual_prompts and "cls" in visual_prompts, (
                 f"Expected 'bboxes' and 'cls' in visual prompts, but got {visual_prompts.keys()}"
             )
-            assert len(visual_prompts["bboxes"]) == len(visual_prompts["cls"]), (
-                f"Expected equal number of bounding boxes and classes, but got {len(visual_prompts['bboxes'])} and "
-                f"{len(visual_prompts['cls'])} respectively"
+            assert len(visual_prompts["bboxes"]) == len(visual_prompts["cls"]) > 0, (
+                f"Expected an equal, non-zero number of bounding boxes and classes, but got "
+                f"{len(visual_prompts['bboxes'])} and {len(visual_prompts['cls'])} respectively"
             )
             if type(self.predictor) is not predictor:
                 args = get_cfg(overrides={**self.overrides, **kwargs})

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1133,6 +1133,7 @@ class WorldModel(DetectionModel):
         """
         from ultralytics.nn.text_model import build_text_model
 
+        assert len(text), f"Expected at least one class name, but got {text}"
         device = next(self.model.parameters()).device
         if not getattr(self, "clip_model", None) and cache_clip_model:
             # For backwards compatibility of models lacking clip_model attribute
@@ -1253,6 +1254,7 @@ class YOLOEModel(DetectionModel):
         """
         from ultralytics.nn.text_model import build_text_model
 
+        assert len(text), f"Expected at least one class name, but got {text}"
         device = next(self.model.parameters()).device
         if not getattr(self, "clip_model", None) and cache_clip_model:
             # For backwards compatibility of models lacking clip_model attribute


### PR DESCRIPTION
## summary

`get_text_pe` reshapes the encoded text features by the class count, so an empty class list reached torch with a zero-width dimension next to an inferred `-1` and reported an ambiguous reshape only after the whole text model had been built and every token encoded. `YOLOE.predict` derived the class count with `max()` over the visual prompts, which two present-but-empty prompt lists satisfied on both existing asserts before failing as `max() arg is an empty sequence`. both entry points now report the empty input before any text encoding or predictor construction, and every non-empty class list and prompt batch keeps its current embeddings, names and prediction output.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚦 Adds validation to prevent empty visual prompts and class-name lists in YOLO prediction and text-embedding workflows.

### 📊 Key Changes

- Requires visual prompts to include at least one bounding box and one matching class label.
- Adds checks to ensure text-embedding methods receive at least one class name.
- Improves error messages by clearly reporting invalid empty inputs.

### 🎯 Purpose & Impact

- ✅ Prevents unclear failures or invalid processing caused by empty prompts or class lists.
- 🛠️ Helps users identify input mistakes earlier during prediction and model setup.
- 🔒 Improves reliability for vision-language and prompt-based YOLO workflows without changing valid usage.