### PR TITLE
Run predict and val against a copy of the caller's model instead of fusing it in place

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -638,9 +638,9 @@ class Model(torch.nn.Module):
         res = fit_calibration_selective(
             self.model, validator.dataloader, validator.device, max_depth=validator.data.get("max_depth") or 100.0
         )
+        self.predictor = None  # the cached predictor wraps a copy of the module the fit just rewrote
         if res is None:
             return None
-        self.predictor = None  # the cached predictor wraps a copy of the module just changed
         LOGGER.info("Call model.save(...) to persist the calibration.")
         return res["a"], res["b"]
 

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -640,6 +640,7 @@ class Model(torch.nn.Module):
         )
         if res is None:
             return None
+        self.predictor = None  # the cached predictor wraps a copy of the module just changed
         LOGGER.info("Call model.save(...) to persist the calibration.")
         return res["a"], res["b"]
 

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -309,6 +309,7 @@ class Model(torch.nn.Module):
                 m.reset_parameters()
         for p in self.model.parameters():
             p.requires_grad = True
+        self.predictor = None  # the cached predictor wraps a copy of the module just changed
         return self
 
     def load(self, weights: str | Path = "yolo26n.pt") -> Model:
@@ -336,6 +337,7 @@ class Model(torch.nn.Module):
             self.overrides["pretrained"] = weights  # remember the weights for DDP training
             weights, self.ckpt = load_checkpoint(weights)
         self.model.load(weights)
+        self.predictor = None  # the cached predictor wraps a copy of the module just changed
         return self
 
     def save(self, filename: str | Path = "saved_model.pt") -> None:

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import platform
 import re
 import threading
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Callable
 
@@ -420,6 +421,9 @@ class BasePredictor:
             model (str | Path | torch.nn.Module): Model to load or use.
             verbose (bool): Whether to print verbose output.
         """
+        if isinstance(model, torch.nn.Module):
+            # Configuring the head and fusing below rewrite the module in place, and the caller still owns this one
+            model = deepcopy(model)
         if hasattr(model, "end2end"):
             if self.args.end2end is not None:
                 model.end2end = self.args.end2end

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import json
 import time
+from copy import deepcopy
 from pathlib import Path
 
 import numpy as np
@@ -171,6 +172,9 @@ class BaseValidator:
             if str(self.args.model).endswith(".yaml") and model is None:
                 LOGGER.warning("validating an untrained model YAML will result in 0 mAP.")
             callbacks.add_integration_callbacks(self)
+            if isinstance(model, torch.nn.Module):
+                # Configuring the head and fusing below rewrite the module in place, and the caller still owns this one
+                model = deepcopy(model)
             if hasattr(model, "end2end"):
                 if self.args.end2end is not None:
                     model.end2end = self.args.end2end

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -194,16 +194,18 @@ class YOLOWorld(Model):
         Args:
             classes (list[str]): A list of categories i.e. ["person"].
         """
-        # Snapshot before the delegate rewrites names in place, so an unchanged list keeps the predictor
+        # Compare what the delegate is about to embed, sentinel and order included, against what the model
+        # already carries: only an identical list leaves the cached predictor's copy valid
         names = list(self.model.names.values() if isinstance(self.model.names, dict) else self.model.names)
+        rebuilt = names != classes
         self.model.set_classes(classes)
         # Remove background if it's given
         background = " "
         if background in classes:
             classes.remove(background)
         self.model.names = classes
-        if names != classes:  # order matters: the delegate rewrote txt_feats in the new order
-            self.predictor = None  # the cached predictor wraps a copy of the classes just replaced
+        if rebuilt:
+            self.predictor = None  # the cached predictor wraps a copy of the head the delegate just rewrote
 
 
 class YOLOE(Model):

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -194,18 +194,13 @@ class YOLOWorld(Model):
         Args:
             classes (list[str]): A list of categories i.e. ["person"].
         """
-        # Compare what the delegate is about to embed, sentinel and order included, against what the model
-        # already carries: only an identical list leaves the cached predictor's copy valid
-        names = list(self.model.names.values() if isinstance(self.model.names, dict) else self.model.names)
-        rebuilt = names != classes
         self.model.set_classes(classes)
         # Remove background if it's given
         background = " "
         if background in classes:
             classes.remove(background)
         self.model.names = classes
-        if rebuilt:
-            self.predictor = None  # the cached predictor wraps a copy of the head the delegate just rewrote
+        self.predictor = None  # the delegate rewrote the head unconditionally; the cached copy is stale
 
 
 class YOLOE(Model):

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -194,16 +194,16 @@ class YOLOWorld(Model):
         Args:
             classes (list[str]): A list of categories i.e. ["person"].
         """
+        # Snapshot before the delegate rewrites names in place, so an unchanged list keeps the predictor
+        names = list(self.model.names.values() if isinstance(self.model.names, dict) else self.model.names)
         self.model.set_classes(classes)
         # Remove background if it's given
         background = " "
         if background in classes:
             classes.remove(background)
         self.model.names = classes
-
-        # Reset method class names
-        if self.predictor:
-            self.predictor.model.names = classes
+        if names != classes:  # order matters: the delegate rewrote txt_feats in the new order
+            self.predictor = None  # the cached predictor wraps a copy of the classes just replaced
 
 
 class YOLOE(Model):
@@ -337,10 +337,7 @@ class YOLOE(Model):
             if embeddings is None:
                 embeddings = self.get_text_pe(classes)  # generate text embeddings if not provided
             self.model.set_classes(classes, embeddings)
-
-        # Reset method class names
-        if self.predictor:
-            self.predictor.model.names = self.model.names
+            self.predictor = None  # the cached predictor wraps a copy of the module just changed
 
     def _prompt_embedding_model(self) -> str:
         """Return the checkpoint identifier used to bind prompt embeddings to this model."""

--- a/ultralytics/models/yolo/yoloe/val.py
+++ b/ultralytics/models/yolo/yoloe/val.py
@@ -177,6 +177,7 @@ class YOLOEDetectValidator(DetectionValidator):
                 from ultralytics.nn.tasks import load_checkpoint
 
                 model, _ = load_checkpoint(model, device=self.device)  # model, ckpt
+            # BaseValidator copies whatever module it is handed, so this path needs no copy of its own
             model.eval().to(self.device)
             data = check_det_dataset(refer_data or self.args.data)
             names = [name.split("/", 1)[0] for name in list(data["names"].values())]

--- a/ultralytics/models/yolo/yoloe/val.py
+++ b/ultralytics/models/yolo/yoloe/val.py
@@ -177,7 +177,6 @@ class YOLOEDetectValidator(DetectionValidator):
                 from ultralytics.nn.tasks import load_checkpoint
 
                 model, _ = load_checkpoint(model, device=self.device)  # model, ckpt
-            # BaseValidator copies whatever module it is handed, so this path needs no copy of its own
             model.eval().to(self.device)
             data = check_det_dataset(refer_data or self.args.data)
             names = [name.split("/", 1)[0] for name in list(data["names"].values())]

--- a/ultralytics/models/yolo/yoloe/val.py
+++ b/ultralytics/models/yolo/yoloe/val.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
@@ -197,14 +196,14 @@ class YOLOEDetectValidator(DetectionValidator):
                 dataloader = self.get_vpe_dataloader(data)
                 vpe = self.get_visual_pe(dataloader, model)
                 model.set_classes(names, vpe)
-                stats = super().__call__(model=deepcopy(model))
+                stats = super().__call__(model=model)
             elif isinstance(model.model[-1], YOLOEDetect) and hasattr(model.model[-1], "lrpc"):  # prompt-free
                 return super().__call__(trainer, model)
             else:
                 LOGGER.info("Validate using the text prompt.")
                 tpe = model.get_text_pe(names)
                 model.set_classes(names, tpe)
-                stats = super().__call__(model=deepcopy(model))
+                stats = super().__call__(model=model)
         return stats
 
 


### PR DESCRIPTION
## summary

`BasePredictor.setup_model` and `BaseValidator.__call__` configured the head of, and then fused, froze, cast and moved, the very `nn.Module` the caller still holds, so inference silently rewrote a model that was mid-training or about to be trained. both now do that work on a copy, which leaves the caller's model alone and keeps the fused copy the backend runs, and the five public methods that rewrite `Model.model` in place drop the cached predictor because it no longer aliases them. rewriting `Model.model` by hand after a prediction therefore no longer reaches inference; `YOLOE.set_vocab` and `get_vocab` need the same refresh and get it in #25691, and `AutoBackend` constructed directly with a live module is still mutated. the copy covers the head configuration and the fusion that follow it, not what a specialized validator does before delegating: `YOLOEDetectValidator` and `WorldValidator` both call `eval().to(...)` on the caller's module first, and `YOLOEDetectValidator` leaves its `set_classes(...)` standing where `WorldValidator` restores the class state in a `finally`, so `YOLOE.val()` leaves `model.pe` written exactly as it does today, unchanged by this PR and tracked separately. its own `deepcopy` is dropped because it sat after those writes and shielded nothing the base validator does not now shield.

## measured

`predict()` followed by `train()` transferred 94 of 499 pretrained tensors for yolo11n and 108 of 708 for yolo26n, with the transferred convolutions already folded into their batch norms; both now transfer everything, matching a `train()` with nothing before it, and `val()` had the same effect. predicting from an `on_fit_epoch_end` callback failed at epoch 2 with `RuntimeError: element 0 of tensors does not require grad` on yolo11n and `KeyError: 'boxes'` on yolo26n, and both now complete. `predict(end2end=False)` on yolo26n permanently switched the caller's loss from `E2ELoss` to `v8DetectionLoss` and `predict(max_det=1000, agnostic_nms=True)` permanently rewrote its head, because both are written before fusion reads them; neither happens now. `YOLOWorld.val()` left a caller's model with 54 of its 115 norm layers and none of its 522 gradient-carrying parameters, and now returns all 115 and all 522, while the eval mode and device the specialized validator sets before delegating still move on both sides. predictions are byte-identical across detect, segment, pose and classify, and the model the predictor runs is still fully fused. the copy costs 16 ms and 10 MB for yolo11n and 44 ms and 88 MB for yolo26m, once per predictor and transiently per `val()`, and dropping the predictor on a repeated `set_classes` with an unchanged list adds 49 ms to the next prediction.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ Prevents prediction and validation from mutating the caller’s model while keeping cached predictors synchronized after model changes.

### 📊 Key Changes
- 🧬 `Predictor` and `Validator` now deep-copy in-memory PyTorch models before configuring, fusing, or otherwise modifying them.
- 🔄 Cached predictors are cleared after weight resets, weight loading, calibration, and class updates.
- 🏷️ `set_classes()` now invalidates the cached predictor instead of manually updating its class names.
- ✅ YOLOE validation now relies on the validator’s built-in model copying, removing redundant deep-copy operations.

### 🎯 Purpose & Impact
- 🛡️ Prevents inference and validation setup from unexpectedly altering the original model supplied by the user.
- 🔧 Ensures future predictions use the latest weights, calibration, architecture, and class configuration.
- 🐞 Reduces stale-cache bugs and makes repeated model updates more reliable.
- ⚡ Simplifies YOLOE validation code while preserving its existing behavior.