### PR TITLE
Prevent checkout credentials from entering Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -113,6 +113,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0 # copy full .git directory to access full git history in Docker images
+          persist-credentials: false # .git/ ships in the images, so leave no auth config in it
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,10 +36,9 @@ RUN apt-get update && \
 # Create working directory
 WORKDIR /ultralytics
 
-# Copy contents and configure git
+# Copy contents and configure dependencies
 COPY . .
-RUN sed -i '/^\[http "https:\/\/github\.com\/"\]/,+1d' .git/config && \
-    sed -i'' -e 's/"opencv-python/"opencv-python-headless/' pyproject.toml
+RUN sed -i'' -e 's/"opencv-python/"opencv-python-headless/' pyproject.toml
 ADD https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26n.pt .
 
 # Install pip packages (uv already installed in base image)

--- a/docker/Dockerfile-arm64
+++ b/docker/Dockerfile-arm64
@@ -32,10 +32,9 @@ RUN apt-get update && \
 # Create working directory
 WORKDIR /ultralytics
 
-# Copy contents and configure git
+# Copy contents and configure dependencies
 COPY . .
-RUN sed -i '/^\[http "https:\/\/github\.com\/"\]/,+1d' .git/config && \
-    sed -i'' -e 's/"opencv-python/"opencv-python-headless/' pyproject.toml
+RUN sed -i'' -e 's/"opencv-python/"opencv-python-headless/' pyproject.toml
 ADD https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26n.pt .
 
 # Install pip packages, create python symlink, and remove build files

--- a/docker/Dockerfile-jetson-jetpack4
+++ b/docker/Dockerfile-jetson-jetpack4
@@ -36,10 +36,9 @@ RUN ln -sf /usr/bin/python3.8 /usr/bin/python3 && \
 # Create working directory
 WORKDIR /ultralytics
 
-# Copy contents and configure git
+# Copy contents and configure dependencies
 COPY . .
-RUN sed -i '/^\[http "https:\/\/github\.com\/"\]/,+1d' .git/config && \
-    sed -i'' -e 's/"opencv-python/"opencv-python-headless/' pyproject.toml
+RUN sed -i'' -e 's/"opencv-python/"opencv-python-headless/' pyproject.toml
 ADD https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26n.pt .
 
 # Replace pyproject.toml TF.js version with 'tensorflowjs>=3.9.0' for JetPack4 compatibility

--- a/docker/Dockerfile-jetson-jetpack5
+++ b/docker/Dockerfile-jetson-jetpack5
@@ -28,10 +28,9 @@ RUN apt-get update && \
 # Create working directory
 WORKDIR /ultralytics
 
-# Copy contents and configure git
+# Copy contents and configure dependencies
 COPY . .
-RUN sed -i '/^\[http "https:\/\/github\.com\/"\]/,+1d' .git/config && \
-    sed -i'' -e 's/"opencv-python/"opencv-python-headless/' pyproject.toml
+RUN sed -i'' -e 's/"opencv-python/"opencv-python-headless/' pyproject.toml
 ADD https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26n.pt .
 
 # Replace pyproject.toml TF.js version with 'tensorflowjs>=3.9.0' for JetPack5 compatibility and install packages

--- a/docker/Dockerfile-jetson-jetpack6
+++ b/docker/Dockerfile-jetson-jetpack6
@@ -40,10 +40,9 @@ RUN dpkg -i cuda-keyring_1.1-1_all.deb && \
 # Create working directory
 WORKDIR /ultralytics
 
-# Copy contents and configure git
+# Copy contents and configure dependencies
 COPY . .
-RUN sed -i '/^\[http "https:\/\/github\.com\/"\]/,+1d' .git/config && \
-    sed -i'' -e 's/"opencv-python/"opencv-python-headless/' pyproject.toml
+RUN sed -i'' -e 's/"opencv-python/"opencv-python-headless/' pyproject.toml
 ADD https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26n.pt .
 
 # Pip install onnxruntime-gpu, torch, torchvision and ultralytics, then remove build files

--- a/docker/Dockerfile-nvidia-arm64
+++ b/docker/Dockerfile-nvidia-arm64
@@ -27,10 +27,9 @@ RUN apt-get update && \
 # Create working directory
 WORKDIR /ultralytics
 
-# Copy contents and configure git
+# Copy contents and configure dependencies
 COPY . .
-RUN sed -i '/^\[http "https:\/\/github\.com\/"\]/,+1d' .git/config && \
-    sed -i'' -e 's/"opencv-python/"opencv-python-headless/' pyproject.toml
+RUN sed -i'' -e 's/"opencv-python/"opencv-python-headless/' pyproject.toml
 ADD https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26n.pt .
 
 # Install pip packages (uv already installed in base image)

--- a/docker/Dockerfile-python
+++ b/docker/Dockerfile-python
@@ -28,10 +28,9 @@ RUN apt-get update && \
 # Create working directory
 WORKDIR /ultralytics
 
-# Copy contents and configure git
+# Copy contents and configure dependencies
 COPY . .
-RUN sed -i '/^\[http "https:\/\/github\.com\/"\]/,+1d' .git/config && \
-    sed -i'' -e 's/"opencv-python/"opencv-python-headless/' pyproject.toml
+RUN sed -i'' -e 's/"opencv-python/"opencv-python-headless/' pyproject.toml
 ADD https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26n.pt .
 
 # Install pip packages

--- a/docs/en/guides/export-non-yolo-models.md
+++ b/docs/en/guides/export-non-yolo-models.md
@@ -167,7 +167,7 @@ Requirements:
 - `onnx2tf>=1.26.3,<1.29.0`
 - `tf_keras<=2.19.0`
 - `sng4onnx>=1.0.1`
-- `onnx_graphsurgeon>=0.3.26` (install with `--extra-index-url https://pypi.ngc.nvidia.com`)
+- `onnx_graphsurgeon>=0.3.26`
 - `ai-edge-litert>=1.2.0,<1.4.0` on macOS (`ai-edge-litert>=1.2.0` on other platforms)
 - `onnxslim>=0.1.82`
 - `onnx>=1.12.0,<2.0.0`

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -288,9 +288,7 @@ EXPORT_ENVS = {
             "onnxruntime",
             "protobuf>=5",
         ],
-        "indexes": [
-            ("--extra-index-url", "https://pypi.ngc.nvidia.com"),
-        ],
+        "indexes": [],
         "env": {},
         "smoke": ["yolo export format=saved_model model=yolo26n.pt imgsz=32"],
     },

--- a/ultralytics/utils/export/tensorflow.py
+++ b/ultralytics/utils/export/tensorflow.py
@@ -119,8 +119,7 @@ def onnx2saved_model(
             "protobuf>=6.31.1,<7.0.0"
             if IS_PYTHON_MINIMUM_3_13
             else "protobuf>=5",  # TF>2.19 (Python 3.13) needs protobuf>=6.31.1; cap <7 to match TF gencode and avoid PaddlePaddle segfault
-        ),
-        cmds="--extra-index-url https://pypi.ngc.nvidia.com",  # onnx_graphsurgeon only on NVIDIA
+        )
     )
 
     LOGGER.info(f"\n{prefix} starting export with tensorflow {tf.__version__}...")


### PR DESCRIPTION
## Summary

- disable persisted checkout credentials before the repository enters the Docker build context
- remove ineffective post-`COPY` credential scrubbing from all seven source-copying Dockerfiles
- remove the obsolete NVIDIA package index now that `onnx-graphsurgeon` resolves from PyPI
- preserve full Git history and the existing OpenCV dependency rewrite

This replaces #25804, which could not be merged because its CLA was not signed. Thank you @sujeito-operator for identifying the issue and providing a detailed investigation.

## Validation

- all seven `@ultralytics/run-docker` matrix builds and runtime tests passed
- `IsolatedExports` passed without the NVIDIA index
- clean Python 3.12 environment installed and imported `onnx-graphsurgeon==0.6.1` from PyPI alone
- `actionlint .github/workflows/docker.yml`
- Ruff formatting/checks for modified Python files
- Prettier check for modified documentation
- `git diff --check`
- audited every file under `docker/`, all Docker build paths in `.github/workflows/docker.yml`, and all repository checkout/build references under `.github/workflows/`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Docker builds now prevent checkout credentials from entering images and no longer rely on the obsolete NVIDIA package index for ONNX GraphSurgeon installation.

### 📊 Key Changes

- Set `persist-credentials: false` in `.github/workflows/docker.yml` while retaining `fetch-depth: 0` for full Git history.
- Removed post-`COPY` `.git/config` credential-scrubbing commands from all seven source-copying Dockerfiles.
- Removed the NVIDIA extra package index from export dependencies, documentation, and TensorFlow export setup.
- Preserved the existing OpenCV-to-`opencv-python-headless` rewrite in the Dockerfiles.

### 🎯 Purpose & Impact

- Docker images that include `.git` no longer receive persisted checkout authentication configuration.
- ONNX GraphSurgeon installation and related export workflows no longer add an extra NVIDIA package index.
- Full Git history remains available in Docker builds, and the existing OpenCV dependency behavior is unchanged.