### PR TITLE
Build loaded models outside inference mode

### DIFF
--- a/ultralytics/models/yolo/depth/calibrate.py
+++ b/ultralytics/models/yolo/depth/calibrate.py
@@ -215,8 +215,8 @@ def fit_calibration_selective(
         return None
     res = select_calibration_cv(pairs, margin=margin)
     res["images"] = len(pairs)
-    # channels_last=True still converts the module inside the validator's inference_mode, so reassign instead
-    # of an in-place fill_ to keep the write legal on buffers that are inference tensors on that path.
+    # _collect_logpairs moves the model inside inference_mode, so off CPU these buffers are inference tensors;
+    # reassign instead of an in-place fill_ to keep the write legal.
     head.cal_a = torch.full_like(head.cal_a, res["a"])
     head.cal_b = torch.full_like(head.cal_b, res["b"])
     scores = " ".join(f"{n}={v:.4f}" for n, v in res["cv_scores"].items())

--- a/ultralytics/models/yolo/depth/calibrate.py
+++ b/ultralytics/models/yolo/depth/calibrate.py
@@ -215,8 +215,8 @@ def fit_calibration_selective(
         return None
     res = select_calibration_cv(pairs, margin=margin)
     res["images"] = len(pairs)
-    # On CUDA the buffers are inference tensors (the device move ran under inference_mode); reassign instead
-    # of an in-place fill_ so the write is legal and the buffers stay normal/saveable for model.save().
+    # channels_last=True still converts the module inside the validator's inference_mode, so reassign instead
+    # of an in-place fill_ to keep the write legal on buffers that are inference tensors on that path.
     head.cal_a = torch.full_like(head.cal_a, res["a"])
     head.cal_b = torch.full_like(head.cal_b, res["b"])
     scores = " ".join(f"{n}={v:.4f}" for n, v in res["cv_scores"].items())

--- a/ultralytics/nn/backends/pytorch.py
+++ b/ultralytics/nn/backends/pytorch.py
@@ -9,7 +9,7 @@ import torch
 from torch import nn
 
 from ultralytics.utils import IS_JETSON, LOGGER, is_jetson
-from ultralytics.utils.torch_utils import unwrap_model
+from ultralytics.utils.torch_utils import smart_inference_mode, unwrap_model
 
 from .base import BaseBackend
 
@@ -42,6 +42,7 @@ class PyTorchBackend(BaseBackend):
         self.verbose = verbose
         super().__init__(weight, device, fp16)
 
+    @smart_inference_mode(False)  # the loaded module outlives this call, so its weights must not be inference tensors
     def load_model(self, weight: str | torch.nn.Module) -> None:
         """Load a PyTorch model from a checkpoint file or nn.Module instance.
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1883,6 +1883,7 @@ def torch_safe_load(weight, safe_only=None):
     return ckpt, file
 
 
+@smart_inference_mode(False)  # the loaded model outlives this call, so its weights must not be inference tensors
 def load_checkpoint(weight, device=None, inplace=True, fuse=False):
     """Load single model weights.
 

--- a/ultralytics/trackers/utils/reid.py
+++ b/ultralytics/trackers/utils/reid.py
@@ -16,6 +16,7 @@ import torch
 from ultralytics.nn.autobackend import AutoBackend
 from ultralytics.utils.ops import xywh2xyxy
 from ultralytics.utils.plotting import save_one_box
+from ultralytics.utils.torch_utils import smart_inference_mode
 
 REID_ASSETS = frozenset(f"yolo26{k}-reid.onnx" for k in "nsmlx")
 
@@ -23,6 +24,7 @@ REID_ASSETS = frozenset(f"yolo26{k}-reid.onnx" for k in "nsmlx")
 class ReID:
     """ReID encoder. Routes `.pt` to the YOLO predictor path; everything else to `AutoBackend`."""
 
+    @smart_inference_mode(False)  # the encoder is retained by the tracker; trackers are built inside a predict block
     def __init__(self, model: str, imgsz: int = 224, device: str | torch.device | None = None, fp16: bool = False):
         """Initialize encoder for re-identification.
 


### PR DESCRIPTION
## summary

`load_checkpoint`, `PyTorchBackend.load_model` and `ReID.__init__` each build a module the caller keeps, and each is reachable from inside a caller's `inference_mode` — `BaseValidator.__call__` and `BasePredictor.stream_inference` are both `@smart_inference_mode()`, and trackers are built from an `on_predict_start` callback inside the second one. everything created there came back an inference tensor, and the next dtype or device move writes a normal tensor through `param.data`, leaving a parameter that reports `is_inference() == False` while its autograd metadata still comes from the inference tensor, so the following forward raises `RuntimeError: Inference tensors do not track version counter` naming neither the function that created it nor the one that tripped over it. all three now build outside inference mode, one commit per site, the same way `YOLOEDetect.fuse` already does. `AutoBackend.__init__` is already `@torch.no_grad()`, so on every path through it this changes the inference-mode half only and nothing about gradients.

the local workaround in depth calibration stays, because `_collect_logpairs` still moves the model under inference mode and so can still re-create those buffers off cpu; its comment now names that move instead of the device move this changes.

## measured

on `yolo26n.pt` with torch 2.10.0, counting parameters whose `is_inference()` is true, and running the paths from inside `torch.inference_mode()` as the tracker callback does.

| path                                                        | `origin/main` | this PR  |
| ----------------------------------------------------------- | ------------- | -------- |
| params left as inference tensors after `YOLO(ckpt)`         | 366 of 366    | 0 of 366 |
| `predict` on that model                                     | runs          | runs     |
| `ReID("yolo26n-cls.pt")`                                    | builds        | builds   |
| params left in the caller's model after `val(device='cpu')` | 192 of 204    | 0 of 204 |

the backend commit alone turned both of those runtime paths into `RuntimeError: Inference tensors do not track version counter`, and `tests/test_python.py::test_track_stream` from 8 passed to 5 failed, 3 passed on all four os jobs. with the encoder fixed but the loader unfixed, the encoder builds and `YOLO(ckpt).predict(...)` inside `inference_mode` still raises with 366 of 366 parameters inference tensors, which is why the loader is fixed at its own site. all 8 `test_track_stream` parametrizations pass locally on the final tree.

measured not to move, per sample rather than in aggregate:

| control                                                                 | result                                                                                                      |
| ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
| detections on bus.jpg and zidane.jpg                                    | byte-identical                                                                                              |
| coco8 validation, cpu                                                   | precision 0.84913269, recall 0.65446222, mAP50 0.90649419, mAP50-95 0.66477066, identical to eight decimals |
| 2-epoch coco8 training through the trainer's own `load_checkpoint` call | identical final weights, identical box 2.417147 / cls 8.790765 / l1 0.077635                                |

the training control is calibrated: at the default batch, coco8's 4 images and `accumulate = round(nbs / batch)` mean no optimizer step runs at all, so an "identical" result there measures nothing. `batch=64` makes `accumulate == 1`, and the run asserts the trained weights differ from the loaded ones before it reports anything.

the two sites that still build under inference mode are tracked separately: the `channels_last` conversion in the validator, and the sam predictors.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Model loading and ReID encoder construction now run outside PyTorch inference mode so retained model weights remain safe for later device, dtype, and forward operations.

### 📊 Key Changes
- Decorated `load_checkpoint` and `PyTorchBackend.load_model` with `@smart_inference_mode(False)`.
- Decorated `ReID.__init__` with `@smart_inference_mode(False)` because tracker-created encoders outlive the prediction callback.
- Updated the depth calibration comment to document that `_collect_logpairs` can still create inference tensors when moving the model under inference mode; its buffer reassignment workaround remains unchanged.
- The change targets model construction only; `AutoBackend.__init__` remains under `@torch.no_grad()`.

### 🎯 Purpose & Impact
- Models created during validation, prediction, checkpoint loading, and tracker initialization no longer retain inference tensors that can later trigger `RuntimeError: Inference tensors do not track version counter` during subsequent operations.
- Existing prediction outputs, CPU validation metrics, and trainer checkpoint-loading behavior were reported unchanged in the PR measurements.