### PR TITLE
Fix spelling in Platform account settings

### DIFF
--- a/docs/en/platform/account/settings.md
+++ b/docs/en/platform/account/settings.md
@@ -101,7 +101,7 @@ team workspaces have no separate email list.
 | **Set as primary** | Set a verified email as your primary address                               |
 | **Remove**         | Remove a non-primary email address                                         |
 
-Each address is labelled with **Primary**, **Verified** or **Unverified**, and **Company** badges.
+Each address is labeled with **Primary**, **Verified** or **Unverified**, and **Company** badges.
 
 !!! note "Primary Email"
 


### PR DESCRIPTION
### What changed
Fixed British spelling `labelled`→`labeled` in docs/en/platform/account/settings.md line 104; acceptance boundary met (no `labelled` remains); rendered-page output not independently verified as no doc build was run.

### Why
In `docs/en/platform/account/settings.md`, change the sentence `Each address is labelled with **Primary**, **Verified** or **Unverified**, and **Company** badges.` to use American English spelling: `Each address is labeled with **Primary**, **Verified** or **Unverified**, and **Company** badges.` Keep all other content unchanged. This is the source page reported by the `ultralytics/docs` Website links and spellcheck run 31871375684. Acceptance boundary: the rendered account settings page no longer contains the reported `labelled` spelling at this location.

Requested by yasin@ultralytics.com (job `4dce0dbc6a1e`).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the Platform account settings documentation to use the American spelling “labeled” instead of “labelled.”

### 📊 Key Changes
- Changed the email-address description in `docs/en/platform/account/settings.md`.
- Preserved all surrounding wording and badge names: **Primary**, **Verified**, **Unverified**, and **Company**.

### 🎯 Purpose & Impact
- Removes the reported British spelling from the account settings documentation.
- No functional or user-facing product change.