### PR TITLE
Document image upload metadata

### DIFF
--- a/docs/en/datasets/detect/index.md
+++ b/docs/en/datasets/detect/index.md
@@ -117,6 +117,10 @@ An NDJSON dataset file contains:
             "width": 640,
             "height": 480,
             "split": "train",
+            "metadata": {
+                "aircraft": { "family": "A350", "section": "wing" },
+                "inspectionStatus": "reviewed"
+            },
             "annotations": {
                 "boxes": [
                     [0, 0.525, 0.376, 0.284, 0.418],
@@ -212,6 +216,22 @@ An NDJSON dataset file contains:
         ```
 
         Format: `[class_id]`
+
+#### Custom image metadata
+
+Each image record may include a `metadata` JSON object for application-specific context such as capture conditions, equipment identifiers, or review status. Nested values are supported. When imported into Ultralytics Platform, the metadata is stored with that image and can be viewed or edited from its fullscreen information panel.
+
+```json
+{
+    "type": "image",
+    "file": "airbus-wing.jpg",
+    "url": "https://example.com/airbus-wing.jpg",
+    "split": "train",
+    "metadata": { "aircraft": { "family": "A350", "section": "wing" }, "inspectionStatus": "reviewed" }
+}
+```
+
+Platform limits top-level metadata keys to 128 characters, each image's serialized metadata object to 500,000 characters, and the combined effective metadata in one NDJSON import to 500,000 characters.
 
 #### Usage Example
 

--- a/docs/en/platform/api/index.md
+++ b/docs/en/platform/api/index.md
@@ -627,7 +627,7 @@ POST /api/datasets/ingest
 
 Create a dataset ingest job for an existing dataset. The target dataset is always passed as `datasetId` in the JSON body, not in the URL path.
 
-The request body requires `datasetId` plus exactly one of `sessionId` (an uploaded archive's upload session) or `sourceUrl` (a remote ZIP, TAR, TAR.GZ, TGZ, or NDJSON URL). Add optional `targetSplit` (`train`, `val`, or `test`) to override the archive's split structure.
+The request body requires `datasetId` plus exactly one of `sessionId` (an uploaded archive's upload session) or `sourceUrl` (a remote ZIP, TAR, TAR.GZ, TGZ, or NDJSON URL). Add optional `targetSplit` (`train`, `val`, or `test`) to override the archive's split structure. To attach custom metadata, use `imageMetadata`, keyed by each image's exact archive-relative path or NDJSON `file` value.
 
 For uploaded archives, the upload session is already bound to the dataset by the `assetId` passed to `POST /api/upload/signed-url`; ingest validates that `assetId` matches the body `datasetId`. Optional `classMapping` entries map each incoming class name to an existing zero-based class index, a class name to reuse or create, or `null` to skip the class. For remote `sourceUrl` imports, create the dataset first, then pass its `datasetId` to ingest.
 
@@ -640,6 +640,83 @@ For uploaded archives, the upload session is already bound to the dataset by the
     "targetSplit": "train"
 }
 ```
+
+**Body (one or multiple images with metadata):**
+
+```json
+{
+    "datasetId": "dataset_abc123",
+    "sessionId": "session_abc123",
+    "imageMetadata": {
+        "airbus-wing.jpg": { "aircraft": { "family": "A350" }, "inspectionStatus": "reviewed" },
+        "images/tail.jpg": { "aircraft": { "family": "A320" }, "inspectionSeverity": 2 }
+    }
+}
+```
+
+Local images use the existing archive upload flow, whether the archive contains one image or many. The key must match the normalized path inside the archive, including folders. For NDJSON imports, each image record can instead contain its own `metadata` object. Record-local `metadata` takes precedence over a matching `imageMetadata` entry.
+
+Metadata is JSON and supports nested values. Archive paths are limited to 1,024 characters, top-level metadata keys to 128 characters, and each metadata object to 500,000 serialized characters. The complete `imageMetadata` map, or the combined effective metadata across an NDJSON import, is also limited to 500,000 serialized characters. These constraints are included in the [interactive OpenAPI schema](https://platform.ultralytics.com/api/docs).
+
+??? example "Upload one image with metadata using Python"
+
+    The same code handles a group of images: add more files to the ZIP and matching entries to `imageMetadata`.
+
+    ```python
+    import io
+    import zipfile
+    from pathlib import Path
+
+    import requests
+
+    api = "https://platform.ultralytics.com/api"
+    headers = {"Authorization": "Bearer YOUR_API_KEY"}
+    dataset_id = "dataset_abc123"
+    image_path = Path("airbus-wing.jpg")
+
+    archive = io.BytesIO()
+    with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.write(image_path, image_path.name)
+    data = archive.getvalue()
+
+    signed = requests.post(
+        f"{api}/upload/signed-url",
+        headers=headers,
+        json={
+            "assetType": "datasets",
+            "assetId": dataset_id,
+            "filename": "images.zip",
+            "contentType": "application/zip",
+            "totalBytes": len(data),
+        },
+    )
+    signed.raise_for_status()
+    upload = signed.json()
+
+    requests.put(upload["uploadUrl"], headers={"Content-Type": "application/zip"}, data=data).raise_for_status()
+    requests.post(
+        f"{api}/upload/complete",
+        headers=headers,
+        json={"sessionId": upload["sessionId"]},
+    ).raise_for_status()
+
+    ingest = requests.post(
+        f"{api}/datasets/ingest",
+        headers=headers,
+        json={
+            "datasetId": dataset_id,
+            "sessionId": upload["sessionId"],
+            "imageMetadata": {
+                "airbus-wing.jpg": {
+                    "aircraft": {"family": "A350", "section": "wing"},
+                    "inspectionStatus": "reviewed",
+                }
+            },
+        },
+    )
+    ingest.raise_for_status()
+    print(ingest.json())
+    ```
 
 **Body (remote archive or NDJSON):**
 

--- a/docs/en/platform/data/datasets.md
+++ b/docs/en/platform/data/datasets.md
@@ -286,7 +286,8 @@ Images can be sorted and filtered for efficient browsing:
 Click any image to open the fullscreen viewer with:
 
 - **Navigation**: Arrow keys or thumbnail previews to browse
-- **Metadata**: Filename, dimensions, split badge, annotation count
+- **Image information**: Review Platform-generated properties, custom metadata, and embedded file metadata such as EXIF
+- **Custom metadata**: Owners and editors can add or replace a JSON object, including nested values up to 500,000 serialized characters
 - **Annotations**: Toggle annotation overlay visibility
 - **Class Breakdown**: Per-class label counts with color indicators
 - **Annotate**: When you have edit access, annotation controls are active immediately when the fullscreen viewer opens on desktop
@@ -521,9 +522,11 @@ The NDJSON format stores one JSON object per line. The first line contains datas
 
 ```json
 {"type": "dataset", "task": "detect", "name": "my-dataset", "description": "...", "bytes": 12345678, "url": "https://platform.ultralytics.com/...", "class_names": {"0": "person", "1": "car"}, "version": 1, "created_at": "2026-01-15T10:00:00Z", "updated_at": "2026-02-20T14:30:00Z"}
-{"type": "image", "file": "img001.jpg", "url": "https://...", "width": 640, "height": 480, "split": "train", "annotations": {"boxes": [[0, 0.5, 0.5, 0.2, 0.3]]}}
+{"type": "image", "file": "img001.jpg", "url": "https://...", "width": 640, "height": 480, "split": "train", "metadata": {"location": {"site": "factory-1"}, "reviewed": true}, "annotations": {"boxes": [[0, 0.5, 0.5, 0.2, 0.3]]}}
 {"type": "image", "file": "img002.jpg", "url": "https://...", "width": 1280, "height": 720, "split": "val"}
 ```
+
+The optional image-level `metadata` object is preserved when an NDJSON file is imported into Platform. You can inspect or edit it from the image's fullscreen information panel. For programmatic archive uploads, the [Dataset Ingest API](../api/index.md#dataset-ingest) accepts the equivalent `imageMetadata` path map.
 
 !!! note "Signed URLs"
 

--- a/docs/en/platform/data/datasets.md
+++ b/docs/en/platform/data/datasets.md
@@ -298,7 +298,7 @@ Click any image to open the fullscreen viewer with:
 - **Pan**: Hold `Space` and drag to pan the canvas when zoomed
 - **Pixel view**: Toggle pixelated rendering for close inspection
 
-![Ultralytics Platform Datasets Fullscreen Viewer With Metadata Panel](https://cdn.ul.run/i/94b50fcde4feb9a2ae540138010a1d6c.avif)<!-- screenshot -->
+![Ultralytics Platform Datasets Fullscreen Viewer With Metadata Panel](https://cdn.ul.run/i/083e8f7a4ad565c1cca40ec0f214b748.avif)<!-- screenshot -->
 
 ### Filter by Split
 


### PR DESCRIPTION
## Summary
- document custom image metadata in the Platform fullscreen viewer
- add archive and NDJSON upload contracts, precedence, and centralized limits
- include a runnable Python example for uploading one image with metadata

## Validation
- `npx prettier@3.8.5 --tab-width 4 --print-width 120 --write docs/en/platform/api/index.md docs/en/platform/data/datasets.md docs/en/datasets/detect/index.md`
- `python docs/build_docs.py` (strict build: no issues found)
- `git diff --check`

Companion implementation: https://github.com/ultralytics/portal/pull/3404

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Adds support for custom, nested image metadata across NDJSON imports, Dataset Ingest API uploads, and the Ultralytics Platform viewer. 🖼️

### 📊 Key Changes

- Documents optional image-level `metadata` objects in detection NDJSON datasets.
- Adds `imageMetadata` support to the Dataset Ingest API, mapped by archive-relative image paths.
- Defines metadata precedence: NDJSON record metadata overrides matching API-provided metadata.
- Documents metadata size and key limits, including support for nested JSON values.
- Adds a Python example showing how to upload an image archive with custom metadata.
- Updates the Platform dataset viewer documentation to describe viewing and editing custom and embedded file metadata such as EXIF.
- Refreshes the fullscreen viewer screenshot and NDJSON examples.

### 🎯 Purpose & Impact

- Enables users to associate images with application-specific context such as equipment IDs, inspection status, locations, and capture details. 🏷️
- Makes metadata available for review and editing directly within the Ultralytics Platform.
- Supports both individual image records in NDJSON and groups of archive-uploaded images through the API.
- Improves dataset traceability and inspection workflows without affecting existing annotations or image formats.
- Gives developers clear integration guidance, validation limits, and a ready-to-use Python upload example. 🚀