### PR TITLE
Reject a short YOLOE vocabulary before the head is re-parameterized

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -1041,7 +1041,7 @@ class LRPCHead(nn.Module):
     def conv2linear(conv: nn.Conv2d) -> nn.Linear:
         """Convert a 1x1 convolutional layer to a linear layer."""
         assert isinstance(conv, nn.Conv2d) and conv.kernel_size == (1, 1)
-        linear = nn.Linear(conv.in_channels, conv.out_channels)
+        linear = nn.Linear(conv.in_channels, conv.out_channels).requires_grad_(conv.weight.requires_grad)
         linear.weight.data = conv.weight.view(conv.out_channels, -1).data
         linear.bias.data = conv.bias.data
         return linear

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1300,6 +1300,7 @@ class YOLOEModel(DetectionModel):
         head = self.model[-1]
         assert isinstance(head, YOLOEDetect)
         names = check_class_names(names)  # validate before the re-parameterization below, which cannot be undone
+        assert len(vocab) == head.nl, f"Expected one vocabulary item per detection level ({head.nl}), got {len(vocab)}."
 
         # Cache anchors for head
         with torch.no_grad():  # a tracked warmup would build a graph through the backbone


### PR DESCRIPTION
## summary

`YOLOEModel.set_vocab` paired the vocabulary with the head's detection levels through `zip`, which stops at the shortest argument, so a vocabulary holding fewer entries than the head has levels was accepted silently and produced a short `lrpc` while `nc` and `names` were written from the full name list. the mismatch only surfaced at the next predict, as `IndexError: index 2 is out of range` inside torch's `ModuleList`, naming neither the vocabulary nor `set_vocab`, and by then the head had been re-parameterized and could not be undone. the length is now checked next to the existing name validation, before anything is written.

`LRPCHead.conv2linear` also handed back a `requires_grad=True` layer where the conv it replaces had gradients explicitly off: `YOLOEDetect._fuse_tp` builds the fused conv with `.requires_grad_(False)`, and the conversion then took the constructor default. the replacement now inherits the source conv's flag, matching `_fuse_tp` and `RepConv.fuse_convs`.

## measured

on `yoloe-26n-seg.pt`, `set_vocab(get_vocab(names)[:2], names)` on a three-level head completed before and raised `AssertionError: Expected one vocabulary item per detection level (3), got 2.` now, with `nc`, `names` and `lrpc` all unchanged across the rejected call; the following predict raised the `IndexError` before and is no longer reachable. the converted layer's `requires_grad` went from `[True, True, False]` to `[False, False, False]` across the three levels, matching the source convs.

the documented `set_vocab(get_vocab(names), names)` workflow is byte-identical before and after on bus.jpg and zidane.jpg at both fp32 and fp16; a deliberate perturbation of the converted bias moved those detections on bus.jpg, so the comparison discriminates.

the ticket also asked to skip the throwaway initialization the conversion overwrites. measured at the shipped 4585-class vocabulary it is 0.45 ms and 1.5 MB per enabled level, and only two of three levels convert at all, so about 0.9 ms once per `set_vocab` call; skipping it needs `device="meta"` or `torch.nn.utils.skip_init`, both above the declared torch 1.8 floor, and it was left alone.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

YOLOE vocabulary validation now rejects level-count mismatches before head re-parameterization, and converted layers preserve the source convolution’s gradient setting.

### 📊 Key Changes

- `YOLOEModel.set_vocab` checks that the vocabulary contains exactly one item per `YOLOEDetect` detection level before modifying the model.
- Invalid vocabulary lengths raise an `AssertionError` that reports the expected and received counts.
- `LRPCHead.conv2linear` now copies the source convolution’s `requires_grad` state to the replacement linear layer.
- The existing class-name validation and re-parameterization flow remain otherwise unchanged.

### 🎯 Purpose & Impact

- Prevents a short vocabulary from being silently accepted and producing inconsistent head state that fails later during prediction.
- Ensures converted layers retain gradient behavior, including frozen layers created by `_fuse_tp`.
- Valid vocabularies continue through the existing workflow; no user-facing change for valid `set_vocab` calls.