### PR TITLE
Fix #25764: Don't send local project paths as Platform slugs

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -770,6 +770,7 @@ def test_platform_project_slug():
     assert project("username/my-project") == "username/my-project"
     assert project("Glenn-Jocher/My-Project") == "Glenn-Jocher/my-project"  # owner passed through as-is
     assert project("my_local_dir") == "mylocaldir"  # bare project name, owner resolved from the API key
+    assert project("abcd/exp") == "abcd/exp"  # owner at the 4-character Platform username floor
 
     # Path shapes whose components must never become an owner slug
     for path in ("/private/var/folders/ab/proj_x", "/tmp", "C:/Users/me/runs", "C:/runs", "runs\\exp/x", "A B/exp"):
@@ -777,6 +778,10 @@ def test_platform_project_slug():
 
     # An owner with an empty or fully-unslugifiable project half must not produce a truncated "owner/" identifier
     for path in ("username/", "username/!!!"):
+        assert project(path) is None, path
+
+    # Owner outside the documented 4-32 character Platform username range cannot be a real owner
+    for path in ("a/exp", "abc/exp", "x" * 33 + "/exp"):
         assert project(path) is None, path
 
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -775,6 +775,10 @@ def test_platform_project_slug():
     for path in ("/private/var/folders/ab/proj_x", "/tmp", "C:/Users/me/runs", "C:/runs", "runs\\exp/x", "A B/exp"):
         assert project(path) is None, path
 
+    # An owner with an empty or fully-unslugifiable project half must not produce a truncated "owner/" identifier
+    for path in ("username/", "username/!!!"):
+        assert project(path) is None, path
+
 
 def test_platform_job_transport(monkeypatch, tmp_path):
     """Test configurable Platform transport with an existing local checkpoint."""

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -758,33 +758,6 @@ def test_ndjson_conversion_concurrency_and_resume(monkeypatch, tmp_path, task):
     assert sum(counts.values()) == request_count
 
 
-def test_platform_project_slug():
-    """Test that local directory paths are not sent to Platform as owner/project identifiers."""
-    from types import SimpleNamespace
-
-    from ultralytics.utils.callbacks.platform import _get_project_name
-
-    def project(value):
-        return _get_project_name(SimpleNamespace(args=SimpleNamespace(project=value, name="exp")))[0]
-
-    assert project("username/my-project") == "username/my-project"
-    assert project("Glenn-Jocher/My-Project") == "Glenn-Jocher/my-project"  # owner passed through as-is
-    assert project("my_local_dir") == "mylocaldir"  # bare project name, owner resolved from the API key
-    assert project("abcd/exp") == "abcd/exp"  # owner at the 4-character Platform username floor
-
-    # Path shapes whose components must never become an owner slug
-    for path in ("/private/var/folders/ab/proj_x", "/tmp", "C:/Users/me/runs", "C:/runs", "runs\\exp/x", "A B/exp"):
-        assert project(path) is None, path
-
-    # An owner with an empty or fully-unslugifiable project half must not produce a truncated "owner/" identifier
-    for path in ("username/", "username/!!!"):
-        assert project(path) is None, path
-
-    # Owner outside the documented 4-32 character Platform username range cannot be a real owner
-    for path in ("a/exp", "abc/exp", "x" * 33 + "/exp"):
-        assert project(path) is None, path
-
-
 def test_platform_job_transport(monkeypatch, tmp_path):
     """Test configurable Platform transport with an existing local checkpoint."""
     from types import SimpleNamespace

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -758,6 +758,24 @@ def test_ndjson_conversion_concurrency_and_resume(monkeypatch, tmp_path, task):
     assert sum(counts.values()) == request_count
 
 
+def test_platform_project_slug():
+    """Test that local directory paths are not sent to Platform as owner/project identifiers."""
+    from types import SimpleNamespace
+
+    from ultralytics.utils.callbacks.platform import _get_project_name
+
+    def project(value):
+        return _get_project_name(SimpleNamespace(args=SimpleNamespace(project=value, name="exp")))[0]
+
+    assert project("username/my-project") == "username/my-project"
+    assert project("Glenn-Jocher/My-Project") == "Glenn-Jocher/my-project"  # owner passed through as-is
+    assert project("my_local_dir") == "mylocaldir"  # bare project name, owner resolved from the API key
+
+    # Path shapes whose components must never become an owner slug
+    for path in ("/private/var/folders/ab/proj_x", "/tmp", "C:/Users/me/runs", "C:/runs", "runs\\exp/x", "A B/exp"):
+        assert project(path) is None, path
+
+
 def test_platform_job_transport(monkeypatch, tmp_path):
     """Test configurable Platform transport with an existing local checkpoint."""
     from types import SimpleNamespace

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -272,7 +272,13 @@ def _get_project_name(trainer):
     """Get slugified project and name from trainer args, ignoring local directory paths."""
     raw = str(trainer.args.project)
     name = slugify(str(trainer.args.name or "train"))
-    if Path(raw).is_absolute() or "\\" in raw or raw.count("/") > 1 or re.match(r"^[A-Za-z]:/", raw):
+    if (
+        raw.startswith(("~/", "./", "../"))
+        or Path(raw).is_absolute()
+        or "\\" in raw
+        or raw.count("/") > 1
+        or re.match(r"^[A-Za-z]:/", raw)
+    ):
         return None, name
     owner, sep, project = raw.partition("/")
     return (f"{owner}/{slugify(project)}" if sep else slugify(raw)), name

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -274,11 +274,13 @@ def _get_project_name(trainer):
     name = slugify(str(trainer.args.name or "train"))
     owner, sep, raw_project = raw.partition("/")
     project = slugify(raw_project if sep else raw)
-    if (
-        "\\" in raw
-        or re.match(r"^[A-Za-z]:", raw)
-        or (sep and ("/" in raw_project or not project or not re.fullmatch(r"[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*", owner)))
-    ):
+    valid = not sep or (
+        "/" not in raw_project
+        and bool(project)
+        and 4 <= len(owner) <= 32
+        and re.fullmatch(r"[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*", owner)
+    )
+    if "\\" in raw or re.match(r"^[A-Za-z]:", raw) or not valid:
         return None, name
     return (f"{owner}/{project}" if sep else project), name
 

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -276,7 +276,7 @@ def _get_project_name(trainer):
     project = slugify(raw_project if sep else raw)
     valid = not sep or (
         "/" not in raw_project
-        and bool(project)
+        and re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", project)
         and 4 <= len(owner) <= 32
         and re.fullmatch(r"[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*", owner)
     )

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -276,7 +276,9 @@ def _get_project_name(trainer):
     if not sep:
         return slugify(raw), name  # bare project name, owner resolved from the API key
     # An owner is a username slug, so a second separator, a backslash or any non-slug character is a directory path
-    valid = owner and "\\" not in raw and "/" not in project and slugify(owner) == owner.lower()
+    valid = (
+        bool(owner and slugify(project)) and "\\" not in raw and "/" not in project and slugify(owner) == owner.lower()
+    )
     return (f"{owner}/{slugify(project)}" if valid else None), name
 
 

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -274,9 +274,10 @@ def _get_project_name(trainer):
     name = slugify(str(trainer.args.name or "train"))
     owner, sep, raw_project = raw.partition("/")
     project = slugify(raw_project if sep else raw)
-    if "\\" in raw or re.match(r"^[A-Za-z]:", raw) or (
-        sep
-        and ("/" in raw_project or not project or not re.fullmatch(r"[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*", owner))
+    if (
+        "\\" in raw
+        or re.match(r"^[A-Za-z]:", raw)
+        or (sep and ("/" in raw_project or not project or not re.fullmatch(r"[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*", owner)))
     ):
         return None, name
     return (f"{owner}/{project}" if sep else project), name

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -282,7 +282,7 @@ def _get_project_name(trainer):
         and 4 <= len(owner) <= 32
         and "\\" not in raw
         and "/" not in project
-        and slugify(owner) == owner.lower()
+        and re.fullmatch(r"[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*", owner)
     )
     return (f"{owner}/{slugify(project)}" if valid else None), name
 

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -269,22 +269,13 @@ def _get_environment_info():
 
 
 def _get_project_name(trainer):
-    """Get slugified project and name from trainer args, project None when it is a local directory path."""
+    """Get slugified project and name from trainer args, ignoring local directory paths."""
     raw = str(trainer.args.project)
-    owner, sep, project = raw.partition("/")
     name = slugify(str(trainer.args.name or "train"))
-    if not sep and "\\" not in raw:
-        return slugify(raw), name  # bare project name, owner resolved from the API key
-    # An owner is a 4-32 character username slug, so a second separator, a backslash, or any non-slug or
-    # out-of-range owner means a directory path
-    valid = (
-        bool(owner and slugify(project))
-        and 4 <= len(owner) <= 32
-        and "\\" not in raw
-        and "/" not in project
-        and re.fullmatch(r"[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*", owner)
-    )
-    return (f"{owner}/{slugify(project)}" if valid else None), name
+    if Path(raw).is_absolute() or "\\" in raw or raw.count("/") > 1 or re.match(r"^[A-Za-z]:/", raw):
+        return None, name
+    owner, sep, project = raw.partition("/")
+    return (f"{owner}/{slugify(project)}" if sep else slugify(raw)), name
 
 
 def on_pretrain_routine_start(trainer):

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -273,7 +273,7 @@ def _get_project_name(trainer):
     raw = str(trainer.args.project)
     owner, sep, project = raw.partition("/")
     name = slugify(str(trainer.args.name or "train"))
-    if not sep:
+    if not sep and "\\" not in raw:
         return slugify(raw), name  # bare project name, owner resolved from the API key
     # An owner is a 4-32 character username slug, so a second separator, a backslash, or any non-slug or
     # out-of-range owner means a directory path

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -269,11 +269,15 @@ def _get_environment_info():
 
 
 def _get_project_name(trainer):
-    """Get slugified project and name from trainer args."""
+    """Get slugified project and name from trainer args, project None when it is a local directory path."""
     raw = str(trainer.args.project)
-    parts = raw.split("/", 1)
-    project = f"{parts[0]}/{slugify(parts[1])}" if len(parts) == 2 else slugify(raw)
-    return project, slugify(str(trainer.args.name or "train"))
+    owner, sep, project = raw.partition("/")
+    name = slugify(str(trainer.args.name or "train"))
+    if not sep:
+        return slugify(raw), name  # bare project name, owner resolved from the API key
+    # An owner is a username slug, so a second separator, a backslash or any non-slug character is a directory path
+    valid = owner and "\\" not in raw and "/" not in project and slugify(owner) == owner.lower()
+    return (f"{owner}/{slugify(project)}" if valid else None), name
 
 
 def on_pretrain_routine_start(trainer):
@@ -286,6 +290,12 @@ def on_pretrain_routine_start(trainer):
         return
 
     project, name = _get_project_name(trainer)
+    if not project:
+        LOGGER.info(
+            f"{PREFIX}project='{trainer.args.project}' is a local path, not an 'owner/project' Platform ID. "
+            f"Training will not be tracked on Platform."
+        )
+        return
     LOGGER.info(f"{PREFIX}Streaming training metrics to Platform")
 
     from ultralytics.utils.logger import ConsoleLogger

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -275,9 +275,14 @@ def _get_project_name(trainer):
     name = slugify(str(trainer.args.name or "train"))
     if not sep:
         return slugify(raw), name  # bare project name, owner resolved from the API key
-    # An owner is a username slug, so a second separator, a backslash or any non-slug character is a directory path
+    # An owner is a 4-32 character username slug, so a second separator, a backslash, or any non-slug or
+    # out-of-range owner means a directory path
     valid = (
-        bool(owner and slugify(project)) and "\\" not in raw and "/" not in project and slugify(owner) == owner.lower()
+        bool(owner and slugify(project))
+        and 4 <= len(owner) <= 32
+        and "\\" not in raw
+        and "/" not in project
+        and slugify(owner) == owner.lower()
     )
     return (f"{owner}/{slugify(project)}" if valid else None), name
 

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -272,16 +272,14 @@ def _get_project_name(trainer):
     """Get slugified project and name from trainer args, ignoring local directory paths."""
     raw = str(trainer.args.project)
     name = slugify(str(trainer.args.name or "train"))
-    if (
-        raw.startswith(("~/", "./", "../"))
-        or Path(raw).is_absolute()
-        or "\\" in raw
-        or raw.count("/") > 1
-        or re.match(r"^[A-Za-z]:/", raw)
+    owner, sep, raw_project = raw.partition("/")
+    project = slugify(raw_project if sep else raw)
+    if "\\" in raw or re.match(r"^[A-Za-z]:", raw) or (
+        sep
+        and ("/" in raw_project or not project or not re.fullmatch(r"[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*", owner))
     ):
         return None, name
-    owner, sep, project = raw.partition("/")
-    return (f"{owner}/{slugify(project)}" if sep else slugify(raw)), name
+    return (f"{owner}/{project}" if sep else project), name
 
 
 def on_pretrain_routine_start(trainer):


### PR DESCRIPTION
Fixes #25764

### Problem

`project` doubles as a local results directory and as a Platform `owner/project` identifier.
`_get_project_name()` assumed the second, splitting on the first `/` and slugifying only the tail,
so a local path was posted to Platform as an owner/project pair:

| `project=` | sent today | after |
| --- | --- | --- |
| `/private/var/folders/ab/proj_x` | `/privatevarfoldersabprojx` (empty owner → `//` in the model URL) | not sent |
| `C:/Users/me/runs` | `C:/usersmeruns` | not sent |
| `My Folder/exp` | `My Folder/exp` (space in payload and URL) | not sent |
| `../exp` | `../exp` | not sent |
| `username/my-project` | `username/my-project` | identical |
| `Glenn-Jocher/My-Project` | `Glenn-Jocher/my-project` | identical |
| `my_local_dir` | `mylocaldir` | identical |

The `/` split arrived in #23158; before that the value was sent verbatim.

### Fix

Treat the value as a Platform identifier only when the owner half can be a username slug — documented as
4-32 lowercase letters, numbers and non-repeating hyphens, which is exactly what `slugify()` produces.
Anything with a second separator, a backslash, or a non-slug owner is a directory path, and the callback
returns before any request. **Every accepted value is sent exactly as before** — this is purely a
rejection filter, not a change to how valid identifiers are slugified.

### Known gaps (deliberate)

- `runs/my_exp` still streams under owner `runs`. A relative two-segment path is shape-identical to a real
  `owner/project`; separating them needs either a filesystem check or stricter slug rules, both of which
  change behavior for values that work today.
- Bare names (`project="my_exp"`) still stream, under a URL with no owner segment. Whether the backend
  resolves the owner from the API key is the question raised in the issue thread — I can't answer it from
  outside, so this PR leaves that path untouched.

Happy to take either further if you'd prefer the strict version, or to invert the approach and salvage a
project name from the path instead of skipping the run.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Prevents local project directory paths from being sent to Ultralytics Platform as project slugs. 🛡️

### 📊 Key Changes
- Updates `_get_project_name` to distinguish valid `owner/project` identifiers from local paths.
- Rejects path-like values containing directory separators, backslashes, invalid owners, or non-slug characters.
- Skips Platform tracking with an informative log message when a local path is detected.
- Adds tests covering valid project slugs, bare project names, and common Unix, Windows, and relative path formats. ✅

### 🎯 Purpose & Impact
- Avoids incorrectly using local filesystem components as Platform owner or project identifiers.
- Ensures valid owner/project slugs continue to work while bare project names retain API-key owner resolution.
- Improves reliability and user privacy by preventing unintended local path data from being transmitted to Platform. 🔒