### PR TITLE
Update the supported tasks banner and the task enumerations

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -84,7 +84,7 @@ jobs:
             --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com|neptune\.ai|gnu\.org/software/make|survey\.stackoverflow\.co|clear\.ml|gitee\.com)' \
             --exclude 'https?://[^[:space:]]*(%7B|%7D|\{|\}|sentry\.io|google-analytics\.com/mp/collect|storage\.googleapis\.com|packages\.cloud\.google\.com/apt)(/.*)?' \
             --exclude 'https://github\.com/ultralytics/assets/releases/download/v0\.0\.0' \
-            --exclude 'https://raw\.githubusercontent\.com/ultralytics/assets/main/(im/banner-tasks|yolov8/banner-yolov8)\.png/?' \
+            --exclude 'https://raw\.githubusercontent\.com/ultralytics/assets/main/yolov8/banner-yolov8\.png/?' \
             --exclude 'https://static\.pepy\.tech/badge/ultralytics/?' \
             --exclude 'https://docs\.ultralytics\.com/(modes/(predict|val|train|export)|integrations/openvino)//?n' \
             --exclude 'https://ultralytics\.com/assets(/example\.zip)?' \

--- a/docs/en/tasks/index.md
+++ b/docs/en/tasks/index.md
@@ -2,7 +2,7 @@
 title: YOLO26 Computer Vision Tasks Overview
 comments: true
 description: Explore Ultralytics YOLO26 for detection, segmentation, semantic segmentation, depth estimation, classification, pose estimation, and OBB with high accuracy and speed. Learn how to apply each task.
-keywords: Ultralytics YOLO26, detection, segmentation, semantic segmentation, depth estimation, classification, oriented object detection, pose estimation, computer vision, AI framework
+keywords: Ultralytics YOLO26, detection, segmentation, semantic segmentation, depth estimation, classification, pose estimation, oriented object detection, computer vision, AI framework
 ---
 
 # Computer Vision Tasks Supported by Ultralytics YOLO26
@@ -66,7 +66,7 @@ Oriented Bounding Box (OBB) detection enhances traditional object detection by a
 
 ## Conclusion
 
-Ultralytics YOLO26 supports multiple computer vision tasks, including detection, instance segmentation, semantic segmentation, monocular depth estimation, classification, oriented object detection, and keypoint detection. Each task addresses specific needs in the computer vision landscape, from basic object identification to dense per-pixel depth inference. By understanding the capabilities and applications of each task, you can select the most appropriate approach for your specific computer vision challenges and leverage YOLO26's powerful features to build effective solutions.
+Ultralytics YOLO26 supports multiple computer vision tasks, including detection, instance segmentation, semantic segmentation, monocular depth estimation, classification, keypoint detection, and oriented object detection. Each task addresses specific needs in the computer vision landscape, from basic object identification to dense per-pixel depth inference. By understanding the capabilities and applications of each task, you can select the most appropriate approach for your specific computer vision challenges and leverage YOLO26's powerful features to build effective solutions.
 
 ## What's Next
 

--- a/examples/YOLOv8-ONNXRuntime-Rust/README.md
+++ b/examples/YOLOv8-ONNXRuntime-Rust/README.md
@@ -165,7 +165,7 @@ cargo run --release -- --help
 
 ## 🖼️ Examples
 
-![Ultralytics YOLO Tasks](https://raw.githubusercontent.com/ultralytics/assets/main/im/banner-tasks.png)
+![Ultralytics YOLO Tasks](https://cdn.ul.run/i/c99d914c3958d0755b5a3d7204b6f24a.avif)
 
 ### Classification
 

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -217,7 +217,7 @@
         "\n",
         "<p align=\"\"><a href=\"https://platform.ultralytics.com/\"><img width=\"1000\" src=\"https://github.com/ultralytics/assets/raw/main/yolov8/banner-integrations.png\"/></a></p>\n",
         "\n",
-        "Train YOLO26 on [Detect](https://docs.ultralytics.com/tasks/detect/), [Segment](https://docs.ultralytics.com/tasks/segment/), [Semantic](https://docs.ultralytics.com/tasks/semantic/), [Classify](https://docs.ultralytics.com/tasks/classify/) and [Pose](https://docs.ultralytics.com/tasks/pose/) datasets. See [YOLO26 Train Docs](https://docs.ultralytics.com/modes/train/) for more information."
+        "Train YOLO26 on [Detect](https://docs.ultralytics.com/tasks/detect/), [Segment](https://docs.ultralytics.com/tasks/segment/), [Semantic](https://docs.ultralytics.com/tasks/semantic/), [Depth](https://docs.ultralytics.com/tasks/depth/), [Classify](https://docs.ultralytics.com/tasks/classify/), [Pose](https://docs.ultralytics.com/tasks/pose/) and [OBB](https://docs.ultralytics.com/tasks/obb/) datasets. See [YOLO26 Train Docs](https://docs.ultralytics.com/modes/train/) for more information."
       ],
       "metadata": {
         "id": "ktegpM42AooT"
@@ -456,7 +456,7 @@
       "source": [
         "# 6. Tasks\n",
         "\n",
-        "YOLO26 can train, val, predict and export models for the most common tasks in vision AI: [Detect](https://docs.ultralytics.com/tasks/detect/), [Segment](https://docs.ultralytics.com/tasks/segment/), [Semantic](https://docs.ultralytics.com/tasks/semantic/), [Classify](https://docs.ultralytics.com/tasks/classify/) and [Pose](https://docs.ultralytics.com/tasks/pose/). See [YOLO26 Tasks Docs](https://docs.ultralytics.com/tasks/) for more information.\n",
+        "YOLO26 can train, val, predict and export models for the most common tasks in vision AI: [Detect](https://docs.ultralytics.com/tasks/detect/), [Segment](https://docs.ultralytics.com/tasks/segment/), [Semantic](https://docs.ultralytics.com/tasks/semantic/), [Depth](https://docs.ultralytics.com/tasks/depth/), [Classify](https://docs.ultralytics.com/tasks/classify/), [Pose](https://docs.ultralytics.com/tasks/pose/) and [OBB](https://docs.ultralytics.com/tasks/obb/). See [YOLO26 Tasks Docs](https://docs.ultralytics.com/tasks/) for more information.\n",
         "\n",
         "<br><img width=\"1024\" src=\"https://cdn.ul.run/i/c99d914c3958d0755b5a3d7204b6f24a.avif\">"
       ],

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -458,7 +458,7 @@
         "\n",
         "YOLO26 can train, val, predict and export models for the most common tasks in vision AI: [Detect](https://docs.ultralytics.com/tasks/detect/), [Segment](https://docs.ultralytics.com/tasks/segment/), [Semantic](https://docs.ultralytics.com/tasks/semantic/), [Classify](https://docs.ultralytics.com/tasks/classify/) and [Pose](https://docs.ultralytics.com/tasks/pose/). See [YOLO26 Tasks Docs](https://docs.ultralytics.com/tasks/) for more information.\n",
         "\n",
-        "<br><img width=\"1024\" src=\"https://raw.githubusercontent.com/ultralytics/assets/main/im/banner-tasks.png\">"
+        "<br><img width=\"1024\" src=\"https://cdn.ul.run/i/c99d914c3958d0755b5a3d7204b6f24a.avif\">"
       ],
       "metadata": {
         "id": "yq26lwpYK1lq"


### PR DESCRIPTION
## summary

- replaces the remaining `im/banner-tasks.png` references with the seven-task banner already used in the READMEs and tasks docs (#25788): `examples/tutorial.ipynb` section 6 and the Rust ONNX Runtime example README
- lists Depth and OBB in the notebook's two task enumerations, which named five of seven; the depth release (#25065) swept the READMEs and docs but never touched `examples/tutorial.ipynb`
- orders pose before OBB in `docs/en/tasks/index.md` keywords and Conclusion, which disagreed with that page's own seven `##` sections and its intro
- drops the now-unreferenced `im/banner-tasks` entry from the lychee exclude list in `links.yml`, keeping only `yolov8/banner-yolov8.png`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated task references and banners across the tutorial, Rust ONNX Runtime README, and task documentation to consistently represent all seven YOLO26 tasks and remove an obsolete link exclusion.

### 📊 Key Changes

- Replaced `im/banner-tasks.png` with the current seven-task banner in `examples/tutorial.ipynb` and the Rust ONNX Runtime README.
- Added Depth and OBB to both task lists in `examples/tutorial.ipynb`.
- Reordered Pose and OBB in `docs/en/tasks/index.md` keywords and the conclusion to match the page’s task sections and introduction.
- Removed the unused `im/banner-tasks` pattern from the Lychee link-check exclusions.

### 🎯 Purpose & Impact

- Documentation and examples now consistently list Detect, Segment, Semantic, Depth, Classify, Pose, and OBB, while link checking no longer excludes the unreferenced banner path.