### PR TITLE
Move documentation FAQs to page ends

### DIFF
--- a/docs/en/guides/dlstreamer-intel.md
+++ b/docs/en/guides/dlstreamer-intel.md
@@ -148,6 +148,16 @@ gst-launch-1.0 vacompositor name=comp sink_0::xpos=0 sink_0::ypos=0 sink_1::xpos
 
 <img src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/dlstreamer-intel-yolo26-detect-multistream-gpu.avif" alt="Intel DL Streamer Multistream GPU">
 
+## Additional Resources
+
+- [DL Streamer GitHub Repository](https://github.com/open-edge-platform/dlstreamer)
+- [DL Streamer Documentation](https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dlstreamer/)
+- [DL Streamer Elements](https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dlstreamer/elements/elements.html)
+- [OpenVINO™ Toolkit](https://docs.openvino.ai/)
+- [Ultralytics YOLO26](https://www.ultralytics.com/yolo/yolo26)
+- [GStreamer Framework](https://gstreamer.freedesktop.org/)
+- [Supported Models Table](https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dlstreamer/supported_models.html)
+
 ## FAQ
 
 ### How do I set up Ultralytics YOLO26 on an Intel platform with DL Streamer?
@@ -180,13 +190,3 @@ Use the `json` output option to write detection results as JSON-lines to a file:
 ```
 
 Alternatively, use the `gvametapublish` element in custom pipelines to publish metadata to files, MQTT, or Kafka.
-
-## Additional Resources
-
-- [DL Streamer GitHub Repository](https://github.com/open-edge-platform/dlstreamer)
-- [DL Streamer Documentation](https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dlstreamer/)
-- [DL Streamer Elements](https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dlstreamer/elements/elements.html)
-- [OpenVINO™ Toolkit](https://docs.openvino.ai/)
-- [Ultralytics YOLO26](https://www.ultralytics.com/yolo/yolo26)
-- [GStreamer Framework](https://gstreamer.freedesktop.org/)
-- [Supported Models Table](https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dlstreamer/supported_models.html)

--- a/docs/en/integrations/hailo.md
+++ b/docs/en/integrations/hailo.md
@@ -342,6 +342,18 @@ Confirm that `name` matched the physical Hailo architecture and that the device 
 
 Keep `metadata.yaml` beside the HEF so Ultralytics can select the matching YOLOv8, YOLO11, or YOLO26 post-processing path. Custom HailoRT applications must likewise match post-processing to the exported model family.
 
+## Summary
+
+Ultralytics Hailo export provides a direct path from a trained YOLO model to a deployable HEF:
+
+1. Load a YOLOv8, YOLO11, or YOLO26 detection or classification model, a YOLOv8/YOLO11 segmentation, pose, or OBB model, or a YOLO26 semantic segmentation or depth estimation model.
+2. Export with `format="hailo"` and select the target architecture.
+3. Calibrate and compile locally with the matching DFC, or use managed export in Ultralytics Platform.
+4. Copy the HEF and `metadata.yaml` to the Hailo-powered edge device.
+5. Run inference with HailoRT, Raspberry Pi Picamera2, or a GStreamer video pipeline.
+
+For other computer vision deployment targets, see [Export mode](../modes/export.md), [Benchmark mode](../modes/benchmark.md), and the [integrations guide](index.md). Related hardware guides include [ONNX](onnx.md), [OpenVINO](openvino.md), [TensorRT](tensorrt.md), [NCNN](ncnn.md), [RKNN](rockchip-rknn.md), [Sony IMX500](sony-imx500.md), and [Qualcomm QNN](qnn.md).
+
 ## FAQ
 
 ### Can I compile a HEF on a Raspberry Pi?
@@ -379,15 +391,3 @@ Deploy the compiled HEF to the Hailo runtime. ONNX is an intermediate representa
 ### Where can I get the Hailo DFC?
 
 Download the compiler wheel for your hardware generation from the Hailo Developer Zone. The compiler is required only to create the HEF; HailoRT runs it on the target accelerator.
-
-## Summary
-
-Ultralytics Hailo export provides a direct path from a trained YOLO model to a deployable HEF:
-
-1. Load a YOLOv8, YOLO11, or YOLO26 detection or classification model, a YOLOv8/YOLO11 segmentation, pose, or OBB model, or a YOLO26 semantic segmentation or depth estimation model.
-2. Export with `format="hailo"` and select the target architecture.
-3. Calibrate and compile locally with the matching DFC, or use managed export in Ultralytics Platform.
-4. Copy the HEF and `metadata.yaml` to the Hailo-powered edge device.
-5. Run inference with HailoRT, Raspberry Pi Picamera2, or a GStreamer video pipeline.
-
-For other computer vision deployment targets, see [Export mode](../modes/export.md), [Benchmark mode](../modes/benchmark.md), and the [integrations guide](index.md). Related hardware guides include [ONNX](onnx.md), [OpenVINO](openvino.md), [TensorRT](tensorrt.md), [NCNN](ncnn.md), [RKNN](rockchip-rknn.md), [Sony IMX500](sony-imx500.md), and [Qualcomm QNN](qnn.md).

--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -247,6 +247,76 @@ Get started with these resources:
 - [**Trash**](account/trash.md): Recover deleted items
 - [**REST API**](api/index.md): API reference
 
+## Troubleshooting
+
+### Dataset Issues
+
+| Problem                | Solution                                                                                                                                                                                                      |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Dataset won't process  | Check file format is supported (JPEG, PNG, WebP, TIFF, HEIC, AVIF, BMP, JP2, DNG, MPO for images). Max file size: images 50 MB, videos 1 GB, dataset archives 10 GB (Free) / 20 GB (Pro) / 50 GB (Enterprise) |
+| Missing annotations    | Verify labels are in [YOLO format](../datasets/detect/index.md#ultralytics-yolo-format) with `.txt` files matching image filenames, or upload COCO JSON                                                       |
+| "Train split required" | Add `train/` folder to your dataset structure, or redistribute splits via the [split bar](data/datasets.md#split-redistribution)                                                                              |
+| Class names undefined  | Add a `data.yaml` file with `names:` list (see [YOLO format](../datasets/detect/index.md#ultralytics-yolo-format)), or define classes in the [Classes tab](data/datasets.md#classes-tab)                      |
+
+### Training Issues
+
+| Problem              | Solution                                                                            |
+| -------------------- | ----------------------------------------------------------------------------------- |
+| Training won't start | Check credit balance in Settings > Billing. Positive balance required               |
+| Out of memory error  | Reduce batch size, use smaller model (n/s), or select GPU with more VRAM            |
+| Poor metrics         | Check dataset quality, increase epochs, try data augmentation, verify class balance |
+| Training slow        | Select faster GPU, reduce image size, check dataset isn't bottlenecked              |
+
+### Deployment Issues
+
+| Problem                 | Solution                                                                                                                    |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Endpoint not responding | Check endpoint status (Ready vs Stopped). Cold start may take 5-15 seconds                                                  |
+| 401 Unauthorized        | Verify the API key is active and copied correctly                                                                           |
+| Slow inference          | Check model size, consider [TensorRT export](train/models.md#supported-formats), select closer region                       |
+| Export failed           | Some formats require specific model architectures. Try [ONNX](train/models.md#supported-formats) for broadest compatibility |
+
+### Common Questions
+
+??? question "Can I change my username after signup?"
+
+    No, usernames are permanent and cannot be changed. Choose carefully during signup.
+
+??? question "Can I change my data region?"
+
+    Your data region is selected during onboarding and can't be changed yourself. To switch regions, contact support to request a region change.
+
+??? question "How do I get more credits?"
+
+    Go to **Settings > Billing** and click **Top Up**. Purchase credits from $5 to $1,000. Purchased credits never
+    expire.
+
+??? question "What happens if training fails?"
+
+    If cloud compute had started, elapsed GPU time is charged. Failures before a GPU starts have no compute usage
+    charge.
+
+??? question "Can I download my trained model?"
+
+    Yes. Click the download icon on a model page for its `.pt` weights, or open the **Export** tab for completed exported formats.
+
+??? question "How do I share my work publicly?"
+
+    Open the project or dataset, click its **Private** badge in the top navigation bar, and confirm **Make Public**.
+    Public content appears on the Explore page.
+
+??? question "What are the file size limits?"
+
+    Images: 50MB, Videos: 1GB, datasets: 10GB on Free, 20GB on Pro, 50GB on Enterprise. For larger files, split into multiple uploads.
+
+??? question "How long are deleted items kept in Trash?"
+
+    30 days. After that, items are permanently deleted and cannot be recovered.
+
+??? question "Can I use Platform models commercially?"
+
+    Free and Pro plans use the AGPL license. For commercial use without AGPL requirements, see [Ultralytics Licensing](https://www.ultralytics.com/license).
+
 ## FAQ
 
 ### How do I get started with Ultralytics Platform?
@@ -361,73 +431,3 @@ The Platform supports the same 20 deployment formats as Ultralytics Export mode.
 {% include "macros/export-table.md" %}
 
 See [Models Export](train/models.md#export-model), the [Export mode guide](../modes/export.md), and the [Integrations index](../integrations/index.md) for format-specific options.
-
-## Troubleshooting
-
-### Dataset Issues
-
-| Problem                | Solution                                                                                                                                                                                                      |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Dataset won't process  | Check file format is supported (JPEG, PNG, WebP, TIFF, HEIC, AVIF, BMP, JP2, DNG, MPO for images). Max file size: images 50 MB, videos 1 GB, dataset archives 10 GB (Free) / 20 GB (Pro) / 50 GB (Enterprise) |
-| Missing annotations    | Verify labels are in [YOLO format](../datasets/detect/index.md#ultralytics-yolo-format) with `.txt` files matching image filenames, or upload COCO JSON                                                       |
-| "Train split required" | Add `train/` folder to your dataset structure, or redistribute splits via the [split bar](data/datasets.md#split-redistribution)                                                                              |
-| Class names undefined  | Add a `data.yaml` file with `names:` list (see [YOLO format](../datasets/detect/index.md#ultralytics-yolo-format)), or define classes in the [Classes tab](data/datasets.md#classes-tab)                      |
-
-### Training Issues
-
-| Problem              | Solution                                                                            |
-| -------------------- | ----------------------------------------------------------------------------------- |
-| Training won't start | Check credit balance in Settings > Billing. Positive balance required               |
-| Out of memory error  | Reduce batch size, use smaller model (n/s), or select GPU with more VRAM            |
-| Poor metrics         | Check dataset quality, increase epochs, try data augmentation, verify class balance |
-| Training slow        | Select faster GPU, reduce image size, check dataset isn't bottlenecked              |
-
-### Deployment Issues
-
-| Problem                 | Solution                                                                                                                    |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| Endpoint not responding | Check endpoint status (Ready vs Stopped). Cold start may take 5-15 seconds                                                  |
-| 401 Unauthorized        | Verify the API key is active and copied correctly                                                                           |
-| Slow inference          | Check model size, consider [TensorRT export](train/models.md#supported-formats), select closer region                       |
-| Export failed           | Some formats require specific model architectures. Try [ONNX](train/models.md#supported-formats) for broadest compatibility |
-
-### Common Questions
-
-??? question "Can I change my username after signup?"
-
-    No, usernames are permanent and cannot be changed. Choose carefully during signup.
-
-??? question "Can I change my data region?"
-
-    Your data region is selected during onboarding and can't be changed yourself. To switch regions, contact support to request a region change.
-
-??? question "How do I get more credits?"
-
-    Go to **Settings > Billing** and click **Top Up**. Purchase credits from $5 to $1,000. Purchased credits never
-    expire.
-
-??? question "What happens if training fails?"
-
-    If cloud compute had started, elapsed GPU time is charged. Failures before a GPU starts have no compute usage
-    charge.
-
-??? question "Can I download my trained model?"
-
-    Yes. Click the download icon on a model page for its `.pt` weights, or open the **Export** tab for completed exported formats.
-
-??? question "How do I share my work publicly?"
-
-    Open the project or dataset, click its **Private** badge in the top navigation bar, and confirm **Make Public**.
-    Public content appears on the Explore page.
-
-??? question "What are the file size limits?"
-
-    Images: 50MB, Videos: 1GB, datasets: 10GB on Free, 20GB on Pro, 50GB on Enterprise. For larger files, split into multiple uploads.
-
-??? question "How long are deleted items kept in Trash?"
-
-    30 days. After that, items are permanently deleted and cannot be recovered.
-
-??? question "Can I use Platform models commercially?"
-
-    Free and Pro plans use the AGPL license. For commercial use without AGPL requirements, see [Ultralytics Licensing](https://www.ultralytics.com/license).

--- a/docs/en/platform/train/cloud-training.md
+++ b/docs/en/platform/train/cloud-training.md
@@ -399,74 +399,6 @@ Before starting a cloud job, the training dialog shows your current credit balan
 | Training slow        | Consider faster GPU                  |
 | Task mismatch error  | Ensure model and dataset tasks match |
 
-## FAQ
-
-### How long does training take?
-
-Training time depends on:
-
-- Dataset size
-- Model size
-- Number of epochs
-- GPU selected
-
-Typical times (1000 images, 100 epochs):
-
-| Model   | RTX PRO 6000 | A100 SXM |
-| ------- | ------------ | -------- |
-| YOLO26n | ~6 min       | ~5 min   |
-| YOLO26m | ~15 min      | ~12 min  |
-| YOLO26x | ~30 min      | ~25 min  |
-
-!!! note "Approximate Times"
-
-    Training times are approximate and vary with dataset complexity, augmentation settings, and batch size. Use the training dialog's cost estimate for more accurate predictions.
-
-### Can I train overnight?
-
-Yes. Training can run unattended while it remains funded, and the Platform records a completion or failure event. If
-metering drives the balance below zero, active paid cloud runs stop and settle the GPU time already used.
-
-### What happens if I run out of credits?
-
-Cloud usage is metered as training progresses. If a charge pushes your balance below zero, active paid cloud training
-runs are stopped and settled for the GPU time already used. Add credits or enable auto top-up to keep long-running jobs
-funded.
-
-!!! note "Negative Balance"
-
-    A zero or negative balance prevents new paid cloud training jobs. A negative metered balance also triggers shutdown
-    of active paid cloud training runs.
-
-### What happens if my training costs more than the estimate?
-
-Cost estimates are approximate — actual training time may vary due to factors like data loading speed, GPU warmup, and
-model convergence behavior. If actual usage exhausts the available balance, the Platform stops active paid cloud runs
-after the balance goes negative.
-
-To manage costs:
-
-- Monitor training progress in real-time and cancel early if needed
-- Enable [auto top-up](../account/billing.md#auto-top-up) to automatically replenish credits
-- Start with shorter runs (fewer epochs) to calibrate expectations
-
-### Can I use custom training arguments?
-
-Yes, expand the **Advanced Settings** section in the training dialog to access a YAML editor with 40+ configurable parameters. Non-default values are included in both cloud and local training commands.
-
-The YAML editor also supports **importing configurations from previous training runs**:
-
-- **Copy from existing model**: On any completed model's page, the Training Configuration card has a **Copy as JSON** button. Copy the JSON and paste it directly into the YAML editor — it auto-detects JSON format and imports all parameters.
-- **Paste YAML or JSON**: Paste any valid YAML or JSON training configuration into the editor. Parameters are validated automatically, with out-of-range values clamped and warnings displayed.
-- **Drag and drop files**: Drag a `.yaml` or `.json` file directly into the editor to import its parameters.
-
-![Ultralytics Platform Training Dialog Copy Training Config JSON](https://cdn.ul.run/i/d03490834657b55f99a40363f102f47d.avif)<!-- screenshot -->
-This makes it easy to reproduce or iterate on previous training configurations without manually re-entering each parameter.
-
-### Can I train from a dataset page?
-
-Yes, the **New Model** button on dataset pages opens the training dialog with the dataset preselected and locked. You then select a project and model to begin training.
-
 ## Training Parameters Reference
 
 === "Core"
@@ -560,3 +492,71 @@ Yes, the **New Model** button on dataset pages opens the training dialog with th
     - **Detection tasks only** (detect, segment, pose, OBB — not classify): `box`, `dfl`, `degrees`, `translate`, `shear`, `perspective`, `mosaic`, `mixup`, `close_mosaic`
     - **Segment only**: `copy_paste`
     - **Pose only**: `pose` (loss weight), `kobj` (keypoint objectness)
+
+## FAQ
+
+### How long does training take?
+
+Training time depends on:
+
+- Dataset size
+- Model size
+- Number of epochs
+- GPU selected
+
+Typical times (1000 images, 100 epochs):
+
+| Model   | RTX PRO 6000 | A100 SXM |
+| ------- | ------------ | -------- |
+| YOLO26n | ~6 min       | ~5 min   |
+| YOLO26m | ~15 min      | ~12 min  |
+| YOLO26x | ~30 min      | ~25 min  |
+
+!!! note "Approximate Times"
+
+    Training times are approximate and vary with dataset complexity, augmentation settings, and batch size. Use the training dialog's cost estimate for more accurate predictions.
+
+### Can I train overnight?
+
+Yes. Training can run unattended while it remains funded, and the Platform records a completion or failure event. If
+metering drives the balance below zero, active paid cloud runs stop and settle the GPU time already used.
+
+### What happens if I run out of credits?
+
+Cloud usage is metered as training progresses. If a charge pushes your balance below zero, active paid cloud training
+runs are stopped and settled for the GPU time already used. Add credits or enable auto top-up to keep long-running jobs
+funded.
+
+!!! note "Negative Balance"
+
+    A zero or negative balance prevents new paid cloud training jobs. A negative metered balance also triggers shutdown
+    of active paid cloud training runs.
+
+### What happens if my training costs more than the estimate?
+
+Cost estimates are approximate — actual training time may vary due to factors like data loading speed, GPU warmup, and
+model convergence behavior. If actual usage exhausts the available balance, the Platform stops active paid cloud runs
+after the balance goes negative.
+
+To manage costs:
+
+- Monitor training progress in real-time and cancel early if needed
+- Enable [auto top-up](../account/billing.md#auto-top-up) to automatically replenish credits
+- Start with shorter runs (fewer epochs) to calibrate expectations
+
+### Can I use custom training arguments?
+
+Yes, expand the **Advanced Settings** section in the training dialog to access a YAML editor with 40+ configurable parameters. Non-default values are included in both cloud and local training commands.
+
+The YAML editor also supports **importing configurations from previous training runs**:
+
+- **Copy from existing model**: On any completed model's page, the Training Configuration card has a **Copy as JSON** button. Copy the JSON and paste it directly into the YAML editor — it auto-detects JSON format and imports all parameters.
+- **Paste YAML or JSON**: Paste any valid YAML or JSON training configuration into the editor. Parameters are validated automatically, with out-of-range values clamped and warnings displayed.
+- **Drag and drop files**: Drag a `.yaml` or `.json` file directly into the editor to import its parameters.
+
+![Ultralytics Platform Training Dialog Copy Training Config JSON](https://cdn.ul.run/i/d03490834657b55f99a40363f102f47d.avif)<!-- screenshot -->
+This makes it easy to reproduce or iterate on previous training configurations without manually re-entering each parameter.
+
+### Can I train from a dataset page?
+
+Yes, the **New Model** button on dataset pages opens the training dialog with the dataset preselected and locked. You then select a project and model to begin training.

--- a/docs/en/yolov5/tutorials/multi-gpu-training.md
+++ b/docs/en/yolov5/tutorials/multi-gpu-training.md
@@ -157,24 +157,6 @@ python -m torch.distributed.run --nproc_per_node 8 train.py --batch-size 128 --d
 
 As shown in the results, using [DistributedDataParallel](https://docs.pytorch.org/docs/stable/nn.html#torch.nn.parallel.DistributedDataParallel) with multiple GPUs provides nearly linear scaling in training speed. With 8 GPUs, training completes approximately 6.5 times faster than with a single GPU, while maintaining the same memory usage per device.
 
-## FAQ
-
-Read the checklist below before opening an issue — it often saves time.
-
-<details>
-  <summary>Checklist (click to expand)</summary>
-
-- Have you read this guide end-to-end?
-- Have you re-cloned the codebase? The code changes **daily**.
-- Have you searched for the error message? Someone may have already hit the same issue and shared a fix.
-- Have you installed all the requirements (including the correct Python and PyTorch versions)?
-- Have you tried one of the supported environments listed below?
-- Have you tried a smaller dataset such as `coco128` or `coco2017` to isolate the root cause?
-
-If all of the above check out, open an Issue with as much detail as possible, following the template.
-
-</details>
-
 ## Supported Environments
 
 Ultralytics provides a range of ready-to-use environments, each pre-installed with essential dependencies such as [CUDA](https://developer.nvidia.com/cuda), [CUDNN](https://developer.nvidia.com/cudnn), [Python](https://www.python.org/), and [PyTorch](https://pytorch.org/), to kickstart your projects.
@@ -200,3 +182,21 @@ We would like to thank @MagicFrogSJTU, who did all the heavy lifting, and @glenn
 - [Train Mode](../../modes/train.md) - Learn about training YOLO models with Ultralytics
 - [Hyperparameter Tuning](../../guides/hyperparameter-tuning.md) - Optimize your model's performance
 - [Docker Quickstart Guide](../../guides/docker-quickstart.md) - Set up your Docker environment for training
+
+## FAQ
+
+Read the checklist below before opening an issue — it often saves time.
+
+<details>
+  <summary>Checklist (click to expand)</summary>
+
+- Have you read this guide end-to-end?
+- Have you re-cloned the codebase? The code changes **daily**.
+- Have you searched for the error message? Someone may have already hit the same issue and shared a fix.
+- Have you installed all the requirements (including the correct Python and PyTorch versions)?
+- Have you tried one of the supported environments listed below?
+- Have you tried a smaller dataset such as `coco128` or `coco2017` to isolate the root cause?
+
+If all of the above check out, open an Issue with as much detail as possible, following the template.
+
+</details>

--- a/docs/en/yolov5/tutorials/multi-gpu-training.md
+++ b/docs/en/yolov5/tutorials/multi-gpu-training.md
@@ -194,7 +194,7 @@ Read the checklist below before opening an issue — it often saves time.
 - Have you re-cloned the codebase? The code changes **daily**.
 - Have you searched for the error message? Someone may have already hit the same issue and shared a fix.
 - Have you installed all the requirements (including the correct Python and PyTorch versions)?
-- Have you tried one of the supported environments listed below?
+- Have you tried one of the supported environments listed above?
 - Have you tried a smaller dataset such as `coco128` or `coco2017` to isolate the root cause?
 
 If all of the above check out, open an Issue with as much detail as possible, following the template.


### PR DESCRIPTION
## Summary

- move the five FAQ sections with trailing H2 sections to the end of their pages
- preserve every FAQ block byte-for-byte
- make all 252 FAQ pages across `ultralytics/docs` and `ultralytics/ultralytics/docs` follow the same final-section contract used by the shared Portal renderer

## Validation

- audited all 252 `## FAQ` pages: zero trailing H2 sections
- verified the five moved FAQ blocks are unchanged
- `npx prettier@3.8.5 --tab-width 4 --print-width 120 --check <five files>`
- Portal corpus validation: 251 accordion pages, one checklist-only plain-Markdown page, 1,300 questions with matching TOC IDs
- Portal production docs build from these local sources

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Reordered FAQ content and trailing sections in five documentation pages so FAQ blocks appear at the end of their pages and follow the shared Portal renderer’s final-section structure.

### 📊 Key Changes

- Moved the **Additional Resources**, **Summary**, and **Troubleshooting** sections before their respective FAQ blocks.
- Moved the cloud-training FAQ below the **Training Parameters Reference**.
- Moved the YOLOv5 multi-GPU training checklist FAQ below the page’s related resources.
- Preserved the moved FAQ content without edits while aligning the broader documentation corpus with the same section-ordering contract.

### 🎯 Purpose & Impact

- FAQ content now appears as the final section on the affected pages, providing consistent navigation and Portal rendering across the documentation set.
- No FAQ wording or checklist content was changed; the impact is limited to page structure and section ordering.