### PR TITLE
Align grounding segmentation fallback

### DIFF
--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -727,8 +727,6 @@ class GroundingDataset(YOLODataset):
                     raw_seg = ann.get("segmentation")
                     segmented |= raw_seg is not None
                     seg = raw_seg if isinstance(raw_seg, list) else []
-                    if seg and all(isinstance(x, list) and len(x) == 2 for x in seg):
-                        seg = [[c for point in seg for c in point]]  # [[x, y], ...] is one polygon
                     polygons = [
                         p
                         for p in seg


### PR DESCRIPTION
## summary

align grounding handling of malformed bare coordinate-pair segmentations with the COCO converter. both paths now retain the existing bounding-box fallback.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Grounding label handling now preserves the existing bounding-box fallback for malformed bare coordinate-pair segmentations, matching the COCO converter behavior.

### 📊 Key Changes

- Removed the conversion of coordinate pairs such as `[[x, y], ...]` into a single polygon in `Dataset.cache_labels`.
- Malformed bare coordinate-pair segmentations now continue through the existing polygon filtering and bounding-box fallback path.
- Grounding dataset handling is aligned with the corresponding COCO conversion behavior.

### 🎯 Purpose & Impact

- Affected annotations use their existing bounding boxes instead of being reinterpreted as polygons; other segmentation handling is unchanged.