### PR TITLE
Build the name=model save directory from the model stem

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -513,10 +513,9 @@ def get_save_dir(args: SimpleNamespace, name: str | None = None) -> Path:
 
     Examples:
         >>> from types import SimpleNamespace
-        >>> args = SimpleNamespace(project="my_project", task="detect", mode="train", exist_ok=True)
-        >>> save_dir = get_save_dir(args)
-        >>> print(save_dir)
-        runs/detect/my_project/train
+        >>> args = SimpleNamespace(project="my_project", name="exp", task="detect", mode="train", exist_ok=True)
+        >>> get_save_dir(args).parts[-3:]
+        ('detect', 'my_project', 'exp')
     """
     if getattr(args, "save_dir", None):
         save_dir = args.save_dir
@@ -611,6 +610,7 @@ def check_dict_alignment(
         ...     check_dict_alignment(base_cfg, custom_cfg)
         ... except SyntaxError:
         ...     print("Mismatched keys found")
+        Mismatched keys found
 
     Notes:
         - Suggests corrections for mismatched keys based on similarity to valid keys.

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -382,7 +382,7 @@ def get_cfg(
         if k in cfg and isinstance(cfg[k], FLOAT_OR_INT):
             cfg[k] = str(cfg[k])
     if cfg.get("name") == "model":  # assign model to 'name' arg
-        cfg["name"] = str(cfg.get("model", "")).partition(".")[0]
+        cfg["name"] = Path(str(cfg.get("model") or "")).stem
         LOGGER.warning(f"'name=model' automatically updated to 'name={cfg['name']}'.")
 
     # Type and Value checks


### PR DESCRIPTION
## summary

`get_cfg` resolved the `name="model"` sentinel by slicing the raw model string at its first dot, so an absolute model path became the whole `name` and `Path(project) / name` then discarded `project`, writing the run next to the checkpoint. taking the stem instead keeps `yolo26n.pt -> yolo26n` unchanged, turns any path into a bare directory name, and stops a dot in a directory component truncating it. the same commit makes an unset `model` resolve to an empty name so the run falls back to the mode instead of a literal `None` directory. a second commit corrects two docstring examples in the same file: `get_save_dir` raised `AttributeError` because its namespace had no `name`, and `check_dict_alignment` did not declare its printed output.

## measured

on `origin/main` a343ddd8d, over the seven model-string shapes the package accepts or produces, five resolved to a wrong name and two were correct; after the change all seven are correct, with the two bare-filename shapes byte-identical. end to end, `YOLO("<abs>/yolo26n.pt").val(project=P, name="model")` wrote to `<abs>/yolo26n` before and writes to `P/yolo26n` now, while the bare-filename control writes to `P/yolo26n` on both. the old and new expressions differ only on strings containing a path separator, on more than one dot, or on `None`; they agree on every bare `stem.suffix`. doctests on the touched module went from four failures to two, both of which are the pre-existing placeholder-path examples.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Run directories built from `name="model"` now use the model path’s filename stem, preserving the configured project directory and avoiding invalid path-derived names.

### 📊 Key Changes

- Replaced first-dot string slicing with `Path(...).stem` when resolving the `name="model"` sentinel.
- Unset `model` values now resolve to an empty name instead of a literal `None` directory.
- Updated `get_save_dir` documentation to include the required `name` attribute and a valid expected result.
- Updated the `check_dict_alignment` example to declare its printed `Mismatched keys found` output.

### 🎯 Purpose & Impact

- A model such as `/path/to/yolo26n.pt` now produces a save path under `project/yolo26n` rather than next to the checkpoint.
- Dots in directory names no longer truncate the generated run name, while bare model filenames retain their existing behavior.
- The affected docstring examples now match the function interfaces and shown output.