### PR TITLE
Revert "Build loaded models outside inference mode"

### DIFF
--- a/ultralytics/models/yolo/depth/calibrate.py
+++ b/ultralytics/models/yolo/depth/calibrate.py
@@ -215,8 +215,8 @@ def fit_calibration_selective(
         return None
     res = select_calibration_cv(pairs, margin=margin)
     res["images"] = len(pairs)
-    # _collect_logpairs moves the model inside inference_mode, so off CPU these buffers are inference tensors;
-    # reassign instead of an in-place fill_ to keep the write legal.
+    # On CUDA the buffers are inference tensors (the device move ran under inference_mode); reassign instead
+    # of an in-place fill_ so the write is legal and the buffers stay normal/saveable for model.save().
     head.cal_a = torch.full_like(head.cal_a, res["a"])
     head.cal_b = torch.full_like(head.cal_b, res["b"])
     scores = " ".join(f"{n}={v:.4f}" for n, v in res["cv_scores"].items())

--- a/ultralytics/nn/backends/pytorch.py
+++ b/ultralytics/nn/backends/pytorch.py
@@ -9,7 +9,7 @@ import torch
 from torch import nn
 
 from ultralytics.utils import IS_JETSON, LOGGER, is_jetson
-from ultralytics.utils.torch_utils import smart_inference_mode, unwrap_model
+from ultralytics.utils.torch_utils import unwrap_model
 
 from .base import BaseBackend
 
@@ -42,7 +42,6 @@ class PyTorchBackend(BaseBackend):
         self.verbose = verbose
         super().__init__(weight, device, fp16)
 
-    @smart_inference_mode(False)  # the loaded module outlives this call, so its weights must not be inference tensors
     def load_model(self, weight: str | torch.nn.Module) -> None:
         """Load a PyTorch model from a checkpoint file or nn.Module instance.
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1884,7 +1884,6 @@ def torch_safe_load(weight, safe_only=None):
     return ckpt, file
 
 
-@smart_inference_mode(False)  # the loaded model outlives this call, so its weights must not be inference tensors
 def load_checkpoint(weight, device=None, inplace=True, fuse=False):
     """Load single model weights.
 

--- a/ultralytics/trackers/utils/reid.py
+++ b/ultralytics/trackers/utils/reid.py
@@ -16,7 +16,6 @@ import torch
 from ultralytics.nn.autobackend import AutoBackend
 from ultralytics.utils.ops import xywh2xyxy
 from ultralytics.utils.plotting import save_one_box
-from ultralytics.utils.torch_utils import smart_inference_mode
 
 REID_ASSETS = frozenset(f"yolo26{k}-reid.onnx" for k in "nsmlx")
 
@@ -24,7 +23,6 @@ REID_ASSETS = frozenset(f"yolo26{k}-reid.onnx" for k in "nsmlx")
 class ReID:
     """ReID encoder. Routes `.pt` to the YOLO predictor path; everything else to `AutoBackend`."""
 
-    @smart_inference_mode(False)  # the encoder is retained by the tracker; trackers are built inside a predict block
     def __init__(self, model: str, imgsz: int = 224, device: str | torch.device | None = None, fp16: bool = False):
         """Initialize encoder for re-identification.
 


### PR DESCRIPTION
Reverts ultralytics/ultralytics#25748

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Reverts the explicit opt-out from PyTorch inference mode when loading models and initializing ReID encoders, while retaining safe reassignment of depth-calibration buffers.

### 📊 Key Changes
- Removes `smart_inference_mode(False)` from `load_checkpoint()` and the PyTorch backend’s `load_model()`.
- Removes the same decorator from `ReID.__init__()`, allowing encoder initialization to follow the caller’s inference-mode context.
- Keeps depth calibration updates implemented with tensor reassignment rather than in-place `fill_`, preserving legal writes and saveable buffers on CUDA.

### 🎯 Purpose & Impact
- Loaded PyTorch models and retained ReID encoders are no longer explicitly constructed outside inference mode.
- Depth calibration continues to replace `cal_a` and `cal_b` with new tensors so calibrated buffers remain writable and saveable.