### PR TITLE
Restore the model override after training

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -844,6 +844,7 @@ class Model(torch.nn.Module):
             self.model, self.ckpt = load_checkpoint(ckpt)
             self.predictor = None  # the checkpoint replaced the module again; covers resume and YAML runs too
             self.overrides = self._reset_ckpt_args(self.model.args)
+            self.overrides["model"] = self.model.pt_path  # the reset drops it, train() and tune() read it back
             self.metrics = getattr(self.trainer.validator, "metrics", None)
             if self.metrics is None and self.ckpt:  # recover from checkpoint under DDP (validator runs in subprocess)
                 self.metrics = self.ckpt.get("train_metrics")

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -844,7 +844,7 @@ class Model(torch.nn.Module):
             self.model, self.ckpt = load_checkpoint(ckpt)
             self.predictor = None  # the checkpoint replaced the module again; covers resume and YAML runs too
             self.overrides = self._reset_ckpt_args(self.model.args)
-            self.overrides["model"] = self.model.pt_path  # the reset drops it, train() and tune() read it back
+            self.overrides["model"] = str(ckpt)  # the reset drops it, train() and tune() read it back
             self.metrics = getattr(self.trainer.validator, "metrics", None)
             if self.metrics is None and self.ckpt:  # recover from checkpoint under DDP (validator runs in subprocess)
                 self.metrics = self.ckpt.get("train_metrics")


### PR DESCRIPTION
## summary

`Model.train` ended by rebuilding `self.overrides` from the trained checkpoint through `_reset_ckpt_args`, whose whitelist does not include `model`, so the key the next `train()` reads at the top of the same method was gone and a second `train()` on the same object raised `KeyError: 'model'`. This restores the key from the checkpoint just loaded, the way `_load` already does after the identical reset. It also repairs `tune()` after `train()`, which was sending `model=None` to its subprocess and silently falling back to a stock `yolo26n.pt`.

## measured

`origin/main` a343ddd8d, macOS CPU, torch 2.13.0, `coco8.yaml`, `epochs=1 imgsz=32 device=cpu`.

what changed:

| case | before | after |
| --- | --- | --- |
| second `train()`, `yolo26n.pt` | `KeyError: 'model'` | completes |
| second `train()`, `yolo26n-seg.pt` | `KeyError: 'model'` | completes |
| second `train()`, `YOLO("yolo26n.yaml")` | `KeyError: 'model'` | completes |
| model the tuner subprocess trains after a `train()` | stock `yolo26n.pt` | the trained `best.pt` |

what does not move, per call:

| case | result |
| --- | --- |
| `val()` save directory after `train()` | `val`-prefixed on both revisions, never a `train*` directory |
| `val()` box mAP50-95 after `train()` | identical |
| `predict()` detections after `train()` | identical |
| `export(format="torchscript")` output filename | identical |
| every config the validator, predictor and exporter are constructed with after `train()` | one key added, `model`; a key-by-key diff shows nothing else |
| untrained model: overrides, `val()` save directory, `predict()` detections, full consumer configs | identical |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Restored the trained checkpoint path in `Model.train()` overrides so repeated training and tuning reuse the correct model instead of losing the `model` argument.

### 📊 Key Changes
- Adds `self.overrides["model"] = str(ckpt)` after `_reset_ckpt_args()` rebuilds overrides from the trained checkpoint.
- Allows a second `train()` call on checkpoint, segmentation, and YAML-initialized models to access the required `model` key.
- Ensures `tune()` subprocesses receive the trained `best.pt` rather than falling back to `yolo26n.pt`.
- Leaves other post-training consumer configuration values unchanged apart from restoring the `model` key.

### 🎯 Purpose & Impact
- Repeated training on the same model object no longer raises `KeyError: 'model'`.
- Tuning after training now starts from the trained checkpoint.
- No user-facing changes were reported for validation output paths, validation metrics, prediction detections, export filenames, or untrained-model behavior.