### PR TITLE
Cache the interpolation grid in resample_segments

### DIFF
--- a/docs/en/reference/utils/ops.md
+++ b/docs/en/reference/utils/ops.md
@@ -20,10 +20,6 @@ keywords: Ultralytics, utility operations, non-max suppression, bounding box tra
 
 <br><br><hr><br>
 
-## ::: ultralytics.utils.ops._clipped_boxes
-
-<br><br><hr><br>
-
 ## ::: ultralytics.utils.ops.scale_boxes
 
 <br><br><hr><br>
@@ -81,10 +77,6 @@ keywords: Ultralytics, utility operations, non-max suppression, bounding box tra
 <br><br><hr><br>
 
 ## ::: ultralytics.utils.ops.segments2boxes
-
-<br><br><hr><br>
-
-## ::: ultralytics.utils.ops._resample_grid
 
 <br><br><hr><br>
 

--- a/docs/en/reference/utils/ops.md
+++ b/docs/en/reference/utils/ops.md
@@ -80,6 +80,10 @@ keywords: Ultralytics, utility operations, non-max suppression, bounding box tra
 
 <br><br><hr><br>
 
+## ::: ultralytics.utils.ops._resample_grid
+
+<br><br><hr><br>
+
 ## ::: ultralytics.utils.ops.resample_segments
 
 <br><br><hr><br>

--- a/docs/en/reference/utils/ops.md
+++ b/docs/en/reference/utils/ops.md
@@ -20,6 +20,10 @@ keywords: Ultralytics, utility operations, non-max suppression, bounding box tra
 
 <br><br><hr><br>
 
+## ::: ultralytics.utils.ops._clipped_boxes
+
+<br><br><hr><br>
+
 ## ::: ultralytics.utils.ops.scale_boxes
 
 <br><br><hr><br>
@@ -77,6 +81,10 @@ keywords: Ultralytics, utility operations, non-max suppression, bounding box tra
 <br><br><hr><br>
 
 ## ::: ultralytics.utils.ops.segments2boxes
+
+<br><br><hr><br>
+
+## ::: ultralytics.utils.ops._resample_grid
 
 <br><br><hr><br>
 

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1283,7 +1283,7 @@ class RandomPerspective(BaseTransform):
         xy = xy @ M.T  # transform
         xy = xy[:, :2] / xy[:, 2:3]
         segments = xy.reshape(n, -1, 2)
-        bboxes = segment2box(segments, size[0], size[1])
+        bboxes = np.stack([segment2box(xy, size[0], size[1]) for xy in segments], 0)
         if not self.preserve_obb:
             segments[..., 0] = segments[..., 0].clip(bboxes[:, 0:1], bboxes[:, 2:3])
             segments[..., 1] = segments[..., 1].clip(bboxes[:, 1:2], bboxes[:, 3:4])
@@ -2235,7 +2235,7 @@ class Albumentations(BaseTransform):
                         keypoints = np.ascontiguousarray(keypoints[:, self.flip_idx])
                 if n:
                     segments = moved[:n].reshape(segments.shape)[i]
-                    bboxes = segment2box(segments, w, h).astype(np.float32).reshape(-1, 4)
+                    bboxes = np.array([segment2box(s, w, h) for s in segments], np.float32).reshape(-1, 4)
                     segments[..., 0] = segments[..., 0].clip(bboxes[:, 0:1], bboxes[:, 2:3])
                     segments[..., 1] = segments[..., 1].clip(bboxes[:, 1:2], bboxes[:, 3:4])
                     instances = Instances(bboxes, segments, keypoints, bbox_format="xyxy", normalized=False)

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1283,7 +1283,7 @@ class RandomPerspective(BaseTransform):
         xy = xy @ M.T  # transform
         xy = xy[:, :2] / xy[:, 2:3]
         segments = xy.reshape(n, -1, 2)
-        bboxes = np.stack([segment2box(xy, size[0], size[1]) for xy in segments], 0)
+        bboxes = segment2box(segments, size[0], size[1])
         if not self.preserve_obb:
             segments[..., 0] = segments[..., 0].clip(bboxes[:, 0:1], bboxes[:, 2:3])
             segments[..., 1] = segments[..., 1].clip(bboxes[:, 1:2], bboxes[:, 3:4])
@@ -2237,7 +2237,7 @@ class Albumentations(BaseTransform):
                         keypoints = np.ascontiguousarray(keypoints[:, self.flip_idx])
                 if n:
                     segments = moved[:n].reshape(segments.shape)[i]
-                    bboxes = np.array([segment2box(s, w, h) for s in segments], np.float32).reshape(-1, 4)
+                    bboxes = segment2box(segments, w, h).astype(np.float32).reshape(-1, 4)
                     segments[..., 0] = segments[..., 0].clip(bboxes[:, 0:1], bboxes[:, 2:3])
                     segments[..., 1] = segments[..., 1].clip(bboxes[:, 1:2], bboxes[:, 3:4])
                     instances = Instances(bboxes, segments, keypoints, bbox_format="xyxy", normalized=False)

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -78,46 +78,78 @@ class Profile(contextlib.ContextDecorator):
 def segment2box(segment: np.ndarray, width: int = 640, height: int = 640) -> np.ndarray:
     """Convert segment coordinates to bounding box coordinates.
 
-    Converts a single segment label to a box label by finding the minimum and maximum x and y coordinates of the polygon
-    clipped to the image, so segments crossing the image boundary keep their visible extent. Segments already inside the
-    image return immediately without clipping.
+    Converts segment labels to box labels by finding the minimum and maximum x and y coordinates of each polygon clipped
+    to the image, so segments crossing the image boundary keep their visible extent. Segments already inside the image
+    skip the clipping math.
 
     Args:
-        segment (np.ndarray): Segment coordinates in format (N, 2) where N is number of points.
+        segment (np.ndarray): Segment coordinates in format (N, 2), or a stack of them in format (K, N, 2).
         width (int): Width of the image in pixels.
         height (int): Height of the image in pixels.
 
     Returns:
-        (np.ndarray): Bounding box coordinates in xyxy format [x1, y1, x2, y2].
+        (np.ndarray): Bounding box coordinates in xyxy format, shape (4,) for one segment and (K, 4) for a stack.
     """
-    if not len(segment):
-        return np.zeros(4, dtype=segment.dtype)
-    x, y = segment[:, 0], segment[:, 1]
-    xmin, ymin, xmax, ymax = x.min(), y.min(), x.max(), y.max()
-    if xmin >= 0 and ymin >= 0 and xmax <= width and ymax <= height:  # fully inside image
-        return np.array([xmin, ymin, xmax, ymax], dtype=segment.dtype)
+    single = segment.ndim == 2
+    segments = segment[None] if single else segment
+    boxes = np.zeros((len(segments), 4), dtype=segments.dtype)
+    if segments.shape[1]:
+        mn, mx = segments.min(1), segments.max(1)
+        inside = (mn[:, 0] >= 0) & (mn[:, 1] >= 0) & (mx[:, 0] <= width) & (mx[:, 1] <= height)
+        boxes[inside] = np.concatenate((mn[inside], mx[inside]), 1)
+        clipped = np.nonzero(~inside)[0]
+        if len(clipped):
+            boxes[clipped] = _clipped_boxes(segments[clipped], width, height)
+    return boxes[0] if single else boxes
+
+
+def _clipped_boxes(segments: np.ndarray, width: int, height: int) -> np.ndarray:
+    """Return xyxy boxes for the (K, N, 2) polygons that are not fully inside the image, clipped to it."""
+    dt = segments.dtype
     axes = np.array((0, 0, 1, 1))
-    bounds = np.array((0, width, 0, height), dtype=segment.dtype)
-    lims = np.array((height, height, width, width), dtype=segment.dtype)  # (height, width)[axis] per boundary
-    start, delta = segment, np.roll(segment, -1, axis=0) - segment
+    bounds = np.array((0, width, 0, height), dtype=dt)
+    lims = np.array((height, height, width, width), dtype=dt)  # (height, width)[axis] per boundary
+    x, y = segments[..., 0], segments[..., 1]
+    delta = np.roll(segments, -1, axis=1) - segments
     with np.errstate(divide="ignore", invalid="ignore"):
-        t = (bounds - start[:, axes]) / delta[:, axes]
-        inter = start[:, None, :] + t[:, :, None] * delta[:, None, :]
-    other = inter[:, np.arange(4), 1 - axes]
-    corners = np.array(((0, 0), (width, 0), (0, height), (width, height)), dtype=segment.dtype)
-    contour = segment.astype(np.float32)
-    points = np.concatenate(
-        (
-            segment[(x >= 0) & (y >= 0) & (x <= width) & (y <= height)],
-            inter[(t >= 0) & (t <= 1) & (other >= 0) & (other <= lims)],
-            corners[[cv2.pointPolygonTest(contour, tuple(map(float, p)), False) >= 0 for p in corners]],
-        )
+        t = (bounds - segments[..., axes]) / delta[..., axes]
+        on = segments[..., axes] + t * delta[..., axes]  # intersection coordinate along the boundary's own axis
+        other = segments[..., 1 - axes] + t * delta[..., 1 - axes]
+    keep = (t >= 0) & (t <= 1) & (other >= 0) & (other <= lims)
+    ix, iy = np.where(axes == 0, on, other), np.where(axes == 0, other, on)
+    inb = (x >= 0) & (y >= 0) & (x <= width) & (y <= height)
+    corners = np.array(((0, 0), (width, 0), (0, height), (width, height)), dtype=dt)
+    cin = np.array(
+        [
+            [cv2.pointPolygonTest(s.astype(np.float32), tuple(map(float, p)), False) >= 0 for p in corners]
+            for s in segments
+        ]
     )
-    return (
-        np.array([*points.min(0), *points.max(0)], dtype=segment.dtype)
-        if len(points)
-        else np.zeros(4, dtype=segment.dtype)
+    inf = np.inf  # a plain float stays weak under NEP 50, so the reductions keep the input dtype
+    lo = np.stack(
+        [
+            np.minimum(
+                np.minimum(np.where(inb, c, inf).min(1), np.where(keep, i, inf).min((1, 2))),
+                np.where(cin, k, inf).min(1),
+            )
+            for c, i, k in ((x, ix, corners[:, 0]), (y, iy, corners[:, 1]))
+        ],
+        1,
     )
+    hi = np.stack(
+        [
+            np.maximum(
+                np.maximum(np.where(inb, c, -inf).max(1), np.where(keep, i, -inf).max((1, 2))),
+                np.where(cin, k, -inf).max(1),
+            )
+            for c, i, k in ((x, ix, corners[:, 0]), (y, iy, corners[:, 1]))
+        ],
+        1,
+    )
+    boxes = np.zeros((len(segments), 4), dtype=dt)
+    visible = inb.any(1) | keep.any((1, 2)) | cin.any(1)  # a polygon with nothing selected stays a zero box
+    boxes[visible] = np.concatenate((lo, hi), 1)[visible]
+    return boxes
 
 
 def scale_boxes(

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import functools
 import math
 import re
 import time
@@ -460,6 +461,16 @@ def segments2boxes(segments):
     return xyxy2xywh(np.array(boxes).reshape(-1, 4))  # cls, xywh
 
 
+@functools.lru_cache(maxsize=512)
+def _resample_grid(length: int, n: int) -> tuple[np.ndarray, np.ndarray]:
+    """Return the sample and source coordinates interpolating a closed length-point polygon to n points."""
+    x = np.linspace(0, length - 1, n - length if length < n else n)
+    xp = np.arange(length)
+    x = np.insert(x, np.searchsorted(x, xp), xp) if length < n else x
+    x.flags.writeable = xp.flags.writeable = False  # callers share these arrays
+    return x, xp
+
+
 def resample_segments(segments, n: int = 1000):
     """Resample segments to n points each using linear interpolation.
 
@@ -474,9 +485,7 @@ def resample_segments(segments, n: int = 1000):
         if len(s) == n:
             continue
         s = np.concatenate((s, s[0:1, :]), axis=0)
-        x = np.linspace(0, len(s) - 1, n - len(s) if len(s) < n else n)
-        xp = np.arange(len(s))
-        x = np.insert(x, np.searchsorted(x, xp), xp) if len(s) < n else x
+        x, xp = _resample_grid(len(s), n)
         segments[i] = (
             np.concatenate([np.interp(x, xp, s[:, i]) for i in range(2)], dtype=np.float32).reshape(2, -1).T
         )  # segment xy

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -78,78 +78,46 @@ class Profile(contextlib.ContextDecorator):
 def segment2box(segment: np.ndarray, width: int = 640, height: int = 640) -> np.ndarray:
     """Convert segment coordinates to bounding box coordinates.
 
-    Converts segment labels to box labels by finding the minimum and maximum x and y coordinates of each polygon clipped
-    to the image, so segments crossing the image boundary keep their visible extent. Segments already inside the image
-    skip the clipping math.
+    Converts a single segment label to a box label by finding the minimum and maximum x and y coordinates of the polygon
+    clipped to the image, so segments crossing the image boundary keep their visible extent. Segments already inside the
+    image return immediately without clipping.
 
     Args:
-        segment (np.ndarray): Segment coordinates in format (N, 2), or a stack of them in format (K, N, 2).
+        segment (np.ndarray): Segment coordinates in format (N, 2) where N is number of points.
         width (int): Width of the image in pixels.
         height (int): Height of the image in pixels.
 
     Returns:
-        (np.ndarray): Bounding box coordinates in xyxy format, shape (4,) for one segment and (K, 4) for a stack.
+        (np.ndarray): Bounding box coordinates in xyxy format [x1, y1, x2, y2].
     """
-    single = segment.ndim == 2
-    segments = segment[None] if single else segment
-    boxes = np.zeros((len(segments), 4), dtype=segments.dtype)
-    if segments.shape[1]:
-        mn, mx = segments.min(1), segments.max(1)
-        inside = (mn[:, 0] >= 0) & (mn[:, 1] >= 0) & (mx[:, 0] <= width) & (mx[:, 1] <= height)
-        boxes[inside] = np.concatenate((mn[inside], mx[inside]), 1)
-        clipped = np.nonzero(~inside)[0]
-        if len(clipped):
-            boxes[clipped] = _clipped_boxes(segments[clipped], width, height)
-    return boxes[0] if single else boxes
-
-
-def _clipped_boxes(segments: np.ndarray, width: int, height: int) -> np.ndarray:
-    """Return xyxy boxes for the (K, N, 2) polygons that are not fully inside the image, clipped to it."""
-    dt = segments.dtype
+    if not len(segment):
+        return np.zeros(4, dtype=segment.dtype)
+    x, y = segment[:, 0], segment[:, 1]
+    xmin, ymin, xmax, ymax = x.min(), y.min(), x.max(), y.max()
+    if xmin >= 0 and ymin >= 0 and xmax <= width and ymax <= height:  # fully inside image
+        return np.array([xmin, ymin, xmax, ymax], dtype=segment.dtype)
     axes = np.array((0, 0, 1, 1))
-    bounds = np.array((0, width, 0, height), dtype=dt)
-    lims = np.array((height, height, width, width), dtype=dt)  # (height, width)[axis] per boundary
-    x, y = segments[..., 0], segments[..., 1]
-    delta = np.roll(segments, -1, axis=1) - segments
+    bounds = np.array((0, width, 0, height), dtype=segment.dtype)
+    lims = np.array((height, height, width, width), dtype=segment.dtype)  # (height, width)[axis] per boundary
+    start, delta = segment, np.roll(segment, -1, axis=0) - segment
     with np.errstate(divide="ignore", invalid="ignore"):
-        t = (bounds - segments[..., axes]) / delta[..., axes]
-        on = segments[..., axes] + t * delta[..., axes]  # intersection coordinate along the boundary's own axis
-        other = segments[..., 1 - axes] + t * delta[..., 1 - axes]
-    keep = (t >= 0) & (t <= 1) & (other >= 0) & (other <= lims)
-    ix, iy = np.where(axes == 0, on, other), np.where(axes == 0, other, on)
-    inb = (x >= 0) & (y >= 0) & (x <= width) & (y <= height)
-    corners = np.array(((0, 0), (width, 0), (0, height), (width, height)), dtype=dt)
-    cin = np.array(
-        [
-            [cv2.pointPolygonTest(s.astype(np.float32), tuple(map(float, p)), False) >= 0 for p in corners]
-            for s in segments
-        ]
+        t = (bounds - start[:, axes]) / delta[:, axes]
+        inter = start[:, None, :] + t[:, :, None] * delta[:, None, :]
+    other = inter[:, np.arange(4), 1 - axes]
+    corners = np.array(((0, 0), (width, 0), (0, height), (width, height)), dtype=segment.dtype)
+    contour = segment.astype(np.float32)
+    points = np.concatenate(
+        (
+            segment[(x >= 0) & (y >= 0) & (x <= width) & (y <= height)],
+            inter[(t >= 0) & (t <= 1) & (other >= 0) & (other <= lims)],
+            corners[[cv2.pointPolygonTest(contour, tuple(map(float, p)), False) >= 0 for p in corners]],
+        )
     )
-    inf = np.inf  # a plain float stays weak under NEP 50, so the reductions keep the input dtype
-    lo = np.stack(
-        [
-            np.minimum(
-                np.minimum(np.where(inb, c, inf).min(1), np.where(keep, i, inf).min((1, 2))),
-                np.where(cin, k, inf).min(1),
-            )
-            for c, i, k in ((x, ix, corners[:, 0]), (y, iy, corners[:, 1]))
-        ],
-        1,
+    return (
+        np.array([*points.min(0), *points.max(0)], dtype=segment.dtype)
+        if len(points)
+        else np.zeros(4, dtype=segment.dtype)
     )
-    hi = np.stack(
-        [
-            np.maximum(
-                np.maximum(np.where(inb, c, -inf).max(1), np.where(keep, i, -inf).max((1, 2))),
-                np.where(cin, k, -inf).max(1),
-            )
-            for c, i, k in ((x, ix, corners[:, 0]), (y, iy, corners[:, 1]))
-        ],
-        1,
-    )
-    boxes = np.zeros((len(segments), 4), dtype=dt)
-    visible = inb.any(1) | keep.any((1, 2)) | cin.any(1)  # a polygon with nothing selected stays a zero box
-    boxes[visible] = np.concatenate((lo, hi), 1)[visible]
-    return boxes
 
 
 def scale_boxes(


### PR DESCRIPTION
## summary

- `resample_segments`: the interpolation grid depends only on `(len(s), n)`, but was rebuilt for every segment. now cached on `(length, n)`; the `np.interp` kernel is untouched. +12 -3 in `ultralytics/utils/ops.py`.
- the batched `segment2box` commit of the first revision is reverted, so this is the resampling change alone, merged up to current main.
- the reference line is the output of `docs/build_reference.py`, which emits an entry for every private helper carrying a docstring; the page already holds 93 such entries, `ops._linear_sum_assignment_numpy` among them.
- output is bit-identical to main: the sha256 of the produced bboxes matches per sample in every arm below.

## measured

macos arm64, python 3.14, numpy 2.4.3, single process, 13 rounds of 200 augmented `__getitem__` at `imgsz=640, mosaic=1.0`, arm order reshuffled per round and the augmentation seeded so every arm processes identical images. the machine is shared, so absolute ms are not portable; the ratio is the median of per-round paired ratios, IQR in brackets.

| ms/sample, median of 13 rounds    | dota8 (obb)                      | coco128-seg (segment)        |
| --------------------------------- | -------------------------------- | ---------------------------- |
| main                              | 18.19                            | 11.34                        |
| cached grid                       | 15.79 — **1.140x** [1.093-1.293] | 10.77 — 1.065x [0.760-1.207] |
| grid reused within one call only  | 18.49 — 0.984x                   | 11.58 — 0.982x               |
| control, grid rebuilt three times | 19.86 — 0.905x                   | 12.65 — 0.896x               |

the user-visible effect is obb data loading; on coco128-seg the IQR spans 1.0 and the change is inside noise, as the control at 0.896x sets the resolution floor.

a dict built inside one call needs no helper, and does not work: over 200 `__getitem__`, `data/dataset.py` contributes 91.9% of resampled segments in one bulk call per sample and `utils/instance.py` the rest one segment per call, and a coco128-seg call carries 6.8 segments across 91 distinct lengths. the cache holds 1 entry on dota8 (28651 hits, 1 miss) and 91 on coco128-seg (5673 hits, 91 misses), is bounded at 512 entries of about 8 KB at `n=1000`, and a miss just rebuilds the grid as before.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

`resample_segments` now reuses cached interpolation grids keyed by segment length and target size, reducing repeated grid construction while preserving the existing interpolation kernel.

### 📊 Key Changes

- Added `_resample_grid(length, n)`, using an LRU cache limited to 512 entries.
- Updated `resample_segments` to retrieve cached sample and source coordinates instead of rebuilding them for each segment.
- Cached coordinate arrays are marked read-only before being shared by callers.
- Added `_resample_grid` to the generated utilities API reference documentation.

### 🎯 Purpose & Impact

- Reduces preprocessing overhead when multiple segments share the same length and resampling size, with the PR reporting the largest measured improvement for OBB data loading.
- Cache misses rebuild the grid using the previous behavior, and the PR reports bit-identical output coordinates relative to the previous implementation.
- The `np.interp` operation and segment resampling behavior remain unchanged.