### PR TITLE
Align Platform workflow diagrams with the product

### DIFF
--- a/docs/en/platform/data/annotation.md
+++ b/docs/en/platform/data/annotation.md
@@ -13,7 +13,7 @@ keywords: Ultralytics Platform, annotation, labeling, SAM, auto-annotation, boun
 
 ```mermaid
 graph TB
-    subgraph Draw["Draw Mode"]
+    subgraph Draw["Shape set by the dataset task"]
         A[Box]:::start & B[Polygon]:::start & C[Classify]:::start & D[Keypoint]:::start & E[OBB]:::start
     end
     subgraph AI["AI-Assisted"]

--- a/docs/en/platform/data/index.md
+++ b/docs/en/platform/data/index.md
@@ -40,8 +40,8 @@ The Data section of Ultralytics Platform helps you:
 ```mermaid
 graph LR
     A[Upload]:::start --> B[Annotate]:::proc
+    B --> D[Train]:::out
     B --> C[Analyze]:::proc
-    C --> D[Train]:::out
 
     classDef start fill:#4CAF50,color:#fff
     classDef proc fill:#2196F3,color:#fff

--- a/docs/en/platform/deploy/monitoring.md
+++ b/docs/en/platform/deploy/monitoring.md
@@ -22,7 +22,7 @@ graph TB
         Map[World Map]:::proc --- Cards[Overview Cards]:::proc
         Cards --- List[Deployments List]:::decide
     end
-    subgraph "Per Deployment"
+    subgraph "Per Ready Deployment"
         Metrics[Metrics Row]:::out
         Health[Health Check]:::out
         Logs[Logs Tab]:::out
@@ -89,7 +89,7 @@ Below the overview cards, the deployments list shows all endpoints across your p
 
 ## Per-Deployment Metrics
 
-Each deployment card (in cards view) shows real-time metrics:
+Each deployment card (in cards view) shows real-time metrics. The metrics row, health check, and the `Logs`, `Code`, and `Predict` tabs described below appear only while the deployment is **Ready**:
 
 ### Metrics Row
 

--- a/docs/en/platform/explore.md
+++ b/docs/en/platform/explore.md
@@ -143,7 +143,7 @@ graph TD
     A[Find Content on Explore]:::start --> B{Content Type}:::decide
     B --> C[Dataset]:::proc
     B --> D[Project]:::proc
-    B --> E[Model]:::proc
+    D --> E[Model in the Project]:::proc
     C --> F[Clone Dataset]:::proc
     D --> G[Clone Project]:::proc
     E --> H[Download Model]:::proc
@@ -269,13 +269,13 @@ profiles. The **Share** button next to it copies a link or opens a pre-filled so
 
 ## Make Your Content Public
 
-Make your work available to the community. Public content appears on the Explore page and is visible to everyone, including users who aren't signed in.
+Make your work available to the community. Public content is visible to everyone, including users who aren't signed in. Explore lists public datasets that contain at least one image and public projects that contain at least one model, so an empty dataset or a project with no models stays off the Explore page until you add content to it. Models follow the visibility of the project that holds them and have no separate badge.
 
 ```mermaid
 graph LR
-    A[Your Private Content]:::start --> B[Click Private Badge]:::proc
+    A[Your Private Dataset or Project]:::start --> B[Click Private Badge]:::proc
     B --> C[Confirm Make Public]:::proc
-    C --> D[Appears on Explore Page]:::proc
+    C --> D[Appears on Explore Once It Has Content]:::proc
     D --> E[Community Can Clone/Download]:::out
 
     classDef start fill:#4CAF50,color:#fff

--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -32,7 +32,9 @@ graph LR
         G[Export]:::proc
         H[Deploy Endpoint]:::proc --> I[Monitor]:::out
     end
-    Data --> Train --> Deploy
+    Data --> Train
+    E --> G
+    E --> H
 
     classDef start fill:#4CAF50,color:#fff
     classDef proc fill:#2196F3,color:#fff

--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -28,7 +28,7 @@ graph LR
         D[Configure]:::proc --> E[Train on GPU]:::proc
         E --> F[View Metrics]:::out
     end
-    subgraph Deploy["🌐 Deploy"]
+    subgraph Deploy["🌐 Export or Deploy"]
         G[Export]:::proc
         H[Deploy Endpoint]:::proc --> I[Monitor]:::out
     end

--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -15,7 +15,7 @@ keywords: Ultralytics Platform, YOLO, computer vision, model training, cloud dep
 
 Ultralytics Platform brings dataset management and annotation, experiment tracking, cloud and remote training, model export, dedicated inference endpoints, and deployment monitoring into one workspace. It has native support for [YOLO26](../models/yolo26.md), [YOLO11](../models/yolo11.md), [YOLOv8](../models/yolov8.md), and [YOLOv5](../models/yolov5.md) models.
 
-## Workflow: Upload → Annotate → Train → Export → Deploy
+## Workflow: Upload → Annotate → Train → Export or Deploy
 
 The Platform provides an end-to-end workflow:
 
@@ -23,15 +23,14 @@ The Platform provides an end-to-end workflow:
 graph LR
     subgraph Data["📁 Data"]
         A[Upload]:::start --> B[Annotate]:::proc
-        B --> C[Analyze]:::proc
     end
     subgraph Train["🚀 Train"]
         D[Configure]:::proc --> E[Train on GPU]:::proc
         E --> F[View Metrics]:::out
     end
     subgraph Deploy["🌐 Deploy"]
-        G[Export]:::proc --> H[Deploy Endpoint]:::proc
-        H --> I[Monitor]:::out
+        G[Export]:::proc
+        H[Deploy Endpoint]:::proc --> I[Monitor]:::out
     end
     Data --> Train --> Deploy
 

--- a/docs/en/platform/train/cloud-training.md
+++ b/docs/en/platform/train/cloud-training.md
@@ -232,8 +232,8 @@ what it has before exiting.
 
 ```mermaid
 graph LR
-    A[Local GPU]:::start --> B[Train]:::proc
-    B --> C[ultralytics Package]:::proc
+    A[Local GPU]:::start --> B[ultralytics Package]:::proc
+    B --> C[Train]:::proc
     C --> D[Stream Metrics]:::proc
     D --> E[Platform Dashboard]:::out
 
@@ -357,8 +357,8 @@ Estimates are based on real cloud training runs, and the estimate always uses th
 ```mermaid
 graph LR
     A[Estimate Cost]:::start --> B[Balance Check]:::decide
-    B --> C[Train]:::proc
-    C --> D[Charge Actual Runtime]:::out
+    B --> C[Train and Meter GPU Time]:::proc
+    C --> D[Settle at Terminal State]:::out
 
     classDef start fill:#4CAF50,color:#fff
     classDef proc fill:#2196F3,color:#fff
@@ -370,8 +370,8 @@ Cloud training billing flow:
 
 1. **Estimate**: Cost calculated before training starts
 2. **Balance Check**: Available credits are checked before launch
-3. **Train**: Job runs on selected compute
-4. **Charge**: Final cost is based on actual runtime
+3. **Train and Meter**: The job runs on the selected compute, and accrued GPU time is debited from your balance in steps while it runs
+4. **Settle**: At the terminal state the remaining tail is debited and a single **Training** transaction is written for the whole run
 
 !!! success "Consumer Protection"
 

--- a/docs/en/platform/train/projects.md
+++ b/docs/en/platform/train/projects.md
@@ -15,12 +15,11 @@ graph TB
     P[Project]:::start --> M1[Model 1]:::proc
     P --> M2[Model 2]:::proc
     P --> M3[Model 3]:::proc
-    M1 --> C[Charts for selected models]:::out
-    M2 --> C
-    M3 --> C
-    M1 --> T[Comparison of selected models]:::out
-    M2 --> T
-    M3 --> T
+    M1 --> S[Check in Sidebar]:::proc
+    M2 --> S
+    M3 --> S
+    S --> C[Charts]:::out
+    S --> T[Comparison Table]:::out
 
     classDef start fill:#4CAF50,color:#fff
     classDef proc fill:#2196F3,color:#fff

--- a/docs/en/platform/train/projects.md
+++ b/docs/en/platform/train/projects.md
@@ -15,10 +15,10 @@ graph TB
     P[Project]:::start --> M1[Model 1]:::proc
     P --> M2[Model 2]:::proc
     P --> M3[Model 3]:::proc
-    M1 --> C[Charts Dashboard]:::out
+    M1 --> C[Charts for selected models]:::out
     M2 --> C
     M3 --> C
-    M1 --> T[Comparison Table]:::out
+    M1 --> T[Comparison of selected models]:::out
     M2 --> T
     M3 --> T
 


### PR DESCRIPTION
## summary

- Several Platform workflow diagrams had drifted from the prose on their own pages. `train/projects.md` says charts and comparison show "checked models" while its diagram fanned every model in automatically; `deploy/monitoring.md` says metrics are collected only in the **Ready** state while its diagram labelled the panels "Per Deployment"; `data/annotation.md` describes `Draw` as the "default manual mode with task-specific drawing tools" while its diagram presented the five shapes as free choices. Each diagram now matches its page.
- `index.md` drew `Export → Deploy Endpoint` as a chain, though the page's own stage table and its second diagram already treat them as siblings, and a dedicated endpoint serves the `.pt` checkpoint directly. Export and Deploy are now parallel, and the section heading reads "Export or Deploy".
- `Analyze` sat on the required path between Annotate and Train. Analysis is a separate action that is unavailable for connected datasets and for datasets below the embedding minimum, and training never requires it. It is removed from the spine in `index.md` (whose stage table never listed it) and becomes an optional branch in `data/index.md`.
- `train/cloud-training.md` still described a single charge after the run, and `explore.md` promised that any public item appears on Explore. Billing is metered during the run with only the remainder settled at the terminal state, matching `account/billing.md`; Explore lists public datasets with at least one image and public projects with at least one model. The remote-training diagram also ordered `Train` before the `ultralytics` package that provides the command.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated Ultralytics Platform documentation diagrams and workflow descriptions so they match the documented model-selection, deployment, analysis, annotation, billing, and Explore behaviors.

### 📊 Key Changes

- Project charts and comparison tables now flow through a model-selection step, and annotation diagrams identify shapes as task-specific rather than freely selectable.
- Platform workflows now show Analyze as optional, and show Export and Deploy Endpoint as parallel paths after training.
- Monitoring documentation limits metrics, health checks, and related tabs to **Ready** deployments.
- Explore documentation now reflects content requirements: datasets need at least one image, projects need at least one model, and models inherit their project’s visibility.
- Cloud-training diagrams now show the `ultralytics` package before training and document GPU-time metering during runs with final settlement at the terminal state.

### 🎯 Purpose & Impact

- Platform documentation now presents workflows that match the described product behavior, including optional analysis and independent export or endpoint deployment.
- Users can see when deployment metrics are available and when public content appears in Explore.
- Cloud-training billing documentation now describes incremental metering and terminal settlement instead of a single post-run charge.