### PR TITLE
Remove the two docs embeds that do not render on the live site

### DIFF
--- a/docs/en/guides/ros-quickstart.md
+++ b/docs/en/guides/ros-quickstart.md
@@ -11,12 +11,9 @@ This guide shows you how to integrate [Ultralytics YOLO](../models/yolo26.md) wi
 
 Jump to [setting up YOLO with ROS](#setting-up-ultralytics-yolo-with-ros), then work with [RGB images](#use-ultralytics-with-ros-sensor_msgsimage), [depth images](#use-ultralytics-with-ros-depth-images), or [point clouds](#use-ultralytics-with-ros-sensor_msgspointcloud2).
 
-<p align="center"> <iframe src="https://player.vimeo.com/video/639236696?h=740f412ce5" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe></p>
-<p align="center"><a href="https://vimeo.com/639236696">ROS Introduction (captioned)</a> from <a href="https://vimeo.com/osrfoundation">Open Robotics</a> on <a href="https://vimeo.com/">Vimeo</a>.</p>
-
 ## What is ROS?
 
-The [Robot Operating System (ROS)](https://www.ros.org/) is an open-source framework widely used in robotics research and industry. ROS provides a collection of [libraries and tools](https://www.ros.org/blog/ecosystem/) to help developers create robot applications. ROS is designed to work with various [robotic platforms](https://robots.ros.org/), making it a flexible and powerful tool for roboticists.
+The [Robot Operating System (ROS)](https://www.ros.org/) is an open-source framework widely used in robotics research and industry. ROS provides a collection of [libraries and tools](https://www.ros.org/blog/ecosystem/) to help developers create robot applications. ROS is designed to work with various [robotic platforms](https://robots.ros.org/), making it a flexible and powerful tool for roboticists. For a brief introduction, watch the three-minute [ROS Introduction](https://vimeo.com/639236696) video from Open Robotics.
 
 ### Key Features of ROS
 

--- a/docs/en/guides/yolo26-training-recipe.md
+++ b/docs/en/guides/yolo26-training-recipe.md
@@ -14,17 +14,7 @@ Knowing what went into the official checkpoints — not just the architecture, b
 
 ## Training Overview
 
-All YOLO26 base models were trained on COCO at **640x640** resolution using the **MuSGD** optimizer with **[batch size](https://www.ultralytics.com/glossary/batch-size) 128**. Rather than starting from random weights in a single run, models were initialized from intermediate pretrained weights and refined with hyperparameters found via [evolutionary search](./hyperparameter-tuning.md#genetic-evolution-and-mutation). Full training logs and metrics for every model size are available on [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/yolo26):
-
-<iframe
-  src="https://platform.ultralytics.com/embed/ultralytics/yolo26"
-  title="YOLO26 COCO training runs and metrics on Ultralytics Platform"
-  loading="lazy"
-  scrolling="no"
-  width="100%"
-  height="290px"
-  style="border:none"
-></iframe>
+All YOLO26 base models were trained on COCO at **640x640** resolution using the **MuSGD** optimizer with **[batch size](https://www.ultralytics.com/glossary/batch-size) 128**. Rather than starting from random weights in a single run, models were initialized from intermediate pretrained weights and refined with hyperparameters found via [evolutionary search](./hyperparameter-tuning.md#genetic-evolution-and-mutation). Full training logs and metrics for every model size are available on [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/yolo26).
 
 Key design choices across all sizes:
 


### PR DESCRIPTION
## summary

two authored iframes in `docs/en` never reach the rendered page: the vimeo embed at the top of the ros quickstart, and the platform run card in the yolo26 training recipe. each sat under a sentence introducing content the reader never saw. this drops both and keeps the destination reachable in prose — the ros guide gains a sentence linking the video in "what is ros?", and the recipe sentence already linked the platform project page.

## measured

authored vs rendered `<iframe>` across every `docs/en` page, against docs.ultralytics.com:

| | count |
| --- | --- |
| pages carrying an iframe | 133 |
| authored iframes | 144 |
| rendered on the live site | 142 |

the two that never rendered are the two removed here; a youtube embed on the same corpus renders, which is what makes the count a measurement rather than a scrape artifact. hosts across the whole tree: 142 `www.youtube.com`, 1 `player.vimeo.com`, 1 `platform.ultralytics.com`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Removed two non-rendering documentation iframes and preserved access to their content through direct links.

### 📊 Key Changes
- Removed the Vimeo iframe and attribution block from the ROS quickstart guide.
- Added a direct link to the ROS Introduction video in the “What is ROS?” section.
- Removed the Ultralytics Platform training-runs iframe from the YOLO26 training recipe.
- Kept the existing link to the YOLO26 project page on Ultralytics Platform.

### 🎯 Purpose & Impact
- Prevents documentation pages from containing embeds that do not appear on the live site.
- Readers can still access the ROS video and YOLO26 training logs through regular links.
- No underlying ROS or YOLO26 training content was changed.