### PR TITLE
Update the Albumentations examples to the 2.x constructor arguments

### DIFF
--- a/docs/en/guides/yolo-data-augmentation.md
+++ b/docs/en/guides/yolo-data-augmentation.md
@@ -391,6 +391,8 @@ Then launch the training with the Python API:
 - **Purpose**: Provides fine-grained control over data augmentation strategies by leveraging the extensive library of Albumentations transforms. This is particularly useful when you need specialized augmentations beyond the built-in YOLO options, such as advanced color adjustments, noise injection, or domain-specific transformations.
 - **Ultralytics' implementation**: [Albumentations](../reference/data/augment.md#ultralytics.data.augment.Albumentations)
 
+The examples below need Albumentations 1.4.22 or newer, and therefore Python 3.9 or newer.
+
 !!! example "Custom Albumentations Example"
 
     === "Python API"
@@ -406,7 +408,7 @@ Then launch the training with the Python API:
         # Define custom Albumentations transforms
         custom_transforms = [
             A.Blur(blur_limit=7, p=0.5),
-            A.GaussNoise(var_limit=(10.0, 50.0), p=0.3),
+            A.GaussNoise(std_range=(0.0124, 0.0277), p=0.3),
             A.CLAHE(clip_limit=4.0, p=0.5),
             A.RandomBrightnessContrast(brightness_limit=0.2, contrast_limit=0.2, p=0.5),
             A.HueSaturationValue(hue_shift_limit=20, sat_shift_limit=30, val_shift_limit=20, p=0.5),
@@ -443,7 +445,7 @@ Then launch the training with the Python API:
             ),
             A.OneOf(
                 [
-                    A.GaussNoise(var_limit=(10.0, 50.0), p=1.0),
+                    A.GaussNoise(std_range=(0.0124, 0.0277), p=1.0),
                     A.ISONoise(color_shift=(0.01, 0.05), intensity=(0.1, 0.5), p=1.0),
                 ],
                 p=0.2,
@@ -451,9 +453,7 @@ Then launch the training with the Python API:
             A.CLAHE(clip_limit=4.0, tile_grid_size=(8, 8), p=0.5),
             A.RandomBrightnessContrast(brightness_limit=0.3, contrast_limit=0.3, brightness_by_max=True, p=0.5),
             A.HueSaturationValue(hue_shift_limit=20, sat_shift_limit=30, val_shift_limit=20, p=0.5),
-            A.CoarseDropout(
-                max_holes=8, max_height=32, max_width=32, min_holes=1, min_height=8, min_width=8, fill_value=0, p=0.2
-            ),
+            A.CoarseDropout(num_holes_range=(1, 8), hole_height_range=(8, 32), hole_width_range=(8, 32), fill=0, p=0.2),
         ]
 
         # Train with advanced custom transforms
@@ -482,7 +482,6 @@ Then launch the training with the Python API:
 
 **Compatibility Notes:**
 
-- Requires Albumentations version 1.0.3 or higher
 - Compatible with all YOLO detection and segmentation tasks
 - Not applicable for classification tasks (classification uses a different augmentation pipeline)
 

--- a/docs/en/integrations/albumentations.md
+++ b/docs/en/integrations/albumentations.md
@@ -66,6 +66,8 @@ To use Albumentations with YOLO26, start by making sure you have the necessary p
 
 For detailed instructions and best practices related to the installation process, check our [Ultralytics Installation guide](../quickstart.md). While installing the required packages for YOLO26, if you encounter any difficulties, consult our [Common Issues guide](../guides/yolo-common-issues.md) for solutions and tips.
 
+The custom transform examples on this page need Albumentations 1.4.22 or newer, and therefore Python 3.9 or newer.
+
 ### Usage
 
 After installing the necessary packages, you're ready to start using Albumentations with YOLO26. When you train YOLO26, a set of augmentations is automatically applied through its integration with Albumentations, making it easy to enhance your model's performance.
@@ -97,7 +99,7 @@ After installing the necessary packages, you're ready to start using Albumentati
         # Define custom Albumentations transforms
         custom_transforms = [
             A.Blur(blur_limit=7, p=0.5),
-            A.GaussNoise(var_limit=(10.0, 50.0), p=0.3),
+            A.GaussNoise(std_range=(0.0124, 0.0277), p=0.3),
             A.CLAHE(clip_limit=4.0, p=0.5),
             A.RandomBrightnessContrast(brightness_limit=0.2, contrast_limit=0.2, p=0.5),
         ]
@@ -173,7 +175,7 @@ The image below shows an example of the CLAHE transformation applied.
 
 ## Using Custom Albumentations Transforms
 
-While the default Albumentations integration provides a solid set of augmentations, you may want to customize the transforms for your specific use case. With Ultralytics YOLO26, you can easily pass custom Albumentations transforms via the Python API using the `augmentations` parameter.
+While the default Albumentations integration provides a solid set of augmentations, you may want to customize the transforms for your specific use case. With Ultralytics YOLO26, you can easily pass custom Albumentations transforms via the Python API using the `augmentations` parameter. The examples in this section need Albumentations 1.4.22 or newer.
 
 ### How to Define Custom Transforms
 
@@ -203,7 +205,7 @@ custom_transforms = [
     # Noise variations
     A.OneOf(
         [
-            A.GaussNoise(var_limit=(10.0, 50.0), p=1.0),
+            A.GaussNoise(std_range=(0.0124, 0.0277), p=1.0),
             A.ISONoise(color_shift=(0.01, 0.05), intensity=(0.1, 0.5), p=1.0),
         ],
         p=0.2,
@@ -213,9 +215,7 @@ custom_transforms = [
     A.RandomBrightnessContrast(brightness_limit=0.3, contrast_limit=0.3, p=0.5),
     A.HueSaturationValue(hue_shift_limit=20, sat_shift_limit=30, val_shift_limit=20, p=0.5),
     # Simulate occlusions
-    A.CoarseDropout(
-        max_holes=8, max_height=32, max_width=32, min_holes=1, min_height=8, min_width=8, fill_value=0, p=0.2
-    ),
+    A.CoarseDropout(num_holes_range=(1, 8), hole_height_range=(8, 32), hole_width_range=(8, 32), fill=0, p=0.2),
 ]
 
 # Train with custom transforms


### PR DESCRIPTION
## summary

the albumentations examples on the augmentation guide and the integration page passed 1.x constructor arguments that later releases accept with a warning and then discard, so the transforms the documented code builds do not match what the pages describe. this ports gaussnoise to std_range and coarsedropout to num_holes_range, hole_height_range, hole_width_range and fill, keeping the noise sigma and the hole geometry the 1.x values produced. those spellings first exist in albumentations 1.4.22, so each page states that floor ahead of the examples that need it, while the install commands and the pyproject extra stay unpinned because the automatic integration does not need it.

## measured

an ast sweep constructs every `A.<Name>(...)` call in every fenced python block on both pages under recorded warnings, on four real installs.

| tree | albumentations 2.0.8 | 1.4.22 | 1.4.21 | albumentationsx 2.3.10 |
| -- | -- | -- | -- | -- |
| before | 6 of 29 | 2 of 29 | 0 of 29 | 29 of 29 |
| after | 0 of 29 | 0 of 29 | 6 of 29 | 23 of 29 |

`A.GaussNoise(std_range=(0.0124, 0.0277))` measures sigma 3.40 to 6.66 in 0-255 gray levels against the 3.16 to 7.07 the old `var_limit=(10.0, 50.0)` produced, and `A.CoarseDropout` cuts 1 to 8 holes of 8 to 32 px on both axes. both new spellings are valid on every install in the table above.

the last column is a separate issue this pr does not close. development of albumentations moved to an `albumentationsx` distribution, which installs under the same `albumentations` import name and renamed every `*_limit` argument to `*_range` with no deprecation period, so 23 example constructors still break there. no single spelling works on both distributions, and picking one is a dependency decision rather than a docs edit, so it is tracked separately.

replaces #25699, rebuilt on current main as one commit.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated Albumentations custom-transform examples on the data augmentation and integration guides to use 2.x constructor arguments while documenting the required minimum version.

### 📊 Key Changes
- Replaced `GaussNoise(var_limit=...)` with `GaussNoise(std_range=...)` while retaining the documented noise range.
- Replaced deprecated `CoarseDropout` arguments with `num_holes_range`, `hole_height_range`, `hole_width_range`, and `fill`.
- Added Albumentations 1.4.22 and Python 3.9 minimum-version notes to the affected examples.
- Removed the outdated compatibility note claiming support for Albumentations 1.0.3 or newer.

### 🎯 Purpose & Impact
- The documented custom-transform examples now construct the intended noise and coarse-dropout configurations without the warnings and discarded arguments associated with the previous constructor names.
- The changes apply to documentation examples only; the automatic Albumentations integration and dependency declarations were not modified.