### PR TITLE
Cap RT-DETR denoising queries at the query budget

### DIFF
--- a/ultralytics/models/utils/loss.py
+++ b/ultralytics/models/utils/loss.py
@@ -426,7 +426,7 @@ class RTDETRDetectionLoss(DETRLoss):
             assert len(batch["gt_groups"]) == len(dn_pos_idx)
 
             # Get the match indices for denoising
-            match_indices = self.get_dn_match_indices(dn_pos_idx, dn_num_group, batch["gt_groups"])
+            match_indices = self.get_dn_match_indices(dn_pos_idx, dn_num_group, dn_meta["dn_gt_idx"])
 
             # Compute the denoising training loss
             dn_loss = super().forward(dn_bboxes, dn_scores, batch, postfix="_dn", match_indices=match_indices)
@@ -439,28 +439,23 @@ class RTDETRDetectionLoss(DETRLoss):
 
     @staticmethod
     def get_dn_match_indices(
-        dn_pos_idx: list[torch.Tensor], dn_num_group: int, gt_groups: list[int]
+        dn_pos_idx: list[torch.Tensor], dn_num_group: int, dn_gt_idx: list[torch.Tensor]
     ) -> list[tuple[torch.Tensor, torch.Tensor]]:
         """Get match indices for denoising.
 
         Args:
             dn_pos_idx (list[torch.Tensor]): List of tensors containing positive indices for denoising.
             dn_num_group (int): Number of denoising groups.
-            gt_groups (list[int]): List of integers representing number of ground truths per image.
+            dn_gt_idx (list[torch.Tensor]): Ground truth index each image's denoising queries reconstruct.
 
         Returns:
             (list[tuple[torch.Tensor, torch.Tensor]]): List of tuples containing matched indices for denoising.
         """
         dn_match_indices = []
-        idx_groups = torch.as_tensor([0, *gt_groups[:-1]]).cumsum_(0)
-        for i, num_gt in enumerate(gt_groups):
-            if num_gt > 0:
-                gt_idx = torch.arange(end=num_gt, dtype=torch.long) + idx_groups[i]
-                gt_idx = gt_idx.repeat(dn_num_group)
-                assert len(dn_pos_idx[i]) == len(gt_idx), (
-                    f"Expected the same length, but got {len(dn_pos_idx[i])} and {len(gt_idx)} respectively."
-                )
-                dn_match_indices.append((dn_pos_idx[i], gt_idx))
-            else:
-                dn_match_indices.append((torch.zeros([0], dtype=torch.long), torch.zeros([0], dtype=torch.long)))
+        for i, gt_idx in enumerate(dn_gt_idx):
+            gt_idx = gt_idx.repeat(dn_num_group)
+            assert len(dn_pos_idx[i]) == len(gt_idx), (
+                f"Expected the same length, but got {len(dn_pos_idx[i])} and {len(gt_idx)} respectively."
+            )
+            dn_match_indices.append((dn_pos_idx[i], gt_idx))
         return dn_match_indices

--- a/ultralytics/models/utils/ops.py
+++ b/ultralytics/models/utils/ops.py
@@ -231,18 +231,29 @@ def get_cdn_group(
     if (not training) or num_dn <= 0 or batch is None:
         return None, None, None, None
     gt_groups = batch["gt_groups"]
-    total_num = sum(gt_groups)
-    max_nums = max(gt_groups)
+    max_nums = min(max(gt_groups), num_dn)
     if max_nums == 0:
         return None, None, None, None
 
-    num_group = num_dn // max_nums
-    num_group = 1 if num_group == 0 else num_group
+    num_group = num_dn // max_nums  # always >= 1, because max_nums is capped at num_dn
     # Pad gt to max_num of a batch
     bs = len(gt_groups)
     gt_cls = batch["cls"]  # (bs*num, )
     gt_bbox = batch["bboxes"]  # bs*num, 4
     b_idx = batch["batch_idx"]
+
+    # Denoise a random subset of any image carrying more than num_dn boxes. Uncapped, num_group collapses to 1
+    # and a 700-box image emits 1400 denoising queries against a budget of 200, growing decoder self-attention
+    # quadratically. The subset is redrawn on every call, so all boxes are still denoised across training.
+    gt_idx = torch.arange(sum(gt_groups), dtype=torch.long, device=gt_bbox.device)
+    if max(gt_groups) > max_nums:
+        offsets = torch.as_tensor([0, *gt_groups[:-1]]).cumsum_(0)
+        gt_idx = torch.cat(
+            [torch.randperm(n, device=gt_bbox.device)[:max_nums].sort().values + o for n, o in zip(gt_groups, offsets)]
+        )
+        gt_cls, gt_bbox, b_idx = gt_cls[gt_idx], gt_bbox[gt_idx], b_idx[gt_idx]
+        gt_groups = [min(n, max_nums) for n in gt_groups]
+    total_num = sum(gt_groups)
 
     # Each group has positive and negative queries
     dn_cls = gt_cls.repeat(2 * num_group)  # (2*num_group*bs*num, )
@@ -302,6 +313,7 @@ def get_cdn_group(
             attn_mask[max_nums * 2 * i : max_nums * 2 * (i + 1), : max_nums * 2 * i] = True
     dn_meta = {
         "dn_pos_idx": [p.reshape(-1) for p in pos_idx.cpu().split(list(gt_groups), dim=1)],
+        "dn_gt_idx": list(gt_idx.cpu().split(list(gt_groups))),  # gt each denoising query reconstructs
         "dn_num_group": num_group,
         "dn_num_split": [num_dn, num_queries],
     }

--- a/ultralytics/models/utils/ops.py
+++ b/ultralytics/models/utils/ops.py
@@ -243,7 +243,7 @@ def get_cdn_group(
     b_idx = batch["batch_idx"]
 
     # Denoise a random subset of any image carrying more than num_dn boxes. Uncapped, num_group collapses to 1
-    # and a 700-box image emits 1400 denoising queries against a budget of 200, growing decoder self-attention
+    # and a 700-box image emits 1400 denoising queries against the 2 * num_dn budget, growing decoder self-attention
     # quadratically. The subset is redrawn on every call, so all boxes are still denoised across training.
     gt_idx = torch.arange(sum(gt_groups), dtype=torch.long, device=gt_bbox.device)
     if max(gt_groups) > max_nums:


### PR DESCRIPTION
An image with 700 boxes emitted 1400 denoising queries against a budget of 200, growing decoder self-attention quadratically.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

On datasets whose images carry more boxes than `num_dn`, `get_cdn_group` sized the denoising group from the largest image in the batch instead of from the budget, so the denoising block and the decoder self-attention mask grew with the box count, wasting memory and running training out of it on dense data. That cost is quadratic in the block size and paid again in every decoder layer, so capping the group at `num_dn` keeps the mask at the budgeted size and lets dense datasets train within memory and faster. Images above the budget denoise a uniformly random subset of their boxes redrawn on every call, so every box is still denoised over training, while images under the budget keep all of theirs.

```python
from ultralytics import RTDETR

RTDETR("rtdetr-l.yaml").train(data="SKU-110K.yaml", epochs=1, imgsz=640)
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
RT-DETR denoising queries are now capped at the configured `num_dn` budget by sampling oversized ground-truth sets before building the denoising block.

### 📊 Key Changes
- `get_cdn_group` limits the per-image denoising box count to `num_dn` and selects a new random subset when an image contains more boxes.
- Denoising groups and attention-mask dimensions are calculated from the capped count instead of the largest uncapped image.
- Denoising metadata now records the selected ground-truth indices through `dn_gt_idx`.
- `get_dn_match_indices` uses those selected indices to match denoising predictions with their corresponding targets.

### 🎯 Purpose & Impact
- Images with more than `num_dn` boxes no longer expand the denoising block and decoder self-attention mask beyond the configured budget; images within the budget retain all their boxes.
- The selected subset is regenerated on each call, while denoising loss matching remains aligned with the sampled targets.