### PR TITLE
Register the World pretrain hook once per model

### DIFF
--- a/ultralytics/models/yolo/world/train.py
+++ b/ultralytics/models/yolo/world/train.py
@@ -86,7 +86,9 @@ class WorldTrainer(DetectionTrainer):
         )
         if weights:
             model.load(weights)
-        self.add_callback("on_pretrain_routine_end", on_pretrain_routine_end)
+        # the caller's Model shares this dict, so a bare append outlives the trainer and stacks on every later one
+        if on_pretrain_routine_end not in self.callbacks["on_pretrain_routine_end"]:
+            self.add_callback("on_pretrain_routine_end", on_pretrain_routine_end)
 
         return model
 


### PR DESCRIPTION
## summary

worldtrainer.get_model appended its on_pretrain_routine_end hook into the callback dict the model shares with every component it builds, so a multi-dataset train(data=[...]) sweep accumulated one copy per dataset and re-ran set_classes for each. the registration now happens only when the hook is not already present, matching how register_tracker was made idempotent.

the guard stays inside get_model rather than moving to _setup_train or __init__ because three yoloe trainers carry worldtrainer in their mro while overriding get_model, and relocating it would start applying set_classes to them.

## measured

yolov8s-worldv2.pt, dota8.yaml twice, epochs=1 imgsz=32, cpu. before: 2 registrations and 3 set_classes calls across the sweep. after: 1 registration and 2 calls, one per dataset. growth was N(N+1)/2 in the number of datasets, each redundant call re-encoding the clip text. tests/test_python.py::test_yolo_world passes on both revisions.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
The World trainer now registers its pretraining callback only once per shared callback registry, preventing duplicate `set_classes` executions during multi-dataset training sweeps.

### 📊 Key Changes
- Added a duplicate check before registering `on_pretrain_routine_end` in `worldtrainer.get_model`.
- Prevented callback registrations from accumulating across trainers that share the model’s callback dictionary.
- Preserved the registration location in `get_model` to avoid applying the World-specific `set_classes` behavior to YOLOE trainers that override this method.
- Multi-dataset sweeps now perform one callback execution per dataset instead of re-running previously registered callbacks.

### 🎯 Purpose & Impact
- Reduces redundant CLIP text re-encoding and prevents callback growth across datasets.
- The existing `tests/test_python.py::test_yolo_world` test passes with the change.