### PR TITLE
Fix nonuniform ratio-pad coordinate scaling

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1487,6 +1487,20 @@ def test_utils_ops():
     assert segment2box(seg, 640, 640).tolist() == [0, 0, 640, 640]
 
 
+def test_scale_coords_nonuniform_letterbox():
+    """Coordinate scaling must invert independent height and width gains from stretched preprocessing."""
+    from ultralytics.data.augment import LetterBox
+    from ultralytics.utils import ops
+
+    labels = {"img": np.zeros((320, 640, 3), dtype=np.uint8), "ratio_pad": (3.2, 3.2)}
+    ratio_pad = LetterBox((640, 640), scale_fill=True)(labels)["ratio_pad"]
+    boxes = np.array([[32.0, 64.0, 320.0, 384.0]])
+    coords = torch.tensor([[160.0, 128.0]])
+    assert ratio_pad == ((6.4, 3.2), (0, 0))
+    assert np.allclose(ops.scale_boxes((640, 640), boxes, (100, 200), ratio_pad), [[10, 10, 100, 60]])
+    assert torch.allclose(ops.scale_coords((640, 640), coords, (100, 200), ratio_pad), coords.new_tensor([[50, 20]]))
+
+
 def test_nms_end2end_classes_before_max_det():
     """The end-to-end NMS branch must filter classes before truncating to max_det, like the NMS-based branch."""
     from ultralytics.utils.nms import non_max_suppression

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1500,6 +1500,11 @@ def test_scale_coords_nonuniform_letterbox():
     assert np.allclose(ops.scale_boxes((640, 640), boxes, (100, 200), ratio_pad), [[10, 10, 100, 60]])
     assert torch.allclose(ops.scale_coords((640, 640), coords, (100, 200), ratio_pad), coords.new_tensor([[50, 20]]))
 
+    boxes = np.array([[32.0, 192.0, 320.0, 352.0]])
+    coords = torch.tensor([[160.0, 224.0]])
+    assert np.allclose(ops.scale_boxes((640, 640), boxes, (100, 200)), [[10, 10, 100, 60]])
+    assert torch.allclose(ops.scale_coords((640, 640), coords, (100, 200)), coords.new_tensor([[50, 20]]))
+
 
 def test_nms_end2end_classes_before_max_det():
     """The end-to-end NMS branch must filter classes before truncating to max_det, like the NMS-based branch."""

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1847,7 +1847,12 @@ class LetterBox(BaseTransform):
         if "instances" in labels:
             labels = self._update_labels(labels, params["ratio"], params["left"], params["top"], params["orig_shape"])
         if labels.get("ratio_pad"):
-            labels["ratio_pad"] = (labels["ratio_pad"], (params["left"], params["top"]))  # for evaluation
+            gain_h, gain_w = labels["ratio_pad"]
+            ratio_w, ratio_h = params["ratio"]
+            labels["ratio_pad"] = (
+                (gain_h * ratio_h, gain_w * ratio_w),
+                (params["left"], params["top"]),
+            )  # for evaluation
         return labels
 
     @staticmethod

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -136,7 +136,7 @@ def scale_boxes(
         img1_shape (tuple[int, int]): Shape of the source image (height, width).
         boxes (torch.Tensor | np.ndarray): Bounding boxes to rescale in format (N, 4).
         img0_shape (tuple[int, int]): Shape of the target image (height, width).
-        ratio_pad (tuple, optional): Tuple of (ratio, pad) for scaling. If None, calculated from image shapes.
+        ratio_pad (tuple, optional): Ratio and padding as ((ratio_h, ratio_w), (pad_w, pad_h)).
         padding (bool): Whether boxes are based on YOLO-style augmented images with padding.
         xywh (bool): Whether box format is xywh (True) or xyxy (False).
 
@@ -145,10 +145,11 @@ def scale_boxes(
     """
     if ratio_pad is None:  # calculate from img0_shape
         gain = min(img1_shape[0] / img0_shape[0], img1_shape[1] / img0_shape[1])  # gain  = old / new
+        gain_y = gain_x = gain
         pad_x = round((img1_shape[1] - round(img0_shape[1] * gain)) / 2 - 0.1)
         pad_y = round((img1_shape[0] - round(img0_shape[0] * gain)) / 2 - 0.1)
     else:
-        gain = ratio_pad[0][0]
+        gain_y, gain_x = ratio_pad[0]
         pad_x, pad_y = ratio_pad[1]
 
     if padding:
@@ -157,7 +158,10 @@ def scale_boxes(
         if not xywh:
             boxes[..., 2] -= pad_x  # x padding
             boxes[..., 3] -= pad_y  # y padding
-    boxes[..., :4] /= gain
+    boxes[..., 0] /= gain_x
+    boxes[..., 1] /= gain_y
+    boxes[..., 2] /= gain_x
+    boxes[..., 3] /= gain_y
     return boxes if xywh else clip_boxes(boxes, img0_shape)
 
 
@@ -623,16 +627,17 @@ def scale_coords(img1_shape, coords, img0_shape, ratio_pad=None, normalize: bool
     if ratio_pad is None:  # calculate from img0_shape
         img1_h, img1_w = img1_shape[:2]  # supports both HWC or HW shapes
         gain = min(img1_h / img0_h, img1_w / img0_w)  # gain  = old / new
+        gain_y = gain_x = gain
         pad = round((img1_w - round(img0_w * gain)) / 2 - 0.1), round((img1_h - round(img0_h * gain)) / 2 - 0.1)
     else:
-        gain = ratio_pad[0][0]
+        gain_y, gain_x = ratio_pad[0]
         pad = ratio_pad[1]
 
     if padding:
         coords[..., 0] -= pad[0]  # x padding
         coords[..., 1] -= pad[1]  # y padding
-    coords[..., 0] /= gain
-    coords[..., 1] /= gain
+    coords[..., 0] /= gain_x
+    coords[..., 1] /= gain_y
     coords = clip_coords(coords, img0_shape)
     if normalize:
         coords[..., 0] /= img0_w  # width


### PR DESCRIPTION
## Summary

- compose the existing dataset resize gain with `LetterBox`'s per-axis ratio
- restore boxes and coordinates with independent height and width gains
- cover stretched preprocessing with an end-to-end coordinate restoration regression

## Root cause

`ratio_pad` retained only the resize that happened before `LetterBox`, while `scale_boxes` and `scale_coords` divided every axis by the first gain. With nonuniform preprocessing such as `scale_fill=True`, the vertical gain can differ from the horizontal gain, so restored boxes and keypoints were distorted and could be clipped at the image boundary.

## Validation

- `pytest tests/test_python.py::test_scale_coords_nonuniform_letterbox tests/test_python.py::test_utils_ops -q`
- `pytest tests/test_python.py -q` (132 passed, 2 skipped; the two NDJSON cases initially lacked `aiohttp`)
- `pytest 'tests/test_python.py::test_ndjson_conversion_concurrency_and_resume[detect]' 'tests/test_python.py::test_ndjson_conversion_concurrency_and_resume[classify]' -q` after installing `aiohttp` (2 passed)
- `ruff format --check ultralytics/data/augment.py ultralytics/utils/ops.py tests/test_python.py`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated ratio-pad handling and coordinate restoration to preserve independent height and width resize gains during nonuniform preprocessing.

### 📊 Key Changes
- Composes existing dataset resize gains with `LetterBox` per-axis ratios when storing `ratio_pad`.
- Updates `scale_boxes` and `scale_coords` to apply separate vertical and horizontal gains.
- Preserves existing uniform-scaling behavior when `ratio_pad` is calculated from image shapes.
- Adds regression coverage for stretched `LetterBox` preprocessing and restored boxes and coordinates.

### 🎯 Purpose & Impact
Boxes and coordinates are restored correctly after stretched preprocessing such as `scale_fill=True`, preventing distortion and incorrect clipping at image boundaries.