### PR TITLE
Reuse one OpenVINO Core to fix segfault on repeated model loads

### DIFF
--- a/ultralytics/nn/backends/openvino.py
+++ b/ultralytics/nn/backends/openvino.py
@@ -20,6 +20,8 @@ class OpenVINOBackend(BaseBackend):
     selection, Intel-specific device targeting, and async inference for throughput optimization.
     """
 
+    core = None  # shared process-wide ov.Core(), as repeated creation crashes on plugin reload
+
     def load_model(self, weight: str | Path) -> None:
         """Load an Intel OpenVINO IR model from a .xml/.bin file pair or model directory.
 
@@ -30,7 +32,9 @@ class OpenVINOBackend(BaseBackend):
         check_requirements("openvino>=2024.0.0")
         import openvino as ov
 
-        core = ov.Core()
+        if OpenVINOBackend.core is None:
+            OpenVINOBackend.core = ov.Core()
+        core = OpenVINOBackend.core
         fallback_device = "CPU" if core.available_devices == ["CPU"] else "AUTO"
         device_name = fallback_device
 


### PR DESCRIPTION
`OpenVINOBackend.load_model` created a new `ov.Core()` for every model load. Creating a second `Core` and querying it in the same process segfaults, so loading more than one OpenVINO model in a process crashes.

This is what kills the SlowTests runner in [run 32231215311](https://github.com/ultralytics/ultralytics/actions/runs/32231215311/job/96067867633), where the worker dies inside `forward` after ~20 OpenVINO loads:

```
    Fatal Python error: Fatal Python error: Segmentation fault
    
    Segmentation fault
    
    Thread 0x00007fe6a1ba96c0 (most recent call first):
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
    
    Thread 0x00007fe6a26e4740 (most recent call first):
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/openvino/_ov_api.py", line 202 in infer
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/openvino/_ov_api.py", line 470 in __call__
      File "/home/runner/work/ultralytics/ultralytics/ultralytics/nn/backends/openvino.py", line 115 in forward
      File "/home/runner/work/ultralytics/ultralytics/ultralytics/nn/autobackend.py", line 285 in forward
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1527 in _call_impl
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1518 in _wrapped_call_impl
      File "/home/runner/work/ultralytics/ultralytics/ultralytics/engine/predictor.py", line 198 in inference
      File "/home/runner/work/ultralytics/ultralytics/ultralytics/engine/predictor.py", line 349 in stream_inference
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 35 in generator_context
      File "/home/runner/work/ultralytics/ultralytics/ultralytics/engine/predictor.py", line 241 in __call__
      File "/home/runner/work/ultralytics/ultralytics/ultralytics/engine/model.py", line 520 in predict
      File "/home/runner/work/ultralytics/ultralytics/ultralytics/engine/model.py", line 166 in __call__
      File "/home/runner/work/ultralytics/ultralytics/tests/test_exports.py", line 295 in test_export_openvino_matrix
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/_pytest/python.py", line 167 in pytest_pyfunc_call
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/pluggy/_callers.py", line 121 in _multicall
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/pluggy/_manager.py", line 120 in _hookexec
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/pluggy/_hooks.py", line 512 in __call__
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/_pytest/python.py", line 1707 in runtest
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/_pytest/runner.py", line 184 in pytest_runtest_call
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/pluggy/_callers.py", line 121 in _multicall
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/pluggy/_manager.py", line 120 in _hookexec
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/pluggy/_hooks.py", line 512 in __call__
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/_pytest/runner.py", line 250 in <lambda>
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/_pytest/runner.py", line 361 in from_call
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/_pytest/runner.py", line 249 in call_and_report
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/_pytest/runner.py", line 139 in runtestprotocol
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/_pytest/runner.py", line 118 in pytest_runtest_protocol
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/pluggy/_callers.py", line 121 in _multicall
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/pluggy/_manager.py", line 120 in _hookexec
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/pluggy/_hooks.py", line 512 in __call__
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/xdist/remote.py", line 227 in run_one_test
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/xdist/remote.py", line 206 in pytest_runtestloop
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/pluggy/_callers.py", line 121 in _multicall
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/pluggy/_manager.py", line 120 in _hookexec
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/pluggy/_hooks.py", line 512 in __call__
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/_pytest/main.py", line 384 in _main
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/_pytest/main.py", line 330 in wrap_session
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/_pytest/main.py", line 377 in pytest_cmdline_main
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/pluggy/_callers.py", line 121 in _multicall
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/pluggy/_manager.py", line 120 in _hookexec
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/pluggy/_hooks.py", line 512 in __call__
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/xdist/remote.py", line 427 in <module>
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/execnet/gateway_base.py", line 1291 in executetask
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/execnet/gateway_base.py", line 389 in integrate_as_primary_thread
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/execnet/gateway_base.py", line 1273 in serve
      File "/home/runner/work/ultralytics/ultralytics/.venv/lib/python3.11/site-packages/execnet/gateway_base.py", line 1806 in serve
      File "<string>", line 8 in <module>
      File "<string>", line 1 in <module>
    
    Extension modules: numpy.core._multiarray_umath, numpy.core._multiarray_tests, numpy.linalg._umath_linalg, numpy.fft._pocketfft_internal, numpy.random._common, numpy.random.bit_generator, numpy.random._bounded_integers, numpy.random._mt19937, numpy.random.mtrand, numpy.random._philox, numpy.random._pcg64, numpy.random._sfc64, numpy.random._generator, torch._C, torch._C._fft, torch._C._linalg, torch._C._nested, torch._C._nn
    Extension modules: numpy.core._multiarray_umath, torch._C._sparse, torch._C._special, numpy.core._multiarray_tests, numpy.linalg._umath_linalg, numpy.fft._pocketfft_internal, numpy.random._common, numpy.random.bit_generator, numpy.random._bounded_integers, numpy.random._mt19937, numpy.random.mtrand, numpy.random._philox, numpy.random._pcg64, numpy.random._sfc64, numpy.random._generator, torch._C, torch._C._fft, torch._C._linalg, torch._C._nested, torch._C._nn, torch._C._sparse, torch._C._special, PIL._imaging, yaml._yaml, PIL._imagingft, kiwisolver._cext, PIL._imaging, yaml._yaml, charset_normalizer.md, PIL._imagingft, charset_normalizer.cd, kiwisolver._cext, charset_normalizer.md, requests.packages.charset_normalizer.md, charset_normalizer.cd, requests.packages.chardet.md, requests.packages.charset_normalizer.cd, requests.packages.chardet.cd, requests.packages.charset_normalizer.md, google._upb._message, requests.packages.chardet.md, requests.packages.charset_normalizer.cd, requests.packages.chardet.cd, PIL._imagingmath, google._upb._message, PIL._avif, PIL._webp, lap._lapjv, PIL._imagingmath, PIL._avif, PIL._webp, lap._lapjv, multidict._multidict, yarl._quoting_c, multidict._multidict, propcache._helpers_c, yarl._quoting_c, , propcache._helpers_caiohttp._http_writer, , aiohttp._http_writeraiohttp._http_parser, aiohttp._http_parser, aiohttp._websocket.mask, aiohttp._websocket.mask, aiohttp._websocket.reader_c, aiohttp._websocket.reader_c, frozenlist._frozenlist, frozenlist._frozenlist, psutil._psutil_linux, psutil._psutil_linux, pyarrow.lib, pyarrow.lib, , pandas._libs.tslibs.ccalendarpandas._libs.tslibs.ccalendar, pandas._libs.tslibs.np_datetime, pandas._libs.tslibs.np_datetime, pandas._libs.tslibs.dtypes, pandas._libs.tslibs.dtypes, pandas._libs.tslibs.base, pandas._libs.tslibs.base, pandas._libs.tslibs.nattype, pandas._libs.tslibs.nattype, , pandas._libs.tslibs.timezonespandas._libs.tslibs.timezones, , pandas._libs.tslibs.fieldspandas._libs.tslibs.fields, , pandas._libs.tslibs.timedeltaspandas._libs.tslibs.timedeltas, pandas._libs.tslibs.tzconversion, pandas._libs.tslibs.tzconversion, pandas._libs.tslibs.timestamps, pandas._libs.tslibs.timestamps, pandas._libs.properties, pandas._libs.properties, pandas._libs.tslibs.offsets, pandas._libs.tslibs.offsets, pandas._libs.tslibs.strptime, pandas._libs.tslibs.strptime, pandas._libs.tslibs.parsing, pandas._libs.tslibs.parsing, pandas._libs.tslibs.conversion, pandas._libs.tslibs.conversion, pandas._libs.tslibs.period, pandas._libs.tslibs.period, pandas._libs.tslibs.vectorized, pandas._libs.tslibs.vectorized, pandas._libs.ops_dispatch, pandas._libs.ops_dispatch, pandas._libs.missing, pandas._libs.missing, pandas._libs.hashtable, pandas._libs.hashtable, pandas._libs.algos, pandas._libs.algos, pandas._libs.interval, pandas._libs.interval, pandas._libs.lib, pandas._libs.lib, pyarrow._compute, pyarrow._compute, pandas._libs.ops, pandas._libs.ops, pandas._libs.hashing, pandas._libs.hashing, pandas._libs.arrays, pandas._libs.arrays, pandas._libs.tslib, pandas._libs.tslib, pandas._libs.sparse, pandas._libs.sparse, pandas._libs.internals, pandas._libs.internals, pandas._libs.indexing, pandas._libs.indexing, pandas._libs.index, pandas._libs.index, pandas._libs.writers, pandas._libs.writers, pandas._libs.join, pandas._libs.join, pandas._libs.window.aggregations, pandas._libs.window.aggregations, pandas._libs.window.indexers, pandas._libs.window.indexers, pandas._libs.reshape, pandas._libs.reshape, pandas._libs.groupby, pandas._libs.groupby, pandas._libs.json, pandas._libs.json, pandas._libs.parsers, pandas._libs.parsers, pandas._libs.testing, pandas._libs.testing, pyarrow._fs, pyarrow._fs, pyarrow._azurefs, pyarrow._azurefs, pyarrow._hdfs, pyarrow._hdfs, pyarrow._gcsfs, pyarrow._gcsfs, pyarrow._s3fs, pyarrow._s3fs, , _cyutility_cyutility, , scipy._cyutilityscipy._cyutility, scipy._lib._ccallback_c, scipy._lib._ccallback_c, , scipy.sparse._sparsetoolsscipy.sparse._sparsetools, , _csparsetools_csparsetools, , scipy.sparse._csparsetoolsscipy.sparse._csparsetools, regex._regex, shapely.lib, shapely._geos, shapely._geometry_helpers, sqlalchemy.cyextension.collections, sqlalchemy.cyextension.immutabledict, sqlalchemy.cyextension.processors, sqlalchemy.cyextension.resultproxy, sqlalchemy.cyextension.util, greenlet._greenlet, markupsafe._speedups, _cffi_backend, scipy.linalg._fblas, scipy.linalg._flapack, scipy.linalg.cython_lapack, scipy.linalg._cythonized_array_utils, scipy.linalg._solve_toeplitz, scipy.linalg._batched_linalg, scipy.linalg._decomp_lu_cython, scipy.linalg._matfuncs_schur_sqrtm, scipy.linalg._matfuncs_expm, scipy.linalg._linalg_pythran, scipy.linalg.cython_blas, scipy.linalg._decomp_update, scipy.special._ufuncs_cxx, scipy.special._ellip_harm_2, scipy.special._special_ufuncs, scipy.special._gufuncs, scipy.special._ufuncs, scipy.special._specfun, scipy.special._comb, scipy.interpolate._fitpack, scipy.interpolate._dfitpack, scipy.sparse.linalg._dsolve._superlu, scipy.sparse.linalg._eigen.arpack._arpacklib, scipy.sparse.linalg._propack, scipy.optimize._group_columns, scipy._lib.messagestream, scipy.optimize._trlib._trlib, scipy.optimize._lbfgsb, _moduleTNC, scipy.optimize._moduleTNC, scipy.optimize._slsqplib, scipy.optimize._minpack, scipy.optimize._lsq.givens_elimination, scipy.optimize._zeros, scipy._lib._uarray._uarray, scipy.linalg._decomp_interpolative, scipy.optimize._bglu_dense, scipy.optimize._lsap, scipy.spatial._ckdtree, scipy.spatial._qhull, scipy.spatial._voronoi, scipy.spatial._hausdorff, scipy.spatial._distance_wrap, scipy.spatial.transform._rotation_cy, scipy.spatial.transform._rigid_transform_cy, scipy.optimize._direct, scipy.interpolate._dierckx, scipy.interpolate._ppoly, scipy.interpolate._interpnd, scipy.interpolate._rbfinterp_pythran, scipy.interpolate._rgi_cython (total: 160)
```

Minimal reproduction with `openvino==2026.3.0`, no Ultralytics code involved:

```python
import openvino as ov

a = ov.Core(); print(a.available_devices)   # ['CPU']
b = ov.Core(); print(b.available_devices)   # Segmentation fault
```

The fix stores one `ov.Core()` on the class and reuses it for every load. A single `Core` per process is also what the OpenVINO docs recommend.

Verified with `pytest --slow tests/test_exports.py -k openvino` pinned to 4 cores, `openvino==2026.3.0`, `nncf==3.3.0`, `torch==2.8.0+cpu`.

| | result |
|---|---|
| before | segfault on the 2nd test |
| after | 54 passed, 4 failed on `depth8` dataset download (local network) |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
`OpenVINOBackend` now reuses a single shared `ov.Core()` when loading models, preventing crashes caused by repeatedly creating OpenVINO cores in one process.

### 📊 Key Changes
- Added a class-level `OpenVINOBackend.core` for shared process-wide core storage.
- Creates `ov.Core()` only when the shared core has not been initialized.
- Reuses the shared core to determine the fallback device for each model load.

### 🎯 Purpose & Impact
Repeated OpenVINO model loads can now share one core instead of creating a new core for every load, avoiding the reported segmentation fault in multi-model test workflows.