### PR TITLE
Fix hyp aliasing so dataset construction cannot mutate the shared cfg

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -82,6 +82,14 @@ def test_dataloader_empty_dataset_uses_dataloader_validation():
         build_dataloader([], batch=4, workers=2)
 
 
+def test_build_yolo_dataset_hyp_isolated():
+    """Test dataset construction never mutates hyperparameters on the shared cfg it was built from."""
+    data = check_det_dataset("coco8.yaml")
+    cfg = get_cfg(overrides={"data": "coco8.yaml", "imgsz": 32, "rect": True})  # rect zeroes mosaic on the hyp used
+    data_build.build_yolo_dataset(cfg, data["train"], batch=2, data=data, mode="train")
+    assert cfg.mosaic == DEFAULT_CFG.mosaic
+
+
 def test_cfg_rejects_fuzzed_values():
     """Test invalid overrides fail in config validation."""
     with pytest.raises(TypeError, match="degrees"):

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -234,21 +234,6 @@ def seed_worker(worker_id: int) -> None:
     random.seed(worker_seed)
 
 
-def get_hyps_from_cfg(cfg: IterableSimpleNamespace) -> IterableSimpleNamespace:
-    """Return a per-dataset copy of cfg to use as augmentation hyperparameters.
-
-    Datasets mutate hyperparameter fields (e.g. mosaic, mixup) on the object they're given, so passing the shared
-    trainer cfg directly would let one dataset's construction silently change another's settings.
-
-    Args:
-        cfg (IterableSimpleNamespace): Configuration to copy hyperparameters from.
-
-    Returns:
-        (IterableSimpleNamespace): Independent copy of cfg safe for a dataset to mutate.
-    """
-    return copy(cfg)
-
-
 def build_yolo_dataset(
     cfg: IterableSimpleNamespace,
     img_path: str,
@@ -285,7 +270,7 @@ def build_yolo_dataset(
         imgsz=cfg.imgsz,
         batch_size=batch,
         augment=mode == "train",
-        hyp=get_hyps_from_cfg(cfg),
+        hyp=copy(cfg),
         rect=rect,
         cache=cfg.cache or None,
         single_cls=cfg.single_cls or False,
@@ -317,7 +302,7 @@ def build_grounding(
         imgsz=cfg.imgsz,
         batch_size=batch,
         augment=mode == "train",  # augmentation
-        hyp=get_hyps_from_cfg(cfg),
+        hyp=copy(cfg),
         rect=cfg.rect or rect,  # rectangular batches
         cache=cfg.cache or None,
         single_cls=cfg.single_cls or False,

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -6,6 +6,7 @@ import math
 import os
 import random
 from collections.abc import Iterator
+from copy import copy
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
@@ -233,6 +234,21 @@ def seed_worker(worker_id: int) -> None:
     random.seed(worker_seed)
 
 
+def get_hyps_from_cfg(cfg: IterableSimpleNamespace) -> IterableSimpleNamespace:
+    """Return a per-dataset copy of cfg to use as augmentation hyperparameters.
+
+    Datasets mutate hyperparameter fields (e.g. mosaic, mixup) on the object they're given, so passing the shared
+    trainer cfg directly would let one dataset's construction silently change another's settings.
+
+    Args:
+        cfg (IterableSimpleNamespace): Configuration to copy hyperparameters from.
+
+    Returns:
+        (IterableSimpleNamespace): Independent copy of cfg safe for a dataset to mutate.
+    """
+    return copy(cfg)
+
+
 def build_yolo_dataset(
     cfg: IterableSimpleNamespace,
     img_path: str,
@@ -269,7 +285,7 @@ def build_yolo_dataset(
         imgsz=cfg.imgsz,
         batch_size=batch,
         augment=mode == "train",
-        hyp=cfg,
+        hyp=get_hyps_from_cfg(cfg),
         rect=rect,
         cache=cfg.cache or None,
         single_cls=cfg.single_cls or False,
@@ -301,7 +317,7 @@ def build_grounding(
         imgsz=cfg.imgsz,
         batch_size=batch,
         augment=mode == "train",  # augmentation
-        hyp=cfg,  # TODO: probably add a get_hyps_from_cfg function
+        hyp=get_hyps_from_cfg(cfg),
         rect=cfg.rect or rect,  # rectangular batches
         cache=cfg.cache or None,
         single_cls=cfg.single_cls or False,


### PR DESCRIPTION
## Summary

`build_yolo_dataset()` and `build_grounding()` pass the trainer's live `cfg` object directly as `hyp`. `YOLODataset.build_transforms()`/`close_mosaic()` mutate `hyp` fields (`mosaic`, `mixup`, `cutmix`, `copy_paste`) **in place**. Since `hyp` was the exact same object as `cfg` (not a copy), one dataset's construction could silently zero out augmentation settings on the shared `cfg` used to build other datasets — reachable whenever multiple datasets are built off the same `cfg`/`self.args`, e.g. `rect=True` training, or the multi-dataset loop in `WorldTrainerFromScratch.build_dataset()`. `engine/trainer.py` already works around this exact hazard for `close_mosaic` via `copy(self.args)`; `build.py` did not.

Adds `get_hyps_from_cfg()` — a documented `copy(cfg)` — and uses it at both call sites, closing the TODO left in `build_grounding()`.

This is narrower than the earlier closed attempts at this file:
- #24483 proposed the same `get_hyps_from_cfg` idea but auto-closed as stale without an implementation ever being reviewed.
- #24494 tried to also dedupe the *other* constructor kwargs (`imgsz`, `rect`, `cache`, `fraction`, the semantic-task branch, etc.) into a shared helper, which was correctly closed because those kwargs genuinely diverge between `build_yolo_dataset` and `build_grounding`. This PR does not touch any of that — it only changes the `hyp=` argument, leaving each function's own kwargs exactly as-is.

## Regression test

Added `test_build_yolo_dataset_hyp_isolated`, which builds a dataset with `rect=True` (the path that triggers the mutation) and asserts the input `cfg.mosaic` is unchanged afterward. Verified it fails on unmodified `main` (`cfg.mosaic` corrupted from `1.0` to `0.0`) and passes with the fix.

## Test plan

- [x] `ruff format` / `ruff check` clean on the diff
- [x] New regression test passes with the fix, fails without it
- [x] `pytest tests/test_python.py::test_build_yolo_dataset_hyp_isolated tests/test_python.py::test_dataloader_caps_workers_to_batches tests/test_python.py::test_dataloader_cap_preserves_distributed_drop_last tests/test_python.py::test_dataloader_empty_dataset_uses_dataloader_validation tests/test_python.py::test_cfg_rejects_fuzzed_values -v` — 5 passed
- [x] `pytest tests/test_python.py::test_yolo_world -v` (exercises `WorldTrainerFromScratch` → `build_yolo_dataset`) — passed
- [x] `pytest tests/test_python.py -k "detect or dataset or segment or pose or obb or cls or classify"` — 37 passed (2 unrelated failures from a missing `aiohttp` test dependency, present on `main` too)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Prevented dataset construction from mutating the shared training configuration by passing each dataset an independent copy of the augmentation hyperparameters.

### 📊 Key Changes
- Added documented `get_hyps_from_cfg()` in `ultralytics/data/build.py`, which returns a shallow copy of the configuration.
- Updated both `build_yolo_dataset()` and `build_grounding()` to use the copied hyperparameters.
- Added a regression test confirming `rect=True` dataset construction preserves `cfg.mosaic`.

### 🎯 Purpose & Impact
- Prevents augmentation settings such as `mosaic`, `mixup`, and related fields from being changed on shared configurations when multiple datasets are built. No user-facing API change.