### PR TITLE
Avoid per-box GPU syncs in `Results.save_txt`/`save_crop`/`summary`

### DIFF
--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -747,6 +747,11 @@ class Results(SimpleClass, DataExportMixin):
             # Classify
             [texts.append(f"{probs.data[j]:.2f} {self.names[j]}") for j in probs.top5]
         elif boxes:
+            boxes = boxes.cpu()  # one host transfer avoids per-box GPU syncs in the loop below
+            if masks:
+                masks = masks.cpu()  # ditto for the per-box masks2segments() sync below
+            if kpts is not None:
+                kpts = kpts.cpu()  # ditto for the per-box keypoints sync below
             # Detect/segment/pose
             for j, d in enumerate(boxes):
                 c, conf, id = int(d.cls.item()), float(d.conf.item()), int(d.id.item()) if d.is_track else None
@@ -804,7 +809,7 @@ class Results(SimpleClass, DataExportMixin):
         if self.depth is not None:
             LOGGER.warning("Depth task does not support `save_crop`.")
             return
-        for d in self.boxes:
+        for d in self.boxes.cpu():  # one host transfer avoids per-box GPU syncs in the loop below
             save_one_box(
                 d.xyxy,
                 self.orig_img.copy(),
@@ -879,6 +884,11 @@ class Results(SimpleClass, DataExportMixin):
 
         is_obb = self.obb is not None
         data = self.obb if is_obb else self.boxes
+        if data:
+            data = data.cpu()  # one host transfer avoids per-row GPU syncs in the loop below
+        kpts = self.keypoints
+        if kpts is not None:
+            kpts = kpts.cpu()  # ditto for the per-row keypoints sync below
         h, w = self.orig_shape if normalize else (1, 1)
         for i, row in enumerate(data):  # xyxy, track_id if tracking, conf, class_id
             class_id, conf = int(row.cls.item()), round(row.conf.item(), decimals)
@@ -896,7 +906,7 @@ class Results(SimpleClass, DataExportMixin):
                     "y": (self.masks.xy[i][:, 1] / h).astype(float).round(decimals).tolist(),
                 }
             if self.keypoints is not None:
-                kpt = self.keypoints[i]
+                kpt = kpts[i]
                 k = kpt.data[0]
                 k = k.cpu().numpy() if isinstance(k, torch.Tensor) else k
                 result["keypoints"] = {

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -747,25 +747,23 @@ class Results(SimpleClass, DataExportMixin):
             # Classify
             [texts.append(f"{probs.data[j]:.2f} {self.names[j]}") for j in probs.top5]
         elif boxes:
-            box_data = boxes.data.tolist()
-            coordinates = (boxes.xyxyxyxyn if is_obb else boxes.xywhn).reshape(len(boxes), -1).tolist()
-            segments = masks.xyn if masks else None
-            if kpts is not None:
-                keypoints = kpts.xyn
-                if kpts.has_visible:
-                    keypoints = torch.cat((torch.as_tensor(keypoints), torch.as_tensor(kpts.conf)[..., None]), 2)
-                keypoints = keypoints.reshape(len(kpts), -1).tolist()
             # Detect/segment/pose
-            for j, d in enumerate(box_data):
-                c, conf, id = int(d[-1]), float(d[-2]), int(d[-3]) if boxes.is_track else None
-                line = (c, *coordinates[j])
+            boxes = boxes.cpu()  # one host transfer avoids per-box GPU syncs in the loop below
+            kpts = kpts.cpu() if kpts is not None else None
+            segments = masks.xyn if masks else None
+            for j, d in enumerate(boxes):
+                c, conf, id = int(d.cls.item()), float(d.conf.item()), int(d.id.item()) if d.is_track else None
+                line = (c, *(d.xyxyxyxyn.reshape(-1) if is_obb else d.xywhn.reshape(-1)))
                 if segments is not None:
                     seg = segments[j]
                     if len(seg) < 3:  # fewer than 3 points is not a polygon, and writes a row no loader accepts
                         continue
                     line = (c, *seg.copy().reshape(-1))  # reversed mask.xyn, (n,2) to (n*2)
                 if kpts is not None:
-                    line += (*keypoints[j],)
+                    kpt = kpts[j].xyn
+                    if kpts[j].has_visible:
+                        kpt = torch.cat((torch.as_tensor(kpt), torch.as_tensor(kpts[j].conf)[..., None]), 2)
+                    line += (*kpt.reshape(-1).tolist(),)
                 line += (conf,) * save_conf + (() if id is None else (id,))
                 texts.append(("%g " * len(line)).rstrip() % line)
 
@@ -905,7 +903,7 @@ class Results(SimpleClass, DataExportMixin):
                     "x": (self.masks.xy[i][:, 0] / w).astype(float).round(decimals).tolist(),
                     "y": (self.masks.xy[i][:, 1] / h).astype(float).round(decimals).tolist(),
                 }
-            if self.keypoints is not None:
+            if kpts is not None:
                 kpt = kpts[i]
                 k = kpt.data[0]
                 k = k.cpu().numpy() if isinstance(k, torch.Tensor) else k

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -747,25 +747,25 @@ class Results(SimpleClass, DataExportMixin):
             # Classify
             [texts.append(f"{probs.data[j]:.2f} {self.names[j]}") for j in probs.top5]
         elif boxes:
-            boxes = boxes.cpu()  # one host transfer avoids per-box GPU syncs in the loop below
-            if masks:
-                masks = masks.cpu()  # ditto for the per-box masks2segments() sync below
+            box_data = boxes.data.tolist()
+            coordinates = (boxes.xyxyxyxyn if is_obb else boxes.xywhn).reshape(len(boxes), -1).tolist()
+            segments = masks.xyn if masks else None
             if kpts is not None:
-                kpts = kpts.cpu()  # ditto for the per-box keypoints sync below
+                keypoints = kpts.xyn
+                if kpts.has_visible:
+                    keypoints = torch.cat((torch.as_tensor(keypoints), torch.as_tensor(kpts.conf)[..., None]), 2)
+                keypoints = keypoints.reshape(len(kpts), -1).tolist()
             # Detect/segment/pose
-            for j, d in enumerate(boxes):
-                c, conf, id = int(d.cls.item()), float(d.conf.item()), int(d.id.item()) if d.is_track else None
-                line = (c, *(d.xyxyxyxyn.reshape(-1) if is_obb else d.xywhn.reshape(-1)))
-                if masks:
-                    seg = masks[j].xyn[0]
+            for j, d in enumerate(box_data):
+                c, conf, id = int(d[-1]), float(d[-2]), int(d[-3]) if boxes.is_track else None
+                line = (c, *coordinates[j])
+                if segments is not None:
+                    seg = segments[j]
                     if len(seg) < 3:  # fewer than 3 points is not a polygon, and writes a row no loader accepts
                         continue
                     line = (c, *seg.copy().reshape(-1))  # reversed mask.xyn, (n,2) to (n*2)
                 if kpts is not None:
-                    kpt = kpts[j].xyn
-                    if kpts[j].has_visible:
-                        kpt = torch.cat((torch.as_tensor(kpt), torch.as_tensor(kpts[j].conf)[..., None]), 2)
-                    line += (*kpt.reshape(-1).tolist(),)
+                    line += (*keypoints[j],)
                 line += (conf,) * save_conf + (() if id is None else (id,))
                 texts.append(("%g " * len(line)).rstrip() % line)
 


### PR DESCRIPTION
`Results.plot()` already avoids per-box GPU syncs by transferring `pred_boxes` to CPU once before its per-box loop (#25230: *"one host transfer avoids per-box GPU syncs in the color and label loops"*). Three sibling methods on the same class never got that treatment and still call `.item()` inside a `for` loop over CUDA-resident boxes: `save_txt()`, `save_crop()`, and `summary()`.

**Changes**

- `save_txt()`: `boxes = boxes.cpu()` before the detect/segment/pose loop that calls `d.cls.item()`, `d.conf.item()`, `d.id.item()` per box, plus the same one-time transfer for `masks`/`kpts` when the task has them — both are read per box inside the same loop (`masks[j].xyn`, `kpts[j].xyn`/`.conf`), so leaving them CUDA-resident would keep the exact per-box sync this PR removes for boxes, just on the segment/pose branch instead.
- `save_crop()`: `for d in self.boxes.cpu():` instead of `for d in self.boxes:` — same per-box `.item()` call for the class-name subdirectory.
- `summary()`: `data = data.cpu()` before the per-row loop, guarded by `if data:` so an empty result set (and OBB's own boxes-vs-obb branch) aren't affected; same one-time transfer added for `keypoints` (the pose branch did its own per-row `.cpu().numpy()` inside the loop). `masks` didn't need it: `self.masks.xy` is a `cached_property` already computed once for the whole batch, so it was never doing a per-row sync.

`BaseTensor.cpu()` is already a no-op when the data is a numpy array (`return self if isinstance(self.data, np.ndarray) else ...`), so this doesn't interact badly with `.numpy()`-converted `Results` (#25318).

**Correctness**

Verified on a real RTX 4060, one full task-by-task pass, unpatched vs. patched, comparing SHA256 of `save_txt()`'s output file and of `summary()`'s dict repr (plus per-file SHA256 for every `save_crop()` JPEG on detect):

| Task | Model | `save_txt()` | `summary()` |
|---|---|---|---|
| detect | `yolo11n.pt` | identical | identical |
| segment | `yolo11n-seg.pt` | identical | identical |
| pose | `yolov8n-pose.pt` | **differs** | identical |
| obb | `yolo11n-obb.pt` | identical | identical |

Pose's `save_txt()` output is not bit-identical, and the mechanism is real: `save_txt` formats raw `float32` values with `%g`, and moving the keypoint tensor to CPU before `.xyn` runs the normalization division on the CPU kernel instead of CUDA — the two aren't guaranteed to round identically, so a coordinate can land 1 ULP apart. `summary()` doesn't show it because it rounds to 5 decimals, which absorbs a difference at that magnitude.

Everything else in that table came back byte-identical in this run, including OBB, which also moves a tensor through CPU-side trig (`xyxyxyxyn`'s `cos`/`sin`). On the one OBB detection `bus.jpg` produces, CPU and CUDA happened to round the same way. I don't have a case that reproduces an OBB difference, so I'm not claiming one exists — only that the same theoretical mechanism as pose applies there too.

I also checked cross-process reproducibility on its own (5 separate unpatched pose runs, 3 separate unpatched OBB runs, same image), because the whole comparison above assumes the unpatched baseline is stable run to run. Every run matched every other run exactly, both tasks. So I don't have evidence of pre-existing cross-process non-determinism here — if it exists, it's not something I could reproduce ..

So this PR is byte-identical for detect and segment, and introduces a real but tiny (1-ULP, `save_txt`-only) numerical change for pose. `plot()` (#25230, already merged, same file) moves OBB boxes and keypoints to CPU the same way before its own loop, so if a CPU/GPU rounding difference like this shows up for some input, it's not new — `plot()` already carries the same risk in production.

Also ran the full existing test coverage for these methods across every task type — `test_results` (detect/seg/pose/obb/cls/semantic/depth), `test_labels_and_crops`, `test_yolov10`, `test_multichannel`, `test_grayscale` (detect/obb/pose/segment) — 23 passed, 0 failed. No new test added: every path this diff touches already has coverage, per this repo's test policy.

**Performance — end-to-end, not just the isolated function**

Isolated `summary()` call (no file I/O, 11 boxes, n=100 reps): 0.405ms → 0.233ms, **1.74x**.

But that isolated number looks better than what a user actually gets, since `save_txt`/`save_crop` still do real file I/O. So I also measured the realistic end-to-end call (`save_txt` + `save_crop` + `summary`, with real file writes, n=100 reps each):

| Detections | Unpatched (median) | Patched (median) | Speedup |
|---|---|---|---|
| 5 (conf=0.25) | 11.02ms | 9.18ms | 1.20x |
| 11 (conf=0.05) | 15.66ms | 12.00ms | 1.31x |

Both gaps are well outside the measurement's own noise (stdev ≤0.7ms on both sides, gap 1.8-3.7ms — a 3-15σ effect, not noise), and the speedup grows with detection count — which is the realistic case for what these methods are used for: batch export, crop extraction from dense/crowded scenes, not a single sparse detection.

**Risk**: low. Same pattern already accepted for `plot()` in #25230, same file, full existing test suite for these methods passes unchanged, and the only behaviour change with any measurable effect (pose/OBB coordinate rounding, above) matches what `plot()` already ships in production.


## Update

The review comment above is right: moving the raw keypoints to CPU before `Keypoints.xyn`/`conf` shifts that normalisation from a CUDA kernel to a CPU one, and the two don't round the same way. Commit `baa931b12` fixes it by keeping every `save_txt()` calculation on its original device — boxes, OBB coordinates and keypoints are all normalised once in bulk on whichever device they started on, and only the finished arrays get pulled to host with `tolist()`. `save_crop()` and `summary()` above are untouched by this commit, they keep the one-time `.cpu()` transfers already described, which don't serialise unrounded coordinates the way this path did.

I reran the full comparison against `main`'s per-row implementation, this time on real `yolo26n` outputs for every task:

| Task | N | CPU Torch | CPU NumPy | CUDA Torch |
|---|---:|---:|---:|---:|
| Detect | 25 | exact | exact | exact |
| Segment | 19 | exact | exact | exact |
| Pose | 5 | exact | exact | exact |
| OBB | 300 | exact | exact | exact |

Each row covers `save_conf` false/true and a second append. On CUDA I also compared the normalised box/OBB/keypoint tensors through their `int32` bit view against the original per-row values: zero mismatches, so the bug flagged above is gone. For reference, the CPU-first approach it replaces changes 36 detect box scalars, 6 pose box scalars and 1,092 OBB scalars at the bit level on the same outputs, which is 3, 1 and 35 TXT rows respectively .. that's the actual size of what's being fixed. A separate 72-case matrix (Torch CPU/CUDA across `float16`/`float32`/`float64`/`bfloat16`, NumPy `float16`/`float32`/`float64`, tracked boxes/OBB, pose with and without visibility, degenerate masks, empty detections, classification) matched byte for byte too.

The existing focused suite still passes unchanged, no new test: `test_results`, `test_labels_and_crops`, `test_val_save_txt_pose`, `test_yolov10`, `test_multichannel`, `test_grayscale` — 19 passed.

Performance holds. CPU-only, 25 paired rounds after 5 discarded warmups, isolated serialisation: Detect 10.75x, Segment 1.65x, Pose 3.34x, OBB 28.39x median speedup. On a full `predict(save_txt=True, save_conf=True)` batch=16 run, repeated four times, the median speedup ranged 1.08x-1.21x; the last run went from 190.83ms to 167.17ms (1.14x). That end-to-end number is noisier than the isolated one and at least one individual pair reversed, but the median favoured the fix in all four runs.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Moves detection results and related masks/keypoints to CPU once before per-item processing in `Results.save_txt()`, `save_crop()`, and `summary()` to avoid repeated GPU synchronization.

### 📊 Key Changes
- Transfers boxes, masks, and keypoints to CPU once in `save_txt()` before extracting per-box values and coordinates.
- Iterates over `self.boxes.cpu()` in `save_crop()` before saving cropped detections.
- Transfers summary box or OBB data once, and caches CPU keypoints for per-row summary generation.
- Preserves the existing empty-data handling in `summary()` and uses the transferred keypoints for pose results.

### 🎯 Purpose & Impact
Reduces per-box and per-row GPU synchronization overhead during text export, crop saving, and summary generation. CPU-side coordinate processing can produce very small floating-point formatting differences, such as the reported 1-ULP change in pose `save_txt()` output.
