### PR TITLE
Reset the YOLOE predictor after the vocabulary delegate

### DIFF
--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -320,14 +320,15 @@ class YOLOE(Model):
         """
         assert isinstance(self.model, YOLOEModel)
         names = check_class_names(names)
-        self.predictor = None  # the delegate destructively re-parameterizes the head
         self.model.set_vocab(vocab, names=names)
+        self.predictor = None  # after the delegate, so a rejected call leaves the predictor alone
 
     def get_vocab(self, names):
         """Get the vocabulary for the given class names, which become the model's classes as the head is fused."""
         assert isinstance(self.model, YOLOEModel)
-        self.predictor = None  # the delegate destructively fuses the promptable head
-        return self.model.get_vocab(names)
+        vocab = self.model.get_vocab(names)
+        self.predictor = None  # after the delegate, so a rejected call leaves the predictor alone
+        return vocab
 
     def set_classes(self, classes: list[str], embeddings: torch.Tensor | None = None) -> None:
         """Set the model's class names and embeddings for detection.


### PR DESCRIPTION
## summary

yoloe.set_vocab and get_vocab cleared the cached predictor before delegating, so every assert inside the delegate raised with model.predictor already dropped, and the next predict silently rebuilt the default predictor from overrides instead of the custom predictor class the caller had passed once and was reusing. the reset now runs after the delegate returns, so a rejected call leaves the model exactly as it found it.

## measured

on yoloe-26n-seg.pt with a predictor warmed by one predict call, both rejected routes previously left predictor before=true after=false: get_vocab on an already fused head, and set_vocab on a model put back in train mode. after the change both keep the same predictor object. a successful get_vocab and set_vocab still clear it and predict reports the new class names, byte identical to the base run.

the automated review asks whether preserving the predictor after a rejected set_vocab can leave a train mode model behind. measured as a 2x2 over trigger and revision: predict, then model.model.train(), then predict already fails with keyerror 0 in segment postprocess on current main with no set_vocab in the picture, so that hazard is pre existing and belongs to the predictor, not here. what this change removes is the accident that hid it on one route. filed separately with the table and a fix at the owner.

stacked on #25744, which is the other open change to this file.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

YOLOE now clears its cached predictor only after `set_vocab` or `get_vocab` succeeds, preserving the existing predictor when either delegated operation is rejected.

### 📊 Key Changes

- Moved predictor reset in `set_vocab` to after `self.model.set_vocab(...)` returns.
- Updated `get_vocab` to store the delegated result, clear the predictor after success, and then return the result.
- Rejected vocabulary operations no longer discard the current predictor before raising an assertion.
- Successful vocabulary operations continue to invalidate the cached predictor.

### 🎯 Purpose & Impact

- A failed `set_vocab` or `get_vocab` leaves the model and its existing predictor unchanged, including custom predictor instances.
- Successful vocabulary updates still cause the next prediction to rebuild the predictor and use the updated class names.