### PR TITLE
Fix OpenVINO INT8 detection head scope

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.120"
+__version__ = "8.4.121"
 
 import importlib
 import os

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1177,17 +1177,13 @@ class Exporter:
             ov.save_model(ov_model, file, compress_to_fp16=self.args.quantize == 16)
             YAML.save(Path(file).parent / "metadata.yaml", self.metadata)  # add metadata.yaml
 
-        calibration_dataset, ignored_scope = None, None
+        calibration_dataset = None
         if self.args.quantize == 8:
             check_requirements("packaging>=23.2")  # must be installed first to build nncf wheel
             check_requirements("nncf>=2.14.0,<3.0.0" if not TORCH_2_3 else "nncf>=2.14.0")
             import nncf
 
             calibration_dataset = nncf.Dataset(self.get_int8_calibration_dataloader(prefix), self._transform_fn)
-            if isinstance(self.model.model[-1], Detect):
-                # Includes all Detect subclasses like Segment, Pose, OBB, WorldDetect, YOLOEDetect
-                head_module_name = ".".join(list(self.model.named_modules())[-1][0].split(".")[:2])
-                ignored_scope = nncf.IgnoredScope(patterns=[f".*{head_module_name}(/|\\.dfl).*"], types=["Sigmoid"])
 
         ov_model = torch2openvino(
             model=NMSModel(self.model, self.args) if self.args.nms else self.model,
@@ -1195,7 +1191,7 @@ class Exporter:
             dynamic=self.args.dynamic,
             quantize=self.args.quantize,
             calibration_dataset=calibration_dataset,
-            ignored_scope=ignored_scope,
+            int8_detect=isinstance(self.model.model[-1], Detect),
             prefix=prefix,
         )
 

--- a/ultralytics/utils/export/openvino.py
+++ b/ultralytics/utils/export/openvino.py
@@ -17,7 +17,7 @@ def torch2openvino(
     dynamic: bool = False,
     quantize: int | str | None = None,
     calibration_dataset: Any | None = None,
-    ignored_scope: dict | None = None,
+    int8_detect: bool = False,
     prefix: str = "",
 ) -> Any:
     """Export a PyTorch model to OpenVINO format with optional INT8 quantization.
@@ -29,7 +29,7 @@ def torch2openvino(
         dynamic (bool): Whether to use dynamic input shapes.
         quantize (int | str | None): Precision scheme, e.g. 16 for FP16 or 8 for INT8.
         calibration_dataset (nncf.Dataset | None): Dataset for INT8 calibration (required when ``quantize=8``).
-        ignored_scope (dict | None): Kwargs passed to ``nncf.IgnoredScope`` for head patterns.
+        int8_detect (bool): Whether to keep the detection head in floating-point precision during INT8 quantization.
         prefix (str): Prefix for log messages.
 
     Returns:
@@ -49,6 +49,19 @@ def torch2openvino(
     if quantize == 8:
         import nncf
 
+        ignored_scope = None
+        if int8_detect:
+            operations = ov_model.get_ordered_ops()
+            sigmoid_names = [op.get_friendly_name() for op in operations if op.get_type_name() == "Sigmoid"]
+            head_scope = sigmoid_names[-1].split("/", 1)[0]
+            ignored_scope = nncf.IgnoredScope(
+                names=[
+                    op.get_friendly_name()
+                    for op in operations
+                    if op.get_type_name() == "Sigmoid"
+                    or op.get_friendly_name().startswith((f"{head_scope}/", f"{head_scope}.dfl"))
+                ]
+            )
         ov_model = nncf.quantize(
             model=ov_model,
             calibration_dataset=calibration_dataset,


### PR DESCRIPTION
## Summary

- fix Sentry ALPHA-1YQ and ALPHA-1YR at the OpenVINO export owner
- replace the PyTorch-derived strict NNCF regex with exact Detect-head names from the converted OpenVINO graph
- preserve the intended float scope for Detect decode, DFL, and Sigmoid operations while keeping strict NNCF validation
- bump the package version to 8.4.121

## Evidence

- Sentry project: `alpha`, environment: `worker-cpu`, window: 24 hours
- ALPHA-1YQ: 5 events; ALPHA-1YR: 4 events in the same 64-second export burst
- deployed stack: Torch 2.12.1, NNCF 3.3.0, OpenVINO 2026.3, YOLO26n-P2 INT8
- failure: the PyTorch-derived `model.29`/`model.23` strict regex did not match the converted NNCF graph
- cross-repo follow-up: ultralytics/portal#3631 will pin 8.4.121 after the package is live on PyPI

## Verification

- Torch 2.12.1 + NNCF 3.3.0 + OpenVINO 2026.3: YOLO26n-P2 INT8 export passed with 55 exact ignored names
- emitted YOLO26n-P2 XML: 55 Detect/DFL operations and zero `FakeQuantize` operations in that scope
- Torch 2.13.0: YOLO26n-P2, YOLO26n, and YOLO11n INT8 exports passed
- pose, segment, OBB, dynamic, and NMS graph scopes reviewed against converted operation names
- `ruff format --check`
- focused `ruff check`
- `python -m compileall`
- `git diff --check`
- two independent exact-head reviews: LGTM

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

OpenVINO INT8 export now derives the Detect-head floating-point scope from converted graph operation names instead of PyTorch module names, fixing strict NNCF scope matching and updating the package version to 8.4.121.

### 📊 Key Changes

- Replaced the PyTorch-derived `IgnoredScope` regex with exact OpenVINO operation names collected from the converted graph.
- Keeps Detect decode, DFL, and Sigmoid operations outside INT8 quantization when exporting detection-based models.
- Added the `int8_detect` parameter to `torch2openvino()` and enabled it from the exporter for `Detect` subclasses, including pose, segment, and OBB heads.
- Removed the previous `ignored_scope` argument and bumped `ultralytics.__version__` from `8.4.120` to `8.4.121`.
- The PR reports successful YOLO26n-P2, YOLO26n, and YOLO11n INT8 export checks across the listed Torch, NNCF, and OpenVINO versions.

### 🎯 Purpose & Impact

- OpenVINO INT8 exports now preserve the intended floating-point Detect-head operations using names that exist in the converted graph, avoiding failures caused by unmatched `model.29` or `model.23` patterns.
- The change affects OpenVINO INT8 export behavior; other export modes are not changed by this diff.