### PR TITLE
Document Windows multi-GPU DDP limitation

### DIFF
--- a/docs/en/modes/train.md
+++ b/docs/en/modes/train.md
@@ -114,6 +114,16 @@ Multi-GPU training allows for more efficient utilization of available hardware r
         yolo detect train data=coco8.yaml model=yolo26n.pt epochs=100 imgsz=640 device=-1,-1
         ```
 
+!!! warning "Windows Multi-GPU Support"
+
+    Multi-GPU training does not work on Windows with the official PyTorch wheels for `torch>=2.4`. Ultralytics launches DDP through `torch.distributed.run`, whose rendezvous step builds a `TCPStore` that has defaulted to the libuv backend since PyTorch 2.4, and the official Windows wheels are built without libuv. Training exits immediately with:
+
+    ```
+    RuntimeError: use_libuv was requested but PyTorch was built without libuv support
+    ```
+
+    Setting `USE_LIBUV=0` does not resolve this, because the rendezvous constructs the `TCPStore` directly and that code path never reads the variable. Train on Linux or [WSL2](https://learn.microsoft.com/windows/wsl/install) to use multiple GPUs, or train on a single GPU with `device=0` on Windows.
+
 !!! note "Multi-GPU Training with Custom Code"
 
     When you specify multiple devices (e.g., `device=[0, 1]`), Ultralytics internally spawns a new trainer instance and executes `torch.distributed.run` under the hood. This works seamlessly for standard CLI usage and unmodified Python scripts.


### PR DESCRIPTION
Closes #25653

Multi-GPU training fails at launch on Windows with `torch>=2.4`. Ultralytics launches DDP via `torch.distributed.run`, and torchelastic's `StaticTCPRendezvous.next_rendezvous()` constructs a `TCPStore` without passing `use_libuv`, so it takes the pybind default of `True`. Official PyTorch Windows wheels are built without libuv, so this raises `use_libuv was requested but PyTorch was built without libuv support`.

The `USE_LIBUV=0` workaround does not apply here: that variable is only read by `torch.distributed.rendezvous._get_use_libuv_from_query_dict` on the `init_process_group` `env://`/`tcp://` path. The elastic rendezvous constructs the `TCPStore` directly, and there is no `getenv` for it on the C++ side.

Verified on Windows / torch 2.8.0:

| Call | Result |
|---|---|
| `TCPStore(use_libuv=True)` | raises |
| `TCPStore(use_libuv=False)` | works |
| `TCPStore(default)` with `USE_LIBUV=0` set | still raises |

`c10d_rendezvous_backend._create_tcp_store` also omits `use_libuv`, so switching `--rdzv-backend` is not a workaround either. Documenting the limitation and pointing users to Linux/WSL2 for multi-GPU.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Documents the Windows multi-GPU DDP limitation with official PyTorch wheels for `torch>=2.4` and explains why training fails at launch.

### 📊 Key Changes
- Adds a warning to the training documentation for Windows multi-GPU usage.
- Identifies the `TCPStore` libuv backend error raised by the `torch.distributed.run` rendezvous process.
- Clarifies that setting `USE_LIBUV=0` does not resolve this rendezvous failure.
- Directs users to Linux or WSL2 for multi-GPU training, or to `device=0` for single-GPU training on Windows.

### 🎯 Purpose & Impact
Windows users with official PyTorch wheels for `torch>=2.4` are informed that multi-GPU training is unsupported through the documented workflow and are provided with supported alternatives.