### PR TITLE
Accept all image formats in classification auto-split and report missing images instead of crashing

### DIFF
--- a/ultralytics/data/split.py
+++ b/ultralytics/data/split.py
@@ -14,7 +14,7 @@ def split_classify_dataset(source_dir: str | Path, train_ratio: float = 0.8) -> 
     """Split classification dataset into train and val directories in a new directory.
 
     Creates a new directory '{source_dir}_split' with train/val subdirectories, preserving the original class structure
-    with an 80/20 split by default.
+    with an 80/20 split by default. Only files with extensions matching IMG_FORMATS are copied.
 
     Directory structure:
         Before:
@@ -71,7 +71,7 @@ def split_classify_dataset(source_dir: str | Path, train_ratio: float = 0.8) -> 
 
     # Process class directories
     class_dirs = [d for d in source_path.iterdir() if d.is_dir()]
-    total_images = sum(len(list(d.glob("*.*"))) for d in class_dirs)
+    total_images = sum(len([f for f in d.glob("*.*") if f.suffix[1:].lower() in IMG_FORMATS]) for d in class_dirs)
     stats = f"{len(class_dirs)} classes, {total_images} images"
     LOGGER.info(f"Splitting {source_path} ({stats}) into {train_ratio:.0%} train, {1 - train_ratio:.0%} val...")
 
@@ -81,7 +81,7 @@ def split_classify_dataset(source_dir: str | Path, train_ratio: float = 0.8) -> 
         (val_path / class_dir.name).mkdir(exist_ok=True)
 
         # Split and copy files
-        image_files = list(class_dir.glob("*.*"))
+        image_files = [f for f in class_dir.glob("*.*") if f.suffix[1:].lower() in IMG_FORMATS]
         random.shuffle(image_files)
         split_idx = int(len(image_files) * train_ratio)
 

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -633,14 +633,14 @@ def check_cls_dataset(dataset: str | Path, split: str = "") -> dict[str, Any]:
     train_set = data_dir / "train"
     if not train_set.is_dir():
         LOGGER.warning(f"Dataset 'split=train' not found at {train_set}")
-        if image_files := list(data_dir.rglob("*.jpg")) + list(data_dir.rglob("*.png")):
+        if image_files := [f for f in data_dir.rglob("*.*") if f.suffix[1:].lower() in IMG_FORMATS]:
             from ultralytics.data.split import split_classify_dataset
 
             LOGGER.info(f"Found {len(image_files)} images in subdirectories. Attempting to split...")
             data_dir = split_classify_dataset(data_dir, train_ratio=0.8)
             train_set = data_dir / "train"
         else:
-            LOGGER.error(f"No images found in {data_dir} or its subdirectories.")
+            raise FileNotFoundError(f"No images found in {data_dir} or its subdirectories.")
     val_set = (
         data_dir / "val"
         if (data_dir / "val").exists()


### PR DESCRIPTION
### Problem

`check_cls_dataset()` detects images with `rglob("*.jpg") + rglob("*.png")` (utils.py:636)
while the same function counts them with `suffix[1:].lower() in IMG_FORMATS` (utils.py:673).

A classification dataset using any other supported extension (`.jpeg`, `.bmp`, `.webp`,
`.tif`, `.avif`, `.heic`, or uppercase `.JPG` on Linux) therefore fails detection, skips the
auto-split, and crashes 30 lines later on `(data_dir / "train").iterdir()`:

    WARNING Dataset 'split=train' not found at ...\clsbug\train
    ERROR No images found in ...\clsbug or its subdirectories.
    Traceback (most recent call last):
      File "ultralytics/data/utils.py", line 664, in check_cls_dataset
        names = dict(enumerate(sorted(x.name for x in (data_dir / "train").iterdir() ...
      FileNotFoundError: [WinError 3] The system cannot find the path specified

The identical dataset with `.jpg` works. `.jpeg` is the second most common image extension.

### Changes

- `data/utils.py:636` — detect via `IMG_FORMATS`, matching line 673 in the same function.
- `data/utils.py:643` — `raise FileNotFoundError` instead of `LOGGER.error`. This is **not** a
  new exception: the old path always crashed at line 664 with a bare OS error. It now fails at
  the point the problem is detected, with a readable message, consistent with the existing
  `raise FileNotFoundError` at line 678.
- `data/split.py:74,84` — filter by `IMG_FORMATS` so `total_images` is accurate and
  `.DS_Store` / `README.md` / `labels.txt` are no longer copied into the split. `IMG_FORMATS`
  was already imported (line 9) and already used by `autosplit()` in the same file (line 120).

### Validation

Focused validation per AGENTS.md rule 4 (no new test code).

```python
# before: FileNotFoundError: [WinError 3] The system cannot find the path specified
# after:  train: ... found 8 images in 2 classes ✅ / nc=2, names={0: 'cat', 1: 'dog'}
import shutil, tempfile, pathlib
from PIL import Image
from ultralytics.data.utils import check_cls_dataset

root = pathlib.Path(tempfile.gettempdir()) / "clsbug"
shutil.rmtree(root, ignore_errors=True)
for c in ["cat", "dog"]:
    (root / c).mkdir(parents=True)
    for i in range(5):
        Image.new("RGB", (32, 32)).save(root / c / f"im{i}.jpeg")
print(check_cls_dataset(root))
```

Also verified: non-image files (`labels.txt`, `.DS_Store`, `README.md`) placed alongside the
images no longer appear anywhere under `*_split/`, and a class directory containing no
supported images now raises `FileNotFoundError: No images found in ...` instead of the bare
`[WinError 3]`.

Existing `tests/test_python.py::test_data_utils` and
`test_ndjson_conversion_concurrency_and_resume` pass unchanged (3 passed in 1.22 s).

### Not included

`check_cls_dataset` detects recursively (`rglob`) while `split_classify_dataset` copies one
level deep (`glob`), so images nested below the class directory log "Found N images" then
"0 images". This is pre-existing and unchanged here; the run now ends in the clear
`'train:' no training images found` error. Switching `split.py` to `rglob` would flatten paths
through `img.name` and silently overwrite same-named files across subdirectories, so it is left
for a separate change.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves classification dataset auto-splitting by supporting all recognized image formats and reporting missing images with a clear error.

### 📊 Key Changes
- Filters classification images using the supported `IMG_FORMATS` list, including during dataset statistics, automatic splitting, and file copying.
- Replaces the no-images log message with a `FileNotFoundError` when no supported images are found.
- Updates the function documentation to clarify that only supported image files are copied.

### 🎯 Purpose & Impact
- ✅ Supports a broader range of image formats and handles uppercase extensions consistently.
- ✅ Prevents unsupported files from being included in automatically split classification datasets.
- ✅ Provides a clearer failure signal when a dataset contains no usable images, improving troubleshooting and downstream reliability.