### PR TITLE
Map semantic mask labels with a 256-entry lookup table

### DIFF
--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -898,6 +898,7 @@ class SemanticDataset(YOLODataset):
         """
         self.data = data or {}
         self.label_mapping = self._parse_label_mapping(self.data.get("label_mapping"))
+        self.label_lut, self.inverse_lut = self._build_label_luts()
         self.mask_files = []
         self.include_class = None
         super().__init__(*args, data=data, **kwargs)
@@ -941,6 +942,16 @@ class SemanticDataset(YOLODataset):
                 dst = int(dst)
             normalized[src] = dst
         return normalized
+
+    def _build_label_luts(self) -> tuple[np.ndarray, np.ndarray]:
+        """Build the 256-entry forward and inverse lookup tables for the dataset label mapping."""
+        forward, inverse = np.arange(256, dtype=np.uint8), np.arange(256, dtype=np.uint8)
+        for k, v in self.label_mapping.items():  # ids outside 0-255 never match a uint8 mask pixel
+            if 0 <= k < 256:
+                forward[k] = v
+            if 0 <= v < 256:
+                inverse[v] = k & 0xFF  # cityscapes maps -1; the inverse caller casts the result to uint8
+        return forward, inverse
 
     def get_label_files(self) -> list[str]:
         """Return the mask PNG paths paired with the dataset's images.
@@ -1028,20 +1039,14 @@ class SemanticDataset(YOLODataset):
         """Convert label values using the dataset's label mapping.
 
         Args:
-            label (np.ndarray): Segmentation label array to convert.
+            label (np.ndarray): Segmentation label array with integer ids in 0-255.
             inverse (bool): If True, apply inverse mapping (mapped -> original). Defaults to False.
 
         Returns:
-            (np.ndarray): Label array with converted values.
+            (np.ndarray): New uint8 array with converted values.
         """
-        temp = label.copy()
-        if inverse:
-            for v, k in self.label_mapping.items():
-                label[temp == k] = v
-        else:
-            for k, v in self.label_mapping.items():
-                label[temp == k] = v
-        return label
+        lut = self.inverse_lut if inverse else self.label_lut
+        return cv2.LUT(label, lut) if label.dtype == np.uint8 else lut[label]  # cv2.LUT needs a uint8 input
 
     def get_image_and_label(self, index):
         """Get image, label and semantic mask for the given index.


### PR DESCRIPTION
## summary

- `SemanticDataset.convert_label` applies two 256-entry lookup tables built once in `__init__` instead of one full-mask boolean-assignment pass per label-mapping entry, using `cv2.LUT` on the uint8 mask path.
- the lookup returns a new array rather than writing into its argument, so `save_pred_masks` no longer remaps the tensor `update_metrics` scores: validating on cpu with `save_json=True` and a dataset that defines `label_mapping`, a run with perfect predictions reports mIoU 1.0 where it reported 0.0.
- output is unchanged: 112 of 126 mapping x input x direction cases hash identically against the previous implementation, and the 14 that differ are `inverse=True` on a uint8 array with a negative source id, which raises `OverflowError` under the current code and which neither call site produces.

## measured

| case | before | after | ratio |
| -- | -- | -- | -- |
| `convert_label`, cityscapes mapping (35 entries), 1024x2048 mask | 9.36-10.00 ms | 0.54-0.56 ms | 17.1-18.4x |
| `convert_label`, ade20k mapping (151 entries), same mask | 18.8-19.3 ms | 0.54-0.55 ms | 34.8-35.0x |
| `SemanticDataset.__getitem__`, cityscapes8, imgsz=640, train | 88.4-90.5 ms/sample | 53.4-56.0 ms/sample | 1.58-1.69x |

medians of 40 reps with the arms interleaved, repeated in two sessions 45 minutes apart; python 3.12, numpy 2.5.2, opencv 5.0.0, apple m4 cpu. a sha-256 fingerprint over every array field of 60 augmented samples is identical on both arms, and a 1-epoch cityscapes8 train through the multiprocess dataloader returns identical metrics. the per-sample saving is 32-37 ms of dataloader work, so 95-110 s per cityscapes epoch at 2975 images.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
`SemanticDataset.convert_label` now uses prebuilt 256-entry lookup tables to convert labels without mutating the input array, improving mask-processing performance and preventing validation metric scores from being remapped.

### 📊 Key Changes
- Builds forward and inverse lookup tables once during `SemanticDataset` initialization from `label_mapping`.
- Uses `cv2.LUT` for `uint8` masks and lookup-table indexing for other integer arrays.
- Returns a new `uint8` array instead of modifying the provided label array.
- Preserves identity values and handles mapping IDs outside the `uint8` range without adding lookup entries.

### 🎯 Purpose & Impact
- `convert_label` measured 17–35 times faster for Cityscapes and ADE20K mappings, while `SemanticDataset.__getitem__` improved by roughly 1.6–1.7 times in the reported benchmark.
- `save_pred_masks` no longer remaps tensors used by `update_metrics`; with `save_json=True` and perfect predictions, the reported mIoU changes from 0.0 to 1.0 for the described mapped-label validation case.