### PR TITLE
Set the confusion matrix confidence default in `BaseValidator`

### DIFF
--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -79,6 +79,7 @@ class BaseValidator:
         speed (dict): Dictionary with keys 'preprocess', 'inference', 'loss', 'postprocess' and their respective batch
             processing times in milliseconds.
         save_dir (Path): Directory to save results.
+        confusion_matrix_conf (float): Confidence threshold used when accumulating the confusion matrix.
         plots (dict): Dictionary to store plots for visualization.
         callbacks (dict): Dictionary to store various callback functions.
         stride (int): Model stride for padding calculations.
@@ -135,6 +136,7 @@ class BaseValidator:
 
         self.save_dir = save_dir or get_save_dir(self.args)
         (self.save_dir / "labels" if self.args.save_txt else self.save_dir).mkdir(parents=True, exist_ok=True)
+        self.confusion_matrix_conf = 0.25 if self.args.conf is None else self.args.conf  # 0.25 unless user-specified
         if self.args.conf is None:
             self.args.conf = 0.01 if self.args.task == "obb" else 0.001  # reduce OBB val memory usage
         self.args.imgsz = check_imgsz(self.args.imgsz, max_dim=1)

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -192,7 +192,7 @@ class DetectionValidator(BaseValidator):
             )
             # Evaluate
             if self.args.plots:
-                self.confusion_matrix.process_batch(predn, pbatch, conf=self.args.conf)
+                self.confusion_matrix.process_batch(predn, pbatch, conf=self.confusion_matrix_conf)
                 if self.args.visualize:
                     self.confusion_matrix.plot_matches(
                         batch["img"][si],

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -50,8 +50,6 @@ class DetectionValidator(BaseValidator):
             args (dict[str, Any], optional): Arguments for the validator.
             _callbacks (dict, optional): Dictionary of callback functions.
         """
-        conf = args.get("conf") if isinstance(args, dict) else getattr(args, "conf", None)
-        self.confusion_matrix_conf = 0.25 if conf is None else conf
         super().__init__(dataloader, save_dir, args, _callbacks)
         self.is_coco = False
         self.is_lvis = False
@@ -194,7 +192,7 @@ class DetectionValidator(BaseValidator):
             )
             # Evaluate
             if self.args.plots:
-                self.confusion_matrix.process_batch(predn, pbatch, conf=self.confusion_matrix_conf)
+                self.confusion_matrix.process_batch(predn, pbatch, conf=self.args.conf)
                 if self.args.visualize:
                     self.confusion_matrix.plot_matches(
                         batch["img"][si],

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -423,7 +423,6 @@ class ConfusionMatrix(DataExportMixin):
             for i in range(gt_cls.shape[0]):
                 self._append_matches("GT", batch, i)  # store GT
         is_obb = gt_bboxes.shape[1] == 5  # check if boxes contains angle for OBB
-        conf = 0.25 if conf in {None, 0.01 if is_obb else 0.001} else conf  # apply 0.25 if default val conf is passed
         no_pred = detections["cls"].shape[0] == 0
         if gt_cls.shape[0] == 0:  # Check if labels is empty
             if not no_pred:

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -423,6 +423,7 @@ class ConfusionMatrix(DataExportMixin):
             for i in range(gt_cls.shape[0]):
                 self._append_matches("GT", batch, i)  # store GT
         is_obb = gt_bboxes.shape[1] == 5  # check if boxes contains angle for OBB
+        conf = 0.25 if conf in {None, 0.01 if is_obb else 0.001} else conf  # apply 0.25 if default val conf is passed
         no_pred = detections["cls"].shape[0] == 0
         if gt_cls.shape[0] == 0:  # Check if labels is empty
             if not no_pred:


### PR DESCRIPTION
Follow-up to #25677, which fixed the flooded confusion matrix reported in #25724.

#25677 works, but it reads `conf` out of the raw `args` in `DetectionValidator.__init__`, before `get_cfg` runs. That duplicates config parsing in a subclass. The code that knows whether the user set `conf` is `BaseValidator.__init__`, since it is what fills in the default.

Two changes:

1. Set `self.confusion_matrix_conf` in `BaseValidator.__init__`, on the line above the `conf` default.
2. Delete the raw `args` parsing from `DetectionValidator.__init__`.

Behavior is unchanged, and `ConfusionMatrix.process_batch` still honors the `conf` it is passed, which was the point of #25320.

`yolo11n` exported to ONNX, validated on `coco8.yaml`:

| `val()` call | `confusion_matrix.matrix.sum()` |
| --- | --- |
| `val()` | 20 |
| `val(conf=0.001)` | 753 |
| `val(conf=0.5)` | 17 |

The unset case matches 8.4.101 entry for entry. Explicit `conf=0.001` is still honored, so a model that peaks near 0.02 can be inspected at its real operating point.

Also smoke tested a 1-epoch `coco8` train, plus `val` for segment, obb and pose.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Centralizes confusion-matrix confidence initialization in `BaseValidator` so the user-specified `conf` is captured before validation defaults are applied, removing duplicate parsing from `DetectionValidator`.

### 📊 Key Changes
- Adds `BaseValidator.confusion_matrix_conf`, using `0.25` when `conf` is unset or the supplied confidence value otherwise.
- Places this assignment before `BaseValidator` applies task-specific default values to `self.args.conf`.
- Removes raw `conf` extraction and `confusion_matrix_conf` assignment from `DetectionValidator`.
- Documents `confusion_matrix_conf` as the confidence threshold used to accumulate the confusion matrix.

### 🎯 Purpose & Impact
- Explicit confidence values remain available to confusion-matrix processing, while the existing validation defaults continue to be applied to `self.args.conf`.
- Configuration handling is shared by `BaseValidator` instead of being duplicated in the detection validator.
- No intended user-facing behavior change.