### PR TITLE
Restore dark theme palette in docs configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,25 @@ use_directory_urls: true # use directory-style URLs instead of file-based paths
 # Theme customization
 theme:
   name: material
+  palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: black
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
 
 extra:
   alternate:


### PR DESCRIPTION
Adding dark theme back to docs for testing.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Restores light and dark color-scheme settings to the MkDocs Material documentation theme, including controls for switching between them.

### 📊 Key Changes
- Adds automatic theme selection based on the user's preferred color scheme.
- Restores a dark `slate` palette with black primary and indigo accent colors.
- Restores a light palette with indigo primary and accent colors.
- Adds theme toggle icons and labels for system preference, light mode, and dark mode.

### 🎯 Purpose & Impact
- Documentation visitors can use the restored theme controls to switch between light mode, dark mode, and system preference in the MkDocs site.