### PR TITLE
Set a dedicated 16:9 OG image on the depth task page

### DIFF
--- a/docs/en/tasks/depth.md
+++ b/docs/en/tasks/depth.md
@@ -3,6 +3,7 @@ comments: true
 description: Learn about monocular depth estimation using YOLO26. Predict per-pixel depth maps from single RGB images with NYU Depth V2 and custom dataset support.
 keywords: monocular depth estimation, YOLO26, depth map, per-pixel depth, NYU Depth V2, DPT, dense prediction, Depth Anything V2, Ultralytics
 model_name: yolo26n-depth
+social_image: https://cdn.ul.run/i/a67470cf77b68b8b7a6d1f2900f1c6c5.avif
 ---
 
 # Monocular Depth Estimation


### PR DESCRIPTION
## summary

the depth task page sets no explicit social image, so its og:image resolves to the first illustration in the article, a 1920x540 strip that does not fit 16:9 card layouts. this adds a social_image frontmatter key pointing at a purpose-built 1920x1080 asset, which is served as a 1200x675 webp for social cards. the key is read by the centralized publisher that renders docs.ultralytics.com, which is also where the current first-image behavior comes from, so no og:image is emitted by the local zensical build for this or any other page. the in-page hero image is unchanged, and a sweep of every page before and after the change confirms this is the only og:image that moves.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Sets a dedicated 16:9 social preview image for the YOLO26 monocular depth estimation task page.

### 📊 Key Changes
- Adds a `social_image` metadata field to `docs/en/tasks/depth.md`.
- Points the depth task page to a dedicated AVIF Open Graph image.

### 🎯 Purpose & Impact
- Improves how the depth task page appears when shared on social media and other link previews.
- Keeps the change limited to documentation metadata with no impact on model behavior or functionality.
