### PR TITLE
Bound SlowTests retry attempts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,7 +352,7 @@ jobs:
               PYTHONFAULTHANDLER=1 PYTHONUNBUFFERED=1 pytest -n 2 --dist=loadfile "${pytest_args[@]}"
             fi
           retries: 1 # Retry once after initial attempt (2 total runs)
-          timeout_minutes: 180
+          timeout_minutes: 120
           retry_delay_seconds: 60
         env:
           YOLO_AUTOINSTALL: "false"


### PR DESCRIPTION
## Summary

- cap each SlowTests pytest attempt at 120 minutes
- retain one retry and the existing 360-minute job ceiling

## Motivation

Run https://github.com/ultralytics/ultralytics/actions/runs/31935546886 hung inside one pytest test until GitHub cancelled the job after six hours. SlowTests normally completes in roughly 30-45 minutes, so 120 minutes provides a generous per-attempt ceiling while leaving time for the retry.

Depends on ultralytics/actions#879, which makes timeout_minutes an enforced per-attempt deadline and terminates hung process trees.

## Validation

- parsed .github/workflows/ci.yml successfully
- git diff check passed
- timeout choice checked against successful neighboring SlowTests shards and the existing job ceiling

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Reduced the per-attempt timeout for the SlowTests CI job from 180 to 120 minutes while preserving one retry and the existing 360-minute job limit.

### 📊 Key Changes
- Updated `.github/workflows/ci.yml` to set `timeout_minutes: 120` for SlowTests attempts.
- Retained `retries: 1`, allowing up to two total attempts.
- Left the existing job-level 360-minute ceiling unchanged.

### 🎯 Purpose & Impact
- Hung SlowTests attempts are terminated sooner, allowing the configured retry to run within the overall job limit.
- No user-facing change.