### PR TITLE
Reuse the dense log-depth tensor for SILog in `DepthLoss26`

### DIFF
--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -1235,20 +1235,17 @@ class DepthLoss26:
             # Keep the result attached so BaseTrainer's unconditional backward() works.
             return pred_depth.sum() * 0.0, dict(zip(self.loss_names, loss.detach()))
 
-        pred_valid = pred_depth[valid]
-        gt_valid = gt_depth[valid]
+        # Dense log-depth also feeds the gradient loss below; SILog reuses it at `valid` instead of a 2nd log().
+        pred_log = torch.log(pred_depth.clamp(min=0.001))
+        gt_log = torch.log(gt_depth.clamp(min=0.001))
 
-        pred_valid = pred_valid.clamp(min=0.001)
-
-        log_diff = torch.log(pred_valid) - torch.log(gt_valid)
+        log_diff = pred_log[valid] - gt_log[valid]
         # Centered variance form: non-negative by construction and fp16-stable near convergence.
         m = log_diff.mean()
         silog = torch.sqrt(((log_diff - m) ** 2).mean() + (1.0 - self.silog_lambda) * m**2 + 1e-6)
         loss[0] = silog * self.silog_weight
 
         # Multi-scale gradient-matching loss.
-        pred_log = torch.log(pred_depth.clamp(min=0.001))
-        gt_log = torch.log(gt_depth.clamp(min=0.001))
         valid_f = valid.float()
         grad_loss = self._grad_l1(pred_log, gt_log, valid_f)
         for _ in range(1, max(self.grad_scales, 1)):


### PR DESCRIPTION
`DepthLoss26` computes `log()` on the predicted/GT depth twice for the same valid pixels: once on a gathered subset for the SILog term, and again on the dense tensor a few lines later for the gradient-matching loss. The dense version is already needed for the pyramid, so SILog can just read from it instead of running its own `log()`.

Deleted: the separate `pred_valid`/`gt_valid` gather-then-log path for SILog (4 lines), reusing the dense `pred_log`/`gt_log` already computed for the gradient loss.

```python
# before
pred_valid = pred_depth[valid]
gt_valid = gt_depth[valid]
pred_valid = pred_valid.clamp(min=0.001)
log_diff = torch.log(pred_valid) - torch.log(gt_valid)
...
pred_log = torch.log(pred_depth.clamp(min=0.001))
gt_log = torch.log(gt_depth.clamp(min=0.001))

# after
pred_log = torch.log(pred_depth.clamp(min=0.001))
gt_log = torch.log(gt_depth.clamp(min=0.001))
log_diff = pred_log[valid] - gt_log[valid]
```

## Forward is exact, backward isn't

Checked both, not just forward, a fix touching a trainable path can change the graph even when the values agree. `torch.log(x)[mask]` and `torch.log(x[mask])` give the same values, `clamp(min=0.001)` before or after the gather is also the same thing for these pixels (values are already `> 0.001` there by construction of `valid`). Ran this on real tensors with `torch.equal`, forward loss is bit for bit identical.

Backward is not exact, and it shouldn't be. Before, `log()` ran as two independent nodes (one feeding SILog, one feeding the gradient loss), each with its own path back to `pred_depth.grad`. Now there is one `log()` node with two consumers, so autograd sums the two contributions in a different order. Floating-point addition isn't associative, so `pred.grad` differs by a few ULPs: max abs diff `7.45e-09`, relative `~1e-7`, float32 machine epsilon. Checked with `torch.testing.assert_close` (`rtol=1e-5, atol=1e-7`) instead of `torch.equal` for the gradient. This noise is already smaller than what batch sampling or AMP add to the gradient every step, so it shouldn't show up in training.

## Measured

Timed the full `DepthLoss26.__call__` (forward + backward, both loss terms, the 4-level gradient pyramid) on a realistic training batch, `bs=16, imgsz=640`, RTX 4060. This machine throttles under sustained load, so instead of a single before/after block I ran interleaved rounds (new, old, new, old, 4 rounds x 5 reps), reporting the minimum of each block since throttling only adds latency:

```
synthetic dense GT (valid=100%):  new min 50.26ms avg vs old min 51.58ms avg -> -2.6% avg per-round delta (4/4 rounds favour the new version)
synthetic sparse GT (valid=15%):  new min 20.09ms avg vs old min 20.20ms avg -> -0.5% avg per-round delta (4/4 rounds favour the new version)
```

Smaller than expected before measuring it .. the isolated SILog computation alone is ~10% faster, but it's a small slice of the full step once the gradient pyramid and the backward pass are included.

I didn't have a real depth GT sparsity number handy, so instead of guessing I also ran this against actual KITTI GT: 16 real samples from `data_depth_selection` (the official KITTI validation-subset archive, converted through the same PNG->`.npy` pipeline `depth-kitti.yaml`'s own `download:` block uses) through the real `DepthDataset` train pipeline (`imgsz=768`, the resolution the published weights use). Measured `valid_frac≈0.071`, sparser than my synthetic guess above. Same picture, new min 27.77ms avg vs old min 27.88ms avg, `-0.4%` avg per-round delta over two independent runs (7 of 8 rounds favour the new code, one round in the second run came out +0.3% .. at this magnitude the effect is close to the machine's noise floor, so a round going the other way isn't surprising). Also re-checked forward on this real batch with the actual `DepthLoss26` class, old and new loaded straight from the real file content, not a hand-copy .. still exact.

All three configurations were faster with the new code on average, real KITTI data included.

## Validation

`tests/test_python.py -k depth` (17 tests, all pass unchanged), including `test_v26_depth_loss_lower_lambda_penalizes_scale_error_more`, which already exercises `DepthLoss26` directly. No new test: existing coverage already runs this path, and the change has no new failure mode to guard against — it's a reordering of already-computed values, verified equivalent above.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Reuses dense log-depth tensors in `DepthLoss26` to compute both SILog and multi-scale gradient losses efficiently. ⚡

### 📊 Key Changes
- Computes clamped logarithms for prediction and ground-truth depth once across the full tensor.
- Reuses the dense `pred_log` and `gt_log` tensors for SILog masking and gradient matching.
- Removes duplicate logarithm calculations while preserving valid-pixel filtering for SILog.

### 🎯 Purpose & Impact
- Reduces redundant computation in depth-loss evaluation and simplifies the implementation.
- Keeps the gradient loss supplied with dense log-depth inputs as required for multi-scale matching.
- Maintains existing numerical safeguards, masking behavior, and loss outputs while potentially improving efficiency. 🚀