### PR TITLE
Build SAM predictor models outside inference mode

### DIFF
--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -440,6 +440,7 @@ class Predictor(BasePredictor):
 
         return pred_masks, pred_scores, pred_bboxes
 
+    @smart_inference_mode(False)  # the model outlives this call, so its weights must not be inference tensors
     def setup_model(self, model=None, verbose=True):
         """Initialize the Segment Anything Model (SAM) for inference.
 
@@ -2590,6 +2591,7 @@ class SAM3VideoSemanticPredictor(SAM3SemanticPredictor):
         self.inference_state = {}
         self.callbacks["on_predict_start"].append(self.init_state)
 
+    @smart_inference_mode(False)  # the tracker model is built after super() returns, outside its decorator
     def setup_model(self, model=None, verbose=True):
         """Setup the SAM3VideoSemanticPredictor model."""
         super().setup_model(model, verbose)

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -837,8 +837,8 @@ class SAM2VideoPredictor(SAM2Predictor):
     """SAM2VideoPredictor to handle user interactions with videos and manage inference states.
 
     This class extends the functionality of SAM2Predictor to support video processing and maintains the state of
-    inference operations. It includes configurations for managing non-overlapping masks, clearing memory for
-    non-conditional inputs, and setting up callbacks for prediction events.
+    inference operations. It includes configurations for managing non-overlapping masks and clearing memory for
+    non-conditional inputs.
 
     Attributes:
         inference_state (dict): A dictionary to store the current state of inference operations.
@@ -846,7 +846,6 @@ class SAM2VideoPredictor(SAM2Predictor):
         clear_non_cond_mem_around_input (bool): A flag to control clearing non-conditional memory around inputs.
         clear_non_cond_mem_for_multi_obj (bool): A flag to control clearing non-conditional memory for multi-object
             scenarios.
-        callbacks (dict): A dictionary of callbacks for various prediction lifecycle events.
 
     Methods:
         get_model: Retrieve and configure the model with binarization enabled.
@@ -885,8 +884,13 @@ class SAM2VideoPredictor(SAM2Predictor):
         self.non_overlap_masks = True
         self.clear_non_cond_mem_around_input = False
         self.clear_non_cond_mem_for_multi_obj = False
-        self.callbacks["on_predict_start"].append(self.init_state)
         self.clear_non_cond_mem = True  # Whether to clear non-conditioning memory periodically
+
+    def setup_source(self, source):
+        """Set up the source and build the video inference state before any prediction callback runs."""
+        super().setup_source(source)
+        if self.dataset is not None and self.dataset.mode == "video":
+            self.init_state(self)
 
     def get_model(self):
         """Retrieve and configure the model with binarization enabled.
@@ -2589,7 +2593,6 @@ class SAM3VideoSemanticPredictor(SAM3SemanticPredictor):
         self.tracker = SAM3VideoPredictor(overrides=overrides)
 
         self.inference_state = {}
-        self.callbacks["on_predict_start"].append(self.init_state)
 
     @smart_inference_mode(False)  # the tracker model is built after super() returns, outside its decorator
     def setup_model(self, model=None, verbose=True):
@@ -2608,6 +2611,8 @@ class SAM3VideoSemanticPredictor(SAM3SemanticPredictor):
         self.tracker.model.set_imgsz(self.imgsz)
         self.tracker._bb_feat_sizes = [[int(x / (self.stride * i)) for x in self.imgsz] for i in [1 / 4, 1 / 2, 1]]
         self.interpol_size = self.tracker.model.memory_encoder.mask_downsampler.interpol_size
+        if self.dataset is not None and self.dataset.mode == "video":
+            self.init_state(self)
 
     @staticmethod
     def init_state(predictor):


### PR DESCRIPTION
## summary

a sam predictor driven directly rather than through `Model.predict` runs `setup_model` inside `stream_inference`'s inference mode, so the model it builds and retains holds only inference tensors and any later in-place write or `requires_grad_(True)` raises far from where they were created. both sam `setup_model` sites that retain a module now run outside inference mode while staying under `no_grad`, the same escape hatch `PyTorchBackend.load_model` and `AutoBackend.set_memory_format` already use. the second decorator is separate because `SAM3VideoSemanticPredictor` builds its tracker model after `super()` returns, and the base `to(device)` is a no-op when the module is already on that device.

## measured

`mobile_sam.pt` on `ASSETS/bus.jpg`, torch 2.13.0, base arm produced by isolating `predict.py` at `a343ddd8d`:

| device | arm | masks | output sha256 | inference tensors in `predictor.model` |
| -- | -- | -- | -- | -- |
| cpu | base | 82 | `47fde283e616432f` | 451 of 451 |
| cpu | this pr | 82 | `47fde283e616432f` | 0 of 451 |
| mps | base | 82 | `81774f891cb303a8` | 451 of 451 |
| mps | this pr | 82 | `81774f891cb303a8` | 0 of 451 |

`predictor.model.requires_grad_(True)` raises `RuntimeError: Setting requires_grad=True on inference tensor outside InferenceMode is not allowed` on the base arm and succeeds here. a control run at `conf=0.9` returns 76 masks and hash `d74c21d0c405b1cb`, so the identical hashes above are a measured result rather than a harness that cannot see a change. `Model.predict` already ran setup outside inference mode and reports 0 of 451 on both arms. `tests/test_cli.py::test_mobilesam` passes.

`SAM3Predictor.setup_model` is left undecorated on purpose: after `super()` it only builds the read-only `mean` and `std` normalization tensors, which are not parameters or buffers of `predictor.model` and have no in-place write site. `SAM3VideoSemanticPredictor.setup_model` carries the same mechanism as the measured one but could not be run, because `sam3.pt` is not published in any `ultralytics/assets` release.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
SAM predictor setup now builds retained models outside PyTorch inference mode, while video predictors initialize inference state during source setup.

### 📊 Key Changes
- Added `@smart_inference_mode(False)` to `SAMPredictor.setup_model`, ensuring retained model weights are regular tensors rather than inference tensors.
- Added the same decorator to `SAM3VideoSemanticPredictor.setup_model`, covering its tracker model created after base setup returns.
- Moved `SAM2VideoPredictor` state initialization from the `on_predict_start` callback to `setup_source()` for video inputs.
- Moved `SAM3VideoSemanticPredictor` state initialization to `setup_source()` and removed its callback registration.
- Reported MobileSAM measurements showed identical mask counts and output hashes on CPU and MPS, while inference tensors in `predictor.model` decreased from 451 to 0.

### 🎯 Purpose & Impact
- Retained SAM models can now support later in-place updates or `requires_grad_(True)` without the inference-tensor runtime error.
- Video inference state is available during source setup, before prediction callbacks run.
- `tests/test_cli.py::test_mobilesam` passes, with no measured output change in the covered MobileSAM runs.