### PR TITLE
Fix Windows semantic mask shape regression

### DIFF
--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -1011,6 +1011,8 @@ class SemanticDataset(YOLODataset):
         mask = cv2.imread(mask_file, cv2.IMREAD_GRAYSCALE)
         if mask is None:
             raise FileNotFoundError(f"Semantic mask not found or unreadable: {mask_file}")
+        if mask.ndim == 3:
+            mask = mask[..., 0]  # Windows patched cv2.imread expands grayscale reads to (H, W, 1)
         if int(self.data.get("nc", 0)) == 1 and self.labels[index]["is_1bit"]:
             mask[mask == 255] = 1  # cv2 expands 1-bit PNG foreground to 255.
         if self.label_mapping:


### PR DESCRIPTION
Fixes the Windows regression reported in https://github.com/ultralytics/ultralytics/issues/24578#issuecomment-5225794666.

On Windows `cv2.imread` is patched to `ultralytics.utils.patches.imread`, which always adds a channel dim, so `cv2.imread(mask_file, cv2.IMREAD_GRAYSCALE)` returns `(H, W, 1)`. Mosaic then fails:

```
File "ultralytics/data/augment.py", line 679, in apply_semantic
    mask4[y1a:y2a, x1a:x2a] = mask[y1b:y2b, x1b:x2b]
ValueError: could not broadcast input array from shape (1024,926,1) into shape (1024,926)
```

`load_mask` now drops the extra dim again, so masks stay `(H, W)` on all platforms.

Reproduced on Linux by applying the Windows patch manually (`cv2.imread = patches.imread`) and loading `cityscapes8` with `augment=True`: the error above before the fix, `load_mask` shape `(1024, 2048)` and a clean `epochs=1` semantic train after it.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes a Windows-specific semantic mask shape regression by normalizing grayscale masks before processing. 🛠️

### 📊 Key Changes
- Detects three-dimensional masks returned by patched Windows OpenCV builds.
- Converts `(H, W, 1)` grayscale masks to the expected two-dimensional format.
- Preserves existing 1-bit PNG handling and label-mapping behavior.

### 🎯 Purpose & Impact
- Prevents downstream shape-related errors when loading semantic masks on Windows. 🪟
- Improves cross-platform consistency without changing normal grayscale mask behavior.
- Reduces risk of regressions for semantic segmentation workflows.