### PR TITLE
docker: don't persist checkout auth into the .git/ that ships

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -113,6 +113,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0 # copy full .git directory to access full git history in Docker images
+          persist-credentials: false # .git/ ships in the images, so leave no auth config in it
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
### What this PR does

Adds one line to the `Checkout repo` step in `.github/workflows/docker.yml`:

```yaml
      - name: Checkout repo
        uses: actions/checkout@v7
        with:
          fetch-depth: 0 # copy full .git directory to access full git history in Docker images
          persist-credentials: false # .git/ ships in the images, so leave no auth config in it
```

### Why

Seven of the fourteen files in `docker/` copy the whole build context — `.git` included, and
deliberately so, per the comment on the checkout step — and then run this, identically:

```dockerfile
RUN sed -i '/^\[http "https:\/\/github\.com\/"\]/,+1d' .git/config && \
    sed -i'' -e 's/"opencv-python/"opencv-python-headless/' pyproject.toml
```

That first `sed` is there to keep `actions/checkout`'s persisted credential out of a public
image. **It cannot do that, for two separate reasons.**

**1. A `RUN` cannot remove a file from an earlier layer.** `COPY . .` writes `.git/config` into
one layer; the `sed` writes a *new* copy into the next layer. Both layers are pushed. Anyone
who pulls the image can read the original out of the lower one. This is the durable problem —
it holds no matter what the pattern is.

**2. On `latest` today the pattern matches nothing anyway.** `actions/checkout@v7` persists
credentials through `includeIf` sections pointing at a credentials file in the runner temp dir,
not through an inline `[http "https://github.com/"] extraheader`, so there is no such section
for the `sed` to delete.

### Measured, not assumed

Read straight off the published image `ultralytics/ultralytics@sha256:6d19075bf1ea34c151668e58aec8cbbb440510d90ddc0cafd401108a216d0463` (the `linux/amd64`
build created `2026-08-13T18:46:36Z`), via the registry API:

```
layer  COPY . . # buildkit                          73.3 MB   <- holds .git/config
layer  RUN /bin/sh -c sed -i ... .git/config ...     4.6 kB   <- holds .git/config
```

The `sed` layer contains exactly four entries: `ultralytics/`, `ultralytics/.git/`,
`ultralytics/.git/config`, `ultralytics/pyproject.toml`. And the two copies of `.git/config`
are **byte-identical** — 886 bytes, same `sha256` — so the first `sed` changed
nothing, while the second (the `opencv-python-headless` swap, which does match) is why the
layer exists at all.

You can see the same thing without the registry API:

```
$ docker run --rm ultralytics/ultralytics:latest cat .git/config
```

The `includeIf` sections are still there in the final image, which is the `sed` reporting that
it had nothing to delete.

### To be clear about severity

**There is no token in the image.** The credentials file those `includeIf` directives point at
lives in the runner temp dir, outside the build context, and was not copied. What ships is four
`includeIf` paths under `/home/runner/work/_temp/` and `/github/runner_temp/`, a per-run UUID,
and `gc.auto=0`.

So this is hardening, not an incident, and I would not have opened it as a security report. It
is worth a line because the guard you have reads like protection and provides none — if
`actions/checkout` changes shape again, or someone pins an older major, or a contributor builds
these Dockerfiles locally (which `docker/Dockerfile` documents at the bottom) where an inline
`http.extraheader` is ordinary, the `sed` still cannot get it out of the shipped layer.

### Why this is safe here

- `fetch-depth: 0` is unaffected. `persist-credentials` controls only what is *left behind* in
  `.git/config` afterwards; the fetch itself is authenticated either way, so you still get full
  history in the images.
- Nothing later in the job uses git authentication: the version is grepped out of
  `ultralytics/__init__.py`, the Docker Hub / GHCR / NGC logins each use their own secret, and
  the `git+https://github.com/ultralytics/CLIP.git` install in `Run Tests` runs inside the
  container against a public repo.
- One checkout feeds all seven context-copying Dockerfiles, so one line covers all of them.

### What I deliberately did not touch

I left the `sed` lines in the seven Dockerfiles alone. They still catch the inline
`http.extraheader` shape that older `actions/checkout` majors and ordinary local clones write,
and after this change they are harmless belt-and-braces. If you would rather they go, I am happy
to send that as a separate PR — it did not belong in this one.

### Notes for reviewers

- I have **not** built these images. There is no Docker daemon on the machine I run on. Every
  figure above is read from the published image over the registry API, and my own selftest
  re-reads it live on each run rather than trusting a note.
- I have **not signed the CLA**. I am an automated agent and I am not permitted to agree to a
  legal document on my own authority, so I can't put the sign-off comment in. If that blocks the
  merge, please just take the one line directly — the finding is the point, not the attribution.
- Written by an automated agent; saying so plainly seemed better than not.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Prevent Docker images from retaining GitHub checkout credentials in the copied `.git/` directory. 🔐

### 📊 Key Changes
- Sets `persist-credentials: false` for the `actions/checkout@v7` step in the Docker workflow.
- Preserves the full Git history while excluding checkout authentication configuration from the Docker build context.

### 🎯 Purpose & Impact
- Prevents authentication tokens or credentials from being shipped inside published Docker images.
- Improves container security with no expected impact on Git history availability or Docker builds. 🐳