### PR TITLE
Fix unbounded SavedModel and LiteRT INT8 calibration memory

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1394,7 +1394,13 @@ class Exporter:
         # Export to TF
         images = None
         if self.args.quantize == 8 and self.args.data:
-            images = [batch["img"] for batch in self.get_int8_calibration_dataloader(prefix)]
+            images, n = [], 0
+            for batch in self.get_int8_calibration_dataloader(prefix):
+                images.append(batch["img"])
+                n += images[-1].shape[0]
+                if n >= 512:
+                    break
+            LOGGER.info(f"{prefix} using {n} INT8 calibration images (target 512) to bound host memory")
             images = (
                 torch.nn.functional.interpolate(torch.cat(images, 0).float(), size=self.imgsz)
                 .permute(0, 2, 3, 1)

--- a/ultralytics/utils/export/litert.py
+++ b/ultralytics/utils/export/litert.py
@@ -76,7 +76,7 @@ def torch2litert(
         if static_int8 or static_int16:  # static schemes calibrate over representative images
             act = "int8" if static_int8 else "int16"
             LOGGER.info(f"{prefix} applying static quantization (int8 weights + {act} activations)...")
-            calib_samples = []
+            calib_samples, n = [], 0
             for batch in calibration_dataset:
                 imgs = batch["img"].cpu().float() / 255.0
                 # litert-torch traces a fixed batch; tile under-sized batches up to im's batch dim (repeats are
@@ -84,6 +84,10 @@ def torch2litert(
                 if imgs.shape[0] < im.shape[0]:
                     imgs = imgs.repeat(-(-im.shape[0] // imgs.shape[0]), 1, 1, 1)[: im.shape[0]]
                 calib_samples.append({"args_0": imgs.numpy()})
+                n += batch["img"].shape[0]  # source images, before tiling
+                if n >= 512:
+                    break
+            LOGGER.info(f"{prefix} using {n} INT8 calibration images (target 512) to bound host memory")
             qt.load_quantization_recipe(recipe.static_wi8_ai8() if static_int8 else recipe.static_wi8_ai16())
             # Keep FP32 graph input/output (weights/activations stay int8/int16 internally): matches the historical
             # onnx2tf "fp32 in/out" contract that downstream consumers (LiteRT GPU delegate, on-device runtimes) expect,


### PR DESCRIPTION
While validating INT8 exports on COCO, I found SavedModel and LiteRT retain every calibration image in host memory before downstream quantization.

This change bounds those two materializing paths to a target of 512 source images, matching ModelOpt’s existing local calibration pattern. ONNX/QNN and TensorRT remain unchanged because they stream calibration data.

Diff: code +12/-2.

Replaced: unbounded SavedModel and LiteRT calibration collection with local counted loops.

Added: per-format log reporting selected calibration-image count and target.

Validation on CPU-only Ubuntu 22.04, full COCO val2017, `yolo26n.pt`, `imgsz=640`:
  - SavedModel INT8 export completed with 512 calibration images; peak RSS: 9.06 GiB.
  - LiteRT INT8 export completed with 512 calibration images; peak RSS: 4.45 GiB.
  - COCO mAP50-95: FP32 0.400, SavedModel INT8 0.403, LiteRT INT8 0.320.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Bounds INT8 calibration image collection for SavedModel and LiteRT exports to prevent unbounded host-memory usage.

### 📊 Key Changes
- Limits calibration collection to approximately 512 source images in SavedModel export.
- Applies the same 512-image cap to static INT8 and INT16 LiteRT calibration.
- Preserves LiteRT fixed-batch tiling behavior while counting original source images.
- Adds logging to report the number of calibration images used.

### 🎯 Purpose & Impact
- Prevents memory growth when calibration datasets are large.
- Makes quantized exports more reliable and predictable on memory-constrained systems.
- May use fewer calibration samples than before, while retaining the established calibration workflow.