### PR TITLE
Replace selection-matrix matmuls with direct slicing in the Kalman filter

### DIFF
--- a/ultralytics/trackers/bot_sort.py
+++ b/ultralytics/trackers/bot_sort.py
@@ -109,7 +109,7 @@ class BOTrack(STrack):
         """Predict the mean and covariance for multiple object tracks using a shared Kalman filter."""
         if not stracks:
             return
-        multi_mean = np.asarray([st.mean.copy() for st in stracks])
+        multi_mean = np.asarray([st.mean for st in stracks])
         multi_covariance = np.asarray([st.covariance for st in stracks])
         for i, st in enumerate(stracks):
             if st.state != TrackState.Tracked:

--- a/ultralytics/trackers/byte_tracker.py
+++ b/ultralytics/trackers/byte_tracker.py
@@ -87,7 +87,7 @@ class STrack(BaseTrack):
         """Perform multi-object predictive tracking using Kalman filter for the provided list of STrack instances."""
         if not stracks:
             return
-        multi_mean = np.asarray([st.mean.copy() for st in stracks])
+        multi_mean = np.asarray([st.mean for st in stracks])
         multi_covariance = np.asarray([st.covariance for st in stracks])
         for i, st in enumerate(stracks):
             if st.state != TrackState.Tracked:

--- a/ultralytics/trackers/utils/kalman_filter.py
+++ b/ultralytics/trackers/utils/kalman_filter.py
@@ -154,8 +154,8 @@ class KalmanFilterXYAH:
         if confidence is not None:  # NSA-Kalman: scale measurement noise by detection confidence (StrongSORT)
             innovation_cov *= max(1.0 - float(confidence), 0.05)
 
-        mean = np.dot(self._update_mat, mean)
-        covariance = np.linalg.multi_dot((self._update_mat, covariance, self._update_mat.T))
+        mean = mean[:4].copy()
+        covariance = covariance[:4, :4]
         return mean, covariance + innovation_cov
 
     def multi_predict(self, mean: np.ndarray, covariance: np.ndarray):
@@ -189,7 +189,8 @@ class KalmanFilterXYAH:
         ]
         sqr = np.square(np.r_[std_pos, std_vel]).T
 
-        motion_cov = sqr[:, :, None] * np.eye(8)
+        motion_cov = np.zeros((sqr.shape[0], 8, 8))
+        motion_cov[:, range(8), range(8)] = sqr
 
         mean = np.dot(mean, self._motion_mat.T)
         left = np.dot(self._motion_mat, covariance).transpose((1, 0, 2))
@@ -223,7 +224,7 @@ class KalmanFilterXYAH:
         """
         projected_mean, projected_cov = self.project(mean, covariance, confidence)
 
-        kalman_gain = np.linalg.solve(projected_cov, np.dot(covariance, self._update_mat.T).T).T
+        kalman_gain = np.linalg.solve(projected_cov, covariance[:, :4].T).T
         innovation = measurement - projected_mean
 
         new_mean = mean + np.dot(innovation, kalman_gain.T)
@@ -410,8 +411,8 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
         if confidence is not None:  # NSA-Kalman: scale measurement noise by detection confidence (StrongSORT)
             innovation_cov *= max(1.0 - float(confidence), 0.05)
 
-        mean = np.dot(self._update_mat, mean)
-        covariance = np.linalg.multi_dot((self._update_mat, covariance, self._update_mat.T))
+        mean = mean[:4].copy()
+        covariance = covariance[:4, :4]
         return mean, covariance + innovation_cov
 
     def multi_predict(self, mean: np.ndarray, covariance: np.ndarray):
@@ -445,7 +446,8 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
         ]
         sqr = np.square(np.r_[std_pos, std_vel]).T
 
-        motion_cov = sqr[:, :, None] * np.eye(8)
+        motion_cov = np.zeros((sqr.shape[0], 8, 8))
+        motion_cov[:, range(8), range(8)] = sqr
 
         mean = np.dot(mean, self._motion_mat.T)
         left = np.dot(self._motion_mat, covariance).transpose((1, 0, 2))


### PR DESCRIPTION
Five byte-identical changes in the tracker Kalman filter, all of them replacing a matmul (or a redundant copy) with the direct operation that already does the same thing.

Deleted: the `np.dot`/`np.linalg.multi_dot` calls against the `_update_mat` selection matrix in `project()`/`update()` (4 sites across `KalmanFilterXYAH`/`KalmanFilterXYWH`), the redundant `.copy()` on `covariance` in `project()` (2 sites, see below), and the redundant `.copy()` in the `multi_predict()` stacking (`bot_sort.py`, `byte_tracker.py`). Net +2 lines, not net-negative. `multi_predict()`'s diagonal build (2 sites) needs an explicit `np.zeros(...)` + index-assignment pair where the deleted one-liner built a dense `(N, 8, 8)` identity broadcast just to zero it back out. So each of those two sites trades 1 line for 2.

## `project()`

`self._update_mat` is `np.eye(ndim, 2 * ndim)`, a pure selection matrix. So `np.dot(self._update_mat, mean)` is just `mean[:4]`, and `np.linalg.multi_dot((self._update_mat, covariance, self._update_mat.T))` is just `covariance[:4, :4]`.

`covariance`'s `.copy()` is dropped too. The next line, `covariance + innovation_cov`, already allocates a new array, so copying the slice first just to add to it right after was wasted work. `mean` keeps its `.copy()` — it's returned as-is with no further op, and a bare `mean[:4]` would hand the caller a view aliased to the live state array:

```python
mean = mean[:4].copy()
covariance = covariance[:4, :4]
return mean, covariance + innovation_cov
```

## `update()`

Same idea for the kalman gain, `np.dot(covariance, self._update_mat.T).T` is `covariance[:, :4].T`:

```python
kalman_gain = np.linalg.solve(projected_cov, covariance[:, :4].T).T
```

## `multi_predict()`

`motion_cov = sqr[:, :, None] * np.eye(8)` builds a diagonal (N, 8, 8) matrix from a (N, 8) vector by multiplying against an 8x8 identity, so it computes 56 of 64 entries per track knowing they'll be zero:

```python
motion_cov = np.zeros((sqr.shape[0], 8, 8))
motion_cov[:, range(8), range(8)] = sqr
```

Same three fixes apply to `KalmanFilterXYAH` and `KalmanFilterXYWH`. `update()` is only defined once (`KalmanFilterXYWH.update()` just calls `super().update()`).

## The `.copy()` in `multi_predict()` stacking

`bot_sort.py:112` and `byte_tracker.py:90` do `np.asarray([st.mean.copy() for st in stracks])`. The `.copy()` per element is redundant — `np.asarray()` over a list of arrays already copies while stacking them into a new buffer. Checked that mutating the result does not touch the original `st.mean`:

```python
multi_mean = np.asarray([st.mean for st in stracks])
```

`deep_oc_sort.py:119`, a different stacking helper (`DeepOCSortTrack.multi_gmc`, not `multi_predict`), already does it this way, no `.copy()`. So the codebase was inconsistent with itself here .. this brings the other two trackers in line with that one.

## Why this survived

`git blame` on the `project()` matmul lines traces them to the original ByteTracker/BoT-SORT integration commit from Feb 2023, untouched since. They mirror the textbook Kalman filter formulation, an `H` observation matrix applied generically, rather than using the fact that `_update_mat` happens to be a trivial selection matrix in this specific tracker. Everything that touched this file after that was feature work (BoT-SORT, OC-SORT, DeepOCSORT, GMC, ReID), not a perf pass on the core matrix maths, so it never got a second look.

## Verified equivalent

All five checked with `np.array_equal` across 5 random seeds, including the dtype edge case. `sqr[:, :, None] * np.eye(8)` upcasts float32 `sqr` to float64 (`np.eye` defaults to float64), and `np.zeros((N, 8, 8))` without an explicit dtype also defaults to float64, so that matches too.

Also checked the same edge case for `project()`'s `mean`/`covariance` (candidate 1 in `repro/verify_kalman_candidates.py`). A synthetic float32 input would come out float64 via the old `np.dot`, float32 via the new slice, values still equal. Just to confirm this never bites in practice: `kalman_filter.py`'s `initiate()` casts every measurement to float64 before `mean`/`covariance` exist, and every later `predict()`/`update()` step keeps them float64 via matmul against float64 matrices, so the two dtypes are never observed to diverge on a real `STrack`.

Then a stronger, end-to-end check. Ran all 6 built-in trackers (`bytetrack`, `botsort`, `tracktrack`, `fasttrack`, `ocsort`, `deepocsort`) over a synthetic 40-frame sequence with 12 objects appearing and disappearing, and compared the full output array of every frame of every tracker between old and new code. 240 arrays compared, 0 differences, bit for bit. `tracktrack`'s `TTSTrack` extends `BOTrack` without overriding `multi_predict`, so it runs through the same patched `BOTrack.multi_predict`/`KalmanFilterXYWH.multi_predict` as `botsort` — checked directly, not assumed.

Repeated that same check on real detections, not synthetic ones. Ran `yolo26n.pt` on the real `decelera_portrait_min.mov` test video (the one `test_track_stream` already uses), and fed the real per-frame boxes into all 6 trackers, old code and new code. 66 frame-arrays compared, 0 differences. The video is short, 11 frames, 14 detections total, too short to time reliably, so it only covers correctness — the timing numbers below are still from the longer synthetic sequence.

## Measured, and a correction along the way

First timing pass (run the whole benchmark on the new code, then on the old code) gave a misleading result, the "optimised" code looked slower (bytetrack 435ms vs 375ms baseline). That didn't square with five changes that are each doing strictly less work.

The machine has thermal throttling, `cat /proc/cpuinfo | grep MHz` showed cores dropping to 800MHz mid-run, and a sequential before/after block is exactly the kind of comparison that noise can flip. Fixed it with an interleaved run instead: 4 rounds alternating new, old, new, old, 5 repeats per tracker per round (200 frames x 40 objects each). Reporting the minimum of each 5-repeat block, since throttling can only add latency, never remove it.

That gave a consistent picture: new is faster than old in 18 of 20 round-by-tracker comparisons. Per tracker, minimum-time delta averaged over the 4 rounds:

```
bytetrack    -8.3%
botsort      -3.1%
fasttrack    -3.2%
ocsort      -12.9%
deepocsort  -10.0%
```

Each number there is the average of that tracker's 4 per-round deltas (not a ratio of pooled sums, that biases toward the slower rounds). Average of those 5 is -7.5%. `tracktrack` isn't in this table, its Kalman-filter usage (inherited `BOTrack.multi_predict`) is covered by the correctness check above — this is a timing gap, not a correctness one — and `botsort`'s number is the closest proxy since both share the same `multi_predict` path.

Reproduce with one command: `PY=/path/to/python bash bench_interleave.sh` (both scripts attached below). It stashes/pops this diff four times, so the OLD half of each round runs on unmodified `main` in the same process, same machine state. Raw output below, all 20 round/tracker pairs with mean/std/min, not just the summary above:

```
--- round 1: NEW ---
new-r1 bytetrack: mean=415.8ms std=43.6ms min=344.7ms (n=5, 200 frames x 40 objs)
new-r1 botsort: mean=446.6ms std=79.4ms min=349.0ms (n=5, 200 frames x 40 objs)
new-r1 fasttrack: mean=451.1ms std=42.7ms min=402.5ms (n=5, 200 frames x 40 objs)
new-r1 ocsort: mean=618.1ms std=8.7ms min=608.0ms (n=5, 200 frames x 40 objs)
new-r1 deepocsort: mean=620.5ms std=9.3ms min=609.6ms (n=5, 200 frames x 40 objs)
--- round 1: OLD ---
old-r1 bytetrack: mean=369.7ms std=18.1ms min=350.4ms (n=5, 200 frames x 40 objs)
old-r1 botsort: mean=362.4ms std=3.8ms min=356.1ms (n=5, 200 frames x 40 objs)
old-r1 fasttrack: mean=436.1ms std=33.9ms min=414.7ms (n=5, 200 frames x 40 objs)
old-r1 ocsort: mean=807.0ms std=55.1ms min=756.0ms (n=5, 200 frames x 40 objs)
old-r1 deepocsort: mean=771.9ms std=5.7ms min=763.5ms (n=5, 200 frames x 40 objs)
--- round 2: NEW ---
new-r2 bytetrack: mean=400.1ms std=19.8ms min=362.0ms (n=5, 200 frames x 40 objs)
new-r2 botsort: mean=410.7ms std=1.4ms min=408.3ms (n=5, 200 frames x 40 objs)
new-r2 fasttrack: mean=487.0ms std=11.6ms min=476.5ms (n=5, 200 frames x 40 objs)
new-r2 ocsort: mean=760.2ms std=18.9ms min=745.0ms (n=5, 200 frames x 40 objs)
new-r2 deepocsort: mean=771.6ms std=55.8ms min=724.6ms (n=5, 200 frames x 40 objs)
--- round 2: OLD ---
old-r2 bytetrack: mean=458.1ms std=77.9ms min=345.4ms (n=5, 200 frames x 40 objs)
old-r2 botsort: mean=511.2ms std=62.5ms min=432.5ms (n=5, 200 frames x 40 objs)
old-r2 fasttrack: mean=535.0ms std=12.5ms min=512.1ms (n=5, 200 frames x 40 objs)
old-r2 ocsort: mean=879.3ms std=96.7ms min=800.4ms (n=5, 200 frames x 40 objs)
old-r2 deepocsort: mean=903.8ms std=149.8ms min=782.6ms (n=5, 200 frames x 40 objs)
--- round 3: NEW ---
new-r3 bytetrack: mean=417.9ms std=37.4ms min=346.0ms (n=5, 200 frames x 40 objs)
new-r3 botsort: mean=487.6ms std=59.0ms min=421.8ms (n=5, 200 frames x 40 objs)
new-r3 fasttrack: mean=577.1ms std=54.0ms min=515.5ms (n=5, 200 frames x 40 objs)
new-r3 ocsort: mean=858.2ms std=121.9ms min=737.4ms (n=5, 200 frames x 40 objs)
new-r3 deepocsort: mean=848.2ms std=97.0ms min=743.7ms (n=5, 200 frames x 40 objs)
--- round 3: OLD ---
old-r3 bytetrack: mean=439.1ms std=7.5ms min=425.8ms (n=5, 200 frames x 40 objs)
old-r3 botsort: mean=435.8ms std=4.2ms min=431.2ms (n=5, 200 frames x 40 objs)
old-r3 fasttrack: mean=571.9ms std=67.3ms min=498.9ms (n=5, 200 frames x 40 objs)
old-r3 ocsort: mean=834.9ms std=77.2ms min=776.9ms (n=5, 200 frames x 40 objs)
old-r3 deepocsort: mean=961.1ms std=154.3ms min=820.1ms (n=5, 200 frames x 40 objs)
--- round 4: NEW ---
new-r4 bytetrack: mean=411.2ms std=23.6ms min=364.6ms (n=5, 200 frames x 40 objs)
new-r4 botsort: mean=519.9ms std=101.8ms min=429.7ms (n=5, 200 frames x 40 objs)
new-r4 fasttrack: mean=608.5ms std=60.3ms min=507.7ms (n=5, 200 frames x 40 objs)
new-r4 ocsort: mean=838.8ms std=90.3ms min=757.3ms (n=5, 200 frames x 40 objs)
new-r4 deepocsort: mean=765.0ms std=2.6ms min=760.5ms (n=5, 200 frames x 40 objs)
--- round 4: OLD ---
old-r4 bytetrack: mean=472.0ms std=40.9ms min=443.2ms (n=5, 200 frames x 40 objs)
old-r4 botsort: mean=535.8ms std=110.2ms min=441.7ms (n=5, 200 frames x 40 objs)
old-r4 fasttrack: mean=648.3ms std=122.0ms min=540.9ms (n=5, 200 frames x 40 objs)
old-r4 ocsort: mean=1053.7ms std=78.4ms min=946.5ms (n=5, 200 frames x 40 objs)
old-r4 deepocsort: mean=814.5ms std=50.0ms min=784.7ms (n=5, 200 frames x 40 objs)
```

That's well short of the 1.3x-2.2x a microbenchmark of each function in isolation would suggest. In the real pipeline the Kalman math is only part of the per-frame cost (`Boxes` construction, IoU matching, track bookkeeping all add up too), so the saving gets smaller. The number reported here is the one that survived the interleaved run, not the bigger one from the isolated functions.

One limit on this benchmark: it calls `tracker.update(det)` with no image, so GMC never runs, even for `botsort`, where `gmc_method: sparseOptFlow` is on by default. GMC does real optical-flow work per frame. With an image in the loop, the Kalman filter's share of the total gets smaller still, so the `botsort`/`deepocsort` numbers above are closer to an upper bound than what you'd see with GMC active. Correctness is unaffected either way, the bit-identical check does not depend on GMC.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves Kalman filter tracking performance by replacing selection-matrix matrix multiplications with direct array slicing and more efficient diagonal covariance construction.

### 📊 Key Changes
- Replaces measurement projection and Kalman gain selection-matrix operations with direct slicing in both Kalman filter implementations.
- Builds batched motion covariance matrices using zero initialization and diagonal assignment instead of broadcasting against an identity matrix.
- Removes redundant `.copy()` calls when assembling batched track means in ByteTrack and BoT-SORT.

### 🎯 Purpose & Impact
- Reduces unnecessary matrix operations and intermediate allocations during tracking.
- Preserves the existing Kalman filter behavior while improving computational efficiency.
- May lower tracking overhead for workloads with many simultaneous objects; regression testing should confirm numerical equivalence across supported tracking scenarios.