### PR TITLE
Simplify Platform project path slugging

### DIFF
--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -272,7 +272,7 @@ def _get_project_name(trainer):
     """Get slugified project and name from trainer args."""
     raw = str(trainer.args.project)
     parts = raw.split("/", 1)
-    project = f"{parts[0]}/{slugify(parts[1])}" if len(parts) == 2 else slugify(raw)
+    project = f"{parts[0]}/{slugify(parts[1].replace('/', '-'))}" if len(parts) == 2 else slugify(raw)
     return project, slugify(str(trainer.args.name or "train"))
 
 

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -269,20 +269,11 @@ def _get_environment_info():
 
 
 def _get_project_name(trainer):
-    """Get slugified project and name from trainer args, ignoring local directory paths."""
+    """Get slugified project and name from trainer args."""
     raw = str(trainer.args.project)
-    name = slugify(str(trainer.args.name or "train"))
-    owner, sep, raw_project = raw.partition("/")
-    project = slugify(raw_project if sep else raw)
-    valid = not sep or (
-        "/" not in raw_project
-        and re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", project)
-        and 4 <= len(owner) <= 32
-        and re.fullmatch(r"[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*", owner)
-    )
-    if "\\" in raw or re.match(r"^[A-Za-z]:", raw) or not valid:
-        return None, name
-    return (f"{owner}/{project}" if sep else project), name
+    parts = raw.split("/", 1)
+    project = f"{parts[0]}/{slugify(parts[1])}" if len(parts) == 2 else slugify(raw)
+    return project, slugify(str(trainer.args.name or "train"))
 
 
 def on_pretrain_routine_start(trainer):
@@ -295,12 +286,6 @@ def on_pretrain_routine_start(trainer):
         return
 
     project, name = _get_project_name(trainer)
-    if not project:
-        LOGGER.info(
-            f"{PREFIX}project='{trainer.args.project}' is a local path, not an 'owner/project' Platform ID. "
-            f"Training will not be tracked on Platform."
-        )
-        return
     LOGGER.info(f"{PREFIX}Streaming training metrics to Platform")
 
     from ultralytics.utils.logger import ConsoleLogger


### PR DESCRIPTION
## Summary

- revert the client-side path and username validation added in #25824
- preserve the existing owner/project behavior
- replace additional project path separators with hyphens before the existing slugification

This restores the complete pre-#25824 callback flow, then applies the path fix at the existing slug owner in one line.

## Validation

- verified `project="glenn-jocher/busy-hornet"` remains `glenn-jocher/busy-hornet`
- verified `project="runs/detect/exp"` becomes `runs/detect-exp`
- verified the examples from #25764 directly through `_get_project_name`
- `python3 -m compileall -q ultralytics/utils/callbacks/platform.py`
- `uvx ruff format --check ultralytics/utils/callbacks/platform.py`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Simplified Platform project-name generation by removing client-side validation and replacing additional path separators with hyphens during slugification.

### 📊 Key Changes

- `_get_project_name` now preserves the first `owner/` segment and slugifies the remaining project path after replacing additional `/` characters with `-`.
- Single-segment project values continue to use the existing slugification behavior.
- Project names are always returned with a slugified training name, defaulting to `train`.
- Removed the local-path validation and the callback early return that previously skipped Platform metric streaming.

### 🎯 Purpose & Impact

- `glenn-jocher/busy-hornet` remains `glenn-jocher/busy-hornet`, while `runs/detect/exp` becomes `runs/detect-exp`.
- Path-like project values are no longer rejected by `_get_project_name` or excluded from the Platform streaming callback.