### PR TITLE
Fix: `autocast_list` loses image filename after `exif_transpose`

### DIFF
--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -651,7 +651,12 @@ def autocast_list(source: list[Any]) -> list[Image.Image | np.ndarray]:
                 import requests  # scoped as slow import
 
                 im = BytesIO(requests.get(im).content)
-            files.append(ImageOps.exif_transpose(Image.open(im)))
+            im = Image.open(urllib.request.urlopen(im) if str(im).startswith("http") else im)
+            filename = getattr(im, "filename", "")
+            file = ImageOps.exif_transpose(im)
+            if filename and not getattr(im, "filename", ""):
+                file.filename = filename
+            files.append(file)
         elif isinstance(im, (Image.Image, np.ndarray)):  # PIL or np Image
             files.append(im)
         else:

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -654,7 +654,7 @@ def autocast_list(source: list[Any]) -> list[Image.Image | np.ndarray]:
             im = Image.open(urllib.request.urlopen(im) if str(im).startswith("http") else im)
             filename = getattr(im, "filename", "")
             file = ImageOps.exif_transpose(im)
-            if filename and not getattr(im, "filename", ""):
+            if filename and not getattr(file, "filename", ""):
                 file.filename = filename
             files.append(file)
         elif isinstance(im, (Image.Image, np.ndarray)):  # PIL or np Image

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -651,12 +651,11 @@ def autocast_list(source: list[Any]) -> list[Image.Image | np.ndarray]:
                 import requests  # scoped as slow import
 
                 im = BytesIO(requests.get(im).content)
-            im = Image.open(urllib.request.urlopen(im) if str(im).startswith("http") else im)
-            filename = getattr(im, "filename", "")
-            file = ImageOps.exif_transpose(im)
-            if filename and not getattr(file, "filename", ""):
-                file.filename = filename
-            files.append(file)
+            im = Image.open(im)
+            filename = im.filename
+            im = ImageOps.exif_transpose(im)
+            im.filename = filename
+            files.append(im)
         elif isinstance(im, (Image.Image, np.ndarray)):  # PIL or np Image
             files.append(im)
         else:


### PR DESCRIPTION

### Environment

- ultralytics version: latest
- Pillow version: 11.0.0

### Description

When passing a list of image file paths to `model.predict()`, the `autocast_list()` function in `ultralytics/data/loaders.py` converts them to PIL Images via `ImageOps.exif_transpose(Image.open(...))`. However, `exif_transpose` returns a **copy** of the image (either via `.transpose()` or `.copy()`), which does **not** preserve the `filename` attribute from the original `ImageFile` object.

This causes `LoadPilAndNumpy.__init__` to fall back to generated names like `image0.jpg` instead of the real file path, which then propagates to `result.path` in the prediction results.

### Steps to Reproduce

```python
from PIL import Image, ImageOps

# Open an image from a file path
img = Image.open("/path/to/image.jpg")
print(img.filename)  # → "/path/to/image.jpg"  ✅

# After exif_transpose
transposed = ImageOps.exif_transpose(img)
print(transposed.filename)  # → ""  ❌ (attribute missing or empty)
```

Or with ultralytics:
```python
from ultralytics import YOLO

model = YOLO("yolo11n.pt")
results = model.predict(["/path/to/image1.jpg", "/path/to/image2.jpg"])

for r in results:
    print(r.path)  # → "image0.jpg", "image1.jpg"  ❌ (should be real paths)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves image loading in `autocast_list` by supporting URL streams more robustly and preserving source filenames after EXIF correction. 🖼️

### 📊 Key Changes
- Loads HTTP image sources through `urllib.request.urlopen` before opening them with PIL.
- Applies EXIF orientation correction while retaining the original filename metadata when needed.
- Preserves existing handling for local files, PIL images, and NumPy arrays.

### 🎯 Purpose & Impact
- 🛠️ Fixes image metadata loss that can affect downstream filename-dependent processing.
- 🌐 Improves compatibility when loading images from remote URLs.
- ✅ Keeps the change localized to the image-loading path with minimal impact on other input types.