### PR TITLE
Avoid nondeterministic CUDA anchor cumsum

### DIFF
--- a/docs/en/guides/export-non-yolo-models.md
+++ b/docs/en/guides/export-non-yolo-models.md
@@ -167,7 +167,7 @@ Requirements:
 - `onnx2tf>=1.26.3,<1.29.0`
 - `tf_keras<=2.19.0`
 - `sng4onnx>=1.0.1`
-- `onnx_graphsurgeon>=0.3.26` (install with `--extra-index-url https://pypi.ngc.nvidia.com`)
+- `onnx_graphsurgeon>=0.3.26`
 - `ai-edge-litert>=1.2.0,<1.4.0` on macOS (`ai-edge-litert>=1.2.0` on other platforms)
 - `onnxslim>=0.1.82`
 - `onnx>=1.12.0,<2.0.0`

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.119"
+__version__ = "8.4.120"
 
 import importlib
 import os

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -288,9 +288,7 @@ EXPORT_ENVS = {
             "onnxruntime",
             "protobuf>=5",
         ],
-        "indexes": [
-            ("--extra-index-url", "https://pypi.ngc.nvidia.com"),
-        ],
+        "indexes": [],
         "env": {},
         "smoke": ["yolo export format=saved_model model=yolo26n.pt imgsz=32"],
     },

--- a/ultralytics/utils/export/tensorflow.py
+++ b/ultralytics/utils/export/tensorflow.py
@@ -119,8 +119,7 @@ def onnx2saved_model(
             "protobuf>=6.31.1,<7.0.0"
             if IS_PYTHON_MINIMUM_3_13
             else "protobuf>=5",  # TF>2.19 (Python 3.13) needs protobuf>=6.31.1; cap <7 to match TF gencode and avoid PaddlePaddle segfault
-        ),
-        cmds="--extra-index-url https://pypi.ngc.nvidia.com",  # onnx_graphsurgeon only on NVIDIA
+        )
     )
 
     LOGGER.info(f"\n{prefix} starting export with tensorflow {tf.__version__}...")

--- a/ultralytics/utils/tal.py
+++ b/ultralytics/utils/tal.py
@@ -397,9 +397,9 @@ def make_anchors(feats, strides, grid_cell_offset=0.5):
     for i in range(len(feats)):  # use len(feats) to avoid TracerWarning from iterating over strides tensor
         stride = strides[i]
         h, w = feats[i].shape[2:] if isinstance(feats, list) else (int(feats[i][0]), int(feats[i][1]))
-        # new_* factories inherit the device at runtime, unlike torch.arange which bakes it into traced graphs
-        sx = feats[0].new_full((w,), 1, dtype=dtype).cumsum(0) - (1 - grid_cell_offset)  # shift x
-        sy = feats[0].new_full((h,), 1, dtype=dtype).cumsum(0) - (1 - grid_cell_offset)  # shift y
+        # arange(out=new_*) avoids nondeterministic CUDA cumsum while preserving runtime device inheritance in traces
+        sx = torch.arange(w, out=feats[0].new_full((w,), 0, dtype=dtype)) + grid_cell_offset  # shift x
+        sy = torch.arange(h, out=feats[0].new_full((h,), 0, dtype=dtype)) + grid_cell_offset  # shift y
         sy, sx = torch.meshgrid(sy, sx, indexing="ij") if TORCH_1_11 else torch.meshgrid(sy, sx)
         anchor_points.append(torch.stack((sx, sy), -1).view(-1, 2))
         stride_tensor.append(feats[0].new_full((h * w, 1), stride, dtype=dtype))


### PR DESCRIPTION
## Summary

- replace CUDA cumsum anchor coordinates with deterministic arange output
- preserve runtime device inheritance for traced models through the feature-owned output tensor
- remove the obsolete NVIDIA package index from TensorFlow export installation now that onnx-graphsurgeon ships on PyPI
- bump Ultralytics to 8.4.120

## Why

Deterministic training currently emits two cumsum_cuda_kernel warnings every time the task-aligned assigner builds anchors. The warning repeats throughout training and obscures useful logs. A plain device-qualified arange would regress TorchScript GPU inference by baking the trace-time device into the graph, so arange writes into a new_full tensor owned by the runtime feature map.

The isolated TensorFlow export environment also queried pypi.ngc.nvidia.com for every dependency solely to obtain onnx-graphsurgeon. Version 0.6.1 is now a universal wheel on PyPI, making the extra index unnecessary and an avoidable DNS failure point for CPU export CI and users.

## Validation

- exact anchor value, dtype, shape, and device equivalence for float16, float32, and float64
- dynamic TorchScript graph contains new_full and arange, contains no cumsum, and accepts a second spatial shape
- 4 focused TorchScript and ONNX export tests passed
- TensorFlow export environment resolves all 114 packages, including onnx-graphsurgeon 0.6.1, from PyPI without NGC
- 11 export-registry tests passed
- Ruff formatting passed; focused Ruff findings are pre-existing elsewhere in exporter.py

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Replaced CUDA anchor-coordinate cumulative sums with deterministic `arange` output while preserving traced-model device inheritance, removing the NVIDIA package index from TensorFlow exports, and bumping Ultralytics to 8.4.120.

### 📊 Key Changes
- Updated `make_anchors()` in `ultralytics/utils/tal.py` to generate X/Y coordinates with `torch.arange(..., out=...)` and feature-map-owned tensors instead of CUDA `cumsum`.
- Preserved runtime device selection for traced models by using `feats[0].new_full()` as the `arange` output buffer.
- Removed `pypi.ngc.nvidia.com` from TensorFlow export dependency installation and documentation; `onnx_graphsurgeon` is now installed without an extra package index.
- Updated `ultralytics.__version__` from `8.4.119` to `8.4.120`.

### 🎯 Purpose & Impact
- Anchor construction no longer relies on the nondeterministic CUDA cumulative-sum kernel, avoiding its repeated training warnings.
- Dynamic TorchScript tracing can use different runtime spatial shapes without baking the trace-time device into the graph.
- TensorFlow export dependency resolution now uses PyPI without requiring the NVIDIA package index.