### PR TITLE
Document the predictor data attribute as the args copy it holds

### DIFF
--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -82,7 +82,7 @@ class BasePredictor:
         save_dir (Path): Directory to save results.
         done_warmup (bool): Whether the predictor has finished setup.
         model (torch.nn.Module): Model used for prediction.
-        data (str): Data configuration.
+        data (str | Path | None): Copy of args.data, the dataset YAML AutoBackend falls back to for class names.
         device (torch.device): Device used for prediction.
         dataset (Dataset): Dataset used for prediction.
         vid_writer (dict[Path, cv2.VideoWriter]): Dictionary of {save_path: video_writer} for saving video output.
@@ -137,7 +137,7 @@ class BasePredictor:
 
         # Usable if setup is done
         self.model = None
-        self.data = self.args.data  # data_dict
+        self.data = self.args.data
         self.imgsz = None
         self.device = None
         self.dataset = None


### PR DESCRIPTION
## summary

`BasePredictor.data` holds the raw data argument, a `str`, `Path` or `None`, and the predict path forwards `self.args.data` to `AutoBackend`, which reads it only as a class-name fallback when the model carries no class metadata. the attribute docstring called it a data configuration and the trailing comment called it a parsed dataset dict, so both now describe the value that is stored.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Clarifies and preserves the predictor’s dataset configuration for reliable class-name handling. 🏷️

### 📊 Key Changes

- Updated `BasePredictor.data` documentation to support `str`, `Path`, or `None`.
- Clarified that `data` stores a copy of `args.data` used by `AutoBackend` as a fallback for class names.
- Removed the outdated `# data_dict` comment while keeping the existing assignment unchanged.

### 🎯 Purpose & Impact

- Improves code clarity and keeps the predictor documentation aligned with actual behavior. 📚
- Helps ensure class names can be recovered from the dataset YAML when needed.
- No user-facing behavior or prediction workflow changes are expected. ✅