### PR TITLE
fix: add probability guard to CopyPaste in flip mode

### DIFF
--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1919,7 +1919,7 @@ class CopyPaste(BaseMixTransform):
         if len(labels["instances"].segments) == 0 or self.p == 0:
             return labels
         if self.mode == "flip":
-            if random.uniform(0, 1) > self.p:
+            if random.random() >= self.p:
                 return labels
             params = self.get_params(labels)
             labels = self.apply_image(labels, params)
@@ -1955,11 +1955,7 @@ class CopyPaste(BaseMixTransform):
             instances2.fliplr(w)
 
         ioa = bbox_ioa(instances2.bboxes, instances.bboxes)
-        indexes = np.nonzero((ioa < 0.30).all(1))[0]
-        n = len(indexes)
-        sorted_idx = np.argsort(ioa.max(1)[indexes])
-        indexes = indexes[sorted_idx]
-        selected = indexes[: round(self.p * n)]
+        selected = np.nonzero((ioa < 0.30).all(1))[0]
 
         im_new = np.zeros((h, w), np.uint8)
 

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1919,6 +1919,8 @@ class CopyPaste(BaseMixTransform):
         if len(labels["instances"].segments) == 0 or self.p == 0:
             return labels
         if self.mode == "flip":
+            if random.uniform(0, 1) > self.p:
+                return labels
             params = self.get_params(labels)
             labels = self.apply_image(labels, params)
             labels = self.apply_instances(labels, params)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->
This PR adds the missing image-level probability guard `random.uniform(0, 1) > self.p` to the `CopyPaste` augmentation class when operating in `"flip"` mode (the default mode).

### Details
Previously, in `"flip"` mode, the `CopyPaste` transform was unconditionally applied to every image containing segments, making the effective image-level probability 1.0. Instead of behaving as a probability of applying the transformation, the `copy_paste` hyperparameter (`self.p`) was only used as a slicing fraction to select a portion of the candidate objects.

This PR adds the probability check to `"flip"` mode (matching the existing `"mixup"` mode logic), so that `copy_paste` represents the probability of applying the transformation to a given image.

### Verification
- Formatted and linted the changes using `ruff`.
- Ran the pretrained training unit tests successfully:
  ```bash
  pytest tests/test_python.py::test_train_pretrained -v

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a probability guard to `CopyPaste` when operating in flip mode.

### 📊 Key Changes
- Samples a random value and skips augmentation when it exceeds the configured `self.p` probability.
- Applies the guard before generating flip parameters or modifying images and instances.
- Leaves existing behavior unchanged for empty segments and zero-probability configurations.

### 🎯 Purpose & Impact
- Ensures flip-mode CopyPaste respects its configured augmentation probability.
- Prevents unintended augmentation on samples that should be skipped.
- Improves consistency with probabilistic augmentation expectations while keeping the change narrowly scoped.