### PR TITLE
Bump ultralytics-inference version to 0.0.33 in documentation

### DIFF
--- a/docs/en/inference/index.md
+++ b/docs/en/inference/index.md
@@ -57,7 +57,7 @@ Rust 1.89 or newer is required. The [video](#cargo-features) feature additionall
     ```toml
     # Or add it manually to Cargo.toml
     [dependencies]
-    ultralytics-inference = "0.0.32"
+    ultralytics-inference = "0.0.33"
     ```
 
 ## CLI quickstart
@@ -445,7 +445,7 @@ cargo install ultralytics-inference --features cuda,tensorrt
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.32", features = ["video"] }
+ultralytics-inference = { version = "0.0.33", features = ["video"] }
 ```
 
 ## Output and saving


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the Rust inference documentation to reference `ultralytics-inference` version `0.0.33`. 📦

### 📊 Key Changes

- Updated the documented dependency version from `0.0.32` to `0.0.33`.
- Updated both standard and video-enabled Rust setup examples.
- No source code or runtime behavior changes were introduced.

### 🎯 Purpose & Impact

- Keeps the documentation aligned with the latest published Rust inference package.
- Helps users install the correct dependency version when following the Rust inference guide.
- Existing inference functionality and APIs are unaffected. ✅