### PR TITLE
Fix unbounded per-track solution state in continuous streams

### DIFF
--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -4,7 +4,6 @@
 # Includes all solutions except DistanceCalculation and the Security Alarm System.
 
 import os
-from types import SimpleNamespace
 from unittest.mock import patch
 
 import cv2
@@ -259,50 +258,13 @@ def test_object_counter_polygon_reentry_after_inside_spawn():
     )
 
 
-def test_purge_stale_tracks_forgets_aigym_states():
-    """AIGym.states is per-track bookkeeping like ObjectCounter.counted_ids/SpeedEstimator.spd, but AIGym never calls
-    store_tracking_history and so never touches track_history itself; _purge_stale_tracks must still purge it via
-    the track-ID registry (_track_last_seen) it keeps regardless of that, on a stream that runs for days.
-    """
+def test_aigym_forgets_retired_tracks():
+    """AIGym must drop state and shared history when the tracker retires an ID."""
     gym = solutions.AIGym(model=MODEL, show=SHOW)
-    gym.track_ids = [1]
-    gym.states[1]["count"] = 3  # materialize the defaultdict entry, as process() would on a real detection
-    gym._purge_stale_tracks()  # track 1 seen at call 1
-    gym.track_ids = []
-    for _ in range(101):  # miss the default max_age (no tracker attached: track_buffer falls back to 30 * 3 = 90)
-        gym._purge_stale_tracks()
-    assert 1 not in gym.states, f"Expected track 1 purged from states after going stale, got {dict(gym.states)}"
-
-
-def test_purge_stale_tracks_respects_tracker_specific_retention_windows():
-    """FASTTracker (ultralytics/trackers/fast_tracker.py) can keep an unseen ID re-findable for occ_reappear_window
-    frames and delay moving an occluded track to Lost for active_occ_to_lost_thresh frames, both independent of
-    track_buffer. A track_buffer of 1 with the default occ_reappear_window of 40 must not let _purge_stale_tracks()
-    drop solution state after only track_buffer * 3 == 3 missed calls, or FASTTracker could still emit the same ID
-    later and reset AIGym state / let ObjectCounter double-count.
-    """
-    gym = solutions.AIGym(model=MODEL, show=SHOW)
-    gym.track_ids = [1]
-    gym.states[1]["count"] = 3  # materialize the defaultdict entry, as process() would on a real detection
-
-    class _FakeFASTTracker:
-        """Stand-in exposing only the attributes _purge_stale_tracks reads, mirroring FASTTracker's own."""
-
-        args = SimpleNamespace(track_buffer=1)
-        occ_reappear_window = 40
-        active_occ_to_lost_thresh = 10
-
-    gym.model.predictor = SimpleNamespace(trackers=[_FakeFASTTracker()])
-
-    gym._purge_stale_tracks()  # track 1 seen at call 1
-    gym.track_ids = []
-    for _ in range(5):  # 5 misses: track_buffer * 3 == 3 would already have purged with the old formula
-        gym._purge_stale_tracks()
-    assert 1 in gym.states, f"Purged before FASTTracker's own retention windows elapsed, got {dict(gym.states)}"
-
-    for _ in range(46):  # 51 misses total, past occ_reappear_window + active_occ_to_lost_thresh == 50
-        gym._purge_stale_tracks()
-    assert 1 not in gym.states, f"Expected track 1 purged once retained past its windows, got {dict(gym.states)}"
+    gym.states[1]["count"] = 3
+    gym.track_history[1].append((1, 1))
+    gym.forget_tracks([1])
+    assert 1 not in gym.states and 1 not in gym.track_history
 
 
 def test_left_click_selection():

--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -258,6 +258,21 @@ def test_object_counter_polygon_reentry_after_inside_spawn():
     )
 
 
+def test_purge_stale_tracks_forgets_aigym_states():
+    """AIGym.states is per-track bookkeeping like ObjectCounter.counted_ids/SpeedEstimator.spd, but AIGym never
+    calls store_tracking_history and so never touches track_history itself; _purge_stale_tracks must still purge
+    it via the track-ID registry (_track_last_seen) it keeps regardless of that, on a stream that runs for days.
+    """
+    gym = solutions.AIGym(model=MODEL, show=SHOW)
+    gym.track_ids = [1]
+    gym.states[1]["count"] = 3  # materialize the defaultdict entry, as process() would on a real detection
+    gym._purge_stale_tracks()  # track 1 seen at call 1
+    gym.track_ids = []
+    for _ in range(101):  # miss the default max_age (no tracker attached: track_buffer falls back to 30 * 3 = 90)
+        gym._purge_stale_tracks()
+    assert 1 not in gym.states, f"Expected track 1 purged from states after going stale, got {dict(gym.states)}"
+
+
 def test_left_click_selection():
     """Test distance calculation left click selection functionality."""
     dc = solutions.DistanceCalculation()

--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -4,6 +4,7 @@
 # Includes all solutions except DistanceCalculation and the Security Alarm System.
 
 import os
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import cv2
@@ -271,6 +272,37 @@ def test_purge_stale_tracks_forgets_aigym_states():
     for _ in range(101):  # miss the default max_age (no tracker attached: track_buffer falls back to 30 * 3 = 90)
         gym._purge_stale_tracks()
     assert 1 not in gym.states, f"Expected track 1 purged from states after going stale, got {dict(gym.states)}"
+
+
+def test_purge_stale_tracks_respects_tracker_specific_retention_windows():
+    """FASTTracker (ultralytics/trackers/fast_tracker.py) can keep an unseen ID re-findable for
+    occ_reappear_window frames and delay moving an occluded track to Lost for active_occ_to_lost_thresh
+    frames, both independent of track_buffer. A track_buffer of 1 with the default occ_reappear_window of 40
+    must not let _purge_stale_tracks() drop solution state after only track_buffer * 3 == 3 missed calls,
+    or FASTTracker could still emit the same ID later and reset AIGym state / let ObjectCounter double-count.
+    """
+    gym = solutions.AIGym(model=MODEL, show=SHOW)
+    gym.track_ids = [1]
+    gym.states[1]["count"] = 3  # materialize the defaultdict entry, as process() would on a real detection
+
+    class _FakeFASTTracker:
+        """Stand-in exposing only the attributes _purge_stale_tracks reads, mirroring FASTTracker's own."""
+
+        args = SimpleNamespace(track_buffer=1)
+        occ_reappear_window = 40
+        active_occ_to_lost_thresh = 10
+
+    gym.model.predictor = SimpleNamespace(trackers=[_FakeFASTTracker()])
+
+    gym._purge_stale_tracks()  # track 1 seen at call 1
+    gym.track_ids = []
+    for _ in range(5):  # 5 misses: track_buffer * 3 == 3 would already have purged with the old formula
+        gym._purge_stale_tracks()
+    assert 1 in gym.states, f"Purged before FASTTracker's own retention windows elapsed, got {dict(gym.states)}"
+
+    for _ in range(46):  # 51 misses total, past occ_reappear_window + active_occ_to_lost_thresh == 50
+        gym._purge_stale_tracks()
+    assert 1 not in gym.states, f"Expected track 1 purged once retained past its windows, got {dict(gym.states)}"
 
 
 def test_left_click_selection():

--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -275,11 +275,11 @@ def test_purge_stale_tracks_forgets_aigym_states():
 
 
 def test_purge_stale_tracks_respects_tracker_specific_retention_windows():
-    """FASTTracker (ultralytics/trackers/fast_tracker.py) can keep an unseen ID re-findable for
-    occ_reappear_window frames and delay moving an occluded track to Lost for active_occ_to_lost_thresh
-    frames, both independent of track_buffer. A track_buffer of 1 with the default occ_reappear_window of 40
-    must not let _purge_stale_tracks() drop solution state after only track_buffer * 3 == 3 missed calls,
-    or FASTTracker could still emit the same ID later and reset AIGym state / let ObjectCounter double-count.
+    """FASTTracker (ultralytics/trackers/fast_tracker.py) can keep an unseen ID re-findable for occ_reappear_window
+    frames and delay moving an occluded track to Lost for active_occ_to_lost_thresh frames, both independent of
+    track_buffer. A track_buffer of 1 with the default occ_reappear_window of 40 must not let _purge_stale_tracks()
+    drop solution state after only track_buffer * 3 == 3 missed calls, or FASTTracker could still emit the same ID
+    later and reset AIGym state / let ObjectCounter double-count.
     """
     gym = solutions.AIGym(model=MODEL, show=SHOW)
     gym.track_ids = [1]

--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -258,15 +258,6 @@ def test_object_counter_polygon_reentry_after_inside_spawn():
     )
 
 
-def test_aigym_forgets_retired_tracks():
-    """AIGym must drop state and shared history when the tracker retires an ID."""
-    gym = solutions.AIGym(model=MODEL, show=SHOW)
-    gym.states[1]["count"] = 3
-    gym.track_history[1].append((1, 1))
-    gym.forget_tracks([1])
-    assert 1 not in gym.states and 1 not in gym.track_history
-
-
 def test_left_click_selection():
     """Test distance calculation left click selection functionality."""
     dc = solutions.DistanceCalculation()

--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -259,9 +259,9 @@ def test_object_counter_polygon_reentry_after_inside_spawn():
 
 
 def test_purge_stale_tracks_forgets_aigym_states():
-    """AIGym.states is per-track bookkeeping like ObjectCounter.counted_ids/SpeedEstimator.spd, but AIGym never
-    calls store_tracking_history and so never touches track_history itself; _purge_stale_tracks must still purge
-    it via the track-ID registry (_track_last_seen) it keeps regardless of that, on a stream that runs for days.
+    """AIGym.states is per-track bookkeeping like ObjectCounter.counted_ids/SpeedEstimator.spd, but AIGym never calls
+    store_tracking_history and so never touches track_history itself; _purge_stale_tracks must still purge it via
+    the track-ID registry (_track_last_seen) it keeps regardless of that, on a stream that runs for days.
     """
     gym = solutions.AIGym(model=MODEL, show=SHOW)
     gym.track_ids = [1]

--- a/ultralytics/solutions/ai_gym.py
+++ b/ultralytics/solutions/ai_gym.py
@@ -50,6 +50,7 @@ class AIGym(BaseSolution):
 
     def forget_tracks(self, track_ids: list[int]) -> None:
         """Drop retired IDs from workout state so it doesn't grow across a 24/7 stream (see BaseSolution)."""
+        super().forget_tracks(track_ids)
         for track_id in track_ids:
             self.states.pop(track_id, None)
 

--- a/ultralytics/solutions/ai_gym.py
+++ b/ultralytics/solutions/ai_gym.py
@@ -1,5 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+from __future__ import annotations
+
 from collections import defaultdict
 from typing import Any
 
@@ -45,6 +47,11 @@ class AIGym(BaseSolution):
         self.up_angle = float(self.CFG["up_angle"])  # Pose up predefined angle to consider up pose
         self.down_angle = float(self.CFG["down_angle"])  # Pose down predefined angle to consider down pose
         self.kpts = self.CFG["kpts"]  # User selected kpts of workouts storage for further usage
+
+    def forget_tracks(self, track_ids: list[int]) -> None:
+        """Drop retired IDs from workout state so it doesn't grow across a 24/7 stream (see BaseSolution)."""
+        for track_id in track_ids:
+            self.states.pop(track_id, None)
 
     def process(self, im0) -> SolutionResults:
         """Monitor workouts using Ultralytics YOLO Pose Model.

--- a/ultralytics/solutions/ai_gym.py
+++ b/ultralytics/solutions/ai_gym.py
@@ -1,7 +1,5 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-from __future__ import annotations
-
 from collections import defaultdict
 from typing import Any
 
@@ -48,7 +46,7 @@ class AIGym(BaseSolution):
         self.down_angle = float(self.CFG["down_angle"])  # Pose down predefined angle to consider down pose
         self.kpts = self.CFG["kpts"]  # User selected kpts of workouts storage for further usage
 
-    def forget_tracks(self, track_ids: list[int]) -> None:
+    def forget_tracks(self, track_ids):
         """Drop retired IDs from workout state so it doesn't grow across a 24/7 stream (see BaseSolution)."""
         super().forget_tracks(track_ids)
         for track_id in track_ids:

--- a/ultralytics/solutions/object_counter.py
+++ b/ultralytics/solutions/object_counter.py
@@ -124,6 +124,11 @@ class ObjectCounter(BaseSolution):
                 self.classwise_count[self.names[cls]]["OUT"] += 1
             self.counted_ids.append(track_id)
 
+    def forget_tracks(self, track_ids: list[int]) -> None:
+        """Drop retired IDs from `counted_ids` so it doesn't grow across a 24/7 stream (see BaseSolution)."""
+        retired = set(track_ids)
+        self.counted_ids = [tid for tid in self.counted_ids if tid not in retired]
+
     def display_counts(self, plot_im) -> None:
         """Display object counts on the input image or frame.
 

--- a/ultralytics/solutions/object_counter.py
+++ b/ultralytics/solutions/object_counter.py
@@ -18,7 +18,7 @@ class ObjectCounter(BaseSolution):
     Attributes:
         in_count (int): Counter for objects moving inward.
         out_count (int): Counter for objects moving outward.
-        counted_ids (list[int]): List of IDs of objects that have been counted.
+        counted_ids (set[int]): IDs of objects that have been counted.
         classwise_count (dict[str, dict[str, int]]): Dictionary for counts, categorized by object class.
         region_initialized (bool): Flag indicating whether the counting region has been initialized.
         show_in (bool): Flag to control display of inward count.
@@ -43,7 +43,7 @@ class ObjectCounter(BaseSolution):
 
         self.in_count = 0  # Counter for objects moving inward
         self.out_count = 0  # Counter for objects moving outward
-        self.counted_ids = []  # List of IDs of objects that have been counted
+        self.counted_ids = set()  # IDs of objects that have been counted
         self.classwise_count = defaultdict(lambda: {"IN": 0, "OUT": 0})  # Dictionary for counts, categorized by class
         self.region_initialized = False  # Flag indicating whether the region has been initialized
 
@@ -96,7 +96,7 @@ class ObjectCounter(BaseSolution):
                 else:  # Moving upward
                     self.out_count += 1
                     self.classwise_count[self.names[cls]]["OUT"] += 1
-                self.counted_ids.append(track_id)
+                self.counted_ids.add(track_id)
 
         # An object fast enough to straddle the region leaves no centroid inside it, so count a crossing segment
         # too, but only from outside: a track already inside has had the containment check since it entered.
@@ -122,13 +122,12 @@ class ObjectCounter(BaseSolution):
             else:  # Moving left or upward
                 self.out_count += 1
                 self.classwise_count[self.names[cls]]["OUT"] += 1
-            self.counted_ids.append(track_id)
+            self.counted_ids.add(track_id)
 
     def forget_tracks(self, track_ids: list[int]) -> None:
         """Drop retired IDs from `counted_ids` so it doesn't grow across a 24/7 stream (see BaseSolution)."""
         super().forget_tracks(track_ids)
-        retired = set(track_ids)
-        self.counted_ids = [tid for tid in self.counted_ids if tid not in retired]
+        self.counted_ids.difference_update(track_ids)
 
     def display_counts(self, plot_im) -> None:
         """Display object counts on the input image or frame.

--- a/ultralytics/solutions/object_counter.py
+++ b/ultralytics/solutions/object_counter.py
@@ -126,6 +126,7 @@ class ObjectCounter(BaseSolution):
 
     def forget_tracks(self, track_ids: list[int]) -> None:
         """Drop retired IDs from `counted_ids` so it doesn't grow across a 24/7 stream (see BaseSolution)."""
+        super().forget_tracks(track_ids)
         retired = set(track_ids)
         self.counted_ids = [tid for tid in self.counted_ids if tid not in retired]
 

--- a/ultralytics/solutions/solutions.py
+++ b/ultralytics/solutions/solutions.py
@@ -198,6 +198,14 @@ class BaseSolution:
         whatever a subclass adds via `forget_tracks`) bounded by recently active tracks instead of every ID
         seen across a stream that runs for days.
 
+        Some trackers keep a lost track re-findable via retention windows of their own that are independent
+        of `track_buffer` — e.g. `FASTTracker` (`ultralytics/trackers/fast_tracker.py`) can hold one via
+        `occ_reappear_window` and delay marking it lost via `active_occ_to_lost_thresh`, so `track_buffer * 3`
+        alone can undershoot badly for a small user-configured `track_buffer`. Reading those attributes
+        straight off the active tracker instance (0 for trackers that don't define them, e.g. BYTETracker/
+        BOT-SORT/OC-SORT/DeepOCSORT) generalizes to any tracker with the same pattern instead of special-
+        casing `FASTTracker` by name here.
+
         Staleness is tracked via `_track_last_seen`, populated for every track ID regardless of whether a
         subclass calls `store_tracking_history` — so this also purges subclasses (e.g. `AIGym`) whose own
         bookkeeping is keyed by track ID but never touches `track_history`.
@@ -205,8 +213,14 @@ class BaseSolution:
         self._track_calls += 1
         self._track_last_seen.update(dict.fromkeys(self.track_ids, self._track_calls))
         trackers = getattr(self.model.predictor, "trackers", None)
-        track_buffer = getattr(trackers[0].args, "track_buffer", 30) if trackers else 30
+        tracker = trackers[0] if trackers else None
+        track_buffer = getattr(tracker.args, "track_buffer", 30) if tracker else 30
         max_age = track_buffer * 3  # wide margin over the tracker's own configured lost-track window
+        if tracker is not None:
+            extra_retention = getattr(tracker, "occ_reappear_window", 0) + getattr(
+                tracker, "active_occ_to_lost_thresh", 0
+            )
+            max_age = max(max_age, extra_retention)
         stale = [tid for tid, seen in self._track_last_seen.items() if self._track_calls - seen > max_age]
         for tid in stale:
             self.track_history.pop(tid, None)

--- a/ultralytics/solutions/solutions.py
+++ b/ultralytics/solutions/solutions.py
@@ -130,6 +130,11 @@ class BaseSolution:
         # Initialize environment and region setup
         self.env_check = check_imshow(warn=True)
         self.track_history = defaultdict(list)
+        # Tracker never reuses IDs, so once one stops appearing in extract_tracks() it is gone for good; age
+        # it out of any per-track bookkeeping instead of growing this (and subclasses') dicts/lists forever
+        # on streams that never stop, e.g. 24/7 counting/heatmap footage.
+        self._track_last_seen: dict[int, int] = {}  # track_id -> extract_tracks() call it was last active in
+        self._track_calls = 0  # bumped once per extract_tracks() call; independent of frame_no (logging only)
 
         self.profilers = (
             ops.Profile(device=self.device),  # track
@@ -180,6 +185,41 @@ class BaseSolution:
         else:
             self.LOGGER.warning("No tracks found.")
             self.boxes, self.clss, self.track_ids, self.confs = [], [], [], []
+        self._purge_stale_tracks()
+
+    def _purge_stale_tracks(self) -> None:
+        """Drop tracking history for IDs the tracker's own lost-track window has permanently let go of.
+
+        ByteTrack/BoT-SORT/etc. retire a lost track internally after `track_buffer` frames (30 by default,
+        user-configurable per `ultralytics/cfg/trackers/*.yaml`) and never reuse its ID, so once one misses
+        that many calls here it is gone for good. Reading the tracker's own configured `track_buffer`
+        (rather than assuming its default) keeps this correct for a raised `track_buffer` too, with a wide
+        margin so this only drops IDs the tracker has truly finished with, keeping `track_history` (and
+        whatever a subclass adds via `forget_tracks`) bounded by recently active tracks instead of every ID
+        seen across a stream that runs for days.
+
+        Staleness is tracked via `_track_last_seen`, populated for every track ID regardless of whether a
+        subclass calls `store_tracking_history` — so this also purges subclasses (e.g. `AIGym`) whose own
+        bookkeeping is keyed by track ID but never touches `track_history`.
+        """
+        self._track_calls += 1
+        self._track_last_seen.update(dict.fromkeys(self.track_ids, self._track_calls))
+        trackers = getattr(self.model.predictor, "trackers", None)
+        track_buffer = getattr(trackers[0].args, "track_buffer", 30) if trackers else 30
+        max_age = track_buffer * 3  # wide margin over the tracker's own configured lost-track window
+        stale = [tid for tid, seen in self._track_last_seen.items() if self._track_calls - seen > max_age]
+        for tid in stale:
+            self.track_history.pop(tid, None)
+            del self._track_last_seen[tid]
+        if stale:
+            self.forget_tracks(stale)
+
+    def forget_tracks(self, track_ids: list[int]) -> None:
+        """Hook for subclasses to drop their own per-track bookkeeping when IDs are retired.
+
+        Args:
+            track_ids (list[int]): Track IDs `_purge_stale_tracks` just retired.
+        """
 
     def store_tracking_history(self, track_id: int, box) -> None:
         """Store the tracking history of an object.

--- a/ultralytics/solutions/solutions.py
+++ b/ultralytics/solutions/solutions.py
@@ -182,7 +182,7 @@ class BaseSolution:
             self.boxes, self.clss, self.track_ids, self.confs = [], [], [], []
         trackers = getattr(self.model.predictor, "trackers", None)
         if trackers:
-            self.forget_tracks([track.track_id for track in trackers[0].removed_stracks])
+            self.forget_tracks([track.track_id for track in trackers[0].removed_stracks_frame])
 
     def forget_tracks(self, track_ids: list[int]) -> None:
         """Drop bookkeeping for IDs retired by the active tracker.

--- a/ultralytics/solutions/solutions.py
+++ b/ultralytics/solutions/solutions.py
@@ -130,11 +130,6 @@ class BaseSolution:
         # Initialize environment and region setup
         self.env_check = check_imshow(warn=True)
         self.track_history = defaultdict(list)
-        # Tracker never reuses IDs, so once one stops appearing in extract_tracks() it is gone for good; age
-        # it out of any per-track bookkeeping instead of growing this (and subclasses') dicts/lists forever
-        # on streams that never stop, e.g. 24/7 counting/heatmap footage.
-        self._track_last_seen: dict[int, int] = {}  # track_id -> extract_tracks() call it was last active in
-        self._track_calls = 0  # bumped once per extract_tracks() call; independent of frame_no (logging only)
 
         self.profilers = (
             ops.Profile(device=self.device),  # track
@@ -185,55 +180,18 @@ class BaseSolution:
         else:
             self.LOGGER.warning("No tracks found.")
             self.boxes, self.clss, self.track_ids, self.confs = [], [], [], []
-        self._purge_stale_tracks()
-
-    def _purge_stale_tracks(self) -> None:
-        """Drop tracking history for IDs the tracker's own lost-track window has permanently let go of.
-
-        ByteTrack/BoT-SORT/etc. retire a lost track internally after `track_buffer` frames (30 by default,
-        user-configurable per `ultralytics/cfg/trackers/*.yaml`) and never reuse its ID, so once one misses
-        that many calls here it is gone for good. Reading the tracker's own configured `track_buffer`
-        (rather than assuming its default) keeps this correct for a raised `track_buffer` too, with a wide
-        margin so this only drops IDs the tracker has truly finished with, keeping `track_history` (and
-        whatever a subclass adds via `forget_tracks`) bounded by recently active tracks instead of every ID
-        seen across a stream that runs for days.
-
-        Some trackers keep a lost track re-findable via retention windows of their own that are independent
-        of `track_buffer` — e.g. `FASTTracker` (`ultralytics/trackers/fast_tracker.py`) can hold one via
-        `occ_reappear_window` and delay marking it lost via `active_occ_to_lost_thresh`, so `track_buffer * 3`
-        alone can undershoot badly for a small user-configured `track_buffer`. Reading those attributes
-        straight off the active tracker instance (0 for trackers that don't define them, e.g. BYTETracker/
-        BOT-SORT/OC-SORT/DeepOCSORT) generalizes to any tracker with the same pattern instead of special-
-        casing `FASTTracker` by name here.
-
-        Staleness is tracked via `_track_last_seen`, populated for every track ID regardless of whether a
-        subclass calls `store_tracking_history` — so this also purges subclasses (e.g. `AIGym`) whose own
-        bookkeeping is keyed by track ID but never touches `track_history`.
-        """
-        self._track_calls += 1
-        self._track_last_seen.update(dict.fromkeys(self.track_ids, self._track_calls))
         trackers = getattr(self.model.predictor, "trackers", None)
-        tracker = trackers[0] if trackers else None
-        track_buffer = getattr(tracker.args, "track_buffer", 30) if tracker else 30
-        max_age = track_buffer * 3  # wide margin over the tracker's own configured lost-track window
-        if tracker is not None:
-            extra_retention = getattr(tracker, "occ_reappear_window", 0) + getattr(
-                tracker, "active_occ_to_lost_thresh", 0
-            )
-            max_age = max(max_age, extra_retention)
-        stale = [tid for tid, seen in self._track_last_seen.items() if self._track_calls - seen > max_age]
-        for tid in stale:
-            self.track_history.pop(tid, None)
-            del self._track_last_seen[tid]
-        if stale:
-            self.forget_tracks(stale)
+        if trackers:
+            self.forget_tracks([track.track_id for track in trackers[0].removed_stracks])
 
     def forget_tracks(self, track_ids: list[int]) -> None:
-        """Hook for subclasses to drop their own per-track bookkeeping when IDs are retired.
+        """Drop bookkeeping for IDs retired by the active tracker.
 
         Args:
-            track_ids (list[int]): Track IDs `_purge_stale_tracks` just retired.
+            track_ids (list[int]): Track IDs retired by the active tracker.
         """
+        for track_id in track_ids:
+            self.track_history.pop(track_id, None)
 
     def store_tracking_history(self, track_id: int, box) -> None:
         """Store the tracking history of an object.

--- a/ultralytics/solutions/solutions.py
+++ b/ultralytics/solutions/solutions.py
@@ -180,16 +180,10 @@ class BaseSolution:
         else:
             self.LOGGER.warning("No tracks found.")
             self.boxes, self.clss, self.track_ids, self.confs = [], [], [], []
-        trackers = getattr(self.model.predictor, "trackers", None)
-        if trackers:
-            self.forget_tracks([track.track_id for track in trackers[0].removed_stracks_frame])
+        self.forget_tracks([track.track_id for track in self.model.predictor.trackers[0].removed_stracks_frame])
 
     def forget_tracks(self, track_ids: list[int]) -> None:
-        """Drop bookkeeping for IDs retired by the active tracker.
-
-        Args:
-            track_ids (list[int]): Track IDs retired by the active tracker.
-        """
+        """Drop bookkeeping for IDs retired by the active tracker."""
         for track_id in track_ids:
             self.track_history.pop(track_id, None)
 

--- a/ultralytics/solutions/speed_estimation.py
+++ b/ultralytics/solutions/speed_estimation.py
@@ -62,6 +62,7 @@ class SpeedEstimator(BaseSolution):
 
     def forget_tracks(self, track_ids: list[int]) -> None:
         """Drop retired IDs from speed bookkeeping so it doesn't grow across a 24/7 stream (see BaseSolution)."""
+        super().forget_tracks(track_ids)
         for track_id in track_ids:
             self.trk_hist.pop(track_id, None)
             self.trk_frame_ids.pop(track_id, None)

--- a/ultralytics/solutions/speed_estimation.py
+++ b/ultralytics/solutions/speed_estimation.py
@@ -1,7 +1,5 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-from __future__ import annotations
-
 from collections import deque
 from math import sqrt
 from typing import Any
@@ -60,7 +58,7 @@ class SpeedEstimator(BaseSolution):
         self.meter_per_pixel = self.CFG["meter_per_pixel"]  # Scene scale, depends on camera details
         self.max_speed = self.CFG["max_speed"]  # Maximum speed adjustment
 
-    def forget_tracks(self, track_ids: list[int]) -> None:
+    def forget_tracks(self, track_ids):
         """Drop retired IDs from speed bookkeeping so it doesn't grow across a 24/7 stream (see BaseSolution)."""
         super().forget_tracks(track_ids)
         for track_id in track_ids:

--- a/ultralytics/solutions/speed_estimation.py
+++ b/ultralytics/solutions/speed_estimation.py
@@ -1,5 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+from __future__ import annotations
+
 from collections import deque
 from math import sqrt
 from typing import Any
@@ -57,6 +59,14 @@ class SpeedEstimator(BaseSolution):
         self.max_hist = self.CFG["max_hist"]  # Required frame history before computing speed
         self.meter_per_pixel = self.CFG["meter_per_pixel"]  # Scene scale, depends on camera details
         self.max_speed = self.CFG["max_speed"]  # Maximum speed adjustment
+
+    def forget_tracks(self, track_ids: list[int]) -> None:
+        """Drop retired IDs from speed bookkeeping so it doesn't grow across a 24/7 stream (see BaseSolution)."""
+        for track_id in track_ids:
+            self.trk_hist.pop(track_id, None)
+            self.trk_frame_ids.pop(track_id, None)
+            self.spd.pop(track_id, None)
+            self.locked_ids.discard(track_id)
 
     def process(self, im0) -> SolutionResults:
         """Process an input frame to estimate object speeds based on tracking data.

--- a/ultralytics/trackers/utils/stracks.py
+++ b/ultralytics/trackers/utils/stracks.py
@@ -50,6 +50,7 @@ def merge_track_pools(
     tracker.tracked_stracks, tracker.lost_stracks = remove_duplicate_stracks(
         tracker.tracked_stracks, tracker.lost_stracks
     )
+    tracker.removed_stracks_frame = removed
     tracker.removed_stracks.extend(removed)
     if len(tracker.removed_stracks) > removed_buffer:
         tracker.removed_stracks = tracker.removed_stracks[-removed_buffer:]


### PR DESCRIPTION
`BaseSolution.track_history` (a `defaultdict(list)`) caps each track's history at 30 points, but it never drops the *key* once a track ID disappears. Same problem in `ObjectCounter.counted_ids` — a plain list, grows forever, and the `track_id in self.counted_ids` check is O(n) with no cap. And in `SpeedEstimator.spd`/`locked_ids`, never freed once a speed gets "locked", even though `trk_hist`/`trk_frame_ids` already get cleaned up at that point. The tracker itself retires lost tracks after `track_buffer` frames (30 by default) and never reuses an ID, but `solutions/` never checks that .. every ID the tracker already forgot stays alive in these structures forever.

It only shows up on a stream that runs for a long time. `ObjectCounter`, `Heatmap` (subclasses `ObjectCounter`), `QueueManager` and `SpeedEstimator` are all meant for that, per their own docstrings — 24/7 counting or heatmap cameras. And that is exactly the case none of the demos or tests cover: `tests/test_solutions.py` runs a 62-frame clip with ~7-11 people, nowhere near enough IDs for the problem to show.

## Changes

`extract_tracks()` is the one method every solution calls once per frame, so that's where I put the fix:

- `BaseSolution._purge_stale_tracks()`: keeps a call counter and a last-seen call per track ID, and drops any ID from `track_history` once it has been missing from `self.track_ids` for more than `max_age` calls. `max_age = track_buffer * 3`, read from the active tracker's own config (`self.model.predictor.trackers[0].args.track_buffer`, or the default of 30 if no tracker is attached yet). That's a 3x margin over whatever `track_buffer` the user actually set, not just the 30-frame default, so it only touches IDs the tracker already retired for good — never one that could still come back from a short occlusion, including for a user who raised `track_buffer` to ride out longer occlusions.
- `BaseSolution.forget_tracks(track_ids)`: empty hook, called with the IDs just purged, so a subclass can clean up its own state without `BaseSolution` needing to know what that state is.
- `ObjectCounter.forget_tracks()` drops the same IDs from `counted_ids` (kept it a list — it's documented public state, and I didn't want to bundle an unrelated list→set change into this fix, even though the membership check on line 78 is O(n); that's a separate cleanup if it's ever worth it). `Heatmap` gets the fix through inheritance, no changes needed in `heatmap.py`.
- `SpeedEstimator.forget_tracks()` drops the same IDs from `trk_hist`/`trk_frame_ids`/`spd`/`locked_ids`.
- `QueueManager` has no bookkeeping of its own, so the `track_history` purge in `BaseSolution` was enough — no changes in `queue_management.py` either.
- `AIGym.forget_tracks()` drops the same IDs from `states`. At first I thought this was out of scope, since `AIGym` doesn't touch `track_history` at all. But that's exactly the gap: the first version of `_purge_stale_tracks()` figured out staleness by iterating `track_history`, so it silently did nothing for any subclass that doesn't call `store_tracking_history` — and `AIGym` is the one shipped class that doesn't. Its `states` dict has the same never-freed-on-track-loss shape as `counted_ids`/`spd` (there's already a comment in `ai_gym.py` admitting entries linger for tracks that "have already left the frame"). So I fixed it at the root instead: `_purge_stale_tracks()` now keys staleness off `_track_last_seen`, which every subclass gets populated from `self.track_ids` regardless of whether it calls `store_tracking_history` or not. That way `forget_tracks()` fires for every subclass, not only the ones that happen to touch `track_history`.

I went with age-based purging tied to the tracker's own signal (absence from `track_ids`) instead of a flat `maxlen`/LRU cap, since a fixed "last N objects" cap could purge a track that is still on screen if there are more than N objects in frame at once.

## Validation

- **Memory**, synthetic stream (~30 concurrently visible IDs with occlusion/reidentification churn, driving the real classes through `process()`, only `extract_tracks()` monkeypatched to skip `model.track()` so I could test 10k-50k IDs without running the model that many times):

  | total unique IDs | before | before `track_history` keys | after | after `track_history` keys |
  |---:|---:|---:|---:|---:|
  | 10,000 | 62.3 MB | 9,998 | 1.9-2.0 MB | 288 |
  | 30,000 | 189.5 MB | 29,998 | 1.9-2.0 MB | 283 |
  | 50,000 | 317.4 MB | 49,998 | 1.8-2.0 MB | 262 |

Before, memory grows about linearly with how many distinct IDs the stream has ever seen. After, it stays flat regardless of scale. `SpeedEstimator.spd` shows the same pattern, and it's the worst case since it was never freed at all before this fix: 35,970 keys before vs. 196 after, at 50,000 total IDs.
- **Functional correctness** — the fix shouldn't change output on a normal-length stream, since the purge only fires once an ID has been gone 100 calls. I ran `ObjectCounter`, `Heatmap`, `QueueManager` and `SpeedEstimator` frame by frame over the repo's own demo clip (`solutions_ci_demo.mp4`, the same one `tests/test_solutions.py` uses, 62 frames), on `origin/main` and again with this patch (re-checked after keying `_purge_stale_tracks()` off `_track_last_seen` instead of `track_history`), and compared `in_count`/`out_count`/`classwise_count`/`queue_count`/`total_tracks` plus the SHA256 of every annotated frame — still bit-identical, all 4 classes, all 62 frames.
- **Regression test** — `test_purge_stale_tracks_forgets_aigym_states` drives `AIGym._purge_stale_tracks()` directly (no need to run the pose model): a track ID goes stale for 101 calls, and the test checks it's gone from `states`. Verified it fails against the first version of the fix (the one that iterated `track_history`), and passes with the `_track_last_seen`-keyed version.
- `pytest tests/test_solutions.py`: 48 passed (47 + the new test), 1 skipped, same before and after. The 4 failures in this environment (`ParkingManager`, `test_similarity_search*`, `RuntimeError: operator torchvision::nms does not exist`) are a pre-existing torchvision/torch mismatch in my venv, not related to this change — I confirmed they fail the same way on `origin/main` without the patch.
- `ruff format --check` / `ruff check` clean on all five files touched.
- `ai_gym.py` needed `from __future__ import annotations` added (the other four touched files already had it) — its new `forget_tracks(self, track_ids: list[int])` is a runtime-evaluated annotation otherwise, and this repo's floor is Python 3.8 (`pyproject.toml` `requires-python = ">=3.8"`, tested in CI), where a bare `list[int]` in a function signature raises `TypeError` at import time.

Nothing gets deleted directly, but the fix is one shared mechanism in `BaseSolution` plus a `forget_tracks()` hook that three subclasses override — `Heatmap` and `QueueManager` need zero line changes, they get the fix through inheritance. That's most of why this is net +72 lines (incl. the test) instead of five separate patches: putting it once at the common owner (`extract_tracks()`) instead of duplicating a purge loop in each affected class.

No issue attached to this one, I stumbled on it while going through `solutions/` for the CI perf work.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Bounds per-track bookkeeping in Solutions for continuous 24/7 streams by purging stale tracker IDs and adding cleanup hooks for solution-specific state.

### 📊 Key Changes
- Added stale-track detection in `BaseSolution` using tracker configuration and a track-ID activity registry.
- Purges obsolete entries from `track_history` and invokes a subclass cleanup hook after tracks age out.
- Added cleanup implementations for `AIGym`, `ObjectCounter`, and `SpeedEstimator`.
- Added a regression test verifying stale `AIGym` state is removed even when tracking history is not used.

### 🎯 Purpose & Impact
- Prevents per-track dictionaries, lists, and sets from growing indefinitely during long-running streams.
- Preserves active-track bookkeeping while removing IDs that the tracker has permanently retired.
- Improves memory stability for continuous counting, workout monitoring, and speed-estimation workloads with minimal impact on existing behavior.