### PR TITLE
Use canonical PNG depth maps

### DIFF
--- a/docs/en/datasets/depth/arkitscenes.md
+++ b/docs/en/datasets/depth/arkitscenes.md
@@ -23,7 +23,7 @@ The ARKitScenes depth dataset is split into two subsets:
 1. **Train**: 676,080 images with paired depth maps for training.
 2. **Val**: 21,559 images with paired depth maps for validation during model training.
 
-Each sample consists of one RGB image and one paired `.npy` float32 depth map storing per-pixel distances in meters, following the [Ultralytics depth dataset format](index.md).
+Each sample consists of one RGB image and one paired 16-bit depth PNG storing per-pixel distances in meters, following the [Ultralytics depth dataset format](index.md).
 
 ## Obtain the Data
 
@@ -42,6 +42,7 @@ from pathlib import Path
 
 import cv2
 import numpy as np
+from ultralytics.data.utils import save_depth_png
 
 src, dst = Path("data/upsampling"), Path("datasets/depth-arkitscenes")
 for split, out in (("Training", "train"), ("Validation", "val")):
@@ -56,7 +57,7 @@ for split, out in (("Training", "train"), ("Validation", "val")):
             rgb = rgbs[min(rgbs, key=lambda k: abs(k - t))]  # nearest-timestamp RGB frame
             name = f"{video.name}_{depth_png.stem}"
             depth = cv2.imread(str(depth_png), cv2.IMREAD_UNCHANGED).astype(np.float32) / 1000.0  # mm → m
-            np.save(dst / f"depth/{out}/{name}.npy", depth)
+            save_depth_png(dst / f"depth/{out}/{name}.png", depth)
             cv2.imwrite(str(dst / f"images/{out}/{name}.png"), cv2.imread(str(rgb)))
 ```
 

--- a/docs/en/datasets/depth/arkitscenes.md
+++ b/docs/en/datasets/depth/arkitscenes.md
@@ -42,6 +42,7 @@ from pathlib import Path
 
 import cv2
 import numpy as np
+
 from ultralytics.data.utils import save_depth_png
 
 src, dst = Path("data/upsampling"), Path("datasets/depth-arkitscenes")

--- a/docs/en/datasets/depth/depth8.md
+++ b/docs/en/datasets/depth/depth8.md
@@ -19,7 +19,7 @@ The [Ultralytics](https://www.ultralytics.com/) Depth8 dataset is a compact [mon
 Depth8 follows the standard [Ultralytics depth dataset layout](index.md#supported-dataset-format): RGB images with paired 16-bit depth PNGs in meters, matched by file stem.
 
 ```text
-depth8/
+depth8-png/
 ├── images/
 │   ├── train/  # 4 images
 │   └── val/    # 4 images

--- a/docs/en/datasets/depth/depth8.md
+++ b/docs/en/datasets/depth/depth8.md
@@ -16,7 +16,7 @@ The [Ultralytics](https://www.ultralytics.com/) Depth8 dataset is a compact [mon
 
 ## Dataset Structure
 
-Depth8 follows the standard [Ultralytics depth dataset layout](index.md#supported-dataset-format): RGB images with paired `.npy` float32 depth maps in meters, matched by file stem.
+Depth8 follows the standard [Ultralytics depth dataset layout](index.md#supported-dataset-format): RGB images with paired 16-bit depth PNGs in meters, matched by file stem.
 
 ```text
 depth8/
@@ -24,8 +24,8 @@ depth8/
 │   ├── train/  # 4 images
 │   └── val/    # 4 images
 └── depth/
-    ├── train/  # 4 float32 .npy depth maps
-    └── val/    # 4 float32 .npy depth maps
+    ├── train/  # 4 16-bit PNG depth maps
+    └── val/    # 4 16-bit PNG depth maps
 ```
 
 Depth values are real indoor sensor captures ranging from roughly 0.5 m to 4 m, well within the ≤10 m range of the full SUN RGB-D dataset.
@@ -92,7 +92,7 @@ The Ultralytics Depth8 dataset is designed for rapid testing and debugging of [m
 
 ### How does Depth8 differ from the full SUN RGB-D dataset?
 
-Depth8 samples 8 images from SUN RGB-D's 9,245-train/1,090-val split, favoring Kinect v1/v2 captures with clean, dense depth maps. It uses the identical directory layout and `.npy` depth format, so a pipeline that runs on Depth8 runs unmodified on the full dataset — just point `data=` at `depth-sunrgbd.yaml` instead of `depth8.yaml`. Unlike the full dataset, Depth8 downloads in seconds and needs no conversion step.
+Depth8 samples 8 images from SUN RGB-D's 9,245-train/1,090-val split, favoring Kinect v1/v2 captures with clean, dense depth maps. It uses the identical 16-bit PNG depth format, so a pipeline that runs on Depth8 runs unmodified on the full dataset. Unlike the full dataset, Depth8 downloads in seconds and needs no conversion step.
 
 ### Should I use Depth8 for benchmarking?
 

--- a/docs/en/datasets/depth/diode.md
+++ b/docs/en/datasets/depth/diode.md
@@ -23,7 +23,7 @@ The DIODE depth dataset is split into two subsets:
 1. **Train**: 25,458 images with paired depth maps for training.
 2. **Val**: 771 images with paired depth maps for validation during model training.
 
-Each sample consists of one RGB image and one paired `.npy` float32 depth map storing per-pixel distances in meters, following the [Ultralytics depth dataset format](index.md).
+Each sample consists of one RGB image and one paired 16-bit depth PNG storing per-pixel distances in meters, following the [Ultralytics depth dataset format](index.md).
 
 ## Role in YOLO26-Depth
 

--- a/docs/en/datasets/depth/hypersim.md
+++ b/docs/en/datasets/depth/hypersim.md
@@ -25,7 +25,7 @@ The Hypersim depth dataset is split into two subsets:
 1. **Train**: 68,242 images with paired dense depth maps for training.
 2. **Val**: 6,377 images with paired dense depth maps for validation during training.
 
-Each RGB image is paired with a `.npy` float32 depth map storing per-pixel distances in meters, following the [Ultralytics depth dataset format](index.md).
+Each RGB image is paired with a 16-bit depth PNG storing per-pixel distances in meters, following the [Ultralytics depth dataset format](index.md).
 
 ## Obtain the Data
 
@@ -44,6 +44,7 @@ from pathlib import Path
 
 import h5py
 import numpy as np
+from ultralytics.data.utils import save_depth_png
 
 W, H, FOCAL = 1024, 768, 886.81  # Hypersim camera intrinsics
 x, y = np.meshgrid(np.linspace(-W / 2, W / 2, W), np.linspace(-H / 2, H / 2, H))
@@ -59,7 +60,7 @@ for h5 in sorted(src.rglob("*.depth_meters.hdf5")):
     dist = np.asarray(h5py.File(h5)["dataset"], np.float32)
     depth = np.nan_to_num(dist * ray2plane, nan=0.0)  # NaN (sky, glass) → 0 = invalid
     name = f"{scene}_{cam}_{frame}"
-    np.save(dst / f"depth/{out}/{name}.npy", depth)
+    save_depth_png(dst / f"depth/{out}/{name}.png", depth)
     shutil.copy(rgb, dst / f"images/{out}/{name}.jpg")
 ```
 

--- a/docs/en/datasets/depth/hypersim.md
+++ b/docs/en/datasets/depth/hypersim.md
@@ -44,6 +44,7 @@ from pathlib import Path
 
 import h5py
 import numpy as np
+
 from ultralytics.data.utils import save_depth_png
 
 W, H, FOCAL = 1024, 768, 886.81  # Hypersim camera intrinsics

--- a/docs/en/datasets/depth/imagenet-pseudo.md
+++ b/docs/en/datasets/depth/imagenet-pseudo.md
@@ -29,7 +29,7 @@ Because ImageNet ships without depth annotations, depth targets are produced off
 
 1. Each ImageNet training image is run through `depth-anything/DA3MONO-LARGE`, which predicts a highly detailed depth map that is only defined up to an unknown per-image scale and shift, and through `depth-anything/DA3METRIC-LARGE`, whose output is coarser but in real units.
 2. A per-image robust affine fit maps the monocular prediction onto the metric one, `label = a * mono + b`. Every per-pixel detail therefore comes from the monocular checkpoint, while the metric checkpoint only sets the two scalars that place the map on the meter axis. No camera intrinsics are involved, so images without calibration can be labeled.
-3. The result is saved as a `.npy` array in meters, following the [Ultralytics depth dataset format](index.md), and paired with its source image by file stem. These maps are stored as float16 to halve the on-disk footprint across 1.28M files; the dataset loader casts them to float32 on read, and float32 remains the documented format for custom depth datasets.
+3. The result is saved as a self-describing 16-bit PNG in meters, following the [Ultralytics depth dataset format](index.md), and paired with its source image by file stem.
 4. The pseudo-labeled pairs are then added as one component of a larger training mix, where a student YOLO26-Depth model learns to match the teacher while also training on real ground-truth sources.
 
 Because the scale comes from a prediction rather than a measurement, each map can carry a global scale error. YOLO26-Depth trains with a scale-invariant log (SILog) loss plus gradient matching and validates with median alignment, so a per-image scale offset in the pseudo labels is largely absorbed.

--- a/docs/en/datasets/depth/index.md
+++ b/docs/en/datasets/depth/index.md
@@ -1,24 +1,24 @@
 ---
 comments: true
-description: Learn how to prepare depth estimation datasets for Ultralytics YOLO, including .npy depth maps, dataset YAML fields, directory layout, and supported datasets.
-keywords: Ultralytics, YOLO, depth estimation, depth dataset format, npy depth maps, NYU Depth V2, monocular depth, per-pixel depth
+description: Learn how to prepare depth estimation datasets for Ultralytics YOLO, including 16-bit PNG depth maps, dataset YAML fields, directory layout, and supported datasets.
+keywords: Ultralytics, YOLO, depth estimation, depth dataset format, PNG depth maps, NYU Depth V2, monocular depth, per-pixel depth
 ---
 
 # Depth Estimation Datasets Overview
 
-Monocular depth estimation assigns a floating-point depth value in meters to every pixel in an image. The training target is a dense per-pixel depth map stored as a `.npy` float32 array. Each value represents the distance from the camera to the corresponding scene point.
+Monocular depth estimation assigns a depth value in meters to every pixel in an image. The training target is a self-describing 16-bit grayscale PNG that stores its linear meter range in PNG metadata.
 
 This guide explains the dataset format used by Ultralytics YOLO depth estimation models and lists the built-in dataset configurations available for training and validation.
 
 ## Supported Dataset Format
 
-### NPY depth map format
+### PNG depth map format
 
-Each training sample consists of one RGB image and one paired `.npy` depth file. The depth file stores a 2D float32 NumPy array with shape `(H, W)` where values are depths in meters.
+Each training sample consists of one RGB image and one paired `.png` depth file. Code `0` means invalid; writers use codes `256–65535` to linearly cover the valid per-image minimum and maximum stored in the PNG metadata. Starting at 256 preserves the nearest valid band when browsers display the same 16-bit asset as 8-bit.
 
-- Depth files must use the `.npy` extension and contain a float32 array.
-- Each depth file should have the same stem as its matching image file (e.g., `scene_001.npy` pairs with `scene_001.jpg`).
-- The dataset loader finds depth files by replacing the `images` directory component with `depth` in the file path and swapping the image extension for `.npy`.
+- Depth files use the `.png` extension and the Ultralytics `linear-u16` metadata convention.
+- Each depth file should have the same stem as its matching image file (e.g., `scene_001.png` pairs with `scene_001.jpg`).
+- The dataset loader finds depth files by replacing the `images` directory component with `depth` and swapping the image extension for `.png`.
 - Pixels with depth `≤ 0` are treated as invalid and excluded from loss and metric computation.
 
 The standard layout keeps images and depth maps in parallel folders:
@@ -33,7 +33,7 @@ dataset/
     └── val/
 ```
 
-For example, an image at `images/train/scene_001.jpg` is paired with a depth map at `depth/train/scene_001.npy`.
+For example, an image at `images/train/scene_001.jpg` is paired with a depth map at `depth/train/scene_001.png`.
 
 ### Dataset YAML format
 
@@ -110,7 +110,7 @@ Per-model accuracy on these benchmarks and the downloadable pretrained weights a
 ## Adding Your Own Dataset
 
 1. Save RGB images under split folders such as `images/train` and `images/val`.
-2. Save one `.npy` float32 depth array per image under the matching `depth/train` and `depth/val` folders using the same file stem as the image.
+2. Save one 16-bit depth PNG per image under the matching `depth/train` and `depth/val` folders using the same file stem as the image. Use `save_depth_png()` to write the required metadata.
 3. Ensure depth values are in meters and that invalid or missing pixels use `0` or negative values.
 4. Create a dataset YAML with `path`, `train`, `val`, `nc: 1`, and `names: {0: depth}`.
 
@@ -128,7 +128,7 @@ names:
 
 ### What file format should depth maps use?
 
-Depth maps must be saved as NumPy `.npy` files containing float32 arrays of shape `(H, W)`. Each element stores the depth in meters for the corresponding image pixel. Do not use PNG or 16-bit integer formats — the loader expects raw float arrays.
+Depth maps must be self-describing 16-bit PNGs written with `ultralytics.data.utils.save_depth_png()`. The loader reconstructs meter-valued float32 arrays and preserves code `0` as invalid.
 
 ### How are invalid depth pixels handled?
 
@@ -145,4 +145,4 @@ Depth estimation validation reports the standard Depth Anything metric set:
 
 ### Do depth file names need to match image file names?
 
-Yes. Each depth `.npy` file must share the same stem as the corresponding image. The loader derives the depth path by replacing the `images` directory component with `depth` and substituting the image extension for `.npy`. Images whose depth file is missing or unreadable are dropped during the (cached) dataset scan with a warning, exactly like corrupt images; if no valid image-depth pairs are found at all, an error is raised.
+Yes. Each depth `.png` file must share the same stem as the corresponding image. The loader derives the depth path by replacing the `images` directory component with `depth` and substituting the image extension for `.png`. Images whose depth file is missing or unreadable are dropped during the cached dataset scan with a warning.

--- a/docs/en/datasets/depth/kitti.md
+++ b/docs/en/datasets/depth/kitti.md
@@ -14,7 +14,7 @@ The [KITTI](https://www.cvlibs.net/datasets/kitti/) dataset is a real-world outd
 - Depth ground truth obtained from a Velodyne HDL-64 LiDAR and densified with the [Sparsity Invariant CNNs](https://arxiv.org/abs/1708.06500) approach of Uhrig et al. 2017.
 - Sparse supervision: only about 16–20% of pixels per image carry a valid depth value; invalid pixels are masked out of the loss and metrics.
 - Stereo image pairs (left `image_02` and right `image_03`) provide additional viewpoints for training.
-- Depth values are stored as `.npy` float32 arrays in meters, following the [Ultralytics depth dataset format](index.md).
+- Depth values are stored as 16-bit PNGs in meters, following the [Ultralytics depth dataset format](index.md).
 
 ## Dataset Structure
 

--- a/docs/en/datasets/depth/sunrgbd.md
+++ b/docs/en/datasets/depth/sunrgbd.md
@@ -23,7 +23,7 @@ The SUN RGB-D depth dataset is split into two subsets:
 1. **Train**: 9,245 images with paired depth maps for training.
 2. **Val**: 1,090 images with paired depth maps for validation during model training.
 
-Each sample consists of one RGB image and one paired `.npy` float32 depth map storing per-pixel distances in meters, following the [Ultralytics depth dataset format](index.md).
+Each sample consists of one RGB image and one paired 16-bit depth PNG storing per-pixel distances in meters, following the [Ultralytics depth dataset format](index.md).
 
 ## Role in YOLO26-Depth
 

--- a/docs/en/datasets/depth/tartanair.md
+++ b/docs/en/datasets/depth/tartanair.md
@@ -25,7 +25,7 @@ The TartanAir depth dataset is split into two subsets:
 1. **Train**: 55,660 images with paired dense depth maps for training.
 2. **Val**: 5,810 images with paired dense depth maps for validation during training.
 
-Each RGB image is paired with a `.npy` float32 depth map storing per-pixel distances in meters, following the [Ultralytics depth dataset format](index.md).
+Each RGB image is paired with a 16-bit depth PNG storing per-pixel distances in meters, following the [Ultralytics depth dataset format](index.md).
 
 ## Obtain the Data
 
@@ -43,6 +43,7 @@ import shutil
 from pathlib import Path
 
 import numpy as np
+from ultralytics.data.utils import save_depth_png
 
 VAL_ENVS = {"neighborhood"}  # environments held out for validation
 src, dst = Path("data"), Path("datasets/depth-tartanair")
@@ -55,7 +56,7 @@ for depth_file in sorted(src.rglob("depth_left/*_left_depth.npy")):
     depth[depth > 80.0] = 0.0  # sky/extreme range → 0 = invalid
     frame = depth_file.name.replace("_depth.npy", "")  # e.g. 000000_left
     name = f"{env}_{traj}_{frame}"
-    np.save(dst / f"depth/{out}/{name}.npy", depth)
+    save_depth_png(dst / f"depth/{out}/{name}.png", depth)
     shutil.copy(depth_file.parents[1] / "image_left" / f"{frame}.png", dst / f"images/{out}/{name}.png")
 ```
 

--- a/docs/en/datasets/depth/tartanair.md
+++ b/docs/en/datasets/depth/tartanair.md
@@ -43,6 +43,7 @@ import shutil
 from pathlib import Path
 
 import numpy as np
+
 from ultralytics.data.utils import save_depth_png
 
 VAL_ENVS = {"neighborhood"}  # environments held out for validation

--- a/docs/en/datasets/depth/vkitti2.md
+++ b/docs/en/datasets/depth/vkitti2.md
@@ -26,7 +26,7 @@ The Virtual KITTI 2 depth dataset is split into two subsets:
 1. **Train**: 25,780 images with paired dense depth maps for training.
 2. **Val**: 16,740 images with paired dense depth maps for validation during training.
 
-Each RGB image is paired with a `.npy` float32 depth map storing per-pixel distances in meters, following the [Ultralytics depth dataset format](index.md).
+Each RGB image is paired with a 16-bit depth PNG storing per-pixel distances in meters, following the [Ultralytics depth dataset format](index.md).
 
 ## Role in YOLO26-Depth
 

--- a/docs/en/reference/data/utils.md
+++ b/docs/en/reference/data/utils.md
@@ -12,6 +12,18 @@ keywords: Ultralytics, dataset utils, data handling, image verification, Python,
 
 <br>
 
+## ::: ultralytics.data.utils.save_depth_png
+
+<br><br><hr><br>
+
+## ::: ultralytics.data.utils.load_depth
+
+<br><br><hr><br>
+
+## ::: ultralytics.data.utils.verify_depth
+
+<br><br><hr><br>
+
 ## ::: ultralytics.data.utils.img2label_paths
 
 <br><br><hr><br>

--- a/docs/en/reference/data/utils.md
+++ b/docs/en/reference/data/utils.md
@@ -20,10 +20,6 @@ keywords: Ultralytics, dataset utils, data handling, image verification, Python,
 
 <br><br><hr><br>
 
-## ::: ultralytics.data.utils.verify_depth
-
-<br><br><hr><br>
-
 ## ::: ultralytics.data.utils.img2label_paths
 
 <br><br><hr><br>

--- a/docs/en/tasks/depth.md
+++ b/docs/en/tasks/depth.md
@@ -207,7 +207,7 @@ The released `yolo26*-depth.pt` checkpoints ship with this calibration already b
 
 ### Dataset format
 
-Depth estimation datasets pair each RGB image with a corresponding depth file. Depth targets are stored as `.npy` arrays containing float32 values in meters. The dataset YAML points to an `images/` directory; the loader derives the depth file path by replacing the `images` component with `depth` and replacing the image extension with `.npy`.
+Depth estimation datasets pair each RGB image with a corresponding self-describing 16-bit depth PNG. The dataset YAML points to an `images/` directory; the loader derives the depth path by replacing the `images` component with `depth` and the image extension with `.png`.
 
 ```text
 dataset/
@@ -219,7 +219,7 @@ dataset/
     └── val/
 ```
 
-For example, an image at `images/train/scene_001.jpg` is paired with a depth map at `depth/train/scene_001.npy`. See the [Depth Estimation Dataset Guide](../datasets/depth/index.md) for the full format specification.
+For example, an image at `images/train/scene_001.jpg` is paired with a depth map at `depth/train/scene_001.png`. See the [Depth Estimation Dataset Guide](../datasets/depth/index.md) for the full format specification.
 
 ## Val
 
@@ -373,7 +373,7 @@ See full `export` details in the [Export](../modes/export.md) page.
 
 ### How do I train a YOLO26 depth estimation model on a custom dataset?
 
-Prepare paired RGB images and `.npy` depth files, then create a dataset YAML pointing to your `images/` directory. The loader finds depth files automatically by replacing `images` with `depth` in the path and swapping the image extension for `.npy`.
+Prepare paired RGB images and 16-bit depth PNGs, then create a dataset YAML pointing to your `images/` directory. The loader finds depth files automatically by replacing `images` with `depth` in the path and swapping the image extension for `.png`.
 
 Start from pretrained weights and use a low learning rate with AdamW so the fine-tune retains what the model already knows (see [Fine-tuning on your own data](#fine-tuning-on-your-own-data) for why):
 

--- a/tests/test_ndjson_converter.py
+++ b/tests/test_ndjson_converter.py
@@ -23,8 +23,7 @@ class _QuietHandler(SimpleHTTPRequestHandler):
         pass
 
 
-def _write_manifest(path, base_url, *, missing_depth=False, encoding="png-u16-linear"):
-    suffix = "png" if encoding == "png-u16-linear" else "npy"
+def _write_manifest(path, base_url, *, missing_depth=False):
     records = [
         {"type": "dataset", "task": "depth"},
         {
@@ -33,10 +32,10 @@ def _write_manifest(path, base_url, *, missing_depth=False, encoding="png-u16-li
             "url": f"{base_url}/train.jpg?signature=image",
             "split": "train",
             "depth": {
-                "url": f"{base_url}/train.{suffix}?signature=depth",
+                "url": f"{base_url}/train.png?signature=depth",
                 "hash": "depth-train",
                 "shape": [3, 4],
-                "encoding": encoding,
+                "encoding": "png-u16-linear",
                 "unit": "m",
             },
         },
@@ -46,10 +45,10 @@ def _write_manifest(path, base_url, *, missing_depth=False, encoding="png-u16-li
             "url": f"{base_url}/test.jpg?signature=image",
             "split": "val",
             "depth": {
-                "url": f"{base_url}/missing.{suffix}" if missing_depth else f"{base_url}/test.{suffix}?signature=depth",
+                "url": f"{base_url}/missing.png" if missing_depth else f"{base_url}/test.png?signature=depth",
                 "hash": "depth-test",
                 "shape": [3, 4],
-                "encoding": encoding,
+                "encoding": "png-u16-linear",
                 "unit": "m",
             },
         },
@@ -66,7 +65,6 @@ def depth_server(tmp_path):
     for split, value in (("train", 0), ("test", 255)):
         cv2.imwrite(str(source / f"{split}.jpg"), np.full((3, 4, 3), value, dtype=np.uint8))
         save_depth_png(source / f"{split}.png", depth)
-        np.save(source / f"{split}.npy", depth)
     server = ThreadingHTTPServer(("127.0.0.1", 0), partial(_QuietHandler, directory=source))
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -96,18 +94,6 @@ def test_convert_depth_ndjson_downloads_image_target_pairs(tmp_path, depth_serve
     for index, split in enumerate(("train", "val"), 1):
         assert (yaml_path.parent / "images" / split / f"{index}.jpg").is_file()
         np.testing.assert_allclose(load_depth(yaml_path.parent / "depth" / split / f"{index}.png"), depth, atol=1e-3)
-
-
-def test_convert_depth_ndjson_accepts_legacy_npy_during_rollout(tmp_path, depth_server):
-    """Keep existing Portal versions trainable until their backfill completes."""
-    base_url, depth = depth_server
-    manifest = tmp_path / "legacy.ndjson"
-    _write_manifest(manifest, base_url, encoding="npy-f32")
-
-    yaml_path = asyncio.run(convert_ndjson_to_yolo(manifest, tmp_path / "datasets"))
-
-    for index, split in enumerate(("train", "val"), 1):
-        np.testing.assert_array_equal(np.load(yaml_path.parent / "depth" / split / f"{index}.npy"), depth)
 
 
 def test_convert_depth_ndjson_reuses_existing_conversion(tmp_path, depth_server, monkeypatch):
@@ -160,7 +146,7 @@ def test_convert_depth_ndjson_rejects_incomplete_descriptor(tmp_path):
     ]
     manifest.write_text("\n".join(json.dumps(record) for record in records))
 
-    with pytest.raises(ValueError, match="supported encoding and unit='m'"):
+    with pytest.raises(ValueError, match="encoding='png-u16-linear' and unit='m'"):
         asyncio.run(convert_ndjson_to_yolo(manifest, tmp_path / "datasets"))
 
 

--- a/tests/test_ndjson_converter.py
+++ b/tests/test_ndjson_converter.py
@@ -12,6 +12,7 @@ import numpy as np
 import pytest
 
 from ultralytics.data.converter import convert_ndjson_to_yolo
+from ultralytics.data.utils import load_depth, save_depth_png
 from ultralytics.utils import YAML
 
 
@@ -22,7 +23,8 @@ class _QuietHandler(SimpleHTTPRequestHandler):
         pass
 
 
-def _write_manifest(path, base_url, *, missing_depth=False):
+def _write_manifest(path, base_url, *, missing_depth=False, encoding="png-u16-linear"):
+    suffix = "png" if encoding == "png-u16-linear" else "npy"
     records = [
         {"type": "dataset", "task": "depth"},
         {
@@ -31,10 +33,10 @@ def _write_manifest(path, base_url, *, missing_depth=False):
             "url": f"{base_url}/train.jpg?signature=image",
             "split": "train",
             "depth": {
-                "url": f"{base_url}/train.npy?signature=depth",
+                "url": f"{base_url}/train.{suffix}?signature=depth",
                 "hash": "depth-train",
                 "shape": [3, 4],
-                "encoding": "npy-f32",
+                "encoding": encoding,
                 "unit": "m",
             },
         },
@@ -44,10 +46,10 @@ def _write_manifest(path, base_url, *, missing_depth=False):
             "url": f"{base_url}/test.jpg?signature=image",
             "split": "val",
             "depth": {
-                "url": f"{base_url}/missing.npy" if missing_depth else f"{base_url}/test.npy?signature=depth",
+                "url": f"{base_url}/missing.{suffix}" if missing_depth else f"{base_url}/test.{suffix}?signature=depth",
                 "hash": "depth-test",
                 "shape": [3, 4],
-                "encoding": "npy-f32",
+                "encoding": encoding,
                 "unit": "m",
             },
         },
@@ -63,6 +65,7 @@ def depth_server(tmp_path):
     depth = np.arange(12, dtype=np.float32).reshape(3, 4)
     for split, value in (("train", 0), ("test", 255)):
         cv2.imwrite(str(source / f"{split}.jpg"), np.full((3, 4, 3), value, dtype=np.uint8))
+        save_depth_png(source / f"{split}.png", depth)
         np.save(source / f"{split}.npy", depth)
     server = ThreadingHTTPServer(("127.0.0.1", 0), partial(_QuietHandler, directory=source))
     thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -92,6 +95,18 @@ def test_convert_depth_ndjson_downloads_image_target_pairs(tmp_path, depth_serve
     assert not (yaml_path.parent / "labels").exists()
     for index, split in enumerate(("train", "val"), 1):
         assert (yaml_path.parent / "images" / split / f"{index}.jpg").is_file()
+        np.testing.assert_allclose(load_depth(yaml_path.parent / "depth" / split / f"{index}.png"), depth, atol=1e-3)
+
+
+def test_convert_depth_ndjson_accepts_legacy_npy_during_rollout(tmp_path, depth_server):
+    """Keep existing Portal versions trainable until their backfill completes."""
+    base_url, depth = depth_server
+    manifest = tmp_path / "legacy.ndjson"
+    _write_manifest(manifest, base_url, encoding="npy-f32")
+
+    yaml_path = asyncio.run(convert_ndjson_to_yolo(manifest, tmp_path / "datasets"))
+
+    for index, split in enumerate(("train", "val"), 1):
         np.testing.assert_array_equal(np.load(yaml_path.parent / "depth" / split / f"{index}.npy"), depth)
 
 
@@ -106,7 +121,7 @@ def test_convert_depth_ndjson_reuses_existing_conversion(tmp_path, depth_server,
     assert asyncio.run(convert_ndjson_to_yolo(manifest, tmp_path / "datasets")) == yaml_path
 
     monkeypatch.undo()
-    depth_path = yaml_path.parent / "depth" / "val" / "2.npy"
+    depth_path = yaml_path.parent / "depth" / "val" / "2.png"
     depth_path.unlink()
     data = YAML.load(yaml_path)
     data.pop("complete")
@@ -126,7 +141,7 @@ def test_convert_depth_ndjson_removes_incomplete_pair(tmp_path, depth_server):
 
     dataset_dir = next(p for p in (tmp_path / "datasets").iterdir() if p.is_dir())
     assert not (dataset_dir / "images" / "val" / "2.jpg").exists()
-    assert not (dataset_dir / "depth" / "val" / "2.npy").exists()
+    assert not (dataset_dir / "depth" / "val" / "2.png").exists()
     assert not (dataset_dir / "data.yaml").exists()
 
 
@@ -140,12 +155,12 @@ def test_convert_depth_ndjson_rejects_incomplete_descriptor(tmp_path):
             "file": "train.jpg",
             "url": "http://127.0.0.1:1/train.jpg",
             "split": "train",
-            "depth": {"url": "http://127.0.0.1:1/train.npy", "shape": [3, 4], "encoding": "npy-f32"},
+            "depth": {"url": "http://127.0.0.1:1/train.png", "shape": [3, 4], "encoding": "png-u16-linear"},
         },
     ]
     manifest.write_text("\n".join(json.dumps(record) for record in records))
 
-    with pytest.raises(ValueError, match="encoding='npy-f32' and unit='m'"):
+    with pytest.raises(ValueError, match="supported encoding and unit='m'"):
         asyncio.run(convert_ndjson_to_yolo(manifest, tmp_path / "datasets"))
 
 

--- a/tests/test_ndjson_converter.py
+++ b/tests/test_ndjson_converter.py
@@ -35,7 +35,7 @@ def _write_manifest(path, base_url, *, missing_depth=False):
                 "url": f"{base_url}/train.png?signature=depth",
                 "hash": "depth-train",
                 "shape": [3, 4],
-                "encoding": "png-u16-linear",
+                "encoding": "linear-u16",
                 "unit": "m",
             },
         },
@@ -48,7 +48,7 @@ def _write_manifest(path, base_url, *, missing_depth=False):
                 "url": f"{base_url}/missing.png" if missing_depth else f"{base_url}/test.png?signature=depth",
                 "hash": "depth-test",
                 "shape": [3, 4],
-                "encoding": "png-u16-linear",
+                "encoding": "linear-u16",
                 "unit": "m",
             },
         },
@@ -141,12 +141,12 @@ def test_convert_depth_ndjson_rejects_incomplete_descriptor(tmp_path):
             "file": "train.jpg",
             "url": "http://127.0.0.1:1/train.jpg",
             "split": "train",
-            "depth": {"url": "http://127.0.0.1:1/train.png", "shape": [3, 4], "encoding": "png-u16-linear"},
+            "depth": {"url": "http://127.0.0.1:1/train.png", "shape": [3, 4], "encoding": "linear-u16"},
         },
     ]
     manifest.write_text("\n".join(json.dumps(record) for record in records))
 
-    with pytest.raises(ValueError, match="encoding='png-u16-linear' and unit='m'"):
+    with pytest.raises(ValueError, match="encoding='linear-u16' and unit='m'"):
         asyncio.run(convert_ndjson_to_yolo(manifest, tmp_path / "datasets"))
 
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1267,19 +1267,59 @@ def test_depth_trainer_records_portable_calibration_split(tmp_path, monkeypatch,
 def test_depth_dataset_ignores_unreadable_targets(tmp_path):
     """Drop unreadable depth maps and accept single-class mode with empty class labels."""
     from ultralytics.data.dataset import DepthDataset
+    from ultralytics.data.utils import save_depth_png
 
     images, depth = tmp_path / "images" / "train", tmp_path / "depth" / "train"
     images.mkdir(parents=True)
     depth.mkdir(parents=True)
     for name in ("valid", "corrupt", "missing"):
         cv2.imwrite(str(images / f"{name}.jpg"), np.zeros((32, 32, 3), np.uint8))
-    np.save(depth / "valid.npy", np.ones((32, 32), dtype=np.float32))
-    (depth / "corrupt.npy").write_text("not an npy file")
+    save_depth_png(depth / "valid.png", np.ones((32, 32), dtype=np.float32))
+    (depth / "corrupt.png").write_text("not a png file")
 
     data = {"names": {0: "depth"}, "nc": 1, "channels": 3}
     ds = DepthDataset(img_path=str(images), imgsz=32, data=data, augment=False, single_cls=True, batch_size=1)
     assert [Path(f).stem for f in ds.im_files] == ["valid"]
     assert (depth.parent / "train.cache").exists()  # scan results cached next to the depth maps
+
+
+def test_depth_dataset_keeps_targets_paired_after_rect_sort(tmp_path):
+    """Carry each verified depth path with its label when rectangular loading reorders images."""
+    from ultralytics.data.dataset import DepthDataset
+    from ultralytics.data.utils import save_depth_png
+
+    images, depths = tmp_path / "images" / "val", tmp_path / "depth" / "val"
+    images.mkdir(parents=True)
+    depths.mkdir(parents=True)
+    for name, shape, value in (("wide", (32, 64), 1.0), ("tall", (64, 32), 2.0)):
+        cv2.imwrite(str(images / f"{name}.jpg"), np.zeros((*shape, 3), dtype=np.uint8))
+        save_depth_png(depths / f"{name}.png", np.full(shape, value, dtype=np.float32))
+
+    data = {"names": {0: "depth"}, "nc": 1, "channels": 3}
+    dataset = DepthDataset(
+        img_path=str(images), imgsz=64, data=data, augment=False, rect=True, single_cls=True, batch_size=1
+    )
+
+    for index, image_path in enumerate(dataset.im_files):
+        assert Path(dataset.depth_by_image[image_path]).stem == Path(image_path).stem
+        expected = 1.0 if Path(image_path).stem == "wide" else 2.0
+        np.testing.assert_allclose(dataset._load_depth(index), expected)
+
+
+def test_depth_png_round_trip(tmp_path):
+    """Preserve invalid pixels and bound linear uint16 quantization error."""
+    from ultralytics.data.utils import load_depth, save_depth_png
+
+    source = np.array([[0.0, 0.5, 1.0], [10.0, 40.0, 80.0]], dtype=np.float32)
+    path = tmp_path / "depth.png"
+    save_depth_png(path, source)
+    restored = load_depth(path)
+
+    with Image.open(path) as image:
+        codes = np.asarray(image, dtype=np.uint16)
+    assert codes[source > 0].min() >= 256  # nearest values survive browser uint16 → uint8 display
+    assert restored[0, 0] == 0
+    np.testing.assert_allclose(restored[source > 0], source[source > 0], atol=(80.0 - 0.5) / (65535 - 256))
 
 
 def test_utils_init():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1283,22 +1283,6 @@ def test_depth_dataset_ignores_unreadable_targets(tmp_path):
     assert (depth.parent / "train.cache").exists()  # scan results cached next to the depth maps
 
 
-def test_depth_png_round_trip(tmp_path):
-    """Preserve invalid pixels and bound linear uint16 quantization error."""
-    from ultralytics.data.utils import load_depth, save_depth_png
-
-    source = np.array([[0.0, 0.5, 1.0], [10.0, 40.0, 80.0]], dtype=np.float32)
-    path = tmp_path / "depth.png"
-    save_depth_png(path, source)
-    restored = load_depth(path)
-
-    with Image.open(path) as image:
-        codes = np.asarray(image, dtype=np.uint16)
-    assert codes[source > 0].min() >= 256  # nearest values survive browser uint16 → uint8 display
-    assert restored[0, 0] == 0
-    np.testing.assert_allclose(restored[source > 0], source[source > 0], atol=(80.0 - 0.5) / (65535 - 256))
-
-
 def test_utils_init():
     """Test initialization utilities in the Ultralytics library."""
     from ultralytics.utils import get_ubuntu_version, is_github_action_running

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1283,29 +1283,6 @@ def test_depth_dataset_ignores_unreadable_targets(tmp_path):
     assert (depth.parent / "train.cache").exists()  # scan results cached next to the depth maps
 
 
-def test_depth_dataset_keeps_targets_paired_after_rect_sort(tmp_path):
-    """Carry each verified depth path with its label when rectangular loading reorders images."""
-    from ultralytics.data.dataset import DepthDataset
-    from ultralytics.data.utils import save_depth_png
-
-    images, depths = tmp_path / "images" / "val", tmp_path / "depth" / "val"
-    images.mkdir(parents=True)
-    depths.mkdir(parents=True)
-    for name, shape, value in (("wide", (32, 64), 1.0), ("tall", (64, 32), 2.0)):
-        cv2.imwrite(str(images / f"{name}.jpg"), np.zeros((*shape, 3), dtype=np.uint8))
-        save_depth_png(depths / f"{name}.png", np.full(shape, value, dtype=np.float32))
-
-    data = {"names": {0: "depth"}, "nc": 1, "channels": 3}
-    dataset = DepthDataset(
-        img_path=str(images), imgsz=64, data=data, augment=False, rect=True, single_cls=True, batch_size=1
-    )
-
-    for index, image_path in enumerate(dataset.im_files):
-        assert Path(dataset.depth_by_image[image_path]).stem == Path(image_path).stem
-        expected = 1.0 if Path(image_path).stem == "wide" else 2.0
-        np.testing.assert_allclose(dataset._load_depth(index), expected)
-
-
 def test_depth_png_round_trip(tmp_path):
     """Preserve invalid pixels and bound linear uint16 quantization error."""
     from ultralytics.data.utils import load_depth, save_depth_png

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.121"
+__version__ = "8.4.122"
 
 import importlib
 import os

--- a/ultralytics/cfg/datasets/depth-arkitscenes.yaml
+++ b/ultralytics/cfg/datasets/depth-arkitscenes.yaml
@@ -9,7 +9,7 @@
 # └── datasets
 #     └── depth-arkitscenes
 #         ├── images/{train,val}  # RGB images
-#         └── depth/{train,val}   # paired *.npy, float32 meters (images/ -> depth/)
+#         └── depth/{train,val}   # paired 16-bit *.png depth maps (images/ -> depth/)
 
 path: depth-arkitscenes # dataset root dir (relative to Ultralytics settings 'datasets_dir')
 train: images/train # train images (relative to 'path') 676080 images

--- a/ultralytics/cfg/datasets/depth-diode.yaml
+++ b/ultralytics/cfg/datasets/depth-diode.yaml
@@ -8,7 +8,7 @@
 # └── datasets
 #     └── depth-diode  ← downloads here (84 GB archives, ~90 GB converted)
 #         ├── images/{train,val}  # RGB images
-#         └── depth/{train,val}   # paired *.npy, float32 meters (images/ -> depth/)
+#         └── depth/{train,val}   # paired 16-bit *.png depth maps (images/ -> depth/)
 # If an interrupted download leaves a partial dataset, delete the depth-diode dir and re-run to rebuild it.
 
 path: depth-diode # dataset root dir (relative to Ultralytics settings 'datasets_dir')
@@ -29,12 +29,13 @@ download: |
 
   import numpy as np
 
+  from ultralytics.data.utils import save_depth_png
   from ultralytics.utils import TQDM
   from ultralytics.utils.downloads import download
 
   # Download and extract the official archives (train ~81 GB, val ~2.6 GB), then convert:
   # flatten <split>/<scene>/<scan>/*.png into images/<split>/ and save the paired *_depth.npy
-  # (masked invalid -> 0, clipped at 80 m) as depth/<split>/*.npy
+  # (masked invalid -> 0, clipped at 80 m) as depth/<split>/*.png
   dir = Path(yaml["path"])  # dataset root dir
   download([f"https://diode-dataset.s3.amazonaws.com/{s}.tar.gz" for s in ("train", "val")], dir=dir / "source", delete=True)
   for split in ("train", "val"):
@@ -44,6 +45,6 @@ download: |
           name = "_".join(im.relative_to(dir / "source").parts)  # train/indoors/scene/scan/x.png -> train_indoors_scene_scan_x.png
           depth = np.load(im.with_name(f"{im.stem}_depth.npy")).squeeze().astype(np.float32)
           depth[np.load(im.with_name(f"{im.stem}_depth_mask.npy")) == 0] = 0.0  # zero out invalid pixels
-          np.save(dir / "depth" / split / f"{name[:-4]}.npy", depth.clip(max=80))
+          save_depth_png(dir / "depth" / split / f"{name[:-4]}.png", depth.clip(max=80))
           im.replace(dir / "images" / split / name)
   shutil.rmtree(dir / "source")

--- a/ultralytics/cfg/datasets/depth-hypersim.yaml
+++ b/ultralytics/cfg/datasets/depth-hypersim.yaml
@@ -9,7 +9,7 @@
 # └── datasets
 #     └── depth-hypersim
 #         ├── images/{train,val}  # RGB images
-#         └── depth/{train,val}   # paired *.npy, float32 meters (images/ -> depth/)
+#         └── depth/{train,val}   # paired 16-bit *.png depth maps (images/ -> depth/)
 
 path: depth-hypersim # dataset root dir (relative to Ultralytics settings 'datasets_dir')
 train: images/train # train images (relative to 'path') 68242 images

--- a/ultralytics/cfg/datasets/depth-kitti.yaml
+++ b/ultralytics/cfg/datasets/depth-kitti.yaml
@@ -8,7 +8,7 @@
 # └── datasets
 #     └── depth-kitti  ← downloads here (~190 GB archives, ~140 GB converted)
 #         ├── images/{train,val}  # RGB images
-#         └── depth/{train,val}   # paired *.npy, float32 meters (images/ -> depth/)
+#         └── depth/{train,val}   # paired 16-bit *.png depth maps (images/ -> depth/)
 # If an interrupted download leaves a partial dataset, delete the depth-kitti dir and re-run to rebuild it.
 # The download only runs when the val images are missing (train is never checked), so a depth-kitti dir
 # built before this split fix keeps the old split until it is deleted and rebuilt.
@@ -32,6 +32,7 @@ download: |
   import cv2
   import numpy as np
 
+  from ultralytics.data.utils import save_depth_png
   from ultralytics.utils import TQDM
   from ultralytics.utils.downloads import download
 
@@ -92,7 +93,7 @@ download: |
                   continue
               name = f"{drive}_{cam[-2:]}_{png.stem}"
               depth = cv2.imread(str(png), cv2.IMREAD_ANYDEPTH).astype(np.float32) / 256.0
-              np.save(dir / "depth" / split / f"{name}.npy", depth)
+              save_depth_png(dir / "depth" / split / f"{name}.png", depth)
               raw = dir / "source" / "raw" / drive[:10] / gt.name / cam / "data" / png.name
               raw.replace(dir / "images" / split / f"{name}.png")
   shutil.rmtree(dir / "source")

--- a/ultralytics/cfg/datasets/depth-sunrgbd.yaml
+++ b/ultralytics/cfg/datasets/depth-sunrgbd.yaml
@@ -8,7 +8,7 @@
 # └── datasets
 #     └── depth-sunrgbd  ← downloads here (6.5 GB archive, ~14 GB converted)
 #         ├── images/{train,val}  # RGB images
-#         └── depth/{train,val}   # paired *.npy, float32 meters (images/ -> depth/)
+#         └── depth/{train,val}   # paired 16-bit *.png depth maps (images/ -> depth/)
 # If an interrupted download leaves a partial dataset, delete the depth-sunrgbd dir and re-run to rebuild it.
 
 path: depth-sunrgbd # dataset root dir (relative to Ultralytics settings 'datasets_dir')
@@ -30,6 +30,7 @@ download: |
   import cv2
   import numpy as np
 
+  from ultralytics.data.utils import save_depth_png
   from ultralytics.utils import TQDM
   from ultralytics.utils.downloads import download
 
@@ -48,6 +49,6 @@ download: |
       split = "val" if name in val else "train"
       d = cv2.imread(str(next((scene / "depth_bfx").glob("*.png"))), cv2.IMREAD_ANYDEPTH)
       d = (((d >> 3) | (d << 13)) / 1000.0).clip(max=10).astype(np.float32)  # bit-rotated mm -> m
-      np.save(dir / "depth" / split / f"{name}.npy", d)
+      save_depth_png(dir / "depth" / split / f"{name}.png", d)
       next((scene / "image").glob("*.jpg")).replace(dir / "images" / split / f"{name}.jpg")
   shutil.rmtree(dir / "source")

--- a/ultralytics/cfg/datasets/depth-tartanair.yaml
+++ b/ultralytics/cfg/datasets/depth-tartanair.yaml
@@ -9,7 +9,7 @@
 # └── datasets
 #     └── depth-tartanair
 #         ├── images/{train,val}  # RGB images
-#         └── depth/{train,val}   # paired *.npy, float32 meters (images/ -> depth/)
+#         └── depth/{train,val}   # paired 16-bit *.png depth maps (images/ -> depth/)
 
 path: depth-tartanair # dataset root dir (relative to Ultralytics settings 'datasets_dir')
 train: images/train # train images (relative to 'path') 55660 images

--- a/ultralytics/cfg/datasets/depth-vkitti2.yaml
+++ b/ultralytics/cfg/datasets/depth-vkitti2.yaml
@@ -8,7 +8,7 @@
 # └── datasets
 #     └── depth-vkitti2  ← downloads here (15 GB archives, ~85 GB converted)
 #         ├── images/{train,val}  # RGB images
-#         └── depth/{train,val}   # paired *.npy, float32 meters (images/ -> depth/)
+#         └── depth/{train,val}   # paired 16-bit *.png depth maps (images/ -> depth/)
 # If an interrupted download leaves a partial dataset, delete the depth-vkitti2 dir and re-run to rebuild it.
 
 path: depth-vkitti2 # dataset root dir (relative to Ultralytics settings 'datasets_dir')
@@ -30,6 +30,7 @@ download: |
   import cv2
   import numpy as np
 
+  from ultralytics.data.utils import save_depth_png
   from ultralytics.utils import TQDM
   from ultralytics.utils.downloads import download
 
@@ -46,6 +47,6 @@ download: |
       split = "val" if scene == "Scene20" else "train"
       name = f"{scene}_{variation}_{camera}_{im.stem[4:]}"
       depth = cv2.imread(str(im.parents[2] / "depth" / camera / f"depth_{im.stem[4:]}.png"), cv2.IMREAD_ANYDEPTH)
-      np.save(dir / "depth" / split / f"{name}.npy", (depth.astype(np.float32) / 100.0).clip(max=80))  # cm -> m
+      save_depth_png(dir / "depth" / split / f"{name}.png", (depth.astype(np.float32) / 100.0).clip(max=80))  # cm -> m
       im.replace(dir / "images" / split / f"{name}.jpg")
   shutil.rmtree(dir / "source")

--- a/ultralytics/cfg/datasets/depth8.yaml
+++ b/ultralytics/cfg/datasets/depth8.yaml
@@ -8,7 +8,7 @@
 # └── datasets
 #     └── depth8 ← downloads here (1.3 MB)
 #         ├── images/{train,val}  # RGB images
-#         └── depth/{train,val}   # paired *.npy, float32 meters (images/ -> depth/)
+#         └── depth/{train,val}   # paired 16-bit *.png depth maps (images/ -> depth/)
 
 path: depth8 # dataset root dir (relative to Ultralytics settings 'datasets_dir')
 train: images/train # train images (relative to 'path') 4 images
@@ -21,4 +21,4 @@ names:
 channels: 3
 
 # Download script/URL (optional)
-download: https://github.com/ultralytics/assets/releases/download/v0.0.0/depth8.zip
+download: https://github.com/ultralytics/assets/releases/download/v0.0.0/depth8-png.zip

--- a/ultralytics/cfg/datasets/depth8.yaml
+++ b/ultralytics/cfg/datasets/depth8.yaml
@@ -6,11 +6,11 @@
 # parent
 # ├── ultralytics
 # └── datasets
-#     └── depth8 ← downloads here (1.3 MB)
+#     └── depth8-png ← downloads here (1.3 MB)
 #         ├── images/{train,val}  # RGB images
 #         └── depth/{train,val}   # paired 16-bit *.png depth maps (images/ -> depth/)
 
-path: depth8 # dataset root dir (relative to Ultralytics settings 'datasets_dir')
+path: depth8-png # dataset root dir (relative to Ultralytics settings 'datasets_dir')
 train: images/train # train images (relative to 'path') 4 images
 val: images/val # val images (relative to 'path') 4 images
 

--- a/ultralytics/cfg/datasets/nyu-depth.yaml
+++ b/ultralytics/cfg/datasets/nyu-depth.yaml
@@ -7,10 +7,10 @@
 # parent
 # ├── ultralytics
 # └── datasets
-#     └── nyu-depth  ← downloads here (≈1.5 GB)
+#     └── nyu-depth-png  ← downloads here (≈1.5 GB)
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
-path: nyu-depth # dataset root dir (relative to Ultralytics settings 'datasets_dir')
+path: nyu-depth-png # dataset root dir (relative to Ultralytics settings 'datasets_dir')
 train: images/train # train images (relative to 'path') 795 images
 val: images/val # val images (relative to 'path') 654 images
 

--- a/ultralytics/cfg/datasets/nyu-depth.yaml
+++ b/ultralytics/cfg/datasets/nyu-depth.yaml
@@ -14,7 +14,7 @@ path: nyu-depth # dataset root dir (relative to Ultralytics settings 'datasets_d
 train: images/train # train images (relative to 'path') 795 images
 val: images/val # val images (relative to 'path') 654 images
 
-# Depth maps are paired .npy files (float32, meters) under depth/<split>/, resolved by
+# Depth maps are paired self-describing 16-bit PNGs under depth/<split>/, resolved by
 # swapping '/images/' -> '/depth/' on each image path.
 
 # Classes
@@ -25,4 +25,4 @@ names:
 channels: 3
 
 # Download script/URL (optional)
-download: https://github.com/ultralytics/assets/releases/download/v0.0.0/nyu-depth.zip
+download: https://github.com/ultralytics/assets/releases/download/v0.0.0/nyu-depth-png.zip

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -932,8 +932,8 @@ async def _convert_ndjson_to_yolo(ndjson_path: Path, output_path: Path) -> Path:
             depth = record.get("depth")
             if not isinstance(depth, dict) or not isinstance(depth.get("url"), str) or not depth["url"]:
                 raise ValueError(f"Depth record '{record.get('file', '<unknown>')}' is missing depth.url")
-            if depth.get("encoding") not in {"png-u16-linear", "npy-f32"} or depth.get("unit") != "m":
-                raise ValueError("Depth records require a supported encoding and unit='m'")
+            if depth.get("encoding") != "png-u16-linear" or depth.get("unit") != "m":
+                raise ValueError("Depth records require encoding='png-u16-linear' and unit='m'")
             shape = depth.get("shape")
             if not isinstance(shape, list) or len(shape) != 2 or not all(type(x) is int and x > 0 for x in shape):
                 raise ValueError("Depth records require a positive [height, width] shape")
@@ -1070,8 +1070,7 @@ async def _convert_ndjson_to_yolo(ndjson_path: Path, output_path: Path) -> Path:
                 return image_ok
 
             stem = original_name.rsplit(".", 1)[0] or original_name
-            suffix = ".png" if record["depth"]["encoding"] == "png-u16-linear" else ".npy"
-            depth_path = dataset_dir / "depth" / split / f"{stem}{suffix}"
+            depth_path = dataset_dir / "depth" / split / f"{stem}.png"
             depth_ok = await ensure_file(session, depth_path, record["depth"]["url"])
             if not image_ok or not depth_ok:
                 image_path.unlink(missing_ok=True)

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -818,8 +818,8 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
 
     This function converts datasets stored in NDJSON (Newline Delimited JSON) format to the standard YOLO format. For
     detection/segmentation/pose/obb tasks, it creates separate directories for images and labels. Depth datasets use
-    parallel images/ and depth/ trees with self-describing 16-bit PNG targets. Classification tasks use the ImageNet-style
-    {split}/{class_name}/ folder structure. Downloads run concurrently.
+    parallel images/ and depth/ trees with self-describing 16-bit PNG targets. Classification tasks use the
+    ImageNet-style {split}/{class_name}/ folder structure. Downloads run concurrently.
 
     The NDJSON format consists of:
     - First line: Dataset metadata with class names, task type, and configuration

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -818,7 +818,7 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
 
     This function converts datasets stored in NDJSON (Newline Delimited JSON) format to the standard YOLO format. For
     detection/segmentation/pose/obb tasks, it creates separate directories for images and labels. Depth datasets use
-    parallel images/ and depth/ trees with float32 NPY targets. Classification tasks use the ImageNet-style
+    parallel images/ and depth/ trees with self-describing 16-bit PNG targets. Classification tasks use the ImageNet-style
     {split}/{class_name}/ folder structure. Downloads run concurrently.
 
     The NDJSON format consists of:
@@ -932,8 +932,8 @@ async def _convert_ndjson_to_yolo(ndjson_path: Path, output_path: Path) -> Path:
             depth = record.get("depth")
             if not isinstance(depth, dict) or not isinstance(depth.get("url"), str) or not depth["url"]:
                 raise ValueError(f"Depth record '{record.get('file', '<unknown>')}' is missing depth.url")
-            if depth.get("encoding") != "npy-f32" or depth.get("unit") != "m":
-                raise ValueError("Depth records require encoding='npy-f32' and unit='m'")
+            if depth.get("encoding") not in {"png-u16-linear", "npy-f32"} or depth.get("unit") != "m":
+                raise ValueError("Depth records require a supported encoding and unit='m'")
             shape = depth.get("shape")
             if not isinstance(shape, list) or len(shape) != 2 or not all(type(x) is int and x > 0 for x in shape):
                 raise ValueError("Depth records require a positive [height, width] shape")
@@ -1070,7 +1070,8 @@ async def _convert_ndjson_to_yolo(ndjson_path: Path, output_path: Path) -> Path:
                 return image_ok
 
             stem = original_name.rsplit(".", 1)[0] or original_name
-            depth_path = dataset_dir / "depth" / split / f"{stem}.npy"
+            suffix = ".png" if record["depth"]["encoding"] == "png-u16-linear" else ".npy"
+            depth_path = dataset_dir / "depth" / split / f"{stem}{suffix}"
             depth_ok = await ensure_file(session, depth_path, record["depth"]["url"])
             if not image_ok or not depth_ok:
                 image_path.unlink(missing_ok=True)

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -932,8 +932,8 @@ async def _convert_ndjson_to_yolo(ndjson_path: Path, output_path: Path) -> Path:
             depth = record.get("depth")
             if not isinstance(depth, dict) or not isinstance(depth.get("url"), str) or not depth["url"]:
                 raise ValueError(f"Depth record '{record.get('file', '<unknown>')}' is missing depth.url")
-            if depth.get("encoding") != "png-u16-linear" or depth.get("unit") != "m":
-                raise ValueError("Depth records require encoding='png-u16-linear' and unit='m'")
+            if depth.get("encoding") != "linear-u16" or depth.get("unit") != "m":
+                raise ValueError("Depth records require encoding='linear-u16' and unit='m'")
             shape = depth.get("shape")
             if not isinstance(shape, list) or len(shape) != 2 or not all(type(x) is int and x > 0 for x in shape):
                 raise ValueError("Depth records require a positive [height, width] shape")

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -449,15 +449,13 @@ class DepthDataset(YOLODataset):
     format_class = DepthFormat
 
     def _depth_path_for(self, im_file: str) -> str:
-        """Map an image path to its companion depth PNG, falling back to legacy NPY."""
+        """Map an image path to its companion depth PNG."""
         parts = list(Path(im_file).parts)
         for i in range(len(parts) - 1, -1, -1):
             if parts[i] == "images":
                 parts[i] = "depth"
                 break
-        path = Path(*parts).with_suffix(".png")
-        legacy = path.with_suffix(".npy")
-        return str(path if path.exists() or not legacy.exists() else legacy)
+        return str(Path(*parts).with_suffix(".png"))
 
     def get_label_files(self) -> list[str]:
         """Return the depth paths paired with the dataset's images.
@@ -466,7 +464,6 @@ class DepthDataset(YOLODataset):
             (list[str]): List of depth file paths.
         """
         self.depth_files = [self._depth_path_for(f) for f in self.im_files]
-        self.depth_by_image = dict(zip(self.im_files, self.depth_files))
         return self.depth_files
 
     def get_cache_hash(self) -> str:
@@ -508,7 +505,7 @@ class DepthDataset(YOLODataset):
 
     def _load_depth(self, index):
         """Return the native-resolution depth map for an image, with non-finite values mapped to 0 (invalid)."""
-        return load_depth(self.depth_by_image[self.im_files[index]])
+        return load_depth(self._depth_path_for(self.im_files[index]))
 
     def get_image_and_label(self, index):
         """Load image, label, and depth map for the given index."""

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -504,7 +504,7 @@ class DepthDataset(YOLODataset):
         """Skip box and segment checks; depth datasets carry no box or segment annotations."""
 
     def _load_depth(self, index):
-        """Return the native-resolution depth map for an image, with non-finite values mapped to 0 (invalid)."""
+        """Return the native-resolution depth map for an image."""
         return load_depth(self._depth_path_for(self.im_files[index]))
 
     def get_image_and_label(self, index):

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -39,6 +39,7 @@ from .utils import (
     get_hash,
     img2label_paths,
     load_dataset_cache_file,
+    load_depth,
     polygons2masks_overlap,
     save_dataset_cache_file,
     verify_image,
@@ -438,8 +439,8 @@ class YOLODataset(BaseDataset):
 class DepthDataset(YOLODataset):
     """Dataset for monocular depth estimation with paired RGB + depth map loading.
 
-    Extends YOLODataset to load depth ground truth maps alongside RGB images. Depth maps are stored as .npy files in a
-    parallel directory structure (images/train/*.jpg → depth/train/*.npy).
+    Extends YOLODataset to load depth ground truth maps alongside RGB images. Depth maps are stored as 16-bit PNGs in a
+    parallel directory structure (images/train/*.jpg → depth/train/*.png).
 
     Examples:
         >>> dataset = DepthDataset(img_path="/data/nyu/images/train", data={"nc": 1})
@@ -448,21 +449,24 @@ class DepthDataset(YOLODataset):
     format_class = DepthFormat
 
     def _depth_path_for(self, im_file: str) -> str:
-        """Map an image path to its companion depth .npy path (last 'images' path component → 'depth')."""
+        """Map an image path to its companion depth PNG, falling back to legacy NPY."""
         parts = list(Path(im_file).parts)
         for i in range(len(parts) - 1, -1, -1):
             if parts[i] == "images":
                 parts[i] = "depth"
                 break
-        return str(Path(*parts).with_suffix(".npy"))
+        path = Path(*parts).with_suffix(".png")
+        legacy = path.with_suffix(".npy")
+        return str(path if path.exists() or not legacy.exists() else legacy)
 
     def get_label_files(self) -> list[str]:
-        """Return the depth .npy paths paired with the dataset's images.
+        """Return the depth paths paired with the dataset's images.
 
         Returns:
             (list[str]): List of depth file paths.
         """
         self.depth_files = [self._depth_path_for(f) for f in self.im_files]
+        self.depth_by_image = dict(zip(self.im_files, self.depth_files))
         return self.depth_files
 
     def get_cache_hash(self) -> str:
@@ -504,8 +508,7 @@ class DepthDataset(YOLODataset):
 
     def _load_depth(self, index):
         """Return the native-resolution depth map for an image, with non-finite values mapped to 0 (invalid)."""
-        depth = np.load(self._depth_path_for(self.im_files[index])).astype(np.float32)
-        return np.nan_to_num(depth, nan=0.0, posinf=0.0, neginf=0.0)
+        return load_depth(self.depth_by_image[self.im_files[index]])
 
     def get_image_and_label(self, index):
         """Load image, label, and depth map for the given index."""

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -65,13 +65,15 @@ def save_depth_png(path: str | Path, depth: np.ndarray) -> None:
     if maximum == minimum:
         encoded[valid] = 65535
     else:
-        encoded[valid] = DEPTH_PNG_MIN_CODE + np.rint((depth[valid] - minimum) * (65279 / (maximum - minimum))).astype(
-            np.uint16
-        )
+        encoded[valid] = DEPTH_PNG_MIN_CODE + np.rint(
+            (depth[valid] - minimum) * ((65535 - DEPTH_PNG_MIN_CODE) / (maximum - minimum))
+        ).astype(np.uint16)
     metadata = PngImagePlugin.PngInfo()
+    metadata.add_text("ultralytics.depth.encoding", "linear-u16")
     metadata.add_text("ultralytics.depth.min", repr(minimum))
     metadata.add_text("ultralytics.depth.max", repr(maximum))
-    Image.fromarray(encoded).save(path, pnginfo=metadata, compress_level=6)
+    metadata.add_text("ultralytics.depth.unit", "m")
+    Image.fromarray(encoded).save(path, pnginfo=metadata)
 
 
 def load_depth(path: str | Path) -> np.ndarray:
@@ -79,19 +81,21 @@ def load_depth(path: str | Path) -> np.ndarray:
     path = Path(path)
     with Image.open(path) as image:
         info = image.info
+        if info.get("ultralytics.depth.encoding") != "linear-u16" or info.get("ultralytics.depth.unit") != "m":
+            raise ValueError(f"Depth PNG {path} is missing Ultralytics linear-u16 meter metadata")
         minimum, maximum = float(info["ultralytics.depth.min"]), float(info["ultralytics.depth.max"])
         encoded = np.asarray(image, dtype=np.uint16)
+    if encoded.ndim != 2:
+        raise ValueError(f"Depth map {path} must be 2D, got shape {encoded.shape}")
     valid = encoded >= DEPTH_PNG_MIN_CODE
     depth = np.zeros(encoded.shape, dtype=np.float32)
     if maximum == minimum:
         depth[valid] = minimum
     else:
         depth[valid] = minimum + (encoded[valid].astype(np.float32) - DEPTH_PNG_MIN_CODE) * (
-            (maximum - minimum) / 65279
+            (maximum - minimum) / (65535 - DEPTH_PNG_MIN_CODE)
         )
-    if depth.ndim != 2:
-        raise ValueError(f"Depth map {path} must be 2D, got shape {depth.shape}")
-    return np.nan_to_num(depth, nan=0.0, posinf=0.0, neginf=0.0)
+    return depth
 
 
 def img2label_paths(img_paths: list[str], label_dir: str = "labels", suffix: str = ".txt") -> list[str]:
@@ -261,7 +265,13 @@ def verify_image_depth(args: tuple) -> tuple:
             nm = 1
             msg = f"{prefix}{im_file}: ignoring image with missing depth map {depth_file}"
             return None, None, nf, nm, nc, msg
-        load_depth(depth_file)
+        with Image.open(depth_file) as depth:
+            info = depth.info
+            assert depth.mode in {"I", "I;16"}, f"depth map {depth_file} must be 16-bit grayscale"
+            assert info.get("ultralytics.depth.encoding") == "linear-u16" and info.get("ultralytics.depth.unit") == "m"
+            float(info["ultralytics.depth.min"])
+            float(info["ultralytics.depth.max"])
+            depth.verify()
         nf = 1
         return im_file, shape, nf, nm, nc, msg
     except Exception as e:

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -268,7 +268,9 @@ def verify_image_depth(args: tuple) -> tuple:
         with Image.open(depth_file) as depth:
             info = depth.info
             assert depth.mode in {"I", "I;16"}, f"depth map {depth_file} must be 16-bit grayscale"
-            assert info.get("ultralytics.depth.encoding") == "linear-u16" and info.get("ultralytics.depth.unit") == "m"
+            assert (
+                info.get("ultralytics.depth.encoding") == "linear-u16" and info.get("ultralytics.depth.unit") == "m"
+            ), f"depth map {depth_file} must use Ultralytics linear-u16 meter metadata"
             float(info["ultralytics.depth.min"])
             float(info["ultralytics.depth.max"])
             depth.verify()

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import cv2
 import numpy as np
-from PIL import Image, ImageOps
+from PIL import Image, ImageOps, PngImagePlugin
 
 from ultralytics.nn.autobackend import check_class_names
 from ultralytics.utils import (
@@ -50,6 +50,84 @@ IMG_FORMATS = {
 }
 VID_FORMATS = {"asf", "avi", "gif", "m4v", "mkv", "mov", "mp4", "mpeg", "mpg", "ts", "wmv", "webm"}  # videos
 FORMATS_HELP_MSG = f"Supported formats are:\nimages: {IMG_FORMATS}\nvideos: {VID_FORMATS}"
+
+DEPTH_PNG_ENCODING = "linear-u16"
+DEPTH_PNG_KEYS = {
+    "encoding": "ultralytics.depth.encoding",
+    "min": "ultralytics.depth.min",
+    "max": "ultralytics.depth.max",
+    "unit": "ultralytics.depth.unit",
+}
+DEPTH_PNG_MIN_CODE = 256  # survives browser uint16 → uint8 display as 1; zero stays transparent
+DEPTH_PNG_MAX_CODE = np.iinfo(np.uint16).max
+DEPTH_PNG_CODE_SPAN = DEPTH_PNG_MAX_CODE - DEPTH_PNG_MIN_CODE
+
+
+def save_depth_png(path: str | Path, depth: np.ndarray) -> None:
+    """Save metric depth as a self-describing 16-bit PNG with zero reserved for invalid pixels."""
+    depth = np.asarray(depth, dtype=np.float32).squeeze()
+    if depth.ndim != 2:
+        raise ValueError(f"Depth map must be 2D, got shape {depth.shape}")
+    valid = np.isfinite(depth) & (depth > 0)
+    if not valid.any():
+        raise ValueError("Depth map has no valid pixels")
+    minimum, maximum = (float(x) for x in (depth[valid].min(), depth[valid].max()))
+    encoded = np.zeros(depth.shape, dtype=np.uint16)
+    if maximum == minimum:
+        encoded[valid] = DEPTH_PNG_MAX_CODE
+    else:
+        encoded[valid] = DEPTH_PNG_MIN_CODE + np.rint(
+            (depth[valid] - minimum) * (DEPTH_PNG_CODE_SPAN / (maximum - minimum))
+        ).astype(np.uint16)
+    metadata = PngImagePlugin.PngInfo()
+    metadata.add_text(DEPTH_PNG_KEYS["encoding"], DEPTH_PNG_ENCODING)
+    metadata.add_text(DEPTH_PNG_KEYS["min"], repr(minimum))
+    metadata.add_text(DEPTH_PNG_KEYS["max"], repr(maximum))
+    metadata.add_text(DEPTH_PNG_KEYS["unit"], "m")
+    Image.fromarray(encoded).save(path, pnginfo=metadata, compress_level=6)
+
+
+def load_depth(path: str | Path) -> np.ndarray:
+    """Load a metric depth PNG, with temporary support for legacy float NPY maps."""
+    path = Path(path)
+    if path.suffix.lower() == ".npy":
+        depth = np.load(path, allow_pickle=False).astype(np.float32)
+    else:
+        with Image.open(path) as image:
+            info = image.info
+            if info.get(DEPTH_PNG_KEYS["encoding"]) != DEPTH_PNG_ENCODING or info.get(DEPTH_PNG_KEYS["unit"]) != "m":
+                raise ValueError(f"Depth PNG {path} is missing Ultralytics linear-u16 meter metadata")
+            minimum, maximum = float(info[DEPTH_PNG_KEYS["min"]]), float(info[DEPTH_PNG_KEYS["max"]])
+            encoded = np.asarray(image, dtype=np.uint16)
+        valid = encoded >= DEPTH_PNG_MIN_CODE
+        depth = np.zeros(encoded.shape, dtype=np.float32)
+        if maximum == minimum:
+            depth[valid] = minimum
+        else:
+            depth[valid] = minimum + (encoded[valid].astype(np.float32) - DEPTH_PNG_MIN_CODE) * (
+                (maximum - minimum) / DEPTH_PNG_CODE_SPAN
+            )
+    if depth.ndim != 2:
+        raise ValueError(f"Depth map {path} must be 2D, got shape {depth.shape}")
+    return np.nan_to_num(depth, nan=0.0, posinf=0.0, neginf=0.0)
+
+
+def verify_depth(path: str | Path) -> None:
+    """Verify depth shape and encoding metadata without decoding its pixel payload."""
+    path = Path(path)
+    if path.suffix.lower() == ".npy":
+        depth = np.load(path, mmap_mode="r", allow_pickle=False)
+        if depth.ndim != 2 or depth.dtype.kind != "f":
+            raise ValueError(f"Depth map {path} must be a 2D floating-point array")
+        return
+    with Image.open(path) as image:
+        info = image.info
+        if image.mode not in {"I", "I;16"}:
+            raise ValueError(f"Depth PNG {path} must be 16-bit grayscale")
+        if info.get(DEPTH_PNG_KEYS["encoding"]) != DEPTH_PNG_ENCODING or info.get(DEPTH_PNG_KEYS["unit"]) != "m":
+            raise ValueError(f"Depth PNG {path} is missing Ultralytics linear-u16 meter metadata")
+        float(info[DEPTH_PNG_KEYS["min"]])
+        float(info[DEPTH_PNG_KEYS["max"]])
 
 
 def img2label_paths(img_paths: list[str], label_dir: str = "labels", suffix: str = ".txt") -> list[str]:
@@ -208,7 +286,7 @@ def verify_image(args: tuple) -> tuple:
 
 
 def verify_image_depth(args: tuple) -> tuple:
-    """Verify that an image and its paired depth .npy map exist and are readable."""
+    """Verify that an image and its paired depth map exist and are readable."""
     im_file, depth_file, prefix = args
     # Number (found, missing, corrupt), message
     nf, nm, nc, msg = 0, 0, 0, ""
@@ -219,8 +297,7 @@ def verify_image_depth(args: tuple) -> tuple:
             nm = 1
             msg = f"{prefix}{im_file}: ignoring image with missing depth map {depth_file}"
             return None, None, nf, nm, nc, msg
-        depth = np.load(depth_file, mmap_mode="r", allow_pickle=False)
-        assert depth.ndim == 2, f"depth map {depth_file} expected a 2D array, got shape {depth.shape}"
+        verify_depth(depth_file)
         nf = 1
         return im_file, shape, nf, nm, nc, msg
     except Exception as e:

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -51,16 +51,7 @@ IMG_FORMATS = {
 VID_FORMATS = {"asf", "avi", "gif", "m4v", "mkv", "mov", "mp4", "mpeg", "mpg", "ts", "wmv", "webm"}  # videos
 FORMATS_HELP_MSG = f"Supported formats are:\nimages: {IMG_FORMATS}\nvideos: {VID_FORMATS}"
 
-DEPTH_PNG_ENCODING = "linear-u16"
-DEPTH_PNG_KEYS = {
-    "encoding": "ultralytics.depth.encoding",
-    "min": "ultralytics.depth.min",
-    "max": "ultralytics.depth.max",
-    "unit": "ultralytics.depth.unit",
-}
 DEPTH_PNG_MIN_CODE = 256  # survives browser uint16 → uint8 display as 1; zero stays transparent
-DEPTH_PNG_MAX_CODE = np.iinfo(np.uint16).max
-DEPTH_PNG_CODE_SPAN = DEPTH_PNG_MAX_CODE - DEPTH_PNG_MIN_CODE
 
 
 def save_depth_png(path: str | Path, depth: np.ndarray) -> None:
@@ -69,65 +60,38 @@ def save_depth_png(path: str | Path, depth: np.ndarray) -> None:
     if depth.ndim != 2:
         raise ValueError(f"Depth map must be 2D, got shape {depth.shape}")
     valid = np.isfinite(depth) & (depth > 0)
-    if not valid.any():
-        raise ValueError("Depth map has no valid pixels")
-    minimum, maximum = (float(x) for x in (depth[valid].min(), depth[valid].max()))
+    minimum, maximum = (float(x) for x in (depth[valid].min(), depth[valid].max())) if valid.any() else (0.0, 0.0)
     encoded = np.zeros(depth.shape, dtype=np.uint16)
     if maximum == minimum:
-        encoded[valid] = DEPTH_PNG_MAX_CODE
+        encoded[valid] = 65535
     else:
-        encoded[valid] = DEPTH_PNG_MIN_CODE + np.rint(
-            (depth[valid] - minimum) * (DEPTH_PNG_CODE_SPAN / (maximum - minimum))
-        ).astype(np.uint16)
+        encoded[valid] = DEPTH_PNG_MIN_CODE + np.rint((depth[valid] - minimum) * (65279 / (maximum - minimum))).astype(
+            np.uint16
+        )
     metadata = PngImagePlugin.PngInfo()
-    metadata.add_text(DEPTH_PNG_KEYS["encoding"], DEPTH_PNG_ENCODING)
-    metadata.add_text(DEPTH_PNG_KEYS["min"], repr(minimum))
-    metadata.add_text(DEPTH_PNG_KEYS["max"], repr(maximum))
-    metadata.add_text(DEPTH_PNG_KEYS["unit"], "m")
+    metadata.add_text("ultralytics.depth.min", repr(minimum))
+    metadata.add_text("ultralytics.depth.max", repr(maximum))
     Image.fromarray(encoded).save(path, pnginfo=metadata, compress_level=6)
 
 
 def load_depth(path: str | Path) -> np.ndarray:
-    """Load a metric depth PNG, with temporary support for legacy float NPY maps."""
+    """Load a metric depth PNG."""
     path = Path(path)
-    if path.suffix.lower() == ".npy":
-        depth = np.load(path, allow_pickle=False).astype(np.float32)
+    with Image.open(path) as image:
+        info = image.info
+        minimum, maximum = float(info["ultralytics.depth.min"]), float(info["ultralytics.depth.max"])
+        encoded = np.asarray(image, dtype=np.uint16)
+    valid = encoded >= DEPTH_PNG_MIN_CODE
+    depth = np.zeros(encoded.shape, dtype=np.float32)
+    if maximum == minimum:
+        depth[valid] = minimum
     else:
-        with Image.open(path) as image:
-            info = image.info
-            if info.get(DEPTH_PNG_KEYS["encoding"]) != DEPTH_PNG_ENCODING or info.get(DEPTH_PNG_KEYS["unit"]) != "m":
-                raise ValueError(f"Depth PNG {path} is missing Ultralytics linear-u16 meter metadata")
-            minimum, maximum = float(info[DEPTH_PNG_KEYS["min"]]), float(info[DEPTH_PNG_KEYS["max"]])
-            encoded = np.asarray(image, dtype=np.uint16)
-        valid = encoded >= DEPTH_PNG_MIN_CODE
-        depth = np.zeros(encoded.shape, dtype=np.float32)
-        if maximum == minimum:
-            depth[valid] = minimum
-        else:
-            depth[valid] = minimum + (encoded[valid].astype(np.float32) - DEPTH_PNG_MIN_CODE) * (
-                (maximum - minimum) / DEPTH_PNG_CODE_SPAN
-            )
+        depth[valid] = minimum + (encoded[valid].astype(np.float32) - DEPTH_PNG_MIN_CODE) * (
+            (maximum - minimum) / 65279
+        )
     if depth.ndim != 2:
         raise ValueError(f"Depth map {path} must be 2D, got shape {depth.shape}")
     return np.nan_to_num(depth, nan=0.0, posinf=0.0, neginf=0.0)
-
-
-def verify_depth(path: str | Path) -> None:
-    """Verify depth shape and encoding metadata without decoding its pixel payload."""
-    path = Path(path)
-    if path.suffix.lower() == ".npy":
-        depth = np.load(path, mmap_mode="r", allow_pickle=False)
-        if depth.ndim != 2 or depth.dtype.kind != "f":
-            raise ValueError(f"Depth map {path} must be a 2D floating-point array")
-        return
-    with Image.open(path) as image:
-        info = image.info
-        if image.mode not in {"I", "I;16"}:
-            raise ValueError(f"Depth PNG {path} must be 16-bit grayscale")
-        if info.get(DEPTH_PNG_KEYS["encoding"]) != DEPTH_PNG_ENCODING or info.get(DEPTH_PNG_KEYS["unit"]) != "m":
-            raise ValueError(f"Depth PNG {path} is missing Ultralytics linear-u16 meter metadata")
-        float(info[DEPTH_PNG_KEYS["min"]])
-        float(info[DEPTH_PNG_KEYS["max"]])
 
 
 def img2label_paths(img_paths: list[str], label_dir: str = "labels", suffix: str = ".txt") -> list[str]:
@@ -297,7 +261,7 @@ def verify_image_depth(args: tuple) -> tuple:
             nm = 1
             msg = f"{prefix}{im_file}: ignoring image with missing depth map {depth_file}"
             return None, None, nf, nm, nc, msg
-        verify_depth(depth_file)
+        load_depth(depth_file)
         nf = 1
         return im_file, shape, nf, nm, nc, msg
     except Exception as e:

--- a/ultralytics/models/yolo/depth/train.py
+++ b/ultralytics/models/yolo/depth/train.py
@@ -81,7 +81,7 @@ class DepthTrainer(DetectionTrainer):
         per_map_cap = max(1, 1_000_000 // sample_size)  # bound total memory to ~1M values
         values = []
         for idx in indices:
-            d = dataset._load_depth(idx)  # shared loader sanitizes non-finite GT to 0
+            d = dataset._load_depth(idx)
             if d is None:
                 continue
             v = d[d > 0].ravel()


### PR DESCRIPTION
## Summary

- make self-describing 16-bit PNG the only supported depth target
- reserve zero for invalid pixels and reconstruct meters from the PNG embedded min/max range
- remove all NPY loader, path, manifest, converter, and rollout fallback code
- update the existing dataset generators, archives, and documentation to the one-file format

## Rollout

Merge and publish this PR before Portal #3655. Immediately before the Portal merge, the uncommitted production cutover script will migrate and compact every existing hosted depth asset; neither repository carries migration or compatibility code.

Published depth payloads:
- depth8-png.zip: 10,024,176 -> 894,405 bytes (8.9%)
- nyu-depth-png.zip: 890,451,072 -> 352,432,885 bytes (39.6%)

## Validation

- 5 NDJSON conversion tests pass
- 2 focused dataset/codec tests pass
- Ruff formatting and import checks pass
- PNG-only Depth8 scan/load and cross-repository codec contract passed on the previous head

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Depth targets now use self-describing 16-bit PNG files as the sole supported format, with embedded meter ranges and zero reserved for invalid pixels.

### 📊 Key Changes

- Added `save_depth_png()` and `load_depth()` to encode and reconstruct meter-valued depth maps using `linear-u16` PNG metadata.
- Updated `DepthDataset` and depth validation to locate, verify, and load `.png` targets instead of `.npy` arrays.
- Changed NDJSON depth conversion to require `encoding: "linear-u16"` and download PNG targets.
- Updated depth dataset generators, YAML configurations, archives, and documentation—including Depth8 and NYU Depth—to use the PNG format.
- Revised depth-related tests for PNG writing, loading, validation, and NDJSON conversion.

### 🎯 Purpose & Impact

- Existing depth workflows must provide paired 16-bit PNG files with the required Ultralytics metadata; `.npy` depth targets are no longer accepted by the updated loader and converter.
- Invalid pixels remain represented as zero, while valid meter values are reconstructed from each PNG’s stored minimum and maximum range.
- Depth dataset downloads and generated datasets now follow the single PNG-based layout, including the renamed `depth8-png` and `nyu-depth-png` dataset paths.