### PR TITLE
Always unset deterministic state when training ends

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -244,6 +244,8 @@ class BaseTrainer:
                 self._do_train()
         finally:
             unset_deterministic()  # never leave deterministic state on, including the DDP parent and failed runs
+        if not self.ddp:
+            self.run_callbacks("teardown")
 
     def _setup_scheduler(self):
         """Initialize training learning rate scheduler."""
@@ -649,7 +651,6 @@ class BaseTrainer:
         for loader in (self.train_loader, self.test_loader):
             if hasattr(loader, "close"):
                 loader.close()  # shut down persistent dataloader workers so none survive to interpreter exit
-        self.run_callbacks("teardown")
 
     def auto_batch(self, max_num_obj=0, dataset_size=0):
         """Calculate optimal batch size based on model and device memory constraints."""

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -218,29 +218,32 @@ class BaseTrainer:
     def train(self):
         """Execute the training process, using DDP subprocess for multi-GPU or direct training for single-GPU."""
         # Run subprocess if DDP training, else train normally
-        if self.ddp:
-            # Argument checks
-            if self.args.rect:
-                LOGGER.warning("'rect=True' is incompatible with Multi-GPU training, setting 'rect=False'")
-                self.args.rect = False
-            if self.args.batch < 1.0:
-                raise ValueError(
-                    "AutoBatch with batch<1 not supported for Multi-GPU training, "
-                    f"please specify a valid batch size multiple of GPU count {self.world_size}, i.e. batch={self.world_size * 8}."
-                )
+        try:
+            if self.ddp:
+                # Argument checks
+                if self.args.rect:
+                    LOGGER.warning("'rect=True' is incompatible with Multi-GPU training, setting 'rect=False'")
+                    self.args.rect = False
+                if self.args.batch < 1.0:
+                    raise ValueError(
+                        "AutoBatch with batch<1 not supported for Multi-GPU training, "
+                        f"please specify a valid batch size multiple of GPU count {self.world_size}, i.e. batch={self.world_size * 8}."
+                    )
 
-            # Command
-            cmd, file = None, None
-            try:
-                cmd, file = generate_ddp_command(self)
-                LOGGER.info(f"{colorstr('DDP:')} debug command {' '.join(cmd)}")
-                subprocess.run(cmd, check=True)
-            finally:
-                if file is not None:
-                    ddp_cleanup(self, str(file))
+                # Command
+                cmd, file = None, None
+                try:
+                    cmd, file = generate_ddp_command(self)
+                    LOGGER.info(f"{colorstr('DDP:')} debug command {' '.join(cmd)}")
+                    subprocess.run(cmd, check=True)
+                finally:
+                    if file is not None:
+                        ddp_cleanup(self, str(file))
 
-        else:
-            self._do_train()
+            else:
+                self._do_train()
+        finally:
+            unset_deterministic()  # never leave deterministic state on, including the DDP parent and failed runs
 
     def _setup_scheduler(self):
         """Initialize training learning rate scheduler."""
@@ -646,7 +649,6 @@ class BaseTrainer:
         for loader in (self.train_loader, self.test_loader):
             if hasattr(loader, "close"):
                 loader.close()  # shut down persistent dataloader workers so none survive to interpreter exit
-        unset_deterministic()
         self.run_callbacks("teardown")
 
     def auto_batch(self, max_num_obj=0, dataset_size=0):


### PR DESCRIPTION
`unset_deterministic()` ran at the end of `_do_train()`, so any run that did not reach that line left `torch.use_deterministic_algorithms(True)`, `cudnn.deterministic` and `CUBLAS_WORKSPACE_CONFIG` set for the rest of the process. Two cases: the DDP parent, which spawns subprocesses and never calls `_do_train()`, and any training that raises, since the call was not in a `finally`.

The leftover state breaks later work in the same process. `Depth` and `SemanticSegment` export to ONNX fails with `Expected all tensors to be on the same device` because deterministic mode replaces the `upsample_bilinear2d` CUDA kernel with a decomposition whose shape reads become CPU tensors under `torch.jit.trace`.

Move the call into a `finally` in `BaseTrainer.train()`, which covers the DDP parent, DDP children, single device runs, and failures on all of them.

Checked on CPU, printing `torch.are_deterministic_algorithms_enabled()` after `train()` returns or raises:

| Path | Before | After |
| --- | --- | --- |
| Training succeeds | `False` | `False` |
| Training raises | `True` | `False` |
| DDP parent | `True` | `False` |

A trainer whose `__init__` raises after `init_seeds()` still leaks. That is not changed here.

Closes #25861

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
`BaseTrainer.train()` now always clears deterministic execution state when training completes or raises, including DDP parent processes.

### 📊 Key Changes
- Wrapped DDP and single-device training execution in a `try`/`finally` block.
- Calls `unset_deterministic()` from `finally`, covering successful runs, failed runs, DDP children, and DDP parents.
- Removed the previous cleanup call from `_do_train()`, preventing deterministic state from persisting when that method is not reached or exits early.

### 🎯 Purpose & Impact
Prevents deterministic PyTorch and CUDA settings from leaking into later work in the same process, including workflows such as Depth and SemanticSegment ONNX export.