### PR TITLE
Correct the YOLOE agnostic_nms note and add its end-to-end carve-out

### DIFF
--- a/docs/en/models/yoloe.md
+++ b/docs/en/models/yoloe.md
@@ -1032,7 +1032,7 @@ Quickly set up YOLOE with Ultralytics by following these steps:
 6. **Integration Tips**:
     - **Class names**: Default YOLOE outputs use LVIS categories; use `set_classes()` to specify your own labels.
     - **Speed**: YOLOE has no overhead unless using prompts. Text prompts have minimal impact; visual prompts slightly more.
-    - **NMS behavior**: YOLOE automatically uses `agnostic_nms=True` during prediction, merging overlapping boxes across classes. This prevents duplicate detections when the same object matches multiple categories in YOLOE's large vocabulary (1200+ LVIS classes). You can override this by passing `agnostic_nms=False` explicitly.
+    - **NMS behavior**: YOLOE automatically uses `agnostic_nms=True` during prediction, suppressing lower-scoring overlapping boxes across different classes rather than only within the same class. This prevents duplicate detections when the same object matches multiple categories in YOLOE's large vocabulary (1200+ LVIS classes). On end-to-end YOLOE-26 models it only prevents the same detection from appearing under multiple class labels (IoU=1.0 duplicates) and performs no IoU-threshold suppression between distinct boxes. You can override this by passing `agnostic_nms=False` explicitly.
     - **Batch inference**: Supported directly (`model.predict([img1, img2])`). For image-specific prompts, run images individually.
 
 The [Ultralytics documentation](../index.md) provides further resources. YOLOE lets you easily explore powerful open-world capabilities within the familiar YOLO ecosystem.


### PR DESCRIPTION
## summary

the yoloe page said `agnostic_nms=True` merges overlapping boxes across classes; class-agnostic nms suppresses the lower-scoring box and leaves the survivor unchanged. the note also predates the yoloe-26 variants, whose heads are end-to-end, so the described cross-class suppression of distinct boxes does not happen there at all.

the line now matches the wording used in the predict, validation and export argument tables, and states that on end-to-end yoloe-26 models the flag only prevents one detection from appearing under multiple class labels. the default and the `agnostic_nms=False` override are unchanged.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Clarifies YOLOE’s `agnostic_nms` behavior, including its specialized handling for end-to-end YOLOE-26 models. 🔍

### 📊 Key Changes

- Updated the YOLOE documentation to explain that `agnostic_nms=True` suppresses lower-scoring overlapping detections across different classes.
- Clarified that this behavior helps prevent duplicate detections for objects matching multiple categories in YOLOE’s large LVIS vocabulary.
- Documented the YOLOE-26 exception: end-to-end models only remove identical detections with different class labels and do not suppress distinct overlapping boxes based on IoU thresholds.
- Confirmed that users can disable this behavior with `agnostic_nms=False`.

### 🎯 Purpose & Impact

- Improves user understanding of YOLOE prediction and non-maximum suppression behavior. 📚
- Sets accurate expectations for duplicate and overlapping detections across YOLOE model variants.
- Helps developers choose the appropriate `agnostic_nms` setting for their application and interpret YOLOE-26 results more reliably.