### PR TITLE
Reload the checkpoint model when inference fused it before train

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -13,6 +13,7 @@ from PIL import Image
 
 from ultralytics.cfg import TASK2DATA, _handle_deprecation, get_cfg, get_save_dir
 from ultralytics.engine.results import Results
+from ultralytics.nn.modules import Conv
 from ultralytics.nn.tasks import BaseModel, guess_model_task, load_checkpoint, yaml_model_load
 from ultralytics.utils import (
     ARGV,
@@ -309,6 +310,7 @@ class Model(torch.nn.Module):
                 m.reset_parameters()
         for p in self.model.parameters():
             p.requires_grad = True
+        self.model.pt_path = None  # reset weights are no longer the checkpoint this module came from
         return self
 
     def load(self, weights: str | Path = "yolo26n.pt") -> Model:
@@ -336,6 +338,7 @@ class Model(torch.nn.Module):
             self.overrides["pretrained"] = weights  # remember the weights for DDP training
             weights, self.ckpt = load_checkpoint(weights)
         self.model.load(weights)
+        self.model.pt_path = None  # blended weights are no longer the checkpoint this module came from
         return self
 
     def save(self, filename: str | Path = "saved_model.pt") -> None:
@@ -799,6 +802,17 @@ class Model(torch.nn.Module):
             "task": self.task,
         }  # method defaults
         args = {**overrides, **custom, **kwargs, "mode": "train"}  # prioritizes rightmost args
+        pretrained = kwargs.get("pretrained", overrides.get("pretrained", True) if kwargs.get("cfg") else True)
+        # A Conv that lost its batch norm was fused in place by predict() or val(), so this module can no longer seed
+        # training. `is_fused()` cannot answer this: it counts every norm layer, so RT-DETR stays under its threshold.
+        if (
+            pretrained is True
+            and not args.get("resume")
+            and getattr(self.model, "pt_path", None)
+            and any(isinstance(m, Conv) and not hasattr(m, "bn") for m in self.model.modules())
+        ):
+            self.model, _ = load_checkpoint(self.model.pt_path)
+            self.predictor = None  # this module replaced the one the cached predictor wrapped
         if isinstance(args.get("data"), (list, tuple)):  # fine-tune a single base model across multiple datasets
             from ultralytics.engine.trainer import MultiTrainer
 
@@ -811,7 +825,6 @@ class Model(torch.nn.Module):
             )
             self.metrics = self.trainer.train()
             return self.metrics
-        pretrained = kwargs.get("pretrained", overrides.get("pretrained", True) if kwargs.get("cfg") else True)
         if args.get("resume") is True:  # resume=True (boolean) uses current model as checkpoint
             if self.ckpt and self.ckpt.get("epoch", -1) >= 0 and self.ckpt.get("optimizer") is not None:
                 args["resume"] = self.ckpt_path


### PR DESCRIPTION
## summary

`Model.train()` hands the trainer `self.model` as its pretrained donor, and `predict()` and `val()` fuse that very module in place beforehand, so one prediction before a fine-tune silently drops most of the pretrained weights. training now reloads the checkpoint when the live module carries a fused convolution, and `Model.load()` and `reset_weights()` clear the file stamp they invalidate so the reload never runs against a module no file represents.

the predicate is the fusion footprint rather than `is_fused()`, which counts every norm layer and therefore reports false for rt-detr after inference has already stripped 95 of its convolutions. the source is `model.pt_path`, which `load_checkpoint` stamps on every module it produces, so a second `train()` after a first one seeds from the first run's checkpoint rather than the original weights.

## measured

on `yolo26n.pt`, counted by a spy on the product's own `BaseModel.load`: a plain `train()` transfers 708/708, and after one `predict()` or `val()` that becomes 108/708 on main and 708/708 here, with the donor fingerprint restored to the no-inference value rather than merely to a larger count. `yolo26n-seg.pt` goes 128/844 to 844/844 the same way, an explicit `fuse()` before training goes 108/708 to 708/708, and `train()` -> `predict()` -> `train()` goes 282/918 to 918/918 seeding from the first run's `best.pt`.

nothing else moves. a `train()` with no inference before it performs the same single checkpoint read on both revisions, and so do `pretrained=False`, an explicit `pretrained="<path>"`, `resume=True`, a module whose weights came from `Model.load()`, and a module put through `reset_weights()` — the last two because the reload is skipped there entirely, leaving main's behaviour rather than substituting weights the caller did not ask for. the one added read costs 33 ms for yolo26n and 28 ms for yolo26m, once per `train()` call and only on a module inference actually fused. `tests/test_engine.py` passes whole, including the four `test_train_reuses_loaded_checkpoint_model` parametrizations that depend on the donor being the facade's module.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Training now reloads the model’s checkpoint when inference has fused its convolution layers in place, while `load()` and `reset_weights()` clear checkpoint metadata that no longer represents the live weights.

### 📊 Key Changes
- `Model.train()` detects fused `Conv` modules by checking for missing batch normalization and reloads the checkpoint recorded in `model.pt_path`.
- Reloading is limited to standard pretrained training and skipped for `resume=True`, `pretrained=False`, and models without valid checkpoint metadata.
- The cached predictor is cleared after reloading because it references the replaced model module.
- `Model.load()` and `reset_weights()` set `model.pt_path` to `None` after changing the module’s weights.

### 🎯 Purpose & Impact
- A `predict()`, `val()`, or explicit `fuse()` before training no longer causes training to start from a partially fused model; training instead restores the checkpoint-backed model. No user-facing change applies when inference has not fused the model or when training uses non-checkpoint weights.