### PR TITLE
Accept existing depth dataset formats

### DIFF
--- a/docs/en/datasets/depth/arkitscenes.md
+++ b/docs/en/datasets/depth/arkitscenes.md
@@ -23,7 +23,7 @@ The ARKitScenes depth dataset is split into two subsets:
 1. **Train**: 676,080 images with paired depth maps for training.
 2. **Val**: 21,559 images with paired depth maps for validation during model training.
 
-Each sample consists of one RGB image and one paired 16-bit depth PNG storing per-pixel distances in meters, following the [Ultralytics depth dataset format](index.md).
+Each sample consists of one RGB image and one paired uint16 depth PNG in millimeters (`depth_scale: 1000`), following the [Ultralytics depth dataset format](index.md).
 
 ## Obtain the Data
 
@@ -39,11 +39,9 @@ Depth frames are `uint16` PNGs in **millimeters** (0 = invalid), and RGB/depth f
 
 ```python
 from pathlib import Path
+import shutil
 
 import cv2
-import numpy as np
-
-from ultralytics.data.utils import save_depth_png
 
 src, dst = Path("data/upsampling"), Path("datasets/depth-arkitscenes")
 for split, out in (("Training", "train"), ("Validation", "val")):
@@ -57,8 +55,7 @@ for split, out in (("Training", "train"), ("Validation", "val")):
             t = float(depth_png.stem.split("_")[-1])
             rgb = rgbs[min(rgbs, key=lambda k: abs(k - t))]  # nearest-timestamp RGB frame
             name = f"{video.name}_{depth_png.stem}"
-            depth = cv2.imread(str(depth_png), cv2.IMREAD_UNCHANGED).astype(np.float32) / 1000.0  # mm → m
-            save_depth_png(dst / f"depth/{out}/{name}.png", depth)
+            shutil.copy2(depth_png, dst / f"depth/{out}/{name}.png")
             cv2.imwrite(str(dst / f"images/{out}/{name}.png"), cv2.imread(str(rgb)))
 ```
 

--- a/docs/en/datasets/depth/arkitscenes.md
+++ b/docs/en/datasets/depth/arkitscenes.md
@@ -38,8 +38,8 @@ python3 download_data.py upsampling --split Validation --download_dir ./data
 Depth frames are `uint16` PNGs in **millimeters** (0 = invalid), and RGB/depth filenames are capture timestamps that do not match exactly — pair each depth frame with the nearest-timestamp RGB frame. Reference conversion to the [Ultralytics depth dataset format](index.md):
 
 ```python
-from pathlib import Path
 import shutil
+from pathlib import Path
 
 import cv2
 

--- a/docs/en/datasets/depth/depth8.md
+++ b/docs/en/datasets/depth/depth8.md
@@ -16,7 +16,7 @@ The [Ultralytics](https://www.ultralytics.com/) Depth8 dataset is a compact [mon
 
 ## Dataset Structure
 
-Depth8 follows the standard [Ultralytics depth dataset layout](index.md#supported-dataset-format): RGB images with paired 16-bit depth PNGs in meters, matched by file stem.
+Depth8 follows the standard [Ultralytics depth dataset layout](index.md#supported-dataset-format): RGB images with paired uint16 millimeter depth PNGs (`depth_scale: 1000`), matched by file stem.
 
 ```text
 depth8-png/

--- a/docs/en/datasets/depth/diode.md
+++ b/docs/en/datasets/depth/diode.md
@@ -23,7 +23,7 @@ The DIODE depth dataset is split into two subsets:
 1. **Train**: 25,458 images with paired depth maps for training.
 2. **Val**: 771 images with paired depth maps for validation during model training.
 
-Each sample consists of one RGB image and one paired uint16 millimeter depth PNG (`depth_scale: 1000`), following the [Ultralytics depth dataset format](index.md).
+Each sample consists of one RGB image and one paired uint16 depth PNG with 256 units per meter (`depth_scale: 256`), following the [Ultralytics depth dataset format](index.md). This provides 3.90625 mm resolution while representing the full 80 m outdoor range.
 
 ## Role in YOLO26-Depth
 

--- a/docs/en/datasets/depth/diode.md
+++ b/docs/en/datasets/depth/diode.md
@@ -23,7 +23,7 @@ The DIODE depth dataset is split into two subsets:
 1. **Train**: 25,458 images with paired depth maps for training.
 2. **Val**: 771 images with paired depth maps for validation during model training.
 
-Each sample consists of one RGB image and one paired 16-bit depth PNG storing per-pixel distances in meters, following the [Ultralytics depth dataset format](index.md).
+Each sample consists of one RGB image and one paired uint16 millimeter depth PNG (`depth_scale: 1000`), following the [Ultralytics depth dataset format](index.md).
 
 ## Role in YOLO26-Depth
 

--- a/docs/en/datasets/depth/hypersim.md
+++ b/docs/en/datasets/depth/hypersim.md
@@ -25,7 +25,7 @@ The Hypersim depth dataset is split into two subsets:
 1. **Train**: 68,242 images with paired dense depth maps for training.
 2. **Val**: 6,377 images with paired dense depth maps for validation during training.
 
-Each RGB image is paired with a 16-bit depth PNG storing per-pixel distances in meters, following the [Ultralytics depth dataset format](index.md).
+Each RGB image is paired with a scaled uint16 depth PNG, following the [Ultralytics depth dataset format](index.md).
 
 ## Obtain the Data
 

--- a/docs/en/datasets/depth/imagenet-pseudo.md
+++ b/docs/en/datasets/depth/imagenet-pseudo.md
@@ -29,7 +29,7 @@ Because ImageNet ships without depth annotations, depth targets are produced off
 
 1. Each ImageNet training image is run through `depth-anything/DA3MONO-LARGE`, which predicts a highly detailed depth map that is only defined up to an unknown per-image scale and shift, and through `depth-anything/DA3METRIC-LARGE`, whose output is coarser but in real units.
 2. A per-image robust affine fit maps the monocular prediction onto the metric one, `label = a * mono + b`. Every per-pixel detail therefore comes from the monocular checkpoint, while the metric checkpoint only sets the two scalars that place the map on the meter axis. No camera intrinsics are involved, so images without calibration can be labeled.
-3. The result is saved as a self-describing 16-bit PNG in meters, following the [Ultralytics depth dataset format](index.md), and paired with its source image by file stem.
+3. The result is saved as a 16-bit millimeter PNG, following the [Ultralytics depth dataset format](index.md), and paired with its source image by file stem.
 4. The pseudo-labeled pairs are then added as one component of a larger training mix, where a student YOLO26-Depth model learns to match the teacher while also training on real ground-truth sources.
 
 Because the scale comes from a prediction rather than a measurement, each map can carry a global scale error. YOLO26-Depth trains with a scale-invariant log (SILog) loss plus gradient matching and validates with median alignment, so a per-image scale offset in the pseudo labels is largely absorbed.

--- a/docs/en/datasets/depth/index.md
+++ b/docs/en/datasets/depth/index.md
@@ -1,7 +1,7 @@
 ---
 comments: true
-description: Learn how to prepare depth estimation datasets for Ultralytics YOLO, including 16-bit PNG depth maps, dataset YAML fields, directory layout, and supported datasets.
-keywords: Ultralytics, YOLO, depth estimation, depth dataset format, PNG depth maps, NYU Depth V2, monocular depth, per-pixel depth
+description: Learn how to prepare depth estimation datasets for Ultralytics YOLO, including PNG and NPY depth maps, dataset YAML fields, directory layout, and supported datasets.
+keywords: Ultralytics, YOLO, depth estimation, depth dataset format, PNG depth maps, NPY depth maps, NYU Depth V2, monocular depth, per-pixel depth
 ---
 
 # Depth Estimation Datasets Overview
@@ -12,13 +12,14 @@ This guide explains the dataset format used by Ultralytics YOLO depth estimation
 
 ## Supported Dataset Format
 
-### PNG depth map format
+### Depth map format
 
-Each training sample consists of one RGB image and one paired `.png` depth file. Code `0` means invalid; writers use codes `256–65535` to linearly cover the valid per-image minimum and maximum stored in the PNG metadata. Starting at 256 preserves the nearest valid band when browsers display the same 16-bit asset as 8-bit.
+Each training sample consists of one RGB image and one paired depth file. Existing datasets can use floating-point `.npy` maps in meters or ordinary integer `.png` maps with a dataset-level `depth_scale`. For compact, self-describing datasets, `save_depth_png()` writes the meter range into each PNG; code `0` means invalid and codes `256–65535` cover the valid range.
 
-- Depth files use the `.png` extension and the Ultralytics `linear-u16` metadata convention.
+- Depth files use `.png` (preferred) or `.npy`. NPY arrays must be 2D and floating-point, with values in meters.
+- Ordinary integer PNG values are divided by `depth_scale` to produce meters (for example, use `depth_scale: 1000` for millimeters).
 - Each depth file should have the same stem as its matching image file (e.g., `scene_001.png` pairs with `scene_001.jpg`).
-- The dataset loader finds depth files by replacing the `images` directory component with `depth` and swapping the image extension for `.png`.
+- The dataset loader finds depth files by replacing the `images` directory component with `depth`, preferring `.png` and falling back to `.npy`.
 - Pixels with depth `≤ 0` are treated as invalid and excluded from loss and metric computation.
 
 The standard layout keeps images and depth maps in parallel folders:
@@ -39,14 +40,15 @@ For example, an image at `images/train/scene_001.jpg` is paired with a depth map
 
 Depth estimation datasets are configured with YAML files. The main fields are:
 
-| Key     | Description                                                    |
-| ------- | -------------------------------------------------------------- |
-| `path`  | Dataset root directory.                                        |
-| `train` | Training image path relative to `path`, or an absolute path.   |
-| `val`   | Validation image path relative to `path`, or an absolute path. |
-| `test`  | Optional test image path.                                      |
-| `nc`    | Number of classes — always `1` for depth estimation.           |
-| `names` | Class name mapping — always `{0: depth}`.                      |
+| Key           | Description                                                                           |
+| ------------- | ------------------------------------------------------------------------------------- |
+| `path`        | Dataset root directory.                                                               |
+| `train`       | Training image path relative to `path`, or an absolute path.                          |
+| `val`         | Validation image path relative to `path`, or an absolute path.                        |
+| `test`        | Optional test image path.                                                             |
+| `nc`          | Number of classes — always `1` for depth estimation.                                  |
+| `names`       | Class name mapping — always `{0: depth}`.                                             |
+| `depth_scale` | Optional raw integer PNG units per meter; not needed for NPY or self-describing PNGs. |
 
 !!! example "ultralytics/cfg/datasets/nyu-depth.yaml"
 
@@ -110,8 +112,8 @@ Per-model accuracy on these benchmarks and the downloadable pretrained weights a
 ## Adding Your Own Dataset
 
 1. Save RGB images under split folders such as `images/train` and `images/val`.
-2. Save one 16-bit depth PNG per image under the matching `depth/train` and `depth/val` folders using the same file stem as the image. Use `save_depth_png()` to write the required metadata.
-3. Ensure depth values are in meters and that invalid or missing pixels use `0` or negative values.
+2. Save one depth PNG or NPY per image under the matching `depth/train` and `depth/val` folders using the same file stem as the image. Existing integer PNG datasets only need `depth_scale` added to their YAML; use `save_depth_png()` when creating new compact datasets.
+3. Ensure the decoded depth values are in meters and that invalid or missing pixels use `0` or negative values.
 4. Create a dataset YAML with `path`, `train`, `val`, `nc: 1`, and `names: {0: depth}`.
 
 ```yaml
@@ -122,13 +124,16 @@ val: images/val
 nc: 1
 names:
     0: depth
+
+# Only for ordinary integer PNGs, e.g. millimeters:
+depth_scale: 1000
 ```
 
 ## FAQ
 
 ### What file format should depth maps use?
 
-Depth maps must be self-describing 16-bit PNGs written with `ultralytics.data.utils.save_depth_png()`. The loader reconstructs meter-valued float32 arrays and preserves code `0` as invalid.
+Use self-describing 16-bit PNGs written with `ultralytics.data.utils.save_depth_png()` for new datasets. Existing floating-point NPY maps in meters also work directly, and ordinary integer PNG datasets can declare `depth_scale` in their YAML.
 
 ### How are invalid depth pixels handled?
 
@@ -145,4 +150,4 @@ Depth estimation validation reports the standard Depth Anything metric set:
 
 ### Do depth file names need to match image file names?
 
-Yes. Each depth `.png` file must share the same stem as the corresponding image. The loader derives the depth path by replacing the `images` directory component with `depth` and substituting the image extension for `.png`. Images whose depth file is missing or unreadable are dropped during the cached dataset scan with a warning.
+Yes. Each depth `.png` or `.npy` file must share the same stem as the corresponding image. The loader derives the depth path by replacing the `images` directory component with `depth`, preferring PNG and falling back to NPY. Images whose depth file is missing or unreadable are dropped during the cached dataset scan with a warning.

--- a/docs/en/datasets/depth/index.md
+++ b/docs/en/datasets/depth/index.md
@@ -6,7 +6,7 @@ keywords: Ultralytics, YOLO, depth estimation, depth dataset format, PNG depth m
 
 # Depth Estimation Datasets Overview
 
-Monocular depth estimation assigns a depth value in meters to every pixel in an image. The training target is a self-describing 16-bit grayscale PNG that stores its linear meter range in PNG metadata.
+Monocular depth estimation assigns a depth value in meters to every pixel in an image. Depth targets use either scaled 16-bit grayscale PNGs or floating-point NPY arrays in meters.
 
 This guide explains the dataset format used by Ultralytics YOLO depth estimation models and lists the built-in dataset configurations available for training and validation.
 
@@ -14,13 +14,24 @@ This guide explains the dataset format used by Ultralytics YOLO depth estimation
 
 ### Depth map format
 
-Each training sample consists of one RGB image and one paired depth file. Existing datasets can use floating-point `.npy` maps in meters or ordinary integer `.png` maps with a dataset-level `depth_scale`. For compact, self-describing datasets, `save_depth_png()` writes the meter range into each PNG; code `0` means invalid and codes `256–65535` cover the valid range.
+Each training sample consists of one RGB image and one paired depth file. PNG values are divided by the optional dataset-level `depth_scale` to produce meters. The default is `1000`, so a value of `1500` represents `1.5` meters. Code `0` means invalid; PNGs need no embedded metadata.
 
-- Depth files use `.png` (preferred) or `.npy`. NPY arrays must be 2D and floating-point, with values in meters.
-- Ordinary integer PNG values are divided by `depth_scale` to produce meters (for example, use `depth_scale: 1000` for millimeters).
+- Depth files use `.png` (preferred) or `.npy`. PNG maps must be 2D uint16 grayscale images. NPY arrays must be 2D and floating-point, with values in meters.
+- Set `depth_scale` only when PNGs do not use the default millimeter convention. For example, KITTI uses `256` and Virtual KITTI 2 uses `100`.
 - Each depth file should have the same stem as its matching image file (e.g., `scene_001.png` pairs with `scene_001.jpg`).
+- Depth maps may be smaller than their RGB images as long as the aspect ratio matches; training resizes them in memory.
 - The dataset loader finds depth files by replacing the `images` directory component with `depth`, preferring `.png` and falling back to `.npy`.
 - Pixels with depth `≤ 0` are treated as invalid and excluded from loss and metric computation.
+
+Because code `0` is reserved for invalid pixels, a uint16 PNG provides 65,535 positive depth values. The scale controls both precision and range:
+
+| Convention            | `depth_scale` | Resolution |  Maximum depth |
+| --------------------- | ------------: | ---------: | -------------: |
+| Default / ARKitScenes |        `1000` |       1 mm |       65.535 m |
+| KITTI                 |         `256` | 3.90625 mm | 255.99609375 m |
+| Virtual KITTI 2       |         `100` |       1 cm |       655.35 m |
+
+These are storage limits, not recommended training caps. A dataset can set a smaller `max_depth` independently for loss calibration or evaluation.
 
 The standard layout keeps images and depth maps in parallel folders:
 
@@ -40,15 +51,15 @@ For example, an image at `images/train/scene_001.jpg` is paired with a depth map
 
 Depth estimation datasets are configured with YAML files. The main fields are:
 
-| Key           | Description                                                                           |
-| ------------- | ------------------------------------------------------------------------------------- |
-| `path`        | Dataset root directory.                                                               |
-| `train`       | Training image path relative to `path`, or an absolute path.                          |
-| `val`         | Validation image path relative to `path`, or an absolute path.                        |
-| `test`        | Optional test image path.                                                             |
-| `nc`          | Number of classes — always `1` for depth estimation.                                  |
-| `names`       | Class name mapping — always `{0: depth}`.                                             |
-| `depth_scale` | Optional raw integer PNG units per meter; not needed for NPY or self-describing PNGs. |
+| Key           | Description                                                    |
+| ------------- | -------------------------------------------------------------- |
+| `path`        | Dataset root directory.                                        |
+| `train`       | Training image path relative to `path`, or an absolute path.   |
+| `val`         | Validation image path relative to `path`, or an absolute path. |
+| `test`        | Optional test image path.                                      |
+| `nc`          | Number of classes — always `1` for depth estimation.           |
+| `names`       | Class name mapping — always `{0: depth}`.                      |
+| `depth_scale` | Optional PNG units per meter; defaults to `1000`.              |
 
 !!! example "ultralytics/cfg/datasets/nyu-depth.yaml"
 
@@ -112,7 +123,7 @@ Per-model accuracy on these benchmarks and the downloadable pretrained weights a
 ## Adding Your Own Dataset
 
 1. Save RGB images under split folders such as `images/train` and `images/val`.
-2. Save one depth PNG or NPY per image under the matching `depth/train` and `depth/val` folders using the same file stem as the image. Existing integer PNG datasets only need `depth_scale` added to their YAML; use `save_depth_png()` when creating new compact datasets.
+2. Save one depth PNG or NPY per image under the matching `depth/train` and `depth/val` folders using the same file stem as the image. Use `save_depth_png()` to convert meter arrays into compact millimeter PNGs.
 3. Ensure the decoded depth values are in meters and that invalid or missing pixels use `0` or negative values.
 4. Create a dataset YAML with `path`, `train`, `val`, `nc: 1`, and `names: {0: depth}`.
 
@@ -125,7 +136,7 @@ nc: 1
 names:
     0: depth
 
-# Only for ordinary integer PNGs, e.g. millimeters:
+# Optional: PNG integer units per meter (default 1000)
 depth_scale: 1000
 ```
 
@@ -133,7 +144,7 @@ depth_scale: 1000
 
 ### What file format should depth maps use?
 
-Use self-describing 16-bit PNGs written with `ultralytics.data.utils.save_depth_png()` for new datasets. Existing floating-point NPY maps in meters also work directly, and ordinary integer PNG datasets can declare `depth_scale` in their YAML.
+Use scaled 16-bit grayscale PNGs for compact datasets. By default each integer step is one millimeter; set `depth_scale` in the dataset YAML for another scale. `ultralytics.data.utils.save_depth_png()` converts meter arrays to the default format. Floating-point NPY maps in meters also work directly.
 
 ### How are invalid depth pixels handled?
 

--- a/docs/en/datasets/depth/index.md
+++ b/docs/en/datasets/depth/index.md
@@ -134,7 +134,7 @@ val: images/val
 
 nc: 1
 names:
-  0: depth
+    0: depth
 
 # Optional: PNG integer units per meter (default 1000)
 depth_scale: 1000

--- a/docs/en/datasets/depth/index.md
+++ b/docs/en/datasets/depth/index.md
@@ -134,7 +134,7 @@ val: images/val
 
 nc: 1
 names:
-    0: depth
+  0: depth
 
 # Optional: PNG integer units per meter (default 1000)
 depth_scale: 1000

--- a/docs/en/datasets/depth/kitti.md
+++ b/docs/en/datasets/depth/kitti.md
@@ -14,7 +14,7 @@ The [KITTI](https://www.cvlibs.net/datasets/kitti/) dataset is a real-world outd
 - Depth ground truth obtained from a Velodyne HDL-64 LiDAR and densified with the [Sparsity Invariant CNNs](https://arxiv.org/abs/1708.06500) approach of Uhrig et al. 2017.
 - Sparse supervision: only about 16–20% of pixels per image carry a valid depth value; invalid pixels are masked out of the loss and metrics.
 - Stereo image pairs (left `image_02` and right `image_03`) provide additional viewpoints for training.
-- Depth values are stored as 16-bit PNGs in meters, following the [Ultralytics depth dataset format](index.md).
+- Depth values are stored as uint16 PNGs with 256 units per meter (`depth_scale: 256`), following the [Ultralytics depth dataset format](index.md).
 
 ## Dataset Structure
 

--- a/docs/en/datasets/depth/sunrgbd.md
+++ b/docs/en/datasets/depth/sunrgbd.md
@@ -23,7 +23,7 @@ The SUN RGB-D depth dataset is split into two subsets:
 1. **Train**: 9,245 images with paired depth maps for training.
 2. **Val**: 1,090 images with paired depth maps for validation during model training.
 
-Each sample consists of one RGB image and one paired 16-bit depth PNG storing per-pixel distances in meters, following the [Ultralytics depth dataset format](index.md).
+Each sample consists of one RGB image and one paired scaled uint16 depth PNG, following the [Ultralytics depth dataset format](index.md). The built-in conversion writes millimeters, so the default `depth_scale: 1000` applies.
 
 ## Role in YOLO26-Depth
 

--- a/docs/en/datasets/depth/tartanair.md
+++ b/docs/en/datasets/depth/tartanair.md
@@ -25,7 +25,7 @@ The TartanAir depth dataset is split into two subsets:
 1. **Train**: 55,660 images with paired dense depth maps for training.
 2. **Val**: 5,810 images with paired dense depth maps for validation during training.
 
-Each RGB image is paired with a 16-bit depth PNG storing per-pixel distances in meters, following the [Ultralytics depth dataset format](index.md).
+Each RGB image is paired with a scaled uint16 depth PNG, following the [Ultralytics depth dataset format](index.md).
 
 ## Obtain the Data
 

--- a/docs/en/datasets/depth/tartanair.md
+++ b/docs/en/datasets/depth/tartanair.md
@@ -25,7 +25,7 @@ The TartanAir depth dataset is split into two subsets:
 1. **Train**: 55,660 images with paired dense depth maps for training.
 2. **Val**: 5,810 images with paired dense depth maps for validation during training.
 
-Each RGB image is paired with a scaled uint16 depth PNG, following the [Ultralytics depth dataset format](index.md).
+Each RGB image is paired with a scaled uint16 depth PNG with 256 units per meter (`depth_scale: 256`), following the [Ultralytics depth dataset format](index.md). This represents the full 80 m range at 3.90625 mm resolution.
 
 ## Obtain the Data
 
@@ -57,7 +57,7 @@ for depth_file in sorted(src.rglob("depth_left/*_left_depth.npy")):
     depth[depth > 80.0] = 0.0  # sky/extreme range → 0 = invalid
     frame = depth_file.name.replace("_depth.npy", "")  # e.g. 000000_left
     name = f"{env}_{traj}_{frame}"
-    save_depth_png(dst / f"depth/{out}/{name}.png", depth)
+    save_depth_png(dst / f"depth/{out}/{name}.png", depth, scale=256)
     shutil.copy(depth_file.parents[1] / "image_left" / f"{frame}.png", dst / f"images/{out}/{name}.png")
 ```
 

--- a/docs/en/datasets/depth/vkitti2.md
+++ b/docs/en/datasets/depth/vkitti2.md
@@ -26,7 +26,7 @@ The Virtual KITTI 2 depth dataset is split into two subsets:
 1. **Train**: 25,780 images with paired dense depth maps for training.
 2. **Val**: 16,740 images with paired dense depth maps for validation during training.
 
-Each RGB image is paired with a scaled uint16 depth PNG, following the [Ultralytics depth dataset format](index.md). The source PNGs use centimeters (`depth_scale: 100`); the built-in conversion clips them at 80 m and writes the default millimeter format.
+Each RGB image is paired with a scaled uint16 depth PNG, following the [Ultralytics depth dataset format](index.md). The source and converted PNGs use centimeters (`depth_scale: 100`), which preserves the 80 m training range.
 
 ## Role in YOLO26-Depth
 

--- a/docs/en/datasets/depth/vkitti2.md
+++ b/docs/en/datasets/depth/vkitti2.md
@@ -26,7 +26,7 @@ The Virtual KITTI 2 depth dataset is split into two subsets:
 1. **Train**: 25,780 images with paired dense depth maps for training.
 2. **Val**: 16,740 images with paired dense depth maps for validation during training.
 
-Each RGB image is paired with a 16-bit depth PNG storing per-pixel distances in meters, following the [Ultralytics depth dataset format](index.md).
+Each RGB image is paired with a scaled uint16 depth PNG, following the [Ultralytics depth dataset format](index.md). The source PNGs use centimeters (`depth_scale: 100`); the built-in conversion clips them at 80 m and writes the default millimeter format.
 
 ## Role in YOLO26-Depth
 

--- a/docs/en/datasets/detect/index.md
+++ b/docs/en/datasets/detect/index.md
@@ -247,11 +247,14 @@ Each image record may include a `metadata` JSON object for application-specific 
 
 ```json
 {
-    "type": "image",
-    "file": "airbus-wing.jpg",
-    "url": "https://example.com/airbus-wing.jpg",
-    "split": "train",
-    "metadata": { "aircraft": { "family": "A350", "section": "wing" }, "inspectionStatus": "reviewed" }
+  "type": "image",
+  "file": "airbus-wing.jpg",
+  "url": "https://example.com/airbus-wing.jpg",
+  "split": "train",
+  "metadata": {
+    "aircraft": { "family": "A350", "section": "wing" },
+    "inspectionStatus": "reviewed"
+  }
 }
 ```
 

--- a/docs/en/datasets/detect/index.md
+++ b/docs/en/datasets/detect/index.md
@@ -247,14 +247,14 @@ Each image record may include a `metadata` JSON object for application-specific 
 
 ```json
 {
-  "type": "image",
-  "file": "airbus-wing.jpg",
-  "url": "https://example.com/airbus-wing.jpg",
-  "split": "train",
-  "metadata": {
-    "aircraft": { "family": "A350", "section": "wing" },
-    "inspectionStatus": "reviewed"
-  }
+    "type": "image",
+    "file": "airbus-wing.jpg",
+    "url": "https://example.com/airbus-wing.jpg",
+    "split": "train",
+    "metadata": {
+        "aircraft": { "family": "A350", "section": "wing" },
+        "inspectionStatus": "reviewed"
+    }
 }
 ```
 

--- a/docs/en/datasets/detect/index.md
+++ b/docs/en/datasets/detect/index.md
@@ -217,6 +217,30 @@ An NDJSON dataset file contains:
 
         Format: `[class_id]`
 
+    === "Depth"
+
+        The dataset record declares the PNG scale once:
+
+        ```json
+        { "type": "dataset", "task": "depth", "depth_scale": 1000 }
+        ```
+
+        Each image record adds the URL of its paired uint16 depth PNG:
+
+        ```json
+        {
+            "type": "image",
+            "file": "image1.jpg",
+            "url": "https://www.url.com/path/to/image1.jpg",
+            "width": 640,
+            "height": 480,
+            "split": "train",
+            "depth": { "url": "https://www.url.com/path/to/image1.png" }
+        }
+        ```
+
+        `depth_scale` is optional and defaults to `1000`; see the [depth map format](../depth/index.md#depth-map-format).
+
 #### Custom image metadata
 
 Each image record may include a `metadata` JSON object for application-specific context such as capture conditions, equipment identifiers, or review status. Nested values are supported. When imported into Ultralytics Platform, the metadata is stored with that image and can be viewed or edited from its fullscreen information panel.

--- a/docs/en/platform/data/datasets.md
+++ b/docs/en/platform/data/datasets.md
@@ -84,7 +84,7 @@ The file extension alone isn't enough: a video can still fail if its codec canno
 
 ### Preparing Your Dataset
 
-The Platform supports [Ultralytics YOLO](../../datasets/detect/index.md#ultralytics-yolo-format), [COCO](https://cocodataset.org/#format-data), [Ultralytics NDJSON](../../datasets/detect/index.md#ultralytics-ndjson-format), and raw (unannotated) uploads:
+The Platform supports [Ultralytics YOLO](../../datasets/detect/index.md#ultralytics-yolo-format), [COCO](https://cocodataset.org/#format-data), [depth datasets](../../datasets/depth/index.md#depth-map-format), [Ultralytics NDJSON](../../datasets/detect/index.md#ultralytics-ndjson-format), and raw (unannotated) uploads:
 
 === "YOLO Format"
 
@@ -172,6 +172,30 @@ The Platform supports [Ultralytics YOLO](../../datasets/detect/index.md#ultralyt
         ├── cats/
         └── dogs/
     ```
+
+=== "Depth"
+
+    Depth archives keep RGB images and paired targets in parallel `images/` and `depth/` folders. Targets may be
+    floating-point NPY arrays in meters or plain uint16 grayscale PNGs. PNG values are divided by `depth_scale`, which
+    defaults to `1000` (millimeters); no PNG metadata is required.
+
+    ```text
+    my-depth-dataset/
+    ├── data.yaml
+    ├── images/{train,val}/scene.jpg
+    └── depth/{train,val}/scene.png  # or scene.npy
+    ```
+
+    ```yaml
+    train: images/train
+    val: images/val
+    nc: 1
+    names: {0: depth}
+    depth_scale: 1000 # PNG value 1000 = 1 meter
+    ```
+
+    Files pair by stem. Depth maps may use a smaller resolution than their RGB images when the aspect ratio matches.
+    See the [depth dataset format](../../datasets/depth/index.md#depth-map-format).
 
 === "NDJSON"
 
@@ -632,6 +656,10 @@ The NDJSON format stores one JSON object per line. The first line contains datas
 The optional image-level `metadata` object is preserved when an NDJSON file is imported into Platform. You can inspect or edit it from the image's fullscreen information panel. For programmatic archive uploads, the [Ingest Dataset Data API](../api/index.md#ingest-dataset-data) accepts the equivalent `imageMetadata` path map.
 
 Pose datasets also carry a `kpt_shape` field in the dataset header line, inferred from the annotations when it is not already set.
+
+Depth exports declare `"task": "depth"` and `"depth_scale": 1000` in the dataset line. Each image line includes a
+`depth.url` for its paired plain uint16 PNG. Ultralytics downloads image and depth URLs concurrently and writes a
+training YAML with the same scale, so the NDJSON file can be passed directly to `model.train(data=...)`.
 
 !!! note "Signed URLs"
 

--- a/docs/en/platform/data/index.md
+++ b/docs/en/platform/data/index.md
@@ -48,22 +48,23 @@ graph LR
     classDef out fill:#9C27B0,color:#fff
 ```
 
-| Stage        | Description                                                                                                     |
-| ------------ | --------------------------------------------------------------------------------------------------------------- |
-| **Upload**   | Import images, videos, or archives with automatic processing                                                    |
-| **Annotate** | Label data with manual tools for all 6 task types, or use SAM annotation for detect, segment, semantic, and OBB |
-| **Analyze**  | View class distributions, spatial heatmaps, dimension statistics, and embedding clusters                        |
-| **Export**   | Download in [NDJSON format](../../datasets/detect/index.md#ultralytics-ndjson-format) for offline use           |
+| Stage        | Description                                                                                           |
+| ------------ | ----------------------------------------------------------------------------------------------------- |
+| **Upload**   | Import images, videos, or archives with automatic processing                                          |
+| **Annotate** | Label data with manual tools, or use SAM annotation for detect, segment, semantic, and OBB            |
+| **Analyze**  | View class distributions, spatial heatmaps, dimension statistics, and embedding clusters              |
+| **Export**   | Download in [NDJSON format](../../datasets/detect/index.md#ultralytics-ndjson-format) for offline use |
 
 ## Supported Tasks
 
-Ultralytics Platform datasets support 6 of the 7 YOLO task types — [depth](../../tasks/depth.md) datasets are coming soon (depth models and prediction are already supported):
+Ultralytics Platform datasets support all 7 YOLO task types:
 
 | Task                                             | Description                                                     | Annotation Tool   |
 | ------------------------------------------------ | --------------------------------------------------------------- | ----------------- |
 | **[Detect](../../datasets/detect/index.md)**     | Object detection with bounding boxes                            | Rectangle tool    |
 | **[Segment](../../datasets/segment/index.md)**   | Instance segmentation with pixel masks                          | Polygon tool      |
 | **[Semantic](../../datasets/semantic/index.md)** | Semantic segmentation with per-class pixel regions              | Polygon tool      |
+| **[Depth](../../datasets/depth/index.md)**       | Per-pixel metric depth maps                                     | Imported targets  |
 | **[Classify](../../datasets/classify/index.md)** | Image-level classification                                      | Class selector    |
 | **[Pose](../../datasets/pose/index.md)**         | Keypoint estimation with built-in and custom skeleton templates | Keypoint tool     |
 | **[OBB](../../datasets/obb/index.md)**           | Oriented bounding boxes for rotated objects                     | Oriented box tool |

--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -364,7 +364,7 @@ For a detailed guide, see the [Quickstart](quickstart.md) page.
 - **No-Code Training**: Train advanced YOLO models without writing code
 - **Real-Time Metrics**: Stream training progress and monitor deployments
 - **42 Deploy Regions**: Deploy models close to your users worldwide
-- **7 Task Types**: Support for detection, instance segmentation, semantic segmentation, depth estimation (models and prediction today; depth datasets coming soon), classification, pose, and OBB (see [task docs](../tasks/index.md))
+- **7 Task Types**: Support for detection, instance segmentation, semantic segmentation, depth estimation, classification, pose, and OBB (see [task docs](../tasks/index.md))
 - **AI-Assisted Annotation**: [Smart annotation](data/annotation.md#smart-annotation) with SAM and YOLO models to speed up data preparation
 
 ### What GPU options are available for cloud training?

--- a/docs/en/platform/train/cloud-training.md
+++ b/docs/en/platform/train/cloud-training.md
@@ -44,8 +44,8 @@ Within each tab, models are grouped by task in canonical order and sorted by siz
 
 !!! note "Depth Training"
 
-    Depth datasets are not available yet, so depth models are currently for prediction and export only. Every other
-    task can be trained on the Platform.
+    Depth datasets can be uploaded with float NPY targets in meters or uint16 PNG targets using the dataset's
+    `depth_scale`. See the [depth dataset format](../../datasets/depth/index.md#depth-map-format).
 
 ### Step 2: Select Dataset
 

--- a/docs/en/tasks/depth.md
+++ b/docs/en/tasks/depth.md
@@ -207,7 +207,7 @@ The released `yolo26*-depth.pt` checkpoints ship with this calibration already b
 
 ### Dataset format
 
-Depth estimation datasets pair each RGB image with a corresponding self-describing 16-bit depth PNG. The dataset YAML points to an `images/` directory; the loader derives the depth path by replacing the `images` component with `depth` and the image extension with `.png`.
+Depth estimation datasets pair each RGB image with a scaled uint16 depth PNG or floating-point NPY depth map in meters. PNG values use millimeters by default; datasets with another convention set `depth_scale` in their YAML. The loader derives the depth path by replacing the `images` component with `depth`, preferring `.png` and falling back to `.npy`.
 
 ```text
 dataset/
@@ -373,7 +373,7 @@ See full `export` details in the [Export](../modes/export.md) page.
 
 ### How do I train a YOLO26 depth estimation model on a custom dataset?
 
-Prepare paired RGB images and 16-bit depth PNGs, then create a dataset YAML pointing to your `images/` directory. The loader finds depth files automatically by replacing `images` with `depth` in the path and swapping the image extension for `.png`.
+Prepare paired RGB images and either 16-bit depth PNGs or floating-point NPY depth maps in meters, then create a dataset YAML pointing to your `images/` directory. The loader finds depth files automatically by replacing `images` with `depth` in the path, preferring `.png` and falling back to `.npy`.
 
 Start from pretrained weights and use a low learning rate with AdamW so the fine-tune retains what the model already knows (see [Fine-tuning on your own data](#fine-tuning-on-your-own-data) for why):
 

--- a/tests/test_ndjson_converter.py
+++ b/tests/test_ndjson_converter.py
@@ -23,9 +23,9 @@ class _QuietHandler(SimpleHTTPRequestHandler):
         pass
 
 
-def _write_manifest(path, base_url, *, missing_depth=False):
+def _write_manifest(path, base_url, *, missing_depth=False, depth_scale=None):
     records = [
-        {"type": "dataset", "task": "depth"},
+        {"type": "dataset", "task": "depth", **({"depth_scale": depth_scale} if depth_scale else {})},
         {
             "type": "image",
             "file": "camera/train.jpg",
@@ -35,8 +35,6 @@ def _write_manifest(path, base_url, *, missing_depth=False):
                 "url": f"{base_url}/train.png?signature=depth",
                 "hash": "depth-train",
                 "shape": [3, 4],
-                "encoding": "linear-u16",
-                "unit": "m",
             },
         },
         {
@@ -48,8 +46,6 @@ def _write_manifest(path, base_url, *, missing_depth=False):
                 "url": f"{base_url}/missing.png" if missing_depth else f"{base_url}/test.png?signature=depth",
                 "hash": "depth-test",
                 "shape": [3, 4],
-                "encoding": "linear-u16",
-                "unit": "m",
             },
         },
     ]
@@ -66,6 +62,7 @@ def depth_server(tmp_path):
         cv2.imwrite(str(source / f"{split}.jpg"), np.full((3, 4, 3), value, dtype=np.uint8))
         save_depth_png(source / f"{split}.png", depth)
     server = ThreadingHTTPServer(("127.0.0.1", 0), partial(_QuietHandler, directory=source))
+    server.daemon_threads = True
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
@@ -77,7 +74,7 @@ def depth_server(tmp_path):
 
 
 def test_convert_depth_ndjson_downloads_image_target_pairs(tmp_path, depth_server):
-    """Download depth targets beside images using matching indexed stems."""
+    """Download depth targets beside images using matching indexed stems and the default scale."""
     base_url, depth = depth_server
     manifest = tmp_path / "depth.ndjson"
     _write_manifest(manifest, base_url)
@@ -88,12 +85,24 @@ def test_convert_depth_ndjson_downloads_image_target_pairs(tmp_path, depth_serve
     assert data["task"] == "depth"
     assert data["nc"] == 1
     assert data["names"] == {0: "depth"}
+    assert data["depth_scale"] == 1000
     assert data["train"] == "images/train"
     assert data["val"] == "images/val"
     assert not (yaml_path.parent / "labels").exists()
     for index, split in enumerate(("train", "val"), 1):
         assert (yaml_path.parent / "images" / split / f"{index}.jpg").is_file()
         np.testing.assert_allclose(load_depth(yaml_path.parent / "depth" / split / f"{index}.png"), depth, atol=1e-3)
+
+
+def test_convert_depth_ndjson_preserves_scale(tmp_path, depth_server):
+    """Copy a dataset-level PNG scale into the generated training YAML."""
+    base_url, _ = depth_server
+    manifest = tmp_path / "depth.ndjson"
+    _write_manifest(manifest, base_url, depth_scale=256)
+
+    data = YAML.load(asyncio.run(convert_ndjson_to_yolo(manifest, tmp_path / "datasets")))
+
+    assert data["depth_scale"] == 256
 
 
 def test_convert_depth_ndjson_reuses_existing_conversion(tmp_path, depth_server, monkeypatch):
@@ -131,8 +140,8 @@ def test_convert_depth_ndjson_removes_incomplete_pair(tmp_path, depth_server):
     assert not (dataset_dir / "data.yaml").exists()
 
 
-def test_convert_depth_ndjson_rejects_incomplete_descriptor(tmp_path):
-    """Reject incomplete depth descriptors before issuing downloads."""
+def test_convert_depth_ndjson_rejects_missing_url(tmp_path):
+    """Reject a missing depth URL before issuing downloads."""
     manifest = tmp_path / "invalid.ndjson"
     records = [
         {"type": "dataset", "task": "depth"},
@@ -141,12 +150,12 @@ def test_convert_depth_ndjson_rejects_incomplete_descriptor(tmp_path):
             "file": "train.jpg",
             "url": "http://127.0.0.1:1/train.jpg",
             "split": "train",
-            "depth": {"url": "http://127.0.0.1:1/train.png", "shape": [3, 4], "encoding": "linear-u16"},
+            "depth": {},
         },
     ]
     manifest.write_text("\n".join(json.dumps(record) for record in records))
 
-    with pytest.raises(ValueError, match="encoding='linear-u16' and unit='m'"):
+    with pytest.raises(ValueError, match="missing depth.url"):
         asyncio.run(convert_ndjson_to_yolo(manifest, tmp_path / "datasets"))
 
 

--- a/tests/test_ndjson_converter.py
+++ b/tests/test_ndjson_converter.py
@@ -155,7 +155,7 @@ def test_convert_depth_ndjson_rejects_missing_url(tmp_path):
     ]
     manifest.write_text("\n".join(json.dumps(record) for record in records))
 
-    with pytest.raises(ValueError, match="missing depth.url"):
+    with pytest.raises(ValueError, match=r"missing depth\.url"):
         asyncio.run(convert_ndjson_to_yolo(manifest, tmp_path / "datasets"))
 
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1272,17 +1272,25 @@ def test_depth_dataset_ignores_unreadable_targets(tmp_path):
     images, depth = tmp_path / "images" / "train", tmp_path / "depth" / "train"
     images.mkdir(parents=True)
     depth.mkdir(parents=True)
-    for name in ("valid", "scaled", "legacy", "corrupt", "missing"):
+    for name in ("valid", "scaled", "legacy", "aspect", "corrupt", "missing"):
         cv2.imwrite(str(images / f"{name}.jpg"), np.zeros((32, 32, 3), np.uint8))
-    save_depth_png(depth / "valid.png", np.ones((32, 32), dtype=np.float32))
-    cv2.imwrite(str(depth / "scaled.png"), np.full((32, 32), 1500, np.uint16))
-    np.save(depth / "legacy.npy", np.full((32, 32), 2.0, np.float32))
+    save_depth_png(depth / "valid.png", np.ones((32, 32), dtype=np.float32), scale=100)
+    with Image.open(depth / "valid.png") as image:
+        assert not image.info
+        assert np.asarray(image).max() == 100
+    cv2.imwrite(str(depth / "scaled.png"), np.full((32, 32), 150, np.uint16))
+    legacy = np.full((32, 32), 2.0, np.float32)
+    legacy[0, :3] = np.nan, np.inf, -np.inf
+    np.save(depth / "legacy.npy", legacy)
+    cv2.imwrite(str(depth / "aspect.png"), np.ones((16, 32), np.uint16))
     (depth / "corrupt.png").write_text("not a png file")
 
-    data = {"names": {0: "depth"}, "nc": 1, "channels": 3, "depth_scale": 1000}
+    data = {"names": {0: "depth"}, "nc": 1, "channels": 3, "depth_scale": 100}
     ds = DepthDataset(img_path=str(images), imgsz=32, data=data, augment=False, single_cls=True, batch_size=1)
     assert {Path(f).stem for f in ds.im_files} == {"valid", "scaled", "legacy"}
     assert sorted(ds._load_depth(i).max() for i in range(len(ds))) == [1.0, 1.5, 2.0]
+    legacy_index = next(i for i, path in enumerate(ds.im_files) if Path(path).stem == "legacy")
+    assert not ds._load_depth(legacy_index)[0, :3].any()
     assert (depth.parent / "train.cache").exists()  # scan results cached next to the depth maps
 
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1272,14 +1272,17 @@ def test_depth_dataset_ignores_unreadable_targets(tmp_path):
     images, depth = tmp_path / "images" / "train", tmp_path / "depth" / "train"
     images.mkdir(parents=True)
     depth.mkdir(parents=True)
-    for name in ("valid", "corrupt", "missing"):
+    for name in ("valid", "scaled", "legacy", "corrupt", "missing"):
         cv2.imwrite(str(images / f"{name}.jpg"), np.zeros((32, 32, 3), np.uint8))
     save_depth_png(depth / "valid.png", np.ones((32, 32), dtype=np.float32))
+    cv2.imwrite(str(depth / "scaled.png"), np.full((32, 32), 1500, np.uint16))
+    np.save(depth / "legacy.npy", np.full((32, 32), 2.0, np.float32))
     (depth / "corrupt.png").write_text("not a png file")
 
-    data = {"names": {0: "depth"}, "nc": 1, "channels": 3}
+    data = {"names": {0: "depth"}, "nc": 1, "channels": 3, "depth_scale": 1000}
     ds = DepthDataset(img_path=str(images), imgsz=32, data=data, augment=False, single_cls=True, batch_size=1)
-    assert [Path(f).stem for f in ds.im_files] == ["valid"]
+    assert {Path(f).stem for f in ds.im_files} == {"valid", "scaled", "legacy"}
+    assert sorted(ds._load_depth(i).max() for i in range(len(ds))) == [1.0, 1.5, 2.0]
     assert (depth.parent / "train.cache").exists()  # scan results cached next to the depth maps
 
 

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.122"
+__version__ = "8.4.123"
 
 import importlib
 import os

--- a/ultralytics/cfg/datasets/depth-diode.yaml
+++ b/ultralytics/cfg/datasets/depth-diode.yaml
@@ -21,6 +21,7 @@ names:
   0: depth
 
 channels: 3
+depth_scale: 256 # PNG value 256 = 1 meter; represents the 80 m outdoor range
 
 # Download script/URL (optional)
 download: |
@@ -45,6 +46,6 @@ download: |
           name = "_".join(im.relative_to(dir / "source").parts)  # train/indoors/scene/scan/x.png -> train_indoors_scene_scan_x.png
           depth = np.load(im.with_name(f"{im.stem}_depth.npy")).squeeze().astype(np.float32)
           depth[np.load(im.with_name(f"{im.stem}_depth_mask.npy")) == 0] = 0.0  # zero out invalid pixels
-          save_depth_png(dir / "depth" / split / f"{name[:-4]}.png", depth.clip(max=80))
+          save_depth_png(dir / "depth" / split / f"{name[:-4]}.png", depth.clip(max=80), scale=256)
           im.replace(dir / "images" / split / name)
   shutil.rmtree(dir / "source")

--- a/ultralytics/cfg/datasets/depth-kitti.yaml
+++ b/ultralytics/cfg/datasets/depth-kitti.yaml
@@ -23,16 +23,13 @@ names:
   0: depth
 
 channels: 3
+depth_scale: 256 # KITTI PNG value 256 = 1 meter
 
 # Download script/URL (optional)
 download: |
   import shutil
   from pathlib import Path
 
-  import cv2
-  import numpy as np
-
-  from ultralytics.data.utils import save_depth_png
   from ultralytics.utils import TQDM
   from ultralytics.utils.downloads import download
 
@@ -92,8 +89,7 @@ download: |
               if split == "val" and int(png.stem) not in EIGEN_TEST[drive]:
                   continue
               name = f"{drive}_{cam[-2:]}_{png.stem}"
-              depth = cv2.imread(str(png), cv2.IMREAD_ANYDEPTH).astype(np.float32) / 256.0
-              save_depth_png(dir / "depth" / split / f"{name}.png", depth)
+              png.replace(dir / "depth" / split / f"{name}.png")
               raw = dir / "source" / "raw" / drive[:10] / gt.name / cam / "data" / png.name
               raw.replace(dir / "images" / split / f"{name}.png")
   shutil.rmtree(dir / "source")

--- a/ultralytics/cfg/datasets/depth-tartanair.yaml
+++ b/ultralytics/cfg/datasets/depth-tartanair.yaml
@@ -21,3 +21,4 @@ names:
   0: depth
 
 channels: 3
+depth_scale: 256 # PNG value 256 = 1 meter; represents the 80 m outdoor range

--- a/ultralytics/cfg/datasets/depth-vkitti2.yaml
+++ b/ultralytics/cfg/datasets/depth-vkitti2.yaml
@@ -21,6 +21,7 @@ names:
   0: depth
 
 channels: 3
+depth_scale: 100 # source PNG value 100 = 1 meter (centimeters)
 
 # Download script/URL (optional)
 download: |
@@ -47,6 +48,6 @@ download: |
       split = "val" if scene == "Scene20" else "train"
       name = f"{scene}_{variation}_{camera}_{im.stem[4:]}"
       depth = cv2.imread(str(im.parents[2] / "depth" / camera / f"depth_{im.stem[4:]}.png"), cv2.IMREAD_ANYDEPTH)
-      save_depth_png(dir / "depth" / split / f"{name}.png", (depth.astype(np.float32) / 100.0).clip(max=80))  # cm -> m
+      save_depth_png(dir / "depth" / split / f"{name}.png", (depth.astype(np.float32) / 100.0).clip(max=80), scale=100)  # cm -> m -> cm PNG
       im.replace(dir / "images" / split / f"{name}.jpg")
   shutil.rmtree(dir / "source")

--- a/ultralytics/cfg/datasets/depth8.yaml
+++ b/ultralytics/cfg/datasets/depth8.yaml
@@ -2,11 +2,17 @@
 
 # Depth8 dataset (8 clean-label indoor images from SUN RGB-D Kinect v1/v2, 4 train / 4 val) by Ultralytics
 # Documentation: https://docs.ultralytics.com/datasets/depth/depth8
+# Format: https://docs.ultralytics.com/datasets/depth/#depth-map-format
+# uint16 PNG values are divided by depth_scale to produce meters. The default 1000 gives 65,535
+# one-millimeter depth values from 0.001 to 65.535 m; code 0 is invalid.
+# Common values (resolution, uint16 maximum):
+# ARKitScenes and NYU Depth V2: 1000 (1 mm, 65.535 m)
+# KITTI: 256 (3.90625 mm, 255.996 m); Virtual KITTI 2: 100 (1 cm, 655.35 m)
 # Example usage: yolo depth train data=depth8.yaml model=yolo26n-depth.pt
 # parent
 # ├── ultralytics
 # └── datasets
-#     └── depth8-png ← downloads here (1.3 MB)
+#     └── depth8-png ← downloads here (1.2 MB)
 #         ├── images/{train,val}  # RGB images
 #         └── depth/{train,val}   # paired 16-bit *.png depth maps (images/ -> depth/)
 
@@ -19,6 +25,7 @@ names:
   0: depth
 
 channels: 3
+depth_scale: 1000 # PNG value 1000 = 1 meter
 
 # Download script/URL (optional)
 download: https://github.com/ultralytics/assets/releases/download/v0.0.0/depth8-png.zip

--- a/ultralytics/cfg/datasets/depth8.yaml
+++ b/ultralytics/cfg/datasets/depth8.yaml
@@ -12,7 +12,7 @@
 # parent
 # ├── ultralytics
 # └── datasets
-#     └── depth8-png ← downloads here (1.2 MB)
+#     └── depth8-png ← downloads here (1.3 MB)
 #         ├── images/{train,val}  # RGB images
 #         └── depth/{train,val}   # paired 16-bit *.png depth maps (images/ -> depth/)
 

--- a/ultralytics/cfg/datasets/nyu-depth.yaml
+++ b/ultralytics/cfg/datasets/nyu-depth.yaml
@@ -14,7 +14,7 @@ path: nyu-depth-png # dataset root dir (relative to Ultralytics settings 'datase
 train: images/train # train images (relative to 'path') 795 images
 val: images/val # val images (relative to 'path') 654 images
 
-# Depth maps are paired self-describing 16-bit PNGs under depth/<split>/, resolved by
+# Depth maps are paired uint16 millimeter PNGs under depth/<split>/, resolved by
 # swapping '/images/' -> '/depth/' on each image path.
 
 # Classes
@@ -23,6 +23,7 @@ names:
   0: depth
 
 channels: 3
+depth_scale: 1000
 
 # Download script/URL (optional)
 download: https://github.com/ultralytics/assets/releases/download/v0.0.0/nyu-depth-png.zip

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -819,8 +819,8 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
 
     This function converts datasets stored in NDJSON (Newline Delimited JSON) format to the standard YOLO format. For
     detection/segmentation/pose/obb tasks, it creates separate directories for images and labels. Depth datasets use
-    parallel images/ and depth/ trees with scaled uint16 PNG targets. Classification tasks use the
-    ImageNet-style {split}/{class_name}/ folder structure. Downloads run concurrently.
+    parallel images/ and depth/ trees with scaled uint16 PNG targets. Classification tasks use the ImageNet-style
+    {split}/{class_name}/ folder structure. Downloads run concurrently.
 
     The NDJSON format consists of:
     - First line: Dataset metadata with class names, task type, and configuration

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import math
 import random
 import shutil
 from collections import defaultdict
@@ -818,7 +819,7 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
 
     This function converts datasets stored in NDJSON (Newline Delimited JSON) format to the standard YOLO format. For
     detection/segmentation/pose/obb tasks, it creates separate directories for images and labels. Depth datasets use
-    parallel images/ and depth/ trees with self-describing 16-bit PNG targets. Classification tasks use the
+    parallel images/ and depth/ trees with scaled uint16 PNG targets. Classification tasks use the
     ImageNet-style {split}/{class_name}/ folder structure. Downloads run concurrently.
 
     The NDJSON format consists of:
@@ -881,12 +882,23 @@ async def _convert_ndjson_to_yolo(ndjson_path: Path, output_path: Path) -> Path:
     check_requirements("aiohttp")
     import aiohttp
 
-    content = await asyncio.get_running_loop().run_in_executor(None, ndjson_path.read_text)
-    lines = [json.loads(line.strip()) for line in content.splitlines() if line.strip()]
+    def read_records():
+        with ndjson_path.open() as file:
+            return [json.loads(line) for line in file if line.strip()]
+
+    lines = await asyncio.get_running_loop().run_in_executor(None, read_records)
     dataset_record, image_records = lines[0], lines[1:]
     task = dataset_record.get("task", "detect")
     is_classification = task == "classify"
     is_depth = task == "depth"
+    depth_scale = dataset_record.get("depth_scale", 1000)
+    if is_depth and (
+        not isinstance(depth_scale, (int, float))
+        or isinstance(depth_scale, bool)
+        or not math.isfinite(depth_scale)
+        or depth_scale <= 0
+    ):
+        raise ValueError("Depth datasets require a positive finite depth_scale")
     class_names = {int(k): v for k, v in dataset_record.get("class_names", {}).items()}
     classification_ids = set()
 
@@ -932,11 +944,6 @@ async def _convert_ndjson_to_yolo(ndjson_path: Path, output_path: Path) -> Path:
             depth = record.get("depth")
             if not isinstance(depth, dict) or not isinstance(depth.get("url"), str) or not depth["url"]:
                 raise ValueError(f"Depth record '{record.get('file', '<unknown>')}' is missing depth.url")
-            if depth.get("encoding") != "linear-u16" or depth.get("unit") != "m":
-                raise ValueError("Depth records require encoding='linear-u16' and unit='m'")
-            shape = depth.get("shape")
-            if not isinstance(shape, list) or len(shape) != 2 or not all(type(x) is int and x > 0 for x in shape):
-                raise ValueError("Depth records require a positive [height, width] shape")
 
     # Hash-qualified dirs allow identical datasets to reuse downloads while preventing changed datasets from mutating
     # files that another training job may still be reading.
@@ -996,7 +1003,7 @@ async def _convert_ndjson_to_yolo(ndjson_path: Path, output_path: Path) -> Path:
     if not is_classification:
         # Detection/segmentation/pose/obb/depth: prepare YAML and create base structure
         if is_depth:
-            data_yaml = {"task": "depth", "nc": 1, "names": {0: "depth"}}
+            data_yaml = {"task": "depth", "nc": 1, "names": {0: "depth"}, "depth_scale": depth_scale}
         else:
             data_yaml = dict(dataset_record)
             if class_names:
@@ -1078,7 +1085,7 @@ async def _convert_ndjson_to_yolo(ndjson_path: Path, output_path: Path) -> Path:
                 return False
             return True
 
-    # Process all images with async downloads (limit connections for small datasets)
+    # Keep download concurrency high without creating one live coroutine per record for very large datasets.
     semaphore = asyncio.Semaphore(min(128, len(image_records)))
     async with aiohttp.ClientSession(trust_env=True) as session:
         pbar = TQDM(
@@ -1091,11 +1098,13 @@ async def _convert_ndjson_to_yolo(ndjson_path: Path, output_path: Path) -> Path:
             pbar.update(1)
             return result
 
-        results = await asyncio.gather(*[tracked_process(record) for record in image_records])
+        success_count = 0
+        for start in range(0, len(image_records), 1024):
+            results = await asyncio.gather(*[tracked_process(record) for record in image_records[start : start + 1024]])
+            success_count += sum(results)
         pbar.close()
 
     # Validate images were downloaded successfully
-    success_count = sum(1 for r in results if r)
     if not image_records or success_count < len(image_records):
         raise RuntimeError(f"Downloaded {success_count}/{len(image_records)} images from {ndjson_path}")
 

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -439,8 +439,8 @@ class YOLODataset(BaseDataset):
 class DepthDataset(YOLODataset):
     """Dataset for monocular depth estimation with paired RGB + depth map loading.
 
-    Extends YOLODataset to load depth ground truth maps alongside RGB images. Depth maps are stored as 16-bit PNGs in a
-    parallel directory structure (images/train/*.jpg → depth/train/*.png).
+    Extends YOLODataset to load depth ground truth maps alongside RGB images. Depth maps are stored as PNG or NPY files
+    in a parallel directory structure (images/train/*.jpg → depth/train/*.{png,npy}).
 
     Examples:
         >>> dataset = DepthDataset(img_path="/data/nyu/images/train", data={"nc": 1})
@@ -449,13 +449,14 @@ class DepthDataset(YOLODataset):
     format_class = DepthFormat
 
     def _depth_path_for(self, im_file: str) -> str:
-        """Map an image path to its companion depth PNG."""
+        """Map an image path to its companion PNG or NPY depth target."""
         parts = list(Path(im_file).parts)
         for i in range(len(parts) - 1, -1, -1):
             if parts[i] == "images":
                 parts[i] = "depth"
                 break
-        return str(Path(*parts).with_suffix(".png"))
+        path = Path(*parts).with_suffix(".png")
+        return str(path if path.is_file() else path.with_suffix(".npy"))
 
     def get_label_files(self) -> list[str]:
         """Return the depth paths paired with the dataset's images.
@@ -480,7 +481,9 @@ class DepthDataset(YOLODataset):
 
     def verify_args(self) -> tuple:
         """Return the depth verification function and its argument iterable."""
-        return verify_image_depth, zip(self.im_files, self.depth_files, repeat(self.prefix))
+        return verify_image_depth, zip(
+            self.im_files, self.depth_files, repeat(self.prefix), repeat(self.data.get("depth_scale"))
+        )
 
     def result_to_label(self, result: tuple) -> tuple[dict | None, int, int, int, int, str]:
         """Convert one verify_image_depth result into a label dict and scan counter increments."""
@@ -505,7 +508,7 @@ class DepthDataset(YOLODataset):
 
     def _load_depth(self, index):
         """Return the native-resolution depth map for an image."""
-        return load_depth(self._depth_path_for(self.im_files[index]))
+        return load_depth(self._depth_path_for(self.im_files[index]), self.data.get("depth_scale"))
 
     def get_image_and_label(self, index):
         """Load image, label, and depth map for the given index."""

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -464,7 +464,8 @@ class DepthDataset(YOLODataset):
         Returns:
             (list[str]): List of depth file paths.
         """
-        self.depth_files = [self._depth_path_for(f) for f in self.im_files]
+        self.depth_files_by_image = {f: self._depth_path_for(f) for f in self.im_files}
+        self.depth_files = list(self.depth_files_by_image.values())
         return self.depth_files
 
     def get_cache_hash(self) -> str:
@@ -473,7 +474,7 @@ class DepthDataset(YOLODataset):
         Returns:
             (str): Dataset cache hash.
         """
-        return get_hash(self.depth_files + self.im_files)
+        return get_hash(self.depth_files + self.im_files + [str(self.data.get("depth_scale", 1000))])
 
     def scan_summary(self, nf: int, nm: int, ne: int, nc: int) -> str:
         """Return a one-line summary of image-depth scan counters."""
@@ -482,7 +483,7 @@ class DepthDataset(YOLODataset):
     def verify_args(self) -> tuple:
         """Return the depth verification function and its argument iterable."""
         return verify_image_depth, zip(
-            self.im_files, self.depth_files, repeat(self.prefix), repeat(self.data.get("depth_scale"))
+            self.im_files, self.depth_files, repeat(self.prefix), repeat(self.data.get("depth_scale", 1000))
         )
 
     def result_to_label(self, result: tuple) -> tuple[dict | None, int, int, int, int, str]:
@@ -508,7 +509,7 @@ class DepthDataset(YOLODataset):
 
     def _load_depth(self, index):
         """Return the native-resolution depth map for an image."""
-        return load_depth(self._depth_path_for(self.im_files[index]), self.data.get("depth_scale"))
+        return load_depth(self.depth_files_by_image[self.im_files[index]], self.data.get("depth_scale", 1000))
 
     def get_image_and_label(self, index):
         """Load image, label, and depth map for the given index."""

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -85,11 +85,11 @@ def load_depth(path: str | Path, scale: float = DEPTH_PNG_SCALE) -> np.ndarray:
     encoded = cv2.imread(str(path), cv2.IMREAD_UNCHANGED)
     if encoded is None or encoded.ndim != 2 or encoded.dtype.kind not in "iu" or encoded.dtype.itemsize < 2:
         raise ValueError(f"Depth PNG {path} must be a 2D uint16 map")
-    if encoded.dtype != np.uint16:
-        if encoded.size and (encoded.min() < 0 or encoded.max() > np.iinfo(np.uint16).max):
-            raise ValueError(f"Depth PNG {path} contains values outside the uint16 range")
-        encoded = encoded.astype(np.uint16)
-    return encoded.astype(np.float32) / scale
+    if encoded.dtype != np.uint16 and encoded.size and (encoded.min() < 0 or encoded.max() > np.iinfo(np.uint16).max):
+        raise ValueError(f"Depth PNG {path} contains values outside the uint16 range")
+    depth = encoded.astype(np.float32)
+    depth /= scale
+    return depth
 
 
 def img2label_paths(img_paths: list[str], label_dir: str = "labels", suffix: str = ".txt") -> list[str]:

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -76,17 +76,25 @@ def save_depth_png(path: str | Path, depth: np.ndarray) -> None:
     Image.fromarray(encoded).save(path, pnginfo=metadata)
 
 
-def load_depth(path: str | Path) -> np.ndarray:
-    """Load a metric depth PNG."""
+def load_depth(path: str | Path, scale: float | None = None) -> np.ndarray:
+    """Load a metric depth map from an Ultralytics PNG, scaled integer PNG, or floating-point NPY."""
     path = Path(path)
+    if path.suffix.lower() == ".npy":
+        depth = np.load(path, allow_pickle=False)
+        if depth.ndim != 2 or depth.dtype.kind != "f":
+            raise ValueError(f"Depth map {path} must be a 2D floating-point NPY array")
+        return depth.astype(np.float32, copy=False)
     with Image.open(path) as image:
         info = image.info
-        if info.get("ultralytics.depth.encoding") != "linear-u16" or info.get("ultralytics.depth.unit") != "m":
-            raise ValueError(f"Depth PNG {path} is missing Ultralytics linear-u16 meter metadata")
-        minimum, maximum = float(info["ultralytics.depth.min"]), float(info["ultralytics.depth.max"])
-        encoded = np.asarray(image, dtype=np.uint16)
+        encoded = np.asarray(image)
     if encoded.ndim != 2:
         raise ValueError(f"Depth map {path} must be 2D, got shape {encoded.shape}")
+    if info.get("ultralytics.depth.encoding") != "linear-u16" or info.get("ultralytics.depth.unit") != "m":
+        if encoded.dtype.kind not in "ui" or not scale or scale <= 0:
+            raise ValueError(f"Depth PNG {path} requires a positive depth_scale in the dataset YAML")
+        return encoded.astype(np.float32) / scale
+    minimum, maximum = float(info["ultralytics.depth.min"]), float(info["ultralytics.depth.max"])
+    encoded = encoded.astype(np.uint16, copy=False)
     valid = encoded >= DEPTH_PNG_MIN_CODE
     depth = np.zeros(encoded.shape, dtype=np.float32)
     if maximum == minimum:
@@ -255,7 +263,7 @@ def verify_image(args: tuple) -> tuple:
 
 def verify_image_depth(args: tuple) -> tuple:
     """Verify that an image and its paired depth map exist and are readable."""
-    im_file, depth_file, prefix = args
+    im_file, depth_file, prefix, scale = args
     # Number (found, missing, corrupt), message
     nf, nm, nc, msg = 0, 0, 0, ""
     try:
@@ -265,15 +273,21 @@ def verify_image_depth(args: tuple) -> tuple:
             nm = 1
             msg = f"{prefix}{im_file}: ignoring image with missing depth map {depth_file}"
             return None, None, nf, nm, nc, msg
-        with Image.open(depth_file) as depth:
-            info = depth.info
-            assert depth.mode in {"I", "I;16"}, f"depth map {depth_file} must be 16-bit grayscale"
-            assert (
-                info.get("ultralytics.depth.encoding") == "linear-u16" and info.get("ultralytics.depth.unit") == "m"
-            ), f"depth map {depth_file} must use Ultralytics linear-u16 meter metadata"
-            float(info["ultralytics.depth.min"])
-            float(info["ultralytics.depth.max"])
-            depth.verify()
+        if Path(depth_file).suffix.lower() == ".npy":
+            depth = np.load(depth_file, mmap_mode="r", allow_pickle=False)
+            assert depth.ndim == 2 and depth.dtype.kind == "f", "depth NPY must be 2D and floating-point"
+        else:
+            with Image.open(depth_file) as depth:
+                info = depth.info
+                assert depth.mode in {"I", "I;16"}, f"depth map {depth_file} must be an integer grayscale PNG"
+                canonical = (
+                    info.get("ultralytics.depth.encoding") == "linear-u16" and info.get("ultralytics.depth.unit") == "m"
+                )
+                assert canonical or (scale and scale > 0), "integer depth PNG requires a positive depth_scale"
+                if canonical:
+                    float(info["ultralytics.depth.min"])
+                    float(info["ultralytics.depth.max"])
+                depth.verify()
         nf = 1
         return im_file, shape, nf, nm, nc, msg
     except Exception as e:

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -82,8 +82,11 @@ def load_depth(path: str | Path, scale: float = DEPTH_PNG_SCALE) -> np.ndarray:
         return np.nan_to_num(depth.astype(np.float32, copy=False), copy=False, nan=0.0, posinf=0.0, neginf=0.0)
     if not isinstance(scale, (int, float)) or isinstance(scale, bool) or not np.isfinite(scale) or scale <= 0:
         raise ValueError("Depth scale must be a positive finite number")
-    encoded = cv2.imread(str(path), cv2.IMREAD_UNCHANGED)
-    if encoded is None or encoded.ndim != 2 or encoded.dtype.kind not in "iu" or encoded.dtype.itemsize < 2:
+    with Image.open(path) as image:
+        if image.format != "PNG" or image.mode not in {"I", "I;16"}:
+            raise ValueError(f"Depth PNG {path} must be a 2D uint16 map")
+        encoded = np.asarray(image)
+    if encoded.ndim != 2 or encoded.dtype.kind not in "iu" or encoded.dtype.itemsize < 2:
         raise ValueError(f"Depth PNG {path} must be a 2D uint16 map")
     if encoded.dtype != np.uint16 and encoded.size and (encoded.min() < 0 or encoded.max() > np.iinfo(np.uint16).max):
         raise ValueError(f"Depth PNG {path} contains values outside the uint16 range")

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import cv2
 import numpy as np
-from PIL import Image, ImageOps, PngImagePlugin
+from PIL import Image, ImageOps
 
 from ultralytics.nn.autobackend import check_class_names
 from ultralytics.utils import (
@@ -51,59 +51,41 @@ IMG_FORMATS = {
 VID_FORMATS = {"asf", "avi", "gif", "m4v", "mkv", "mov", "mp4", "mpeg", "mpg", "ts", "wmv", "webm"}  # videos
 FORMATS_HELP_MSG = f"Supported formats are:\nimages: {IMG_FORMATS}\nvideos: {VID_FORMATS}"
 
-DEPTH_PNG_MIN_CODE = 256  # survives browser uint16 → uint8 display as 1; zero stays transparent
+DEPTH_PNG_SCALE = 1000  # uint16 millimeters by default; zero is invalid
 
 
-def save_depth_png(path: str | Path, depth: np.ndarray) -> None:
-    """Save metric depth as a self-describing 16-bit PNG with zero reserved for invalid pixels."""
+def save_depth_png(path: str | Path, depth: np.ndarray, scale: float = DEPTH_PNG_SCALE) -> None:
+    """Save metric depth as a scaled uint16 PNG with zero reserved for invalid pixels."""
+    if not isinstance(scale, (int, float)) or isinstance(scale, bool) or not np.isfinite(scale) or scale <= 0:
+        raise ValueError("Depth scale must be a positive finite number")
     depth = np.asarray(depth, dtype=np.float32).squeeze()
     if depth.ndim != 2:
         raise ValueError(f"Depth map must be 2D, got shape {depth.shape}")
     valid = np.isfinite(depth) & (depth > 0)
-    minimum, maximum = (float(x) for x in (depth[valid].min(), depth[valid].max())) if valid.any() else (0.0, 0.0)
     encoded = np.zeros(depth.shape, dtype=np.uint16)
-    if maximum == minimum:
-        encoded[valid] = 65535
-    else:
-        encoded[valid] = DEPTH_PNG_MIN_CODE + np.rint(
-            (depth[valid] - minimum) * ((65535 - DEPTH_PNG_MIN_CODE) / (maximum - minimum))
-        ).astype(np.uint16)
-    metadata = PngImagePlugin.PngInfo()
-    metadata.add_text("ultralytics.depth.encoding", "linear-u16")
-    metadata.add_text("ultralytics.depth.min", repr(minimum))
-    metadata.add_text("ultralytics.depth.max", repr(maximum))
-    metadata.add_text("ultralytics.depth.unit", "m")
-    Image.fromarray(encoded).save(path, pnginfo=metadata)
+    if valid.any():
+        scaled = np.rint(depth[valid] * scale)
+        if scaled.max() > np.iinfo(np.uint16).max:
+            raise ValueError(f"Depth map exceeds the {np.iinfo(np.uint16).max / scale:g} meter PNG limit")
+        encoded[valid] = np.maximum(scaled, 1).astype(np.uint16)
+    if not cv2.imwrite(str(path), encoded):
+        raise OSError(f"Failed to save depth map to {path}")
 
 
-def load_depth(path: str | Path, scale: float | None = None) -> np.ndarray:
-    """Load a metric depth map from an Ultralytics PNG, scaled integer PNG, or floating-point NPY."""
+def load_depth(path: str | Path, scale: float = DEPTH_PNG_SCALE) -> np.ndarray:
+    """Load metric depth from a scaled uint16 PNG or floating-point meter NPY."""
     path = Path(path)
     if path.suffix.lower() == ".npy":
         depth = np.load(path, allow_pickle=False)
         if depth.ndim != 2 or depth.dtype.kind != "f":
             raise ValueError(f"Depth map {path} must be a 2D floating-point NPY array")
-        return depth.astype(np.float32, copy=False)
-    with Image.open(path) as image:
-        info = image.info
-        encoded = np.asarray(image)
-    if encoded.ndim != 2:
-        raise ValueError(f"Depth map {path} must be 2D, got shape {encoded.shape}")
-    if info.get("ultralytics.depth.encoding") != "linear-u16" or info.get("ultralytics.depth.unit") != "m":
-        if encoded.dtype.kind not in "ui" or not scale or scale <= 0:
-            raise ValueError(f"Depth PNG {path} requires a positive depth_scale in the dataset YAML")
-        return encoded.astype(np.float32) / scale
-    minimum, maximum = float(info["ultralytics.depth.min"]), float(info["ultralytics.depth.max"])
-    encoded = encoded.astype(np.uint16, copy=False)
-    valid = encoded >= DEPTH_PNG_MIN_CODE
-    depth = np.zeros(encoded.shape, dtype=np.float32)
-    if maximum == minimum:
-        depth[valid] = minimum
-    else:
-        depth[valid] = minimum + (encoded[valid].astype(np.float32) - DEPTH_PNG_MIN_CODE) * (
-            (maximum - minimum) / (65535 - DEPTH_PNG_MIN_CODE)
-        )
-    return depth
+        return np.nan_to_num(depth.astype(np.float32, copy=False), copy=False, nan=0.0, posinf=0.0, neginf=0.0)
+    if not isinstance(scale, (int, float)) or isinstance(scale, bool) or not np.isfinite(scale) or scale <= 0:
+        raise ValueError("Depth scale must be a positive finite number")
+    encoded = cv2.imread(str(path), cv2.IMREAD_UNCHANGED)
+    if encoded is None or encoded.ndim != 2 or encoded.dtype != np.uint16:
+        raise ValueError(f"Depth PNG {path} must be a 2D uint16 map")
+    return encoded.astype(np.float32) / scale
 
 
 def img2label_paths(img_paths: list[str], label_dir: str = "labels", suffix: str = ".txt") -> list[str]:
@@ -276,18 +258,18 @@ def verify_image_depth(args: tuple) -> tuple:
         if Path(depth_file).suffix.lower() == ".npy":
             depth = np.load(depth_file, mmap_mode="r", allow_pickle=False)
             assert depth.ndim == 2 and depth.dtype.kind == "f", "depth NPY must be 2D and floating-point"
+            depth_shape = depth.shape
         else:
+            assert (
+                isinstance(scale, (int, float)) and not isinstance(scale, bool) and np.isfinite(scale) and scale > 0
+            ), "depth_scale must be a positive finite number"
             with Image.open(depth_file) as depth:
-                info = depth.info
                 assert depth.mode in {"I", "I;16"}, f"depth map {depth_file} must be an integer grayscale PNG"
-                canonical = (
-                    info.get("ultralytics.depth.encoding") == "linear-u16" and info.get("ultralytics.depth.unit") == "m"
-                )
-                assert canonical or (scale and scale > 0), "integer depth PNG requires a positive depth_scale"
-                if canonical:
-                    float(info["ultralytics.depth.min"])
-                    float(info["ultralytics.depth.max"])
+                depth_shape = (depth.height, depth.width)
                 depth.verify()
+        assert abs(np.log((depth_shape[1] / depth_shape[0]) / (shape[1] / shape[0]))) <= 0.02, (
+            f"depth map shape {depth_shape} does not match image shape {shape}"
+        )
         nf = 1
         return im_file, shape, nf, nm, nc, msg
     except Exception as e:

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -86,10 +86,6 @@ def load_depth(path: str | Path, scale: float = DEPTH_PNG_SCALE) -> np.ndarray:
         if image.format != "PNG" or image.mode not in {"I", "I;16"}:
             raise ValueError(f"Depth PNG {path} must be a 2D uint16 map")
         encoded = np.asarray(image)
-    if encoded.ndim != 2 or encoded.dtype.kind not in "iu" or encoded.dtype.itemsize < 2:
-        raise ValueError(f"Depth PNG {path} must be a 2D uint16 map")
-    if encoded.dtype != np.uint16 and encoded.size and (encoded.min() < 0 or encoded.max() > np.iinfo(np.uint16).max):
-        raise ValueError(f"Depth PNG {path} contains values outside the uint16 range")
     depth = encoded.astype(np.float32)
     depth /= scale
     return depth
@@ -271,7 +267,9 @@ def verify_image_depth(args: tuple) -> tuple:
                 isinstance(scale, (int, float)) and not isinstance(scale, bool) and np.isfinite(scale) and scale > 0
             ), "depth_scale must be a positive finite number"
             with Image.open(depth_file) as depth:
-                assert depth.mode in {"I", "I;16"}, f"depth map {depth_file} must be an integer grayscale PNG"
+                assert depth.format == "PNG" and depth.mode in {"I", "I;16"}, (
+                    f"depth map {depth_file} must be an integer grayscale PNG"
+                )
                 depth_shape = (depth.height, depth.width)
                 depth.verify()
         assert abs(np.log((depth_shape[1] / depth_shape[0]) / (shape[1] / shape[0]))) <= 0.02, (

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -85,7 +85,11 @@ def load_depth(path: str | Path, scale: float = DEPTH_PNG_SCALE) -> np.ndarray:
     encoded = cv2.imread(str(path), cv2.IMREAD_UNCHANGED)
     if encoded is None or encoded.ndim != 2 or encoded.dtype.kind not in "iu" or encoded.dtype.itemsize < 2:
         raise ValueError(f"Depth PNG {path} must be a 2D uint16 map")
-    return encoded.astype(np.uint16, copy=False).astype(np.float32) / scale
+    if encoded.dtype != np.uint16:
+        if encoded.size and (encoded.min() < 0 or encoded.max() > np.iinfo(np.uint16).max):
+            raise ValueError(f"Depth PNG {path} contains values outside the uint16 range")
+        encoded = encoded.astype(np.uint16)
+    return encoded.astype(np.float32) / scale
 
 
 def img2label_paths(img_paths: list[str], label_dir: str = "labels", suffix: str = ".txt") -> list[str]:

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -83,9 +83,9 @@ def load_depth(path: str | Path, scale: float = DEPTH_PNG_SCALE) -> np.ndarray:
     if not isinstance(scale, (int, float)) or isinstance(scale, bool) or not np.isfinite(scale) or scale <= 0:
         raise ValueError("Depth scale must be a positive finite number")
     encoded = cv2.imread(str(path), cv2.IMREAD_UNCHANGED)
-    if encoded is None or encoded.ndim != 2 or encoded.dtype != np.uint16:
+    if encoded is None or encoded.ndim != 2 or encoded.dtype.kind not in "iu" or encoded.dtype.itemsize < 2:
         raise ValueError(f"Depth PNG {path} must be a 2D uint16 map")
-    return encoded.astype(np.float32) / scale
+    return encoded.astype(np.uint16, copy=False).astype(np.float32) / scale
 
 
 def img2label_paths(img_paths: list[str], label_dir: str = "labels", suffix: str = ".txt") -> list[str]:


### PR DESCRIPTION
## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Depth datasets now support plain scaled uint16 PNGs and floating-point NPY maps, allowing existing dataset conventions to be loaded and converted without embedded PNG metadata.

### 📊 Key Changes

- `DepthDataset` loads `.png` files first and falls back to `.npy`; PNG values are converted to meters using YAML `depth_scale` (default `1000`), while NPY values are read directly as meters.
- `save_depth_png()` writes scaled uint16 PNGs with zero reserved for invalid values and accepts a configurable scale; legacy metadata-based PNG encoding was removed.
- Depth validation now checks PNG type, NPY shape and floating-point type, positive finite scale values, and matching image/depth aspect ratios.
- NDJSON depth conversion now accepts records containing a depth URL without requiring legacy `encoding`, `unit`, or `shape` fields, preserves `depth_scale` in the generated YAML, and processes downloads in batches.
- Dataset configurations and documentation were updated for ARKitScenes, DIODE, KITTI, TartanAir, Virtual KITTI 2, Depth8, NYU Depth V2, and Platform depth uploads.

### 🎯 Purpose & Impact

- Users can train depth models with existing uint16 PNG datasets using conventions such as millimeters, KITTI units, or centimeters by setting `depth_scale`.
- Floating-point NPY depth maps with invalid values represented by NaN or infinity are accepted and converted to zero during loading.
- Depth maps may have a smaller resolution than their RGB images when their aspect ratios match.
- NDJSON depth imports retain the dataset scale in the training YAML, enabling downloaded image/depth pairs to be used directly for training.