### PR TITLE
Document deployment model replacement

### DIFF
--- a/docs/en/platform/api/index.md
+++ b/docs/en/platform/api/index.md
@@ -1287,6 +1287,7 @@ graph LR
     A[Create]:::start --> B[Deploying]:::proc
     B --> C[Ready]:::out
     C -->|stop| D[Stopped]:::extern
+    C -->|replace model| B
     D -->|start| C
     C -->|delete| E[Deleted]:::error
     D -->|delete| E
@@ -1364,6 +1365,22 @@ GET /api/deployments/{deploymentId}
 ```http
 DELETE /api/deployments/{deploymentId}
 ```
+
+### Replace Deployment Model
+
+```http
+PATCH /api/deployments/{deploymentId}
+```
+
+**Body:**
+
+```json
+{
+    "modelId": "model_xyz789"
+}
+```
+
+Creates a new revision with the selected model while preserving the deployment ID, region, API key, and endpoint URL. The existing revision continues serving until the replacement is ready. The selected model must be a completed model with weights in the same workspace.
 
 ### Start Deployment
 

--- a/docs/en/platform/api/index.md
+++ b/docs/en/platform/api/index.md
@@ -1376,11 +1376,12 @@ PATCH /api/deployments/{deploymentId}
 
 ```json
 {
-    "modelId": "model_xyz789"
+    "modelId": "model_xyz789",
+    "name": "production-detector"
 }
 ```
 
-Creates a new revision with the selected model while preserving the deployment ID, region, API key, and endpoint URL. The existing revision continues serving until the replacement is ready. The selected model must be a completed model with weights in the same workspace.
+Creates a new revision with the selected model while preserving the deployment ID, region, API key, and endpoint URL. Set the optional `name` field to rename the deployment when the replacement becomes ready. The existing revision and name remain active if the replacement fails. The selected model must be a completed model with weights in the same workspace.
 
 ### Start Deployment
 

--- a/docs/en/platform/deploy/endpoints.md
+++ b/docs/en/platform/deploy/endpoints.md
@@ -215,9 +215,10 @@ Replace the model behind a ready endpoint without changing its URL:
 1. Open the deployment in **Cards** view
 2. Click **Replace model**
 3. Select another completed model from the same workspace
-4. Click **Replace Model**
+4. Optionally edit the deployment name
+5. Click **Replace Model**
 
-Platform creates a new revision of the existing service. The current model continues serving while the replacement revision starts and passes its health check. When the revision is ready, traffic moves to the new model and the deployment's URL, region, name, and API key remain unchanged.
+Platform creates a new revision of the existing service. The current model continues serving while the replacement revision starts and passes its health check. When the revision is ready, traffic moves to the new model. The deployment ID, URL, region, and API key remain unchanged; its display name changes only when you enter a new one. If replacement fails, the previous model and name remain active.
 
 !!! note "One Model per Endpoint"
 

--- a/docs/en/platform/deploy/endpoints.md
+++ b/docs/en/platform/deploy/endpoints.md
@@ -44,6 +44,7 @@ stateDiagram-v2
     Creating --> Deploying: Container starting
     Deploying --> Ready: Health check passed
     Ready --> Stopping: Stop
+    Ready --> Deploying: Replace model
     Stopping --> Stopped: Stopped
     Stopped --> Ready: Start
     Ready --> [*]: Delete
@@ -199,13 +200,28 @@ The deployments list supports three view modes:
 
 Each deployment card in the cards view shows:
 
-- **Header**: Name, region flag, status badge, start/stop/delete buttons
+- **Header**: Name, region flag, status badge, replace/start/stop/delete buttons
 - **Endpoint URL**: Copyable URL with link to API docs
 - **Metrics**: Request count (24h), P95 latency, error rate
 - **Health check**: Live health indicator with latency and manual refresh
 - **Tabs**: `Logs`, `Code`, and `Predict`
 
 The `Logs` tab shows recent log entries with severity filtering (All / Errors). The `Code` tab shows ready-to-use code examples in Python, JavaScript, and cURL with your actual endpoint URL and API key. The `Predict` tab provides an inline predict panel for testing directly on the deployment.
+
+### Replace a Model
+
+Replace the model behind a ready endpoint without changing its URL:
+
+1. Open the deployment in **Cards** view
+2. Click **Replace model**
+3. Select another completed model from the same workspace
+4. Click **Replace Model**
+
+Platform creates a new revision of the existing service. The current model continues serving while the replacement revision starts and passes its health check. When the revision is ready, traffic moves to the new model and the deployment's URL, region, name, and API key remain unchanged.
+
+!!! note "One Model per Endpoint"
+
+    Replacement removes the previous model from the deployment. Each endpoint serves one model; create another deployment when you need both models available at the same time.
 
 ### Deployment Statuses
 


### PR DESCRIPTION
## Summary
- document replacing the model behind an existing dedicated endpoint
- clarify that Cloud Run rolls out a new revision while the URL and API key remain stable
- document programmatic replacement through `PATCH /api/deployments/{deploymentId}`

Companion implementation: ultralytics/portal (feature branch `feat/alpha-deployment-model-replacement`).

## Validation
- `npx prettier@3.8.5 --tab-width 4 --print-width 120 --write docs/en/platform/api/index.md docs/en/platform/deploy/endpoints.md`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Documented replacing the model behind an existing deployment while preserving its endpoint identity and clarifying the API and dashboard workflows.

### 📊 Key Changes

- Added `PATCH /api/deployments/{deploymentId}` documentation with `modelId` and optional `name` fields.
- Documented that replacement creates a new revision, keeps the deployment ID, region, API key, and endpoint URL, and only applies a new name when the replacement is ready.
- Documented dashboard steps for replacing a model from the deployment’s **Cards** view.
- Updated deployment state diagrams and card controls to include model replacement.
- Documented that the existing model continues serving until the replacement passes its health check, and remains active if replacement fails.

### 🎯 Purpose & Impact

- Users can find the documented workflow for replacing a model without changing endpoint connection details.
- The documentation clarifies that each endpoint serves one model and that replacement removes the previous model; separate deployments are required to serve both models simultaneously.
- No runtime implementation change is included in this repository PR.