### PR TITLE
Clamp detection top-k to available anchors

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1567,6 +1567,17 @@ def test_nn_modules_block():
     BottleneckCSP(c1, c2)(x)
 
 
+def test_nn_detect_head_export_clamps_max_det():
+    """Detect export postprocess should not request more candidates than available anchors."""
+    from ultralytics.nn.modules.head import Detect
+
+    head = Detect(nc=2, ch=(16,))
+    head.export = True
+    head.format = "onnx"
+    anchors = 21
+    assert head.postprocess(torch.rand(1, anchors, 4 + head.nc)).shape == (1, anchors, 6)
+
+
 def _depth_head_feats():
     """Return a small Depth head constructor kwargs-matched P3/P4/P5 feature pyramid."""
     return [torch.randn(1, 32, 32, 32), torch.randn(1, 64, 16, 16), torch.randn(1, 128, 8, 8)]

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -256,9 +256,7 @@ class Detect(nn.Module):
             (torch.Tensor, torch.Tensor, torch.Tensor): Top scores, class indices, and filtered indices.
         """
         batch_size, anchors, nc = scores.shape  # i.e. shape(16,8400,80)
-        # Use max_det directly during export for TensorRT compatibility (requires k to be constant),
-        # otherwise use min(max_det, anchors) for safety with small inputs during Python inference
-        k = max_det if self.export else min(max_det, anchors)
+        k = min(max_det, anchors)
         if self.agnostic_nms:
             scores, labels = scores.max(dim=-1, keepdim=True)
             scores, indices = scores.topk(k, dim=1)


### PR DESCRIPTION
## Summary

- Clamp end-to-end detection postprocess `k` to the available anchor count in every mode.
- Add focused regression coverage for export postprocessing with fewer anchors than `max_det`.

## Problem

A valid small input such as `imgsz=32` produces 21 P3-P5 anchors. Export postprocessing currently forces `topk(300)` when the default `max_det=300`, which raises `RuntimeError: selected index k out of range` before the model can be exported.

## Fix

Use `min(max_det, anchors)` in the shared detection postprocess so candidate selection never requests more entries than exist. Normal inputs with at least `max_det` anchors retain the same behavior.

## Validation

- `pytest -q tests/test_python.py::test_nn_detect_head_export_clamps_max_det`
- `pytest -q tests/test_python.py::test_predict_classes_with_max_det`
- `pytest -q tests/test_exports.py::test_export_onnx[True]`
- `pytest -q tests/test_exports.py::test_export_torchscript[True]`
- TensorRT 11.2.1.2 FP16 export and inference at `imgsz=32`, producing output shape `(1, 21, 6)`
- `ruff check ultralytics/nn/modules/head.py tests/test_python.py`
- `ruff format --check ultralytics/nn/modules/head.py tests/test_python.py`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Clamp detection export top-k selection to the number of available anchors.

### 📊 Key Changes
- Updated `Detect.get_topk_index()` to always use the smaller of `max_det` and the available anchor count.
- Added a regression test covering ONNX export postprocessing with fewer anchors than the default detection limit.

### 🎯 Purpose & Impact
- 🛠️ Prevents top-k selection errors when exported models receive inputs with a limited number of anchors.
- ✅ Improves detection export robustness while preserving the expected output shape.
- 📦 Reduces the risk of failures in ONNX and other export workflows without changing normal behavior for sufficiently large inputs.