### PR TITLE
Order Pose before OBB in the tasks index keywords and conclusion

### DIFF
--- a/docs/en/tasks/index.md
+++ b/docs/en/tasks/index.md
@@ -2,7 +2,7 @@
 title: YOLO26 Computer Vision Tasks Overview
 comments: true
 description: Explore Ultralytics YOLO26 for detection, segmentation, semantic segmentation, depth estimation, classification, pose estimation, and OBB with high accuracy and speed. Learn how to apply each task.
-keywords: Ultralytics YOLO26, detection, segmentation, semantic segmentation, depth estimation, classification, oriented object detection, pose estimation, computer vision, AI framework
+keywords: Ultralytics YOLO26, detection, segmentation, semantic segmentation, depth estimation, classification, pose estimation, oriented object detection, computer vision, AI framework
 ---
 
 # Computer Vision Tasks Supported by Ultralytics YOLO26
@@ -66,7 +66,7 @@ Oriented Bounding Box (OBB) detection enhances traditional object detection by a
 
 ## Conclusion
 
-Ultralytics YOLO26 supports multiple computer vision tasks, including detection, instance segmentation, semantic segmentation, monocular depth estimation, classification, oriented object detection, and keypoint detection. Each task addresses specific needs in the computer vision landscape, from basic object identification to dense per-pixel depth inference. By understanding the capabilities and applications of each task, you can select the most appropriate approach for your specific computer vision challenges and leverage YOLO26's powerful features to build effective solutions.
+Ultralytics YOLO26 supports multiple computer vision tasks, including detection, instance segmentation, semantic segmentation, monocular depth estimation, classification, keypoint detection, and oriented object detection. Each task addresses specific needs in the computer vision landscape, from basic object identification to dense per-pixel depth inference. By understanding the capabilities and applications of each task, you can select the most appropriate approach for your specific computer vision challenges and leverage YOLO26's powerful features to build effective solutions.
 
 ## What's Next
 


### PR DESCRIPTION
## summary

- `docs/en/tasks/index.md` presents its seven `##` sections in the canonical order, and its intro at `:12` matches, but the `keywords` frontmatter and the Conclusion paragraph both place oriented object detection before pose estimation
- reorders those two lines so every enumeration on the page agrees with the section order it presents

## measured

canonical order is `TASKS` in `ultralytics/cfg/__init__.py:60`, which `AGENTS.md` requires "everywhere — tables, navs, prose, code":

| line | before | after |
| --- | --- | --- |
| `:5` keywords | `… classify, obb, pose` | `… classify, pose, obb` |
| `:12` intro | `… classify, pose, obb` (unchanged) | `… classify, pose, obb` |
| `:69` conclusion | `… classify, obb, pose` | `… classify, pose, obb` |
| `##` sections | `detect, segment, semantic, depth, classify, pose, obb` | unchanged |

Both enumerations were already complete; only the order drifted. `prettier@3.8.5 --tab-width 4 --print-width 120 --check` passes.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the YOLO26 tasks page to list pose estimation before oriented object detection, matching the page’s canonical task order.

### 📊 Key Changes

- Reordered `pose estimation` and `oriented object detection` in the page’s `keywords` frontmatter.
- Reordered `keypoint detection` and `oriented object detection` in the Conclusion paragraph.
- Left the existing task sections and introduction unchanged.

### 🎯 Purpose & Impact

- Keeps the page’s metadata and conclusion consistent with its section order and the canonical task order.
- No user-facing change to model functionality, APIs, or supported tasks.