### PR TITLE
Cache external test assets before pytest

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -15,6 +15,7 @@ TASK_MODEL_DATA = sorted(
 )  # (task, model, data) tuples
 MODELS = sorted([*list(TASK2MODEL.values()), "yolo11n-grayscale.pt"])  # task models plus grayscale variant
 SOLUTION_ASSETS = {
+    "boats": "boats.jpg",
     "demo_video": "solutions_ci_demo.mp4",
     "crop_video": "decelera_landscape_min.mov",
     "pose_video": "solution_ci_pose_demo.mp4",
@@ -23,6 +24,7 @@ SOLUTION_ASSETS = {
     "track_video": "decelera_portrait_min.mov",
     "parking_areas": "solution_ci_parking_areas.json",
     "parking_model": "solutions_ci_parking_model.pt",
+    "similarity_images": "4-imgs-similaritysearch.zip",
 }
 
 __all__ = (

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -845,15 +845,11 @@ def test_predict_callback_and_setup():
 
 
 @pytest.mark.parametrize("model", MODELS)
-def test_results(model: str, tmp_path):
+def test_results(model: str, tmp_path, solution_assets):
     """Test YOLO model results processing and output in various formats."""
     if IS_RASPBERRYPI and model == "yolo26n-sem.pt":
         skip_rpi_semantic()
-    im = (
-        "https://cdn.ul.run/i/186929a91ceb270e952fe4dd27ba0f18.webp"  # boats.jpg
-        if model == "yolo26n-obb.pt"
-        else SOURCE
-    )
+    im = solution_assets("boats") if model == "yolo26n-obb.pt" else SOURCE
     is_semantic = "semantic" in model or "-sem" in model
     results = YOLO(WEIGHTS_DIR / model)([im, im], imgsz=32 if is_semantic else 160)
     for r in results:

--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -13,7 +13,7 @@ import torch
 
 from tests import MODEL
 from ultralytics import solutions
-from ultralytics.utils import ASSETS_URL, IS_RASPBERRYPI, TORCH_VERSION, checks
+from ultralytics.utils import IS_RASPBERRYPI, TORCH_VERSION, checks
 from ultralytics.utils.downloads import safe_download
 from ultralytics.utils.torch_utils import TORCH_2_4
 
@@ -396,9 +396,9 @@ def test_streamlit_handle_video_upload_creates_file(tmp_path):
 
 @pytest.mark.skipif(not TORCH_2_4, reason=f"VisualAISearch requires torch>=2.4 (found torch=={TORCH_VERSION})")
 @pytest.mark.skipif(IS_RASPBERRYPI, reason="Disabled due to slow performance on Raspberry Pi.")
-def test_similarity_search(tmp_path):
+def test_similarity_search(tmp_path, solution_assets):
     """Test similarity search solution with sample images and text query."""
-    safe_download(f"{ASSETS_URL}/4-imgs-similaritysearch.zip", dir=tmp_path)  # 4 dog images for testing in a zip file
+    safe_download(solution_assets("similarity_images"), dir=tmp_path)  # 4 dog images for testing in a zip file
     searcher = solutions.VisualAISearch(data=str(tmp_path / "4-imgs-similaritysearch"))
     _ = searcher("a dog sitting on a bench")  # Returns the results in format "- img name | similarity score"
 


### PR DESCRIPTION
## Summary

- pre-cache the boats image and similarity-search archive with the existing shared asset registry
- reuse the existing session fixture instead of fetching both assets during pytest
- remove the unused direct asset URL import

## Validation

- `YOLO_OFFLINE=true .venv/bin/python -m pytest "tests/test_python.py::test_results[yolo26n-obb.pt]" tests/test_solutions.py::test_similarity_search -q`
- `uvx ruff format --check tests/__init__.py tests/test_python.py tests/test_solutions.py`
- `uvx ruff check tests/__init__.py tests/test_python.py tests/test_solutions.py`
- `git diff --check`

Closes the uncached CDN dependency observed in CI job 93188796011.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
External test assets are now registered in the shared solution asset registry and accessed through the `solution_assets` fixture to avoid direct CDN downloads during pytest.

### 📊 Key Changes
- Added `boats.jpg` and `4-imgs-similaritysearch.zip` to `SOLUTION_ASSETS`.
- Updated the OBB results test to load the boats image through `solution_assets("boats")`.
- Updated the similarity-search test to use `solution_assets("similarity_images")`.
- Removed the unused `ASSETS_URL` import and direct similarity-search asset URL.

### 🎯 Purpose & Impact
- Pytest can use the shared cached asset workflow for both external test resources, removing the uncached CDN dependency observed in CI.
- The affected tests retain their existing inputs and processing behavior; this is a test infrastructure change with no user-facing change.