### PR TITLE
Rasterize YOLOE visual prompts per batch and route tensor sources through the same rule

### DIFF
--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -487,7 +487,7 @@ class YOLOE(Model):
                 f"{len(visual_prompts['bboxes'])} and {len(visual_prompts['cls'])} respectively"
             )
             nested = yolo.yoloe.YOLOEVPDetectPredictor.is_per_image(visual_prompts)  # one prompt array per image
-            # the prompts decide the shape, as they do in pre_transform; only a longer source can override them
+            # the prompts decide the shape; only a longer source can override them
             multi = refer_image is None and (nested or (isinstance(source, (list, tuple)) and len(source) > 1))
             assert nested == multi, (  # each branch below reads the shape the other one cannot
                 f"Expected {'one array per image' if multi else 'a single flat array'} in 'bboxes' and 'cls', "

--- a/ultralytics/models/yolo/yoloe/predict.py
+++ b/ultralytics/models/yolo/yoloe/predict.py
@@ -17,12 +17,14 @@ class YOLOEVPDetectPredictor(DetectionPredictor):
     Attributes:
         model (torch.nn.Module): The YOLO model for inference.
         device (torch.device): Device to run the model on (CPU or CUDA).
-        prompts (dict | torch.Tensor): Visual prompts containing class indices and bounding boxes or masks.
+        prompts (dict): Visual prompts containing class indices and bounding boxes or masks.
+        visuals (torch.Tensor): The prompts rasterized against the shapes of the batch being preprocessed.
 
     Methods:
         setup_model: Initialize the YOLO model and set it to evaluation mode.
         set_prompts: Set the visual prompts for the model.
-        pre_transform: Preprocess images and prompts before inference.
+        is_per_image: Report whether the prompts hold one array per image.
+        preprocess: Preprocess a batch of images and rasterize its visual prompts.
         inference: Run inference with visual prompts.
         get_vpe: Process source to get visual prompt embeddings.
     """
@@ -48,77 +50,55 @@ class YOLOEVPDetectPredictor(DetectionPredictor):
 
     @staticmethod
     def is_per_image(prompts: dict) -> bool:
-        """Return True if 'bboxes' and 'cls' hold one array per image rather than one flat set for a single image."""
+        """Return True if 'bboxes' and 'cls' hold one array per image rather than one set applied to every image."""
         return all(
             isinstance(prompts.get(k), list) and all(isinstance(x, np.ndarray) for x in prompts[k])
             for k in ("bboxes", "cls")
         )
 
     def preprocess(self, im):
-        """Preprocess images, converting dict prompts for tensor sources that never pass through pre_transform."""
-        if isinstance(im, torch.Tensor) and isinstance(self.prompts, dict):
-            h, w = im.shape[2:]  # tensor sources skip letterboxing, so src and dst shapes are identical
-            self.prompts = self._prompts_to_tensor((h, w), (h, w))
-        return super().preprocess(im)
-
-    def _prompts_to_tensor(self, dst_shape, src_shape):
-        """Convert the single-image prompts dict to a batched visuals tensor on the model device.
+        """Preprocess a batch of images and rasterize its visual prompts against the shapes that batch takes.
 
         Args:
-            dst_shape (tuple): The target (height, width) after any letterboxing.
-            src_shape (tuple): The original (height, width) the prompts refer to.
+            im (torch.Tensor | list[np.ndarray]): Images of shape (N, 3, H, W) for tensor, [(H, W, 3) x N] for list.
 
         Returns:
-            (torch.Tensor): Visual prompts tensor of shape (1, N, H, W) in model precision.
+            (torch.Tensor): Preprocessed image tensor of shape (N, 3, H, W).
         """
-        bboxes = self.prompts.get("bboxes", None)
-        masks = self.prompts.get("masks", None)
-        visuals = self._process_single_image(dst_shape, src_shape, self.prompts["cls"], bboxes, masks)
-        prompts = visuals.unsqueeze(0).to(self.device)  # (1, N, H, W)
-        return prompts.half() if self.model.fp16 else prompts.float()
+        imgs = super().preprocess(im)
+        dst_shape = tuple(imgs.shape[2:])  # one letterboxed shape per batch, since preprocess stacks the images
+        # tensor sources skip letterboxing, so their src and dst shapes are identical
+        src_shapes = [dst_shape] * len(im) if isinstance(im, torch.Tensor) else [x.shape[:2] for x in im]
+        self.visuals = self._prompts_to_tensor(dst_shape, src_shapes)
+        return imgs
 
-    def pre_transform(self, im):
-        """Preprocess images and prompts before inference.
-
-        This method applies letterboxing to the input image and transforms the visual prompts (bounding boxes or masks)
-        accordingly.
+    def _prompts_to_tensor(self, dst_shape, src_shapes):
+        """Rasterize the prompts dict into a batched visuals tensor on the model device.
 
         Args:
-            im (list): List of input images.
+            dst_shape (tuple): The (height, width) every image in the batch was letterboxed to.
+            src_shapes (list[tuple]): The original (height, width) of each image in the batch.
 
         Returns:
-            (list): Preprocessed images ready for model inference.
+            (torch.Tensor): Visual prompts tensor of shape (B, N, H, W) in model precision.
 
         Raises:
             ValueError: If neither valid bounding boxes nor masks are provided in the prompts.
+            AssertionError: If per-image prompts do not hold one array per image in the batch.
         """
-        img = super().pre_transform(im)
-        if not isinstance(self.prompts, dict):  # already converted (tensor source, or re-entry at batch=1)
-            return img
-        if len(img) == 1 and not self.is_per_image(self.prompts):
-            self.prompts = self._prompts_to_tensor(img[0].shape[:2], im[0].shape[:2])
+        bboxes, category = self.prompts.get("bboxes", None), self.prompts["cls"]
+        if not self.is_per_image(self.prompts):  # one flat set, rasterized against every image in the batch
+            masks = self.prompts.get("masks", None)
+            visuals = [self._process_single_image(dst_shape, src, category, bboxes, masks) for src in src_shapes]
         else:
-            bboxes = self.prompts.get("bboxes", None)
-            category = self.prompts["cls"]
-            # NOTE: only supports bboxes as prompts for now
-            assert bboxes is not None, f"Expected bboxes, but got {bboxes}!"
-            # NOTE: needs list[np.ndarray]
-            assert isinstance(bboxes, list) and all(isinstance(b, np.ndarray) for b in bboxes), (
-                f"Expected list[np.ndarray], but got {bboxes}!"
-            )
-            assert isinstance(category, list) and all(isinstance(b, np.ndarray) for b in category), (
-                f"Expected list[np.ndarray], but got {category}!"
-            )
-            assert len(im) == len(category) == len(bboxes), (
-                f"Expected same length for all inputs, but got {len(im)}vs{len(category)}vs{len(bboxes)}!"
+            assert len(src_shapes) == len(category) == len(bboxes), (
+                f"Expected same length for all inputs, but got {len(src_shapes)}vs{len(category)}vs{len(bboxes)}!"
             )
             visuals = [
-                self._process_single_image(img[i].shape[:2], im[i].shape[:2], category[i], bboxes[i])
-                for i in range(len(img))
+                self._process_single_image(dst_shape, src, category[i], bboxes[i]) for i, src in enumerate(src_shapes)
             ]
-            prompts = torch.nn.utils.rnn.pad_sequence(visuals, batch_first=True).to(self.device)  # (B, N, H, W)
-            self.prompts = prompts.half() if self.model.fp16 else prompts.float()
-        return img
+        prompts = torch.nn.utils.rnn.pad_sequence(visuals, batch_first=True).to(self.device)  # (B, N, H, W)
+        return prompts.half() if self.model.fp16 else prompts.float()
 
     def _process_single_image(self, dst_shape, src_shape, category, bboxes=None, masks=None):
         """Process a single image by resizing bounding boxes or masks and generating visuals.
@@ -167,12 +147,12 @@ class YOLOEVPDetectPredictor(DetectionPredictor):
         Returns:
             (torch.Tensor): Model prediction results.
         """
-        return super().inference(im, *args, vpe=self.prompts, **kwargs)
+        return super().inference(im, *args, vpe=self.visuals, **kwargs)
 
     def get_vpe(self, source):
         """Process the source to get the visual prompt embeddings (VPE).
 
-        Preprocesses a single image via preprocess(), which converts the visual prompts to tensor format (and
+        Preprocesses a single image via preprocess(), which rasterizes the visual prompts into visuals (and
         letterboxes array inputs), then extracts the VPE from the model.
 
         Args:
@@ -190,7 +170,7 @@ class YOLOEVPDetectPredictor(DetectionPredictor):
         assert len(self.dataset) == 1, "get_vpe only supports one image!"
         for _, im0s, _ in self.dataset:
             im = self.preprocess(im0s)
-            return self.model(im, vpe=self.prompts, return_vpe=True)
+            return self.model(im, vpe=self.visuals, return_vpe=True)
 
 
 class YOLOEVPSegPredictor(YOLOEVPDetectPredictor, SegmentationPredictor):


### PR DESCRIPTION
## summary

a visual prompt dict was rasterized into a tensor once, on the first batch, and every later batch reused it, so a directory or glob source died in the model forward as soon as an image letterboxed to a different shape. the prompt dict now survives the run and is rasterized against the shapes of each batch, which also puts tensor sources on the same nesting rule as every other source instead of a third one of their own in preprocess.

the rasterization had three entry points, and the pre_transform override existed only to reach the letterboxed shapes; those are recoverable from the tensor preprocess already builds, so the override is gone and one converter dispatches on the shared predicate alone. three type asserts went with it, implied by that predicate once it decides the branch. a flat dict handed to a list source of several images is still rejected at the api boundary, which is now narrower than what the predictor accepts, and a directory source carrying one array per image still reports the count mismatch rather than spreading the arrays across batches.

## measured

`yoloe-11s-seg.pt`, product files isolated with `git checkout`, per-side fingerprints asserted different (`d7fb4bf5217f` before, `f60d6b723904` after).

what changed:

| case                                                   | before                                                                      | after                                                              |
| :----------------------------------------------------- | :-------------------------------------------------------------------------- | :----------------------------------------------------------------- |
| directory or glob source, one flat prompt set          | `RuntimeError: shape '[1, 1, 1, 48, 80]' is invalid for input of size 4800` | 2 results, 3 and 0 detections                                      |
| the same call with `batch=2`                           | `AssertionError: Expected list[np.ndarray]`                                 | 2 results, 3 and 0 detections                                      |
| tensor source, one array per image                     | `ValueError: not enough values to unpack (expected 4, got 1)`               | 1 result, boxes byte-identical to the flat call on the same tensor |
| tensor batch of 2, one array per image                 | the same `ValueError`                                                       | 2 results, 3 and 2 detections                                      |
| tensor batch of 2, one flat set                        | `RuntimeError: shape '[2, 1, 1, 80, 80]' is invalid for input of size 6400` | 2 results, 3 and 0 detections                                      |
| directory of two images with different original shapes | 3 and 3 detections, the second scaled by the first image's gain             | 3 and 0 detections, each scaled by its own gain                    |

what is measured not to move, per case:

| control                                                                          | result                                                                                |
| :------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------ |
| the 16 source and prompt combinations of the base pr                             | exception type, message and box hash identical in all 16                              |
| directory of two images sharing one original shape, flat and one-array-per-image | identical, hash `eaf5317e9185`, 0 and 2 detections                                    |
| `refer_image`, image and tensor                                                  | identical, hashes `06eb13ad3aa0` and `bdd5f92ef7ac`                                   |
| directory or glob with two arrays for a one-image batch                          | `AssertionError: Expected same length for all inputs, but got 1vs2vs2!` on both sides |
| mask prompts, through the public api and through a directly built predictor      | rejected and broken identically on both sides                                         |

nine distinct box hashes across the passing cases, and detection counts range over 3, 4, [3, 2] and [3, 2, 3], so the fixtures separate the branches they measure.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

YOLOE visual prompt dictionaries are now rasterized during each batch’s preprocessing step so prompt tensors match the current batch and tensor inputs follow the same per-image handling rules.

### 📊 Key Changes

- Replaced the `pre_transform` prompt conversion path with `preprocess`, which derives letterboxed batch shapes from the preprocessed image tensor.
- Preserved prompt dictionaries during inference and stores the current rasterized result in `self.visuals`, which is passed to inference and visual prompt embedding generation.
- Applied one dispatch rule through `is_per_image()`:
  - Flat prompts are rasterized for every image in the batch.
  - Per-image prompts are validated against the batch size and rasterized using each image’s original shape.
- Removed the separate tensor-source conversion path and the associated type assertions.

### 🎯 Purpose & Impact

- Directory, glob, and tensor sources can now use flat prompts across batches with differing image shapes without reusing an incorrectly sized visual tensor.
- Tensor sources with one prompt array per image are handled using the same nesting rule as other sources.
- Per-image prompt count mismatches remain rejected with an explicit length assertion, while the public API’s validation for flat prompts supplied to multi-image list sources remains unchanged.