### PR TITLE
Use `perf_counter()` for `ProfileModels` and `time_sync()` latency measurement

### DIFF
--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -447,10 +447,10 @@ class ProfileModels:
         # Warmup runs
         elapsed = 0.0
         for _ in range(3):
-            start_time = time.time()
+            start_time = time.perf_counter()
             for _ in range(self.num_warmup_runs):
                 model(input_data, imgsz=self.imgsz, verbose=False)
-            elapsed = time.time() - start_time
+            elapsed = time.perf_counter() - start_time
 
         # Compute number of runs as higher of min_time or num_timed_runs
         num_runs = max(round(self.min_time / (elapsed + eps) * self.num_warmup_runs), self.num_timed_runs * 50)
@@ -523,10 +523,10 @@ class ProfileModels:
         # Warmup runs
         elapsed = 0.0
         for _ in range(3):
-            start_time = time.time()
+            start_time = time.perf_counter()
             for _ in range(self.num_warmup_runs):
                 sess.run([output_name], input_data_dict)
-            elapsed = time.time() - start_time
+            elapsed = time.perf_counter() - start_time
 
         # Compute number of runs as higher of min_time or num_timed_runs
         num_runs = max(round(self.min_time / (elapsed + eps) * self.num_warmup_runs), self.num_timed_runs)
@@ -534,9 +534,9 @@ class ProfileModels:
         # Timed runs
         run_times = []
         for _ in TQDM(range(num_runs), desc=onnx_file):
-            start_time = time.time()
+            start_time = time.perf_counter()
             sess.run([output_name], input_data_dict)
-            run_times.append((time.time() - start_time) * 1000)  # Convert to milliseconds
+            run_times.append((time.perf_counter() - start_time) * 1000)  # Convert to milliseconds
 
         run_times = self.iterative_sigma_clipping(np.array(run_times), sigma=2, max_iters=5)  # sigma clipping
         return np.mean(run_times), np.std(run_times)

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -337,7 +337,7 @@ def time_sync(device: torch.device | None = None):
         accelerator = get_torch_device_backend(device or "cuda")
         if accelerator.is_available() and hasattr(accelerator, "synchronize"):
             accelerator.synchronize()
-    return time.time()
+    return time.perf_counter()
 
 
 def fuse_conv_and_bn(conv, bn):


### PR DESCRIPTION
## summary

- `ProfileModels` timed its warmup and every ONNX sample with `time.time()`, and `time_sync()` — the timestamp behind `profile=True` and `profile_ops()` — returned the same clock. On Windows that is `GetSystemTimeAsFileTime` with ~15.625 ms granularity through Python 3.12 (3.13 switched to `GetSystemTimePreciseAsFileTime`), and the package floor is Python>=3.8, so it is a supported configuration on which a sub-millisecond measurement is unresolvable.
- Every ONNX sample then lands on the tick grid and the reported latency reads `0.000` ms, while a warmup finishing inside one tick measures `elapsed == 0.0`, makes the `eps = 1e-3` guard the divisor and inflates `num_runs` to 600,000 at default settings. Under `profile=True` the per-layer table collapses onto multiples of 1.5625 ms, so most rows read `0.00` and the table no longer says which layer is slow.
- All seven calls now use `time.perf_counter()`, matching `Profile.time()` in `ultralytics/utils/ops.py`. It is monotonic with sub-microsecond resolution on every supported platform, and every in-repo consumer uses the value only as a difference, so both effects disappear at the source and no guard is added.

## measured

Both sites driven through their real entry points with the system clock floored to the 15.625 ms Windows tick.

| site | clock | before | after |
| -- | -- | -- | -- |
| `profile_onnx_model`, `yolo26n.onnx` | 15.625 ms tick | 1000 runs, 2 distinct samples, **0.000 ms** | 592 runs, 583 distinct, 0.901 ms |
| `profile_onnx_model` | fine-grained | 491 runs, 415 distinct, 0.934 ms | 607 runs, 595 distinct, 0.931 ms |
| `_predict_once(profile=True)`, 24 layers | 15.625 ms tick | 1–2 distinct, 22–24 rows `0.00` | 12–14 distinct, 4–5 rows `0.00` |
| `_predict_once(profile=True)` | fine-grained | 13–14 distinct, 2.38–2.40 ms total | 13 distinct, 2.35–2.50 ms total |

The fine-grained rows are the negative control and are indistinguishable between arms, so platforms whose system clock already resolves microseconds are unaffected. `tests/test_python.py::test_utils_benchmarks`, `::test_utils_torchutils` and `::test_model_profile` pass.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Replaced `time.time()` with `time.perf_counter()` in model benchmarking and `time_sync()` to provide higher-resolution elapsed-time measurements.

### 📊 Key Changes
- Updated TensorRT and ONNX warmup timing in `ProfileModels`.
- Updated per-run ONNX latency measurement to use `time.perf_counter()`.
- Updated `time_sync()` in `ultralytics/utils/torch_utils.py`, which provides timestamps for `profile=True` and `profile_ops()`.
- Retained elapsed-time calculations as differences between start and end timestamps.

### 🎯 Purpose & Impact
- Improves latency and warmup measurements on platforms where `time.time()` has coarse resolution, including supported Windows configurations.
- Prevents short measurements from collapsing to zero and producing inflated benchmark run counts.
- Provides more distinct per-layer timing values in profiling output; platforms with fine-grained system clocks receive the same effective behavior.