### PR TITLE
Bump ultralytics-inference docs version to 0.0.34

### DIFF
--- a/docs/en/inference/index.md
+++ b/docs/en/inference/index.md
@@ -57,7 +57,7 @@ Rust 1.89 or newer is required. The [video](#cargo-features) feature additionall
     ```toml
     # Or add it manually to Cargo.toml
     [dependencies]
-    ultralytics-inference = "0.0.33"
+    ultralytics-inference = "0.0.34"
     ```
 
 ## CLI quickstart
@@ -445,7 +445,7 @@ cargo install ultralytics-inference --features cuda,tensorrt
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.33", features = ["video"] }
+ultralytics-inference = { version = "0.0.34", features = ["video"] }
 ```
 
 ## Output and saving


### PR DESCRIPTION
Updates the Cargo.toml snippets on the Inference docs page to 0.0.34, the current release on crates.io.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the Inference documentation’s Rust dependency examples from `ultralytics-inference` 0.0.33 to 0.0.34 to match the current crates.io release.

### 📊 Key Changes
- Updated the basic `Cargo.toml` dependency snippet to `ultralytics-inference = "0.0.34"`.
- Updated the video-feature dependency snippet to use version `0.0.34`.

### 🎯 Purpose & Impact
- Rust users copying the documented dependency examples will reference `ultralytics-inference` 0.0.34.
- No implementation or runtime behavior changed.