### PR TITLE
Reset dataloader workers when resuming after mosaic closure

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1081,6 +1081,7 @@ class BaseTrainer:
         self.start_epoch = start_epoch
         if start_epoch > (self.epochs - self.args.close_mosaic):
             self._close_dataloader_mosaic()
+            self.train_loader.reset()
 
     def _close_dataloader_mosaic(self):
         """Update dataloaders to stop using mosaic augmentation."""


### PR DESCRIPTION
When training crosses the `close_mosaic` boundary normally, the epoch loop rebuilds the dataset transforms and resets the dataloader. On resume after that boundary, `resume_training()` rebuilt the transforms but did not reset the iterator. Because `InfiniteDataLoader` workers are created before `resume_training()` runs, those worker processes kept their original mosaic-enabled dataset copy even though the parent process logged `Closing dataloader mosaic`.

So this adds the missing reset to the resume path, after `_close_dataloader_mosaic()` returns. Keeping it at the call site is important for YOLOE: its override appends `LoadVisualPrompt` after calling `super()`, so all transform changes must finish before new workers are created.

**Validation**

I trained YOLO26n on COCO128 with `epochs=3`, `close_mosaic=2`, `imgsz=64`, `batch=16`, and `workers=8`, then resumed epoch 3 twice from the same epoch-2 checkpoint before and after this change. A worker-side probe recorded the enabled Mosaic state, instance count, and MD5 of each raw image batch.

| Run | Mosaic in workers | Epoch instances | First batch MD5 |
| --- | --- | ---: | --- |
| Fresh mosaic epoch | enabled | 1,092 | `53ae85ca022c6b5c5ad8b48113f3ee7a` |
| Fresh final epoch | disabled | 589 | `f03a5e2dc488d780668c76dc538e519e` |
| Resume before | enabled for 128/128 samples | 1,092 | `53ae85ca022c6b5c5ad8b48113f3ee7a` |
| Resume after | disabled for 128/128 samples | 614 | `7ab73a2ed9e07b62642058ec6ad0f8e3` |

Both before runs were identical to each other, both after runs were identical to each other too, and two complete fresh runs were also identical. Before the fix, the resumed epoch contained 1.854x the instances of the fresh final epoch, its first batch was byte-identical to the fresh mosaic batch. After the fix, all 128 worker samples reported Mosaic disabled. The resumed and uninterrupted no-mosaic batches are not expected to be byte-identical because recreating the iterator at a different point advances the sampler and augmentation RNG streams differently.

The existing seven-task resume coverage passes:

```text
pytest -q tests/test_engine.py::test_resume_incomplete
7 passed, 60 warnings in 16.32s
```

No test code is added: the existing resume test uses `workers=0`, so it covers checkpoint continuation but cannot expose a stale forked dataset copy. The focused 8-worker A/B above exercises the missing process boundary directly.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Resets training dataloader workers when resuming after mosaic augmentation has been closed. 🔄

### 📊 Key Changes
- Calls `self.train_loader.reset()` after closing dataloader mosaic during resume.
- Applies the reset when resuming in the final `close_mosaic` training epochs.

### 🎯 Purpose & Impact
- Ensures dataloader workers correctly reflect the updated augmentation state after resuming.
- Helps prevent stale worker state and supports consistent training behavior across resumed runs. ✅