### PR TITLE
Revert optional channel_divisor model YAML key

### DIFF
--- a/docs/en/guides/model-yaml-config.md
+++ b/docs/en/guides/model-yaml-config.md
@@ -28,13 +28,11 @@ scales: # compound scaling constants [depth, width, max_channels]
     l: [1.00, 1.00, 512] # large: full depth and width
     x: [1.00, 1.50, 512] # extra-large: maximum performance
 kpt_shape: [17, 3] # pose models only
-channel_divisor: 8 # channel rounding granularity (default 8)
 ```
 
 - `nc` sets the number of classes the model predicts.
 - `scales` define compound scaling factors that adjust model depth, width, and maximum channels to produce different size variants (nano through extra-large).
 - `kpt_shape` applies to pose models. It can be `[N, 2]` for `(x, y)` keypoints or `[N, 3]` for `(x, y, visibility)`.
-- `channel_divisor` rounds layer channels up to the nearest multiple (default `8`); set it to `1` to disable multiple-of-8 alignment for tight embedded channel budgets; `C2fAttn` embedding widths always follow the rounded output channels so attention shapes stay valid.
 
 !!! tip "Reduce redundancy with `scales`"
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -129,24 +129,6 @@ def test_cfg_rejects_fuzzed_values():
     assert get_cfg(overrides={"auto_augment": None}).auto_augment is None
 
 
-def test_channel_divisor():
-    """Test custom channel rounding while preserving the default and rejecting invalid divisors."""
-    from ultralytics.nn.tasks import DetectionModel
-
-    cfg = {
-        "nc": 2,
-        "width_multiple": 0.37,
-        "backbone": [[-1, 1, "Conv", [100, 3, 2]]],
-        "head": [[[-1], 1, "Detect", [2]]],
-    }
-    default = DetectionModel(cfg=cfg, verbose=False)
-    exact = DetectionModel(cfg={**cfg, "channel_divisor": 1}, verbose=False)
-    assert default.model[0].conv.out_channels == 40
-    assert exact.model[0].conv.out_channels == 37
-    with pytest.raises(ValueError, match="channel_divisor"):
-        DetectionModel(cfg={**cfg, "channel_divisor": 0}, verbose=False)
-
-
 def skip_rpi_semantic():
     """Skip semantic segmentation tests on Raspberry Pi due to memory constraints."""
     if IS_RASPBERRYPI:

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1949,9 +1949,6 @@ def parse_model(d, ch, verbose=True):
     legacy = True  # backward compatibility for v3/v5/v8/v9 models
     max_channels = float("inf")
     nc, act, scales, end2end = (d.get(x) for x in ("nc", "activation", "scales", "end2end"))
-    channel_divisor = d.get("channel_divisor", 8)
-    if isinstance(channel_divisor, bool) or not isinstance(channel_divisor, int) or channel_divisor <= 0:
-        raise ValueError(f"channel_divisor must be a positive integer, got {channel_divisor}")
     reg_max = d.get("reg_max", 16)
     depth, width, kpt_shape = (d.get(x, 1.0) for x in ("depth_multiple", "width_multiple", "kpt_shape"))
     scale = d.get("scale")
@@ -2046,28 +2043,13 @@ def parse_model(d, ch, verbose=True):
                 with contextlib.suppress(ValueError):
                     args[j] = locals()[a] if a in locals() else ast.literal_eval(a)
         n = n_ = max(round(n * depth), 1) if n > 1 else n  # depth gain
-        adjustments = []
         if m in base_modules:
             c1, c2 = ch[f], args[0]
             if m is not Classify:  # Classify() output must stay at nc; every other layer scales by width
-                c2_requested = min(c2, max_channels) * width
-                c2 = make_divisible(c2_requested, channel_divisor)
-                if c2 != c2_requested:
-                    adjustments.append(f"c2 {c2_requested:g}->{c2}")
+                c2 = make_divisible(min(c2, max_channels) * width, 8)
             if m is C2fAttn:  # set 1) embed channels and 2) num heads
-                embed_channels_requested = min(args[1], max_channels // 2) * width
+                args[1] = make_divisible(min(args[1], max_channels // 2) * width, 8)
                 args[2] = int(max(round(min(args[2], max_channels // 2 // 32)) * width, 1) if args[2] > 1 else args[2])
-                # MaxSigmoidAttnBlock reshapes its ec-channel embed and its hidden-channel projection into nh heads,
-                # so the embed width must equal the attention hidden width and stay divisible by nh
-                hidden_channels = int(c2 * (args[6] if len(args) > 6 else 0.5))
-                if hidden_channels % args[2]:
-                    raise ValueError(
-                        f"C2fAttn hidden channels {hidden_channels} (from c2={c2}) must be divisible by nh={args[2]}; "
-                        f"adjust channel_divisor, width_multiple or nh"
-                    )
-                args[1] = hidden_channels
-                if args[1] != embed_channels_requested:
-                    adjustments.append(f"embed {embed_channels_requested:g}->{args[1]}")
 
             args = [c1, c2, *args[1:]]
             if m in repeat_modules:
@@ -2114,10 +2096,7 @@ def parse_model(d, ch, verbose=True):
         ):
             args.extend([reg_max, end2end, [ch[x] for x in f]])
             if m is Segment or m is YOLOESegment or m is Segment26 or m is YOLOESegment26:
-                mask_channels_requested = min(args[2], max_channels) * width
-                args[2] = make_divisible(mask_channels_requested, channel_divisor)
-                if args[2] != mask_channels_requested:
-                    adjustments.append(f"mask {mask_channels_requested:g}->{args[2]}")
+                args[2] = make_divisible(min(args[2], max_channels) * width, 8)
             if m in {Detect, YOLOEDetect, Segment, Segment26, YOLOESegment, YOLOESegment26, Pose, Pose26, OBB, OBB26}:
                 m.legacy = legacy
         elif m is Depth:
@@ -2148,8 +2127,7 @@ def parse_model(d, ch, verbose=True):
         m_.np = sum(x.numel() for x in m_.parameters())  # number params
         m_.i, m_.f, m_.type = i, f, t  # attach index, 'from' index, type
         if verbose:
-            note = f"  # channel_divisor {channel_divisor}: {', '.join(adjustments)}" if adjustments else ""
-            LOGGER.info(f"{i:>3}{f!s:>20}{n_:>3}{m_.np:10.0f}  {t:<45}{args!s:<30}{note}")  # print
+            LOGGER.info(f"{i:>3}{f!s:>20}{n_:>3}{m_.np:10.0f}  {t:<45}{args!s:<30}")  # print
         save.extend(x % i for x in ([f] if isinstance(f, int) else f) if x != -1)  # append to savelist
         layers.append(m_)
         if i == 0:

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -2048,8 +2048,14 @@ def parse_model(d, ch, verbose=True):
             if m is not Classify:  # Classify() output must stay at nc; every other layer scales by width
                 c2 = make_divisible(min(c2, max_channels) * width, 8)
             if m is C2fAttn:  # set 1) embed channels and 2) num heads
-                args[1] = make_divisible(min(args[1], max_channels // 2) * width, 8)
                 args[2] = int(max(round(min(args[2], max_channels // 2 // 32)) * width, 1) if args[2] > 1 else args[2])
+                hidden_channels = int(c2 * (args[6] if len(args) > 6 else 0.5))
+                if hidden_channels % args[2]:
+                    raise ValueError(
+                        f"C2fAttn hidden channels {hidden_channels} (from c2={c2}) must be divisible by nh={args[2]}; "
+                        "adjust width_multiple, nh, or C2fAttn expansion"
+                    )
+                args[1] = hidden_channels
 
             args = [c1, c2, *args[1:]]
             if m in repeat_modules:


### PR DESCRIPTION
## Summary

Revert #25423 because the optional `channel_divisor` architecture feature is out of scope.

- restore the existing fixed divisor of 8 in the model parser
- remove the parallel validation, adjustment logging, and C2fAttn behavior added with the feature
- delete the feature-specific test and documentation

This is a selective net-negative revert: 3 existing files, +4/-46, with no new files or compatibility scaffolding.

## Validation

- verified the non-standard width example restores the pre-PR 40 output channels
- verified `channel_divisor` has no remaining repository references
- `python3 -m compileall -q ultralytics/nn/tasks.py`
- `uvx ruff format --check ultralytics/nn/tasks.py tests/test_python.py`
- `git diff --check`

Focused Ruff reports only the pre-existing `BLE001` at `ultralytics/nn/tasks.py:1686`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Reverted the optional `channel_divisor` model YAML feature, restoring fixed channel rounding to multiples of 8 and removing its parser, logging, documentation, and test changes.

### 📊 Key Changes
- Restored `make_divisible(..., 8)` for standard layer and segmentation mask channel scaling in `parse_model`.
- Removed `channel_divisor` validation and configuration handling from `ultralytics/nn/tasks.py`.
- Removed channel adjustment details from model parser logs.
- Removed the `channel_divisor` documentation and dedicated test, including validation of custom divisors.

### 🎯 Purpose & Impact
- Model YAML files no longer support a configurable `channel_divisor`; channel rounding consistently uses a divisor of 8.
- Invalid divisor handling, custom divisor behavior, and related adjustment logging are removed.
- `C2fAttn` validation remains, but its error guidance now references `width_multiple`, `nh`, and the expansion setting instead of `channel_divisor`.