### PR TITLE
Remove redundant requirement installation test

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1295,14 +1295,6 @@ def test_utils_checks(monkeypatch):
     assert checks.parse_version("v2.1") == (2, 1, 0)
     assert checks.parse_version("1.0rc1") == (1, 0, 0)  # documented non-PEP-440 tradeoff: pre-releases equal the final
     monkeypatch.setattr(checks.metadata, "version", package_version)
-    monkeypatch.setattr(checks, "ARM64", True)
-    monkeypatch.setattr(checks, "AUTOINSTALL", True)
-    monkeypatch.setattr(checks, "ONLINE", True)
-    commands = []
-    monkeypatch.setattr(checks.subprocess, "check_output", lambda command, **kwargs: commands.append(command) or "")
-    requirements = ["ray[tune]", "nvidia-modelopt[onnx]>=0.44", "$(touch /tmp/pwned)/missing"]
-    assert checks.check_requirements(requirements)
-    assert commands[0][5:] == requirements  # requirements remain individual argv entries, never shell source
     assert not checks.check_version("v2", ">=2.0")  # installed version-shaped package keeps metadata precedence
     versions = ("v2.1-rc.1", "v2.1-beta1", "v2.1rev1", "v2.1-dev1", "v2.1+cu118")
     assert all(checks.check_version(v, ">=2.0") for v in versions)


### PR DESCRIPTION
The production fix in #25720 is already exercised by the existing `check_requirements` paths and subprocess argv construction is directly visible in the owner. Remove the added eight-line monkeypatch test, which replaces module globals and subprocess behavior without covering an otherwise-uncovered high-risk path.

This is a test-only, delete-only follow-up: **+0/-8**.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Removed a redundant eight-line monkeypatch test for `checks.check_requirements` from `tests/test_python.py` because the covered behavior is already exercised elsewhere.

### 📊 Key Changes

- Deleted the test setup that monkeypatched `ARM64`, `AUTOINSTALL`, `ONLINE`, and `subprocess.check_output`.
- Removed assertions covering requirement handling and preservation of individual subprocess argument entries.
- Retained the surrounding version parsing and version-check tests.

### 🎯 Purpose & Impact

- This is a test-only change with no production code changes.
- The removed test is no longer part of the test suite; existing `check_requirements` paths remain in place.
- No user-facing change.