### PR TITLE
Document Platform image delete shortcut

### DIFF
--- a/docs/en/platform/data/annotation.md
+++ b/docs/en/platform/data/annotation.md
@@ -440,6 +440,7 @@ Efficient annotation with keyboard shortcuts:
     | `Cmd/Ctrl+Y`                  | Redo                         |
     | `Escape`                      | Save / Deselect / Exit       |
     | `Delete` / `Backspace`        | Delete selected annotation   |
+    | `Cmd/Ctrl+Delete`             | Delete image                 |
     | `1-9`                         | Select class 1-9             |
     | `Cmd/Ctrl+Scroll`             | Zoom in/out                  |
     | `Cmd/Ctrl++` or `Cmd/Ctrl+=`  | Zoom in                      |


### PR DESCRIPTION
## Summary

- document the shipped `Cmd/Ctrl+Delete` image deletion shortcut in the Platform annotation guide
- keep `Delete` / `Backspace` distinct as annotation deletion

Platform implementation: ultralytics/portal#3534

Closes #25785

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the Platform annotation guide to document the existing `Cmd/Ctrl+Delete` shortcut for deleting images while keeping annotation deletion shortcuts distinct.

### 📊 Key Changes
- Added `Cmd/Ctrl+Delete` to the annotation keyboard-shortcuts table.
- Described the shortcut as deleting the current image.
- Retained `Delete` / `Backspace` for deleting selected annotations.

### 🎯 Purpose & Impact
- Improves discoverability of the Platform’s image-deletion shortcut without changing annotation behavior or implementation.