### PR TITLE
Use model IDs for Platform training callbacks

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -753,12 +753,7 @@ def test_platform_job_transport(monkeypatch, tmp_path):
 
     def post(url, **kwargs):
         captured.update(url=url, **kwargs)
-        response = (
-            {"uploadUrl": "https://upload.test", "gcsPath": "gs://bucket/model.pt"}
-            if url.endswith("/models/upload")
-            else {"received": True}
-        )
-        return SimpleNamespace(status_code=200, json=lambda: response, raise_for_status=lambda: None)
+        return SimpleNamespace(status_code=200, json=lambda: {"received": True}, raise_for_status=lambda: None)
 
     monkeypatch.setattr("requests.post", post)
     monkeypatch.setattr(platform, "_api_key", "api-key")
@@ -767,8 +762,6 @@ def test_platform_job_transport(monkeypatch, tmp_path):
     assert captured["url"] == "https://example.test/api/webhooks/training/metrics"
     assert captured["json"]["data"] == {"epoch": 0}
     assert captured["headers"] == {"Authorization": "Bearer api-key"}
-    assert platform._send("epoch_end", {"epoch": 1}, "user/project", "model", model_id="model-id") == {"received": True}
-    assert captured["json"] == {"event": "epoch_end", "data": {"epoch": 1}, "modelId": "model-id"}
 
     model = tmp_path / "models" / "best.pt"
     model.parent.mkdir()
@@ -778,14 +771,6 @@ def test_platform_job_transport(monkeypatch, tmp_path):
         "modelPath": str(model),
         "modelSize": 7,
     }
-
-    monkeypatch.delenv("PLATFORM_API_URL")
-    monkeypatch.setattr("ultralytics.utils.uploads.safe_upload", lambda **kwargs: True)
-    assert platform._upload_model(model, "user/project", "model", model_id="model-id") == {
-        "modelPath": "gs://bucket/model.pt",
-        "modelSize": 7,
-    }
-    assert captured["json"] == {"filename": "best.pt", "modelId": "model-id"}
 
 
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -753,7 +753,12 @@ def test_platform_job_transport(monkeypatch, tmp_path):
 
     def post(url, **kwargs):
         captured.update(url=url, **kwargs)
-        return SimpleNamespace(status_code=200, json=lambda: {"received": True}, raise_for_status=lambda: None)
+        response = (
+            {"uploadUrl": "https://upload.test", "gcsPath": "gs://bucket/model.pt"}
+            if url.endswith("/models/upload")
+            else {"received": True}
+        )
+        return SimpleNamespace(status_code=200, json=lambda: response, raise_for_status=lambda: None)
 
     monkeypatch.setattr("requests.post", post)
     monkeypatch.setattr(platform, "_api_key", "api-key")
@@ -762,6 +767,8 @@ def test_platform_job_transport(monkeypatch, tmp_path):
     assert captured["url"] == "https://example.test/api/webhooks/training/metrics"
     assert captured["json"]["data"] == {"epoch": 0}
     assert captured["headers"] == {"Authorization": "Bearer api-key"}
+    assert platform._send("epoch_end", {"epoch": 1}, "user/project", "model", model_id="model-id") == {"received": True}
+    assert captured["json"] == {"event": "epoch_end", "data": {"epoch": 1}, "modelId": "model-id"}
 
     model = tmp_path / "models" / "best.pt"
     model.parent.mkdir()
@@ -771,6 +778,14 @@ def test_platform_job_transport(monkeypatch, tmp_path):
         "modelPath": str(model),
         "modelSize": 7,
     }
+
+    monkeypatch.delenv("PLATFORM_API_URL")
+    monkeypatch.setattr("ultralytics.utils.uploads.safe_upload", lambda **kwargs: True)
+    assert platform._upload_model(model, "user/project", "model", model_id="model-id") == {
+        "modelPath": "gs://bucket/model.pt",
+        "modelSize": 7,
+    }
+    assert captured["json"] == {"filename": "best.pt", "modelId": "model-id"}
 
 
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -99,9 +99,11 @@ def _send(event, data, project, name, model_id=None, retry=2, timeout=30):
         return None
     import requests  # scoped as slow import
 
-    payload = {"event": event, "project": project, "name": name, "data": _sanitize_json_value(data)}
+    payload = {"event": event, "data": _sanitize_json_value(data)}
     if model_id:
         payload["modelId"] = model_id
+    else:
+        payload.update(project=project, name=name)
 
     def send_once():
         global _api_key
@@ -170,9 +172,11 @@ def _upload_model(model_path, project, name, progress=False, retry=1, model_id=N
     # Get signed upload URL from Platform (server sanitizes filename for storage safety)
     @Retry(times=3, delay=2)
     def get_signed_url():
-        payload = {"project": project, "name": name, "filename": model_path.name}
+        payload = {"filename": model_path.name}
         if model_id:
             payload["modelId"] = model_id  # Direct lookup avoids slug mismatch from auto-increment
+        else:
+            payload.update(project=project, name=name)
         if run_id:
             payload["runId"] = run_id
         r = requests.post(


### PR DESCRIPTION
## Summary
- keep established `project` + `name` registration for `training_started`
- reuse the returned `modelId` for every subsequent metrics callback and model upload
- avoid repeated project/model slug resolution in steady-state internal training traffic

## Real production validation
- completed a 1-epoch CPU training against production from this branch
- completed a 100-epoch CPU training against production from this branch
- verified both runs registered by project/name, persisted model IDs, streamed console and system telemetry, uploaded `best.pt`, and finalized successfully
- 100-epoch run persisted 101 metric/system entries and complete console history beginning at chunk 1

## Local validation
- Ruff format/check
- existing focused Platform callback test
- normal repository CI

No new mocked test assertions are included.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated Platform training callbacks to use the returned `modelId` for subsequent event and model-upload requests, while retaining `project` and `name` for initial model registration to avoid repeated slug resolution.

### 📊 Key Changes

- `_send()` now sends `modelId` instead of `project` and `name` when a model ID is available.
- Event requests without a model ID continue to use `project` and `name` for model registration.
- `_upload_model()` now resolves signed upload URLs by `modelId` when available, with `project` and `name` retained as the fallback.
- Model uploads continue to include `runId` when provided.

### 🎯 Purpose & Impact

- Platform training traffic uses direct model-ID lookup after registration, reducing repeated project/model slug resolution during metric, telemetry, and model-upload callbacks.
- Initial `training_started` registration behavior remains based on `project` and `name`; no other training workflow behavior is changed.