### PR TITLE
Run the channels_last conversion outside inference mode

### DIFF
--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -439,16 +439,7 @@ class BasePredictor:
         if hasattr(self.model, "imgsz") and not getattr(self.model, "dynamic", False):
             self.args.imgsz = self.model.imgsz  # reuse imgsz from export metadata
         self.model.eval()
-        # channels_last (NHWC) is CUDA-only and native-PyTorch-only: lossless and Tensor-Core friendly there, wrong
-        # on MPS, no CPU gain, and only a native nn.Module has weights to convert.
-        channels_last = self.args.channels_last and self.device.type == "cuda" and self.model.format == "pt"
-        if self.args.channels_last and not channels_last:
-            LOGGER.warning(
-                f"'channels_last=True' applies only to native PyTorch models on CUDA, ignoring for "
-                f"format='{self.model.format}' on '{self.device.type}'."
-            )
-        if channels_last:
-            self.model.to(memory_format=torch.channels_last)
+        self.model.set_memory_format(self.args.channels_last)
         self.model = attempt_compile(self.model, device=self.device, mode=self.args.compile)
 
     def write_results(self, i: int, p: Path, im: torch.Tensor, s: list[str]) -> str:

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -197,15 +197,7 @@ class BaseValidator:
             if augment and not model.base_model:
                 LOGGER.warning(f"'augment' is not supported by this model (format='{fmt}'), ignoring.")
                 augment = False
-            # Same gate as predictor.setup_model: NHWC is lossless only for native PyTorch models on CUDA.
-            channels_last = self.args.channels_last and self.device.type == "cuda" and pt
-            if self.args.channels_last and not channels_last:
-                LOGGER.warning(
-                    f"'channels_last=True' applies only to native PyTorch models on CUDA, ignoring for "
-                    f"format='{fmt}' on '{self.device.type}'."
-                )
-            if channels_last:
-                model.to(memory_format=torch.channels_last)
+            model.set_memory_format(self.args.channels_last)
             imgsz = check_imgsz(self.args.imgsz, stride=stride)
             if fmt not in {"pt", "torchscript"} and not getattr(model, "dynamic", False):
                 if hasattr(model, "imgsz"):

--- a/ultralytics/models/yolo/depth/calibrate.py
+++ b/ultralytics/models/yolo/depth/calibrate.py
@@ -152,7 +152,6 @@ def _collect_logpairs(
     a0, b0 = float(head.cal_a), float(head.cal_b)
     head.cal_a.fill_(1.0)
     head.cal_b.fill_(0.0)
-    model = model.to(device).eval()
     _rewind(dataloader)
     rng = np.random.default_rng(0)
     pairs = []
@@ -188,6 +187,7 @@ def _collect_logpairs(
     return pairs
 
 
+@smart_inference_mode(False)  # the model is the caller's and is written to below, so no inference tensors
 def fit_calibration_selective(
     model: torch.nn.Module,
     dataloader,
@@ -209,16 +209,15 @@ def fit_calibration_selective(
     if head is None:
         LOGGER.warning("calibrate: no Depth head with cal buffers found; skipping.")
         return None
+    model = model.to(device).eval()
     pairs = _collect_logpairs(model, dataloader, device, max_images, max_depth)
     if len(pairs) < 2:
         LOGGER.warning("calibrate: fewer than 2 valid images for fit/score split; calibration skipped.")
         return None
     res = select_calibration_cv(pairs, margin=margin)
     res["images"] = len(pairs)
-    # channels_last=True still converts the module inside the validator's inference_mode, so reassign instead
-    # of an in-place fill_ to keep the write legal on buffers that are inference tensors on that path.
-    head.cal_a = torch.full_like(head.cal_a, res["a"])
-    head.cal_b = torch.full_like(head.cal_b, res["b"])
+    head.cal_a.fill_(res["a"])
+    head.cal_b.fill_(res["b"])
     scores = " ".join(f"{n}={v:.4f}" for n, v in res["cv_scores"].items())
     LOGGER.info(
         f"Depth calibration selected '{res['name']}' (a={res['a']:.4f} b={res['b']:.4f}); CV held-out δ1 {scores}"

--- a/ultralytics/models/yolo/depth/calibrate.py
+++ b/ultralytics/models/yolo/depth/calibrate.py
@@ -215,8 +215,8 @@ def fit_calibration_selective(
         return None
     res = select_calibration_cv(pairs, margin=margin)
     res["images"] = len(pairs)
-    # channels_last=True still converts the module inside the validator's inference_mode, so reassign instead
-    # of an in-place fill_ to keep the write legal on buffers that are inference tensors on that path.
+    # _collect_logpairs moves the model inside inference_mode, so off CPU these buffers are inference tensors;
+    # reassign instead of an in-place fill_ to keep the write legal.
     head.cal_a = torch.full_like(head.cal_a, res["a"])
     head.cal_b = torch.full_like(head.cal_b, res["b"])
     scores = " ".join(f"{n}={v:.4f}" for n, v in res["cv_scores"].items())

--- a/ultralytics/models/yolo/depth/calibrate.py
+++ b/ultralytics/models/yolo/depth/calibrate.py
@@ -215,8 +215,8 @@ def fit_calibration_selective(
         return None
     res = select_calibration_cv(pairs, margin=margin)
     res["images"] = len(pairs)
-    # On CUDA the buffers are inference tensors (the device move ran under inference_mode); reassign instead
-    # of an in-place fill_ so the write is legal and the buffers stay normal/saveable for model.save().
+    # channels_last=True still converts the module inside the validator's inference_mode, so reassign instead
+    # of an in-place fill_ to keep the write legal on buffers that are inference tensors on that path.
     head.cal_a = torch.full_like(head.cal_a, res["a"])
     head.cal_b = torch.full_like(head.cal_b, res["b"])
     scores = " ".join(f"{n}={v:.4f}" for n, v in res["cv_scores"].items())

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -9,8 +9,10 @@ import numpy as np
 import torch
 from torch import nn
 
+from ultralytics.utils import LOGGER
 from ultralytics.utils.checks import check_suffix
 from ultralytics.utils.downloads import is_url
+from ultralytics.utils.torch_utils import smart_inference_mode
 
 from .backends import (
     AscendBackend,
@@ -374,6 +376,23 @@ class AutoBackend(nn.Module):
         if hasattr(self.backend, "model") and hasattr(self.backend.model, "eval"):
             self.backend.model.eval()
         return super().eval()
+
+    @smart_inference_mode(False)  # the converted weights outlive this call, so they must not be inference tensors
+    def set_memory_format(self, channels_last: bool) -> None:
+        """Convert to channels_last (NHWC), lossless and Tensor-Core friendly only for PyTorch models on CUDA.
+
+        Args:
+            channels_last (bool): Whether the caller requested the channels_last memory format.
+        """
+        if not channels_last:
+            return
+        if self.device.type != "cuda" or self.format != "pt":
+            LOGGER.warning(
+                f"'channels_last=True' applies only to native PyTorch models on CUDA, ignoring for "
+                f"format='{self.format}' on '{self.device.type}'."
+            )
+            return
+        self.to(memory_format=torch.channels_last)
 
     def _apply(self, fn) -> AutoBackend:
         """Apply a function to backend.model parameters, buffers, and tensors.

--- a/ultralytics/nn/backends/pytorch.py
+++ b/ultralytics/nn/backends/pytorch.py
@@ -9,7 +9,7 @@ import torch
 from torch import nn
 
 from ultralytics.utils import IS_JETSON, LOGGER, is_jetson
-from ultralytics.utils.torch_utils import unwrap_model
+from ultralytics.utils.torch_utils import smart_inference_mode, unwrap_model
 
 from .base import BaseBackend
 
@@ -42,6 +42,7 @@ class PyTorchBackend(BaseBackend):
         self.verbose = verbose
         super().__init__(weight, device, fp16)
 
+    @smart_inference_mode(False)  # the loaded module outlives this call, so its weights must not be inference tensors
     def load_model(self, weight: str | torch.nn.Module) -> None:
         """Load a PyTorch model from a checkpoint file or nn.Module instance.
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1883,6 +1883,7 @@ def torch_safe_load(weight, safe_only=None):
     return ckpt, file
 
 
+@smart_inference_mode(False)  # the loaded model outlives this call, so its weights must not be inference tensors
 def load_checkpoint(weight, device=None, inplace=True, fuse=False):
     """Load single model weights.
 

--- a/ultralytics/trackers/utils/reid.py
+++ b/ultralytics/trackers/utils/reid.py
@@ -16,6 +16,7 @@ import torch
 from ultralytics.nn.autobackend import AutoBackend
 from ultralytics.utils.ops import xywh2xyxy
 from ultralytics.utils.plotting import save_one_box
+from ultralytics.utils.torch_utils import smart_inference_mode
 
 REID_ASSETS = frozenset(f"yolo26{k}-reid.onnx" for k in "nsmlx")
 
@@ -23,6 +24,7 @@ REID_ASSETS = frozenset(f"yolo26{k}-reid.onnx" for k in "nsmlx")
 class ReID:
     """ReID encoder. Routes `.pt` to the YOLO predictor path; everything else to `AutoBackend`."""
 
+    @smart_inference_mode(False)  # the encoder is retained by the tracker; trackers are built inside a predict block
     def __init__(self, model: str, imgsz: int = 224, device: str | torch.device | None = None, fp16: bool = False):
         """Initialize encoder for re-identification.
 


### PR DESCRIPTION
## summary

standalone validation and a directly driven predictor both reached the channels_last conversion inside smart_inference_mode, so on cuda it turned the caller's conv weights into inference tensors that raise on any later in-place write or requires_grad_(true). the gate, the warning and the conversion now live in one autobackend method decorated with smart_inference_mode(false), which also removes the duplicated block from both engines. depth calibration gets the same treatment: fit_calibration_selective now owns the device move and declares its mode, so the torch.full_like workaround can go back to an in-place fill_.

## measured

a spy on the shared logger recorded torch.is_inference_mode_enabled() at the conversion site on both engines: true and true before, false and false after. the mechanism itself, on a real autobackend, leaves 126 inference tensors in the caller's module when the conversion runs inside inference mode and none outside; it rewrites only 4-d tensors, 91 of 540 on a depth model, which is why the 1-d calibration buffers were never the ones at risk.

calibrate_checkpoint was measured on four cells: on the base it completes on mps and cpu, restoring fill_ alone made it raise on mps, and with the device move hoisted it completes on both again. controls are byte identical across revisions: mAP50-95 0.294717, mAP50 0.534444, zero inference tensors left after a default validation, and calibration a=1.0000 b=-1.3652.

the cuda end to end check is not in these numbers: the product gates the branch to device.type cuda and no cuda host was reachable, so what is measured is that both engines now reach the conversion with inference mode disabled.

stacked on #25748, which is the other open change to calibrate.py.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Channels-last conversion and depth calibration now run outside inference mode so retained model weights and calibration buffers remain writable.

### 📊 Key Changes

- Added `AutoBackend.set_memory_format()`, decorated with `smart_inference_mode(False)`, to centralize the channels-last gate, warning, and conversion for native PyTorch models on CUDA.
- Updated both the predictor and validator to use `set_memory_format()` instead of performing their own conversion logic.
- Decorated PyTorch model loading, checkpoint loading, and ReID initialization with `smart_inference_mode(False)` so retained weights are not created as inference tensors.
- Updated `fit_calibration_selective()` to move the model to its device within its non-inference context and restore in-place `fill_()` updates for depth calibration buffers.

### 🎯 Purpose & Impact

- Direct predictor use and standalone validation no longer convert caller-owned CUDA weights into inference tensors during channels-last setup, allowing later in-place writes and gradient enabling.
- Depth calibration can update its calibration buffers in place after the device move, including on MPS and CPU workflows described in the PR context.
- Channels-last behavior remains restricted to native PyTorch models on CUDA, with the warning now emitted from one shared backend method.