### PR TITLE
Redeploy docs when Python or cfg sources change

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -113,7 +113,9 @@ jobs:
             if [[ "$BEFORE_SHA" == "0000000000000000000000000000000000000000" ]]; then
               BEFORE_SHA=$(git rev-list --max-parents=0 "$CURRENT_SHA")
             fi
-            changed_files=$(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" -- docs/ mkdocs.yml mkdocs.yaml ultralytics/cfg/default.yaml)
+            # ultralytics/ covers docstrings (reference pages are regenerated from them at publish time)
+            # and every cfg/*.yaml consumed by --8<-- snippets, not just cfg/default.yaml.
+            changed_files=$(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" -- docs/ mkdocs.yml mkdocs.yaml ultralytics/)
             if [[ -z "$changed_files" ]]; then
               echo "No docs source changes."
               exit 0

--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -31,6 +31,9 @@
 1185102784@qq.com:
   avatar: https://avatars.githubusercontent.com/u/61612323?v=4
   username: Laughing-q
+123047415+Rahulbiradar9@users.noreply.github.com:
+  avatar: https://avatars.githubusercontent.com/u/123047415?v=4
+  username: Rahulbiradar9
 128489822+SHOscarChen@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/128489822?v=4
   username: SHOscarChen


### PR DESCRIPTION
## Summary

The `Publish Docs` step only fires the Vercel deploy hook when a push to `main` touches `docs/`, `mkdocs.yml`, `mkdocs.yaml` or `ultralytics/cfg/default.yaml`. Two things that **do** change the rendered site are missing from that list:

- **Docstrings.** Portal regenerates every API reference page body from docstrings at build time (it runs `docs/build_reference.py` against a fresh clone). The committed reference stubs are not what gets served. So a Python-only merge changes the live reference content but triggers no deploy.
- **Non-default cfg YAML.** 65 `--8<--` snippets target `ultralytics/cfg/*.yaml`; there are 125 YAML files under `ultralytics/cfg/`, and only `default.yaml` was watched.

In both cases the site stays stale until some unrelated `docs/` commit happens to trigger a build.

Widening the pathspec to `ultralytics/` covers docstrings and every cfg file, and lets the narrower `ultralytics/cfg/default.yaml` entry it supersedes be deleted. Net +2 lines, both of them a comment.

## Evidence

Measured over the last 30 days of `main`:

| | commits |
| --- | --- |
| pushes to `main` | 428 |
| touching the currently-watched paths | 172 |
| touching `ultralytics/` | 294 |
| **touching `ultralytics/` but *not* the watched paths — i.e. silently missed** | **224** |

The most recent commit on `main` is itself an example — #25723 (`Preserve OBB orientation through clipped augmentations`) edited docstrings in `ultralytics/data/augment.py` and `ultralytics/utils/instance.py`:

```
OLD filter matches: []
NEW filter matches: ultralytics/data/augment.py ultralytics/utils/instance.py
```

```diff
+        """Apply the affine transformation to object instances."""
+        """Transform segments and derive their bounding boxes."""
```

Both render into `docs.ultralytics.com` reference pages, and neither triggered a deploy.

## Trade-off, stated plainly

This raises docs deploys from ~172 to ~396 per 30 days (~5.7/day → ~13/day). Each is a Vercel build; the Gemini translation pass is content-hash cached, so unchanged pages cost no translation calls and the marginal cost is build minutes. If that volume is unwelcome, the narrower alternative is `ultralytics/*.py` plus `ultralytics/cfg/`, which lands in the same place for slightly more config.

## Test plan

- [x] `yaml.safe_load` parses the workflow
- [x] Pathspec verified against real history: the new filter matches the docstring-only commits the old one dropped, and still matches everything the old one matched
- [ ] Confirm a Python-only merge to `main` fires the hook and the reference page updates

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the documentation workflow to detect all changes under `ultralytics/` and added a GitHub author mapping so generated documentation reflects Python docstring and configuration updates.

### 📊 Key Changes
- Expanded the `docs.yml` change filter from `ultralytics/cfg/default.yaml` to the entire `ultralytics/` directory.
- Documentation publishing now considers Python docstrings and all configuration YAML files when determining whether sources changed.
- Added `Rahulbiradar9` to `docs/mkdocs_github_authors.yaml`.

### 🎯 Purpose & Impact
- Changes to docstrings or non-default configuration files can now qualify the workflow's documentation publish step instead of being excluded by the previous path filter.
- GitHub contributions from `Rahulbiradar9` can now resolve to the configured username and avatar in documentation author metadata.