### PR TITLE
Clear the checkpoint stamp when set_classes and set_vocab rewrite the module

### DIFF
--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -196,6 +196,7 @@ class YOLOWorld(Model):
             classes (list[str]): A list of categories i.e. ["person"].
         """
         self.model.set_classes(classes)
+        self.model.pt_path = None  # new class embeddings are no longer the checkpoint this module came from
         # Remove background if it's given
         background = " "
         if background in classes:
@@ -322,6 +323,7 @@ class YOLOE(Model):
         names = check_class_names(names)
         self.predictor = None  # the delegate destructively re-parameterizes the head
         self.model.set_vocab(vocab, names=names)
+        self.model.pt_path = None  # the re-parameterized head is no longer the checkpoint this module came from
 
     def get_vocab(self, names):
         """Get the vocabulary for the given class names, which become the model's classes as the head is fused."""
@@ -344,6 +346,7 @@ class YOLOE(Model):
             if embeddings is None:
                 embeddings = self.get_text_pe(classes)  # generate text embeddings if not provided
             self.model.set_classes(classes, embeddings)
+            self.model.pt_path = None  # new class embeddings are no longer the checkpoint this module came from
 
         # Reset method class names
         if self.predictor:
@@ -542,7 +545,7 @@ class YOLOE(Model):
                     refer_image = next(iter(dataset))[1][0]
             if refer_image is not None:
                 vpe = self.predictor.get_vpe(refer_image)
-                self.model.set_classes(self.model.names, vpe)
+                self.set_classes(self.model.names, vpe)
                 self.task = "segment" if isinstance(self.predictor, yolo.segment.SegmentationPredictor) else "detect"
                 self.predictor = None  # reset predictor
         elif isinstance(self.predictor, yolo.yoloe.YOLOEVPDetectPredictor):


### PR DESCRIPTION
## summary

`load_checkpoint` stamps `model.pt_path` with the file a module was deserialized from, and `Model.load()` and `Model.reset_weights()` clear it when they rewrite that module in place. the same in-place rewrites in the family subclasses did not: `YOLOWorld.set_classes`, `YOLOE.set_classes` and `YOLOE.set_vocab` install new embeddings or re-parameterize the head and leave the stamp naming a file the module no longer matches, so a later `train()` reloads that file and silently discards them. the visual-prompt branch of `YOLOE.predict` went through the inner `set_classes` rather than the wrapper and now uses the wrapper, and `YOLOE.set_classes` clears only on the branch that actually rewrites.

## measured

on `yolov8s-worldv2.pt` and `yoloe-26n-seg.pt`, after each of the four writes followed by a `predict()`, `train()` reloaded the checkpoint at all four sites; it now reloads at none, and the export filename, the benchmark filename and the prompt-embedding identifier all resolve to the same strings as before through their existing `ckpt_path` and `yaml_file` fallbacks. an unchanged `set_classes` call with no embeddings still leaves the stamp in place. this holds for `RANK == -1`; a DDP child reconstructs from `args.model` as it already did.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Clears stale checkpoint paths after `set_classes` and `set_vocab` modify model modules so later operations do not reload an outdated checkpoint.

### 📊 Key Changes

- `YOLOWorld.set_classes` now clears `self.model.pt_path` after installing new class embeddings.
- `YOLOE.set_classes` clears the checkpoint path only when it generates or applies embeddings and rewrites the model.
- `YOLOE.set_vocab` clears the checkpoint path after re-parameterizing the detection head.
- Visual-prompt prediction now calls the `YOLOE.set_classes` wrapper, ensuring its generated embeddings also clear the checkpoint path.

### 🎯 Purpose & Impact

- After these in-place model changes, a subsequent `train()` no longer reloads the checkpoint recorded before the rewrite, preserving the updated embeddings or head configuration.
- A `set_classes` call that does not apply embeddings leaves the existing checkpoint path unchanged.
- Existing export, benchmark, and prompt-embedding filename fallbacks continue to use their prior path resolution behavior.