### PR TITLE
Publish docs only from main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -102,7 +102,7 @@ jobs:
             echo "No changes to commit"
           fi
       - name: Publish Docs to https://docs.ultralytics.com
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_docs == 'true')
+        if: github.ref_name == 'main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_docs == 'true'))
         env:
           EVENT_NAME: ${{ github.event_name }}
           VERCEL_DOCS_DEPLOY_HOOK: ${{ secrets.VERCEL_DOCS_DEPLOY_HOOK }}


### PR DESCRIPTION
## Summary

`workflow_dispatch` on **any** branch publishes that branch's docs to https://docs.ultralytics.com.

The publish step gates on event type only:

```yaml
if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_docs == 'true')
```

`on.push.branches` restricts the push path to `main`, but nothing restricts the dispatch path — and `publish_docs` **defaults to `true`**, so a plain `gh workflow run docs.yml --ref <any-branch>` publishes. I hit this while validating a docs branch yesterday and had to cancel the run mid-flight to stop it reaching production.

Adds a branch condition so publishing can only ever happen from `main`, whatever the event.

## Behaviour

| event | ref | `publish_docs` | publishes |
| --- | --- | --- | --- |
| `push` | `main` | – | ✅ (unchanged) |
| `workflow_dispatch` | `main` | `true` | ✅ (unchanged) |
| `workflow_dispatch` | `main` | `false` | ❌ (unchanged) |
| `workflow_dispatch` | feature branch | `true` | ❌ **fixed** |
| `workflow_dispatch` | feature branch | default | ❌ **fixed** |
| `pull_request` | `<n>/merge` | – | ❌ (unchanged) |

Both legitimate publish paths are preserved — a manual republish from `main` still works, which is the flow used when the docs snapshot needs refreshing. Every other step in the job (ruff, reference-section update, mkdocs build, link check) is untouched, so PR builds still validate docs exactly as before.

## Validation

- YAML parses; the `if` expression was evaluated against all six event/ref/input combinations above and matches the table

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔒 Restricts automatic documentation publishing to the `main` branch.

### 📊 Key Changes

- Updated the docs GitHub Actions workflow to publish to `https://docs.ultralytics.com` only when:
  - Changes are pushed to the `main` branch, or
  - A manual workflow run is triggered on `main` with publishing enabled.
- Prevents documentation deployment from other branches, including feature branches and pull requests.

### 🎯 Purpose & Impact

- ✅ Reduces the risk of unintended or premature documentation releases.
- 🛡️ Keeps the public documentation synchronized only with approved `main` branch changes.
- 🚀 Makes manual publishing safer by requiring the workflow to run from `main`.