### PR TITLE
Fix macOS metadata directory cleanup

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1026,10 +1026,17 @@ def test_data_utils(tmp_path):
     images_dir = tmp_path / "coco8/images/val"
     images_dir.mkdir(parents=True)
     Image.new("RGB", (8, 8)).save(images_dir / "test.jpg")
+    metadata_dir = images_dir / "__MACOSX"
+    metadata_dir.mkdir()
+    metadata_file = images_dir / ".DS_Store"
+    metadata_file.write_bytes(b"metadata")
+    (metadata_dir / "._test.jpg").write_bytes(b"metadata")
 
     autosplit(tmp_path / "coco8/images")
     assert any((tmp_path / "coco8").glob("autosplit_*.txt"))
     assert zip_directory(images_dir).is_file()
+    assert not metadata_dir.exists()
+    assert not metadata_file.exists()
     with pytest.raises(ValueError, match="split"):
         check_cls_dataset("imagenet10", split="invalid")
     with pytest.raises(FileNotFoundError, match="'test:' images not found"):

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1028,9 +1028,12 @@ def test_data_utils(tmp_path):
     Image.new("RGB", (8, 8)).save(images_dir / "test.jpg")
     metadata_dir = images_dir / "__MACOSX"
     metadata_dir.mkdir()
+    nested_metadata_dir = metadata_dir / "nested/__MACOSX"
+    nested_metadata_dir.mkdir(parents=True)
     metadata_file = images_dir / ".DS_Store"
     metadata_file.write_bytes(b"metadata")
     (metadata_dir / "._test.jpg").write_bytes(b"metadata")
+    (nested_metadata_dir / "._nested.jpg").write_bytes(b"metadata")
 
     autosplit(tmp_path / "coco8/images")
     assert any((tmp_path / "coco8").glob("autosplit_*.txt"))

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -76,11 +76,11 @@ def is_url(url: str | Path, check: bool = False) -> bool:
 
 
 def delete_dsstore(path: str | Path, files_to_delete: tuple[str, ...] = (".DS_Store", "__MACOSX")) -> None:
-    """Delete all specified system files in a directory.
+    """Delete all specified system files and directories in a directory.
 
     Args:
         path (str | Path): The directory path where the files should be deleted.
-        files_to_delete (tuple[str, ...]): The files to be deleted.
+        files_to_delete (tuple[str, ...]): Names of files and directories to delete.
 
     Examples:
         >>> from ultralytics.utils.downloads import delete_dsstore
@@ -94,7 +94,10 @@ def delete_dsstore(path: str | Path, files_to_delete: tuple[str, ...] = (".DS_St
         matches = list(Path(path).rglob(file))
         LOGGER.info(f"Deleting {file} files: {matches}")
         for f in matches:
-            f.unlink()
+            if f.is_dir() and not f.is_symlink():
+                shutil.rmtree(f)
+            else:
+                f.unlink()
 
 
 def zip_directory(

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -91,7 +91,7 @@ def delete_dsstore(path: str | Path, files_to_delete: tuple[str, ...] = (".DS_St
         are hidden system files and can cause issues when transferring files between different operating systems.
     """
     for file in files_to_delete:
-        matches = list(Path(path).rglob(file))
+        matches = sorted(Path(path).rglob(file), key=lambda x: len(x.parts), reverse=True)
         LOGGER.info(f"Deleting {file} files: {matches}")
         for f in matches:
             if f.is_dir() and not f.is_symlink():


### PR DESCRIPTION
## Summary

- remove `__MACOSX` directories as well as `.DS_Store` files before dataset archives are created
- keep symbolic links on the existing unlink path instead of recursively following them
- extend the existing data utility test with real file and directory metadata entries

## Why

`zip_directory()` calls `delete_dsstore()` before creating an archive, and `__MACOSX` is one of the cleanup names enabled by default. The cleanup loop previously called `Path.unlink()` for every match, which raises when the match is a directory and prevents the archive from being created. This change uses `shutil.rmtree()` for real directories while retaining `unlink()` for files and links.

## Tests

- `pytest tests/test_python.py::test_data_utils -q --disable-warnings` — passed
- related download/archive tests — 4 passed
- `ruff format --check ultralytics/utils/downloads.py tests/test_python.py`
- `ruff check --ignore BLE001 ultralytics/utils/downloads.py tests/test_python.py`
- `python -m py_compile ultralytics/utils/downloads.py tests/test_python.py`
- `git diff --check`

AI assistance was used to help identify the edge case and prepare the focused patch. The behavior and test results were verified locally.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated dataset archive cleanup to safely remove macOS metadata directories and files, preventing directory unlink errors during archive creation.

### 📊 Key Changes
- Enhanced `delete_dsstore()` to remove real directories with `shutil.rmtree()`.
- Preserved `Path.unlink()` for files and symbolic links to avoid recursively following links.
- Extended `test_data_utils` with `__MACOSX`, `.DS_Store`, and AppleDouble metadata fixtures and cleanup assertions.

### 🎯 Purpose & Impact
Dataset archives can now be created when macOS metadata directories are present, while symbolic links retain the existing unlink behavior.