### PR TITLE
Fix depth tensor source color order

### DIFF
--- a/ultralytics/models/yolo/depth/predict.py
+++ b/ultralytics/models/yolo/depth/predict.py
@@ -42,7 +42,7 @@ class DepthPredictor(BasePredictor):
         depth_maps = ops.scale_masks(depth_maps, img.shape[2:], padding=False)
 
         if not isinstance(orig_imgs, list):  # torch.Tensor source (B, 3, H, W)
-            orig_imgs = ops.convert_torch2numpy_batch(orig_imgs)
+            orig_imgs = ops.convert_torch2numpy_batch(orig_imgs)[..., ::-1]
 
         results = []
         for i, orig_img in enumerate(orig_imgs):


### PR DESCRIPTION
## Summary
- convert RGB tensor source images to BGR before storing depth Results
- align depth tensor handling with the other prediction tasks and the Annotator buffer convention

## Testing
- python3 -m pytest -p no:cacheprovider tests/test_python.py::test_results_depth_field tests/test_python.py::test_results_depth_none_summary_len_and_update tests/test_python.py::test_results_plot_with_depth tests/test_python.py::test_annotator_depth_map -q
- ruff check ultralytics/models/yolo/depth/predict.py
- ruff format --check ultralytics/models/yolo/depth/predict.py
- verified a known RGB tensor pixel is stored as BGR and the depth result plots successfully

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
The depth predictor now converts tensor source images from RGB to BGR before storing them in depth `Results`, aligning their color order with the expected image buffer convention.

### 📊 Key Changes
- Updated `ultralytics/models/yolo/depth/predict.py` to reverse the converted tensor image channels before result construction.
- Applied the conversion only when the source images are provided as a tensor; existing list-based image handling is unchanged.
- Keeps depth result plotting and downstream `Annotator` usage consistent with other prediction tasks.

### 🎯 Purpose & Impact
Tensor-backed depth results now store source images in BGR order, preventing channel-order mismatches when visualizing or processing depth predictions. No user-facing API change.