### PR TITLE
Fix pose activation map gradients

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -11,7 +11,6 @@ import torch.nn.functional as F
 from torch import nn
 from torch.nn.init import constant_, xavier_uniform_
 
-from ultralytics.utils import NOT_MACOS14
 from ultralytics.utils.tal import dist2bbox, dist2rbox, make_anchors
 from ultralytics.utils.torch_utils import TORCH_1_11, fuse_conv_and_bn, smart_inference_mode
 
@@ -659,10 +658,7 @@ class Pose(Detect):
         else:
             y = kpts.clone()
             if ndim == 3:
-                if NOT_MACOS14:
-                    y[:, 2::ndim].sigmoid_()
-                else:  # Apple macOS14 MPS bug https://github.com/ultralytics/ultralytics/pull/21878
-                    y[:, 2::ndim] = y[:, 2::ndim].sigmoid()
+                y[:, 2::ndim] = y[:, 2::ndim].sigmoid()
             y[:, 0::ndim] = (y[:, 0::ndim] * 2.0 + (self.anchors[0] - 0.5)) * self.strides
             y[:, 1::ndim] = (y[:, 1::ndim] * 2.0 + (self.anchors[1] - 0.5)) * self.strides
             return y
@@ -776,10 +772,7 @@ class Pose26(Pose):
         else:
             y = kpts.clone()
             if ndim == 3:
-                if NOT_MACOS14:
-                    y[:, 2::ndim].sigmoid_()
-                else:  # Apple macOS14 MPS bug https://github.com/ultralytics/ultralytics/pull/21878
-                    y[:, 2::ndim] = y[:, 2::ndim].sigmoid()
+                y[:, 2::ndim] = y[:, 2::ndim].sigmoid()
             y[:, 0::ndim] = (y[:, 0::ndim] + self.anchors[0]) * self.strides
             y[:, 1::ndim] = (y[:, 1::ndim] + self.anchors[1]) * self.strides
             return y


### PR DESCRIPTION
### Summary

- replace in-place pose visibility sigmoid with the existing autograd-safe assignment
- apply the same owner-level fix to both `Pose` and `Pose26` decoders
- remove the obsolete platform branch and unused import

### Why

Class activation maps require gradients through the inference graph. The in-place visibility sigmoid is followed by two more mutations of the same keypoint tensor, invalidating the sigmoid output version required by autograd under `torch.compile`. Using the existing out-of-place sigmoid assignment preserves identical inference values without invalidating the gradient graph.

Fixes #25654

### Validation

- `git diff --check`
- `ruff format --check ultralytics/nn/modules/head.py`
- no tests added or run, per request
- `ruff check ultralytics/nn/modules/head.py` reports only pre-existing `RUF012` at line 1544

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Simplified keypoint decoding by consistently using an out-of-place sigmoid operation for better device compatibility. ✅

### 📊 Key Changes

- Removed the `NOT_MACOS14` platform-specific check and unused import.
- Updated both keypoint decoding paths to assign `sigmoid()` results instead of using in-place `sigmoid_()`.
- Preserved existing keypoint coordinate and confidence decoding behavior.

### 🎯 Purpose & Impact

- Improves compatibility with Apple macOS 14 MPS devices by avoiding problematic in-place operations. 🍎
- Reduces platform-specific branching, making the code simpler and easier to maintain.
- Provides more consistent keypoint inference behavior across supported devices with minimal expected performance impact.