### PR TITLE
Build the SAM video inference state in the predictor instead of a model callback

### DIFF
--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -837,8 +837,8 @@ class SAM2VideoPredictor(SAM2Predictor):
     """SAM2VideoPredictor to handle user interactions with videos and manage inference states.
 
     This class extends the functionality of SAM2Predictor to support video processing and maintains the state of
-    inference operations. It includes configurations for managing non-overlapping masks, clearing memory for
-    non-conditional inputs, and setting up callbacks for prediction events.
+    inference operations. It includes configurations for managing non-overlapping masks and clearing memory for
+    non-conditional inputs.
 
     Attributes:
         inference_state (dict): A dictionary to store the current state of inference operations.
@@ -846,7 +846,6 @@ class SAM2VideoPredictor(SAM2Predictor):
         clear_non_cond_mem_around_input (bool): A flag to control clearing non-conditional memory around inputs.
         clear_non_cond_mem_for_multi_obj (bool): A flag to control clearing non-conditional memory for multi-object
             scenarios.
-        callbacks (dict): A dictionary of callbacks for various prediction lifecycle events.
 
     Methods:
         get_model: Retrieve and configure the model with binarization enabled.
@@ -885,8 +884,13 @@ class SAM2VideoPredictor(SAM2Predictor):
         self.non_overlap_masks = True
         self.clear_non_cond_mem_around_input = False
         self.clear_non_cond_mem_for_multi_obj = False
-        self.callbacks["on_predict_start"].append(self.init_state)
         self.clear_non_cond_mem = True  # Whether to clear non-conditioning memory periodically
+
+    def setup_source(self, source):
+        """Set up the source and build the video inference state before any prediction callback runs."""
+        super().setup_source(source)
+        if self.dataset is not None and self.dataset.mode == "video":
+            self.init_state(self)
 
     def get_model(self):
         """Retrieve and configure the model with binarization enabled.
@@ -2589,7 +2593,6 @@ class SAM3VideoSemanticPredictor(SAM3SemanticPredictor):
         self.tracker = SAM3VideoPredictor(overrides=overrides)
 
         self.inference_state = {}
-        self.callbacks["on_predict_start"].append(self.init_state)
 
     @smart_inference_mode(False)  # the tracker model is built after super() returns, outside its decorator
     def setup_model(self, model=None, verbose=True):
@@ -2608,6 +2611,8 @@ class SAM3VideoSemanticPredictor(SAM3SemanticPredictor):
         self.tracker.model.set_imgsz(self.imgsz)
         self.tracker._bb_feat_sizes = [[int(x / (self.stride * i)) for x in self.imgsz] for i in [1 / 4, 1 / 2, 1]]
         self.interpol_size = self.tracker.model.memory_encoder.mask_downsampler.interpol_size
+        if self.dataset is not None and self.dataset.mode == "video":
+            self.init_state(self)
 
     @staticmethod
     def init_state(predictor):


### PR DESCRIPTION
## summary

`SAM2VideoPredictor` and `SAM3VideoSemanticPredictor` appended their per-instance `init_state` hook to the callback dict they receive from `Model`, so building either through the public `predictor=` kwarg of `Model.predict` left that hook on the model, and any later predictor built from the same model inherited it and raised `AttributeError` on an ordinary predict. each video predictor now builds its state in its own `setup_source`, which still runs before the prediction callbacks fire, so the model's callback dict is left untouched.

## measured

`mobile_sam.pt` and `sam2_t.pt`, CPU, six-frame clip cut from `solutions_ci_demo.mp4`, prompt point on a person detected at conf 0.83.

changed

| case | before | after |
| --- | --- | --- |
| `model.callbacks["on_predict_start"]` after `model.predict(..., predictor=SAM2VideoPredictor)` | `['on_predict_start', 'init_state']` | `['on_predict_start']` |
| a plain `model.predict` on that same model afterwards | `AttributeError: 'Predictor' object has no attribute 'inference_state'` | 1 result returned |
| a non-video source through a video predictor: image, image folder, numpy array | `AssertionError` | `AttributeError: 'LoadImagesAndVideos' object has no attribute 'frame'` |
| a folder holding both images and videos | `AssertionError` | `KeyError: 'output_dict'` |

the last two rows are unsupported on both sides and raise either way; only the exception changes.

how often the leak was reachable

| spelling | builds a video predictor | leaked |
| --- | --- | --- |
| `SAM(...).predict(...)`, through `task_map` | no | no |
| `SAM2VideoPredictor(overrides=...)` directly, as the docs show | yes | no, `_callbacks=None` gives it its own dict |
| `Model.predict(..., predictor=SAM2VideoPredictor)` | yes | yes |

measured not to move

| control | before | after |
| --- | --- | --- |
| SAM2 six-frame video predict, mask pixels per frame | 1016, 1004, 1004, 984, 977, 967 | identical |
| those masks, sha256 | `2f67e431bb109ae7` | identical |
| a hook on `on_predict_start` reading `inference_state["num_frames"]` | 6 | 6 |
| a hook on `on_predict_batch_start` reading the same | 6 | 6 |
| `SAM2VideoPredictor.set_image("frame0.jpg")` | features built, `inference_state` empty | identical |

the equality check is calibrated: moving the prompt point changes the per-frame mask pixels to 734, 729, 733, 743, 741, 759 and the hash to `fbf9f50fe1ab5184`, so it can see a real change. `SAM3VideoSemanticPredictor` could not be run here because `sam3.pt` is in no assets release, so its half of the output check is by code reading only.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Moved video inference-state initialization for `SAM2VideoPredictor` and `SAM3VideoSemanticPredictor` from model callbacks into `setup_source` so predictors no longer modify the model’s shared callback dictionary.

### 📊 Key Changes
- Removed each video predictor’s registration of `init_state` on `callbacks["on_predict_start"]`.
- Added video-only state initialization in `SAM2VideoPredictor.setup_source`.
- Added equivalent initialization in `SAM3VideoSemanticPredictor.setup_source`.
- Updated `SAM2VideoPredictor` documentation to remove the obsolete callback attribute and description.

### 🎯 Purpose & Impact
- A model used with `Model.predict(..., predictor=SAM2VideoPredictor)` no longer retains the video-specific `init_state` callback for later predictions.
- Video setup still completes before prediction callbacks run, preserving hooks that read `inference_state`.
- Non-video sources passed to video predictors remain unsupported; their exception type may differ because state initialization now occurs during source setup.