### PR TITLE
Add an opt-in export manifest for docs macros

### DIFF
--- a/docs/macros/exports.yml
+++ b/docs/macros/exports.yml
@@ -1,0 +1,21 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+# Macros exported as shared content blocks for other Ultralytics surfaces (currently the blog).
+#
+# Export is opt-in: an entry here makes a macro's rendered table fetchable by id, so a published post
+# can embed the same table the docs page shows and follow it when the numbers change. Add an entry
+# only when a post needs that macro.
+#
+# id        Immutable. A published post references it; renaming one breaks that post.
+# macro     File in this directory.
+# canonical Docs page the block links back to, relative to docs/en/. Readers land on the full context.
+#
+# Only context-free macros can be exported. A macro whose output depends on the including page —
+# supported-tasks.md (page-level `{% set unsupported %}`) or the `param_table` macros
+# (solutions-args, track-args, visualization-args, which every docs page calls with an argument
+# list) — renders something different, and silently plausible, with no page around it.
+
+exports:
+  - id: yolo-det-perf
+    macro: yolo-det-perf.md
+    canonical: tasks/detect.md


### PR DESCRIPTION
## summary

adds `docs/macros/exports.yml`, an opt-in list naming which macros may be fetched as shared content blocks by other Ultralytics surfaces, starting with `yolo-det-perf`. an entry records the macro file and the docs page a reader should land on, so a macro edit reaches an embedding page without anyone editing that page. the file sits outside `docs_dir`, so it is not published, and macros whose output depends on the including page are named in the header as not exportable.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 Adds an export registry for sharing selected documentation macros, starting with the YOLO detection performance table.

### 📊 Key Changes
- Added `docs/macros/exports.yml` to define macros that can be reused across Ultralytics surfaces, such as the blog.
- Registered the `yolo-det-perf` macro from `yolo-det-perf.md`.
- Linked the exported table back to its canonical documentation page, [`tasks/detect.md`](https://github.com/ultralytics/ultralytics/blob/main/docs/en/tasks/detect.md).
- Documented export requirements, including stable IDs and support for only context-free macros.

### 🎯 Purpose & Impact
- 🔄 Enables published blog content to embed the same performance table shown in the documentation.
- 📈 Keeps shared metrics synchronized automatically as the source data changes.
- 🔗 Directs readers back to the full detection-task documentation for additional context.
- 🛡️ Prevents incorrect exports by excluding macros whose output depends on the including page or passed arguments.