### PR TITLE
Establish the per-call inference state on the inference call rather than on predictor setup

### DIFF
--- a/docs/en/reference/engine/validator.md
+++ b/docs/en/reference/engine/validator.md
@@ -14,4 +14,8 @@ keywords: Ultralytics, BaseValidator, model validation, PyTorch, TensorFlow, ONN
 
 ## ::: ultralytics.engine.validator.BaseValidator
 
+<br><br><hr><br>
+
+## ::: ultralytics.engine.validator._restore_head
+
 <br><br>

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -460,14 +460,15 @@ class BasePredictor:
         attrs, prev = {}, {}
         if hasattr(model, "end2end"):
             if self.args.end2end is not None:
-                attrs["end2end"], prev["end2end"] = self.args.end2end, model.end2end
-                model.end2end = self.args.end2end
+                attrs["end2end"] = self.args.end2end
+                prev = model.set_head_attr(**attrs)
             if model.end2end:
                 # Keep head top-k >= 300 so `classes` filtering in NMS sees all candidates before `max_det` truncation
                 top_k = {"max_det": max(self.args.max_det, 300), "agnostic_nms": self.args.agnostic_nms}
-                prev |= model.set_head_attr(**top_k)
-                attrs |= top_k
-        return attrs, prev
+                attrs.update(top_k)
+                prev.update(model.set_head_attr(**top_k))
+        # A head reports back only the attributes it carries, so anything it declined is not ours to hold
+        return {k: v for k, v in attrs.items() if k in prev}, prev
 
     @contextmanager
     def _head_configured(self):

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import platform
 import re
 import threading
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable
 
@@ -154,6 +155,8 @@ class BasePredictor:
         self.transforms = None
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
         self.txt_path = None
+        self._head_model = None  # native module this predictor configures for its own calls
+        self._head_attrs = {}  # head attributes it applies to that module for the duration of each call
         self._lock = threading.Lock()  # for automatic thread-safe inference
         callbacks.add_integration_callbacks(self)
 
@@ -315,7 +318,7 @@ class BasePredictor:
             LOGGER.warning(f"{unsupported} not supported by this model (format='{self.model.format}'), ignoring.")
             self.args.augment, self.args.embed, self.args.visualize = False, None, False
 
-        with self._lock:  # for thread-safe inference
+        with self._lock, self._head_configured():  # thread-safe inference on a head configured for this call only
             # Setup source every time predict is called
             self.setup_source(source if source is not None else self.args.source)
 
@@ -418,21 +421,23 @@ class BasePredictor:
             model (str | Path | torch.nn.Module): Model to load or use.
             verbose (bool): Whether to print verbose output.
         """
-        if hasattr(model, "end2end"):
-            if self.args.end2end is not None:
-                model.end2end = self.args.end2end
-            if model.end2end:
-                # Keep head top-k >= 300 so `classes` filtering in NMS sees all candidates before `max_det` truncation
-                model.set_head_attr(max_det=max(self.args.max_det, 300), agnostic_nms=self.args.agnostic_nms)
-        self.model = AutoBackend(
-            model=model or self.args.model,
-            device=select_device(self.args.device, verbose=verbose),
-            dnn=self.args.dnn,
-            data=self.args.data,
-            fp16=self.args.quantize == 16,
-            fuse=True,
-            verbose=verbose,
-        )
+        # Held for this predictor's life: the fusion below discards the one2many head under this configuration
+        self._head_attrs, prev = self._configure_head(model)
+        try:  # the fusion inside AutoBackend reads `end2end`, so the head is configured across this call only
+            self.model = AutoBackend(
+                model=model or self.args.model,
+                device=select_device(self.args.device, verbose=verbose),
+                dnn=self.args.dnn,
+                data=self.args.data,
+                fp16=self.args.quantize == 16,
+                fuse=True,
+                verbose=verbose,
+            )
+        finally:
+            if prev:
+                model.set_head_attr(**prev)
+        # AutoBackend may keep a different module than it was handed, e.g. distillation fuses to the student
+        self._head_model = self.model.model if self._head_attrs else None
 
         self.device = self.model.device  # update device
         self.args.quantize = 16 if self.model.fp16 else None  # record actual inference precision
@@ -441,6 +446,38 @@ class BasePredictor:
         self.model.eval()
         self.model.set_memory_format(self.args.channels_last)
         self.model = attempt_compile(self.model, device=self.device, mode=self.args.compile)
+
+    def _configure_head(self, model) -> tuple[dict, dict]:
+        """Apply the inference arguments to the model head and return them alongside the values they replaced.
+
+        Args:
+            model (torch.nn.Module): Model to configure, left alone unless it exposes a YOLO detection head.
+
+        Returns:
+            attrs (dict): The head attributes this predictor holds while it runs.
+            prev (dict): The caller's own values, for handing the model back when a call ends.
+        """
+        attrs, prev = {}, {}
+        if hasattr(model, "end2end"):
+            if self.args.end2end is not None:
+                attrs["end2end"], prev["end2end"] = self.args.end2end, model.end2end
+                model.end2end = self.args.end2end
+            if model.end2end:
+                # Keep head top-k >= 300 so `classes` filtering in NMS sees all candidates before `max_det` truncation
+                top_k = {"max_det": max(self.args.max_det, 300), "agnostic_nms": self.args.agnostic_nms}
+                prev |= model.set_head_attr(**top_k)
+                attrs |= top_k
+        return attrs, prev
+
+    @contextmanager
+    def _head_configured(self):
+        """Hold the head configuration set up for this predictor while one inference call runs."""
+        prev = self._head_model.set_head_attr(**self._head_attrs) if self._head_attrs else {}
+        try:
+            yield
+        finally:
+            if prev:
+                self._head_model.set_head_attr(**prev)
 
     def write_results(self, i: int, p: Path, im: torch.Tensor, s: list[str]) -> str:
         """Write inference results to a file or directory.

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -319,6 +319,7 @@ class BasePredictor:
             self.args.augment, self.args.embed, self.args.visualize = False, None, False
 
         with self._lock, self._head_configured():  # thread-safe inference on a head configured for this call only
+            self.model.eval()  # a reused predictor may be handed a module the caller has put back in train mode
             # Setup source every time predict is called
             self.setup_source(source if source is not None else self.args.source)
 
@@ -443,7 +444,6 @@ class BasePredictor:
         self.args.quantize = 16 if self.model.fp16 else None  # record actual inference precision
         if hasattr(self.model, "imgsz") and not getattr(self.model, "dynamic", False):
             self.args.imgsz = self.model.imgsz  # reuse imgsz from export metadata
-        self.model.eval()
         self.model.set_memory_format(self.args.channels_last)
         self.model = attempt_compile(self.model, device=self.device, mode=self.args.compile)
 

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -467,6 +467,8 @@ class BasePredictor:
                 top_k = {"max_det": max(self.args.max_det, 300), "agnostic_nms": self.args.agnostic_nms}
                 attrs.update(top_k)
                 prev.update(model.set_head_attr(**top_k))
+                # The fusion below drops the one2many branch under `end2end`, so that write cannot be handed back
+                prev.pop("end2end", None)
         # A head reports back only the attributes it carries, so anything it declined is not ours to hold
         return {k: v for k, v in attrs.items() if k in prev}, prev
 

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -190,11 +190,10 @@ class BaseValidator:
             callbacks.add_integration_callbacks(self)
             if hasattr(model, "end2end"):
                 if self.args.end2end is not None:
-                    self._head_prev["end2end"] = model.end2end
-                    model.end2end = self.args.end2end
+                    self._head_prev = model.set_head_attr(end2end=self.args.end2end)
                 if model.end2end:
-                    self._head_prev |= model.set_head_attr(
-                        max_det=self.args.max_det, agnostic_nms=self.args.agnostic_nms
+                    self._head_prev.update(
+                        model.set_head_attr(max_det=self.args.max_det, agnostic_nms=self.args.agnostic_nms)
                     )
             with torch_distributed_zero_first(LOCAL_RANK):
                 self.args.data = convert_ndjson_to_yolo_if_needed(self.args.data)

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -195,6 +195,8 @@ class BaseValidator:
                     self._head_prev.update(
                         model.set_head_attr(max_det=self.args.max_det, agnostic_nms=self.args.agnostic_nms)
                     )
+                    # The fusion below drops the one2many branch under `end2end`, so that write cannot be handed back
+                    self._head_prev.pop("end2end", None)
             with torch_distributed_zero_first(LOCAL_RANK):
                 self.args.data = convert_ndjson_to_yolo_if_needed(self.args.data)
             device_type = str(self.args.device).split(":", 1)[0]

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -30,6 +30,7 @@ Usage - formats:
 
 from __future__ import annotations
 
+import functools
 import json
 import time
 from pathlib import Path
@@ -53,6 +54,21 @@ from ultralytics.utils.torch_utils import (
     torch_distributed_zero_first,
     unwrap_model,
 )
+
+
+def _restore_head(fn):
+    """Hand a caller-supplied model back its own head configuration once validation ends."""
+
+    @functools.wraps(fn)
+    def wrapper(self, trainer=None, model=None):
+        self._head_prev = {}
+        try:
+            return fn(self, trainer, model)
+        finally:
+            if self._head_prev:
+                model.set_head_attr(**self._head_prev)
+
+    return wrapper
 
 
 class BaseValidator:
@@ -143,6 +159,7 @@ class BaseValidator:
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
 
     @smart_inference_mode()
+    @_restore_head
     def __call__(self, trainer=None, model=None):
         """Execute validation process, running inference on dataloader and computing performance metrics.
 
@@ -173,9 +190,12 @@ class BaseValidator:
             callbacks.add_integration_callbacks(self)
             if hasattr(model, "end2end"):
                 if self.args.end2end is not None:
+                    self._head_prev["end2end"] = model.end2end
                     model.end2end = self.args.end2end
                 if model.end2end:
-                    model.set_head_attr(max_det=self.args.max_det, agnostic_nms=self.args.agnostic_nms)
+                    self._head_prev |= model.set_head_attr(
+                        max_det=self.args.max_det, agnostic_nms=self.args.agnostic_nms
+                    )
             with torch_distributed_zero_first(LOCAL_RANK):
                 self.args.data = convert_ndjson_to_yolo_if_needed(self.args.data)
             device_type = str(self.args.device).split(":", 1)[0]

--- a/ultralytics/nn/distill_model.py
+++ b/ultralytics/nn/distill_model.py
@@ -294,9 +294,9 @@ class DistillationModel(nn.Module):
         """Forward end-to-end mode update to the student model."""
         self.student_model.end2end = value
 
-    def set_head_attr(self, **kwargs):
+    def set_head_attr(self, **kwargs) -> dict:
         """Forward head-attribute updates (e.g. max_det, agnostic_nms, end2end) to the student model."""
-        self.student_model.set_head_attr(**kwargs)
+        return self.student_model.set_head_attr(**kwargs)
 
     def decouple_outputs(self, preds, branch: str = "one2one"):
         """Decouple outputs for teacher/student models.

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -515,18 +515,23 @@ class DetectionModel(BaseModel):
         """Override the end-to-end detection mode."""
         self.set_head_attr(end2end=value)
 
-    def set_head_attr(self, **kwargs):
+    def set_head_attr(self, **kwargs) -> dict:
         """Set attributes of the model head (last layer).
 
         Args:
             **kwargs (Any): Arbitrary keyword arguments representing attributes to set.
+
+        Returns:
+            (dict): The values this call replaced, for restoring a per-call configuration afterwards.
         """
-        head = self.model[-1]
+        head, prev = self.model[-1], {}
         for k, v in kwargs.items():
             if not hasattr(head, k):
                 LOGGER.warning(f"Head has no attribute '{k}'.")
                 continue
+            prev[k] = getattr(head, k)
             setattr(head, k, v)
+        return prev
 
     def _predict_augment(self, x):
         """Perform augmentations on input image x and return augmented inference and train outputs.


### PR DESCRIPTION
## summary

two pieces of per-call inference state were established when the predictor was built rather than when it runs, so they were wrong for every call after the first. the head configuration `end2end`, `max_det` and `agnostic_nms` was written onto the caller's module and left there, which flipped a yolo26 model's training objective for good; and `eval()` was only reached on the construction path, so a reused predictor kept running a module the caller had put back in train mode. both now happen on the inference call, and the head configuration is handed back when the call ends.

## measured

`yolo26n.pt`, `predict(end2end=False)` on `ASSETS/bus.jpg` at imgsz=160, before and after the call:

|                                      | main                       | branch             |
| ------------------------------------ | -------------------------- | ------------------ |
| `model.model.end2end`                | True -> False              | True -> True       |
| `model.model.model[-1].end2end`      | True -> False              | True -> True       |
| `type(model.model.init_criterion())` | E2ELoss -> v8DetectionLoss | E2ELoss -> E2ELoss |

`val(end2end=False)` restores the same three the same way, and a fresh `predict()` still sees the head configured for its own call.

`predict()`, then `model.model.train()`, then `predict()` on the cached predictor:

| weights          | main                                                     | branch                          |
| ---------------- | -------------------------------------------------------- | ------------------------------- |
| `yolo26n.pt`     | `AttributeError: 'dict' object has no attribute 'shape'` | 3 boxes, same as the first call |
| `yolo26n-seg.pt` | `TypeError: 'NoneType' object is not callable`           | 3 boxes, same as the first call |

the `eval()` moves rather than duplicates, so the ordinary path pays one call on an already-eval module: 0.46 ms, against 7.6 ms for a whole `predict()` at imgsz=160 and 27.7 ms at imgsz=640. a `predict()` still leaves the module in eval mode, as it did before.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Inference and validation now apply YOLO head settings and evaluation mode per call, restoring caller-owned head attributes afterward to support reused predictors and models.

### 📊 Key Changes

- Added per-call head configuration for `end2end`, `max_det`, and `agnostic_nms` in `BasePredictor.stream_inference()` and `BaseValidator.__call__()`.
- Added restoration of replaced head attributes through `set_head_attr()` return values, including support for distilled models.
- Moved `self.model.eval()` into each inference call so cached predictors switch back to evaluation mode when needed.
- Preserved the configured head across `AutoBackend` setup and tracked the resulting native module for subsequent calls.
- Documented the private validator restoration helper.

### 🎯 Purpose & Impact

- Repeated `predict()` and `val()` calls no longer permanently alter the caller’s head configuration.
- A reused predictor now runs inference correctly even after the caller has put its model back into training mode.
- Inference still leaves the model in evaluation mode, while temporary head settings are returned when the call finishes.