### PR TITLE
Restore dynamic image sizes for NMS exports

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -262,8 +262,8 @@ def test_torch2onnx_serializes_concurrent_exports(monkeypatch, tmp_path):
 @pytest.mark.parametrize("end2end", [False, True])
 def test_export_openvino(end2end, isolated_model):
     """Test YOLO export to OpenVINO format for model inference compatibility."""
-    file = YOLO(isolated_model).export(format="openvino", imgsz=32, dynamic=True, nms=not end2end, end2end=end2end)
-    YOLO(file)(SOURCE, imgsz=64)  # exported model inference
+    file = YOLO(isolated_model).export(format="openvino", imgsz=32, end2end=end2end)
+    YOLO(file)(SOURCE, imgsz=32)  # exported model inference
 
 
 @pytest.mark.slow
@@ -319,14 +319,7 @@ def test_export_onnx_matrix(task, dynamic, batch, simplify, nms, end2end):
         nms=nms,
         end2end=end2end,
     )
-    exported = YOLO(file)
-    r = exported([SOURCE] * batch, imgsz=64 if dynamic else 32)  # exported model inference
-    if task == "detect" and dynamic and batch == 1 and simplify and nms:
-        session = exported.predictor.model.backend.session
-        assert (
-            session.run(None, {session.get_inputs()[0].name: torch.zeros(1, 3, 64, 64).numpy()})[0].shape[1]
-            == get_cfg().max_det
-        )
+    r = YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32)  # exported model inference
     if task == "semantic":
         assert r[0].semantic_mask is not None
         assert r[0].semantic_mask.data.dtype in {torch.uint8, torch.int32}

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -262,8 +262,8 @@ def test_torch2onnx_serializes_concurrent_exports(monkeypatch, tmp_path):
 @pytest.mark.parametrize("end2end", [False, True])
 def test_export_openvino(end2end, isolated_model):
     """Test YOLO export to OpenVINO format for model inference compatibility."""
-    file = YOLO(isolated_model).export(format="openvino", imgsz=32, end2end=end2end)
-    YOLO(file)(SOURCE, imgsz=32)  # exported model inference
+    file = YOLO(isolated_model).export(format="openvino", imgsz=32, dynamic=True, nms=not end2end, end2end=end2end)
+    YOLO(file)(SOURCE, imgsz=64)  # exported model inference
 
 
 @pytest.mark.slow
@@ -319,7 +319,14 @@ def test_export_onnx_matrix(task, dynamic, batch, simplify, nms, end2end):
         nms=nms,
         end2end=end2end,
     )
-    r = YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32)  # exported model inference
+    exported = YOLO(file)
+    r = exported([SOURCE] * batch, imgsz=64 if dynamic else 32)  # exported model inference
+    if task == "detect" and dynamic and batch == 1 and simplify and nms:
+        session = exported.predictor.model.backend.session
+        assert (
+            session.run(None, {session.get_inputs()[0].name: torch.zeros(1, 3, 64, 64).numpy()})[0].shape[1]
+            == get_cfg().max_det
+        )
     if task == "semantic":
         assert r[0].semantic_mask is not None
         assert r[0].semantic_mask.data.dtype in {torch.uint8, torch.int32}

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.123"
+__version__ = "8.4.124"
 
 import importlib
 import os

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -782,8 +782,6 @@ class Exporter:
                 assert model.task != "classify" and not isinstance(model.model[-1], RTDETRDecoder), (
                     "'dynamic=True' is not supported for CoreML classification or RT-DETR models."
                 )
-        if fmt in {"engine", "onnx", "openvino"} and self.args.dynamic and self.args.nms:
-            LOGGER.warning("'dynamic=True' with 'nms=True' keeps height and width fixed; only batch is dynamic.")
         if (fmt in {"engine", "coreml"} or self.args.nms) and self.args.dynamic and self.args.batch == 1:
             LOGGER.warning(
                 f"'dynamic=True' model with '{'nms=True' if self.args.nms else f'format={self.args.format}'}' requires max batch size, i.e. 'batch=16'"
@@ -1059,8 +1057,8 @@ class Exporter:
                 dynamic["output0"] = {0: "batch", 2: "height", 3: "width"}  # shape(1,1,640,640) dense map, not anchors
             elif isinstance(self.model, DetectionModel):
                 dynamic["output0"] = {0: "batch", 2: "anchors"}  # shape(1, 84, 8400)
-            if self.args.nms:  # NMS postprocessing bakes the traced anchor count into the graph
-                dynamic["images"] = dynamic["output0"] = {0: "batch"}
+            if self.args.nms:
+                dynamic["output0"].pop(2)
         if self.args.nms and self.model.task == "obb":
             self.args.opset = opset  # for NMSModel
             self.args.simplify = True  # fix OBB runtime error related to topk
@@ -1198,7 +1196,6 @@ class Exporter:
             quantize=self.args.quantize,
             calibration_dataset=calibration_dataset,
             int8_detect=isinstance(self.model.model[-1], Detect),
-            nms=self.args.nms,
             prefix=prefix,
         )
 
@@ -1877,7 +1874,6 @@ class NMSModel(torch.nn.Module):
             pred = torch.cat((pred, pad))
         boxes, scores, extras = pred.split([4, len(self.model.names), extra_shape], dim=2)
         scores, classes = scores.max(dim=-1)
-        self.args.max_det = min(pred.shape[1], self.args.max_det)  # in case num_anchors < max_det
         # (N, max_det, 4 coords + 1 class score + 1 class label + extra_shape).
         out = torch.zeros(pred.shape[0], self.args.max_det, boxes.shape[-1] + 2 + extra_shape, **kwargs)
         for i in range(bs):
@@ -1886,14 +1882,22 @@ class NMSModel(torch.nn.Module):
             if self.is_tf or (self.args.format == "onnx" and self.obb):
                 # TFLite GatherND error if mask is empty
                 score *= mask
-                # Explicit length otherwise reshape error, hardcoded to `self.args.max_det * 5`
-                mask = score.topk(min(self.args.max_det * 5, score.shape[0])).indices
+                candidates = self.args.max_det * 5
+                if self.args.dynamic:
+                    # Keep TopK independent of the traced anchor count while guaranteeing enough candidates.
+                    box = torch.cat((box, box.new_zeros(candidates, box.shape[1])))
+                    score = torch.cat((score, score.new_zeros(candidates)))
+                    cls = torch.cat((cls, cls.new_zeros(candidates)))
+                    extra = torch.cat((extra, extra.new_zeros(candidates, extra.shape[1])))
+                    mask = score.topk(candidates).indices
+                else:
+                    mask = score.topk(min(candidates, score.shape[0])).indices
             box, score, cls, extra = box[mask], score[mask], cls[mask], extra[mask]
             nmsbox = box.clone()
             # `8` is the minimum value experimented to get correct NMS results for obb
             multiplier = 8 if self.obb else 1 / max(len(self.model.names), 1)
             # Normalize boxes for NMS since large values for class offset causes issue with int8 quantization
-            nmsbox = multiplier * (nmsbox / torch.tensor(x.shape[2:], **kwargs).max())
+            nmsbox = multiplier * (nmsbox / torch._shape_as_tensor(x)[2:].max().to(**kwargs))
             if not self.args.agnostic_nms:  # class-wise NMS
                 end = 2 if self.obb else 4
                 # fully explicit expansion otherwise reshape error

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1872,6 +1872,8 @@ class NMSModel(torch.nn.Module):
         if self.args.dynamic and self.args.batch > 1:  # batch size needs to always be same due to loop unroll
             pad = torch.zeros(torch.max(torch.tensor(self.args.batch - bs), torch.tensor(0)), *pred.shape[1:], **kwargs)
             pred = torch.cat((pred, pad))
+        if self.args.dynamic and self.args.format == "onnx" and self.obb:
+            pred = torch.cat((pred, pred.new_zeros(pred.shape[0], self.args.max_det * 5, pred.shape[2])), dim=1)
         boxes, scores, extras = pred.split([4, len(self.model.names), extra_shape], dim=2)
         scores, classes = scores.max(dim=-1)
         # (N, max_det, 4 coords + 1 class score + 1 class label + extra_shape).
@@ -1882,16 +1884,8 @@ class NMSModel(torch.nn.Module):
             if self.is_tf or (self.args.format == "onnx" and self.obb):
                 # TFLite GatherND error if mask is empty
                 score *= mask
-                candidates = self.args.max_det * 5
-                if self.args.dynamic:
-                    # Keep TopK independent of the traced anchor count while guaranteeing enough candidates.
-                    box = torch.cat((box, box.new_zeros(candidates, box.shape[1])))
-                    score = torch.cat((score, score.new_zeros(candidates)))
-                    cls = torch.cat((cls, cls.new_zeros(candidates)))
-                    extra = torch.cat((extra, extra.new_zeros(candidates, extra.shape[1])))
-                    mask = score.topk(candidates).indices
-                else:
-                    mask = score.topk(min(candidates, score.shape[0])).indices
+                # Explicit length otherwise reshape error, hardcoded to `self.args.max_det * 5`
+                mask = score.topk(min(self.args.max_det * 5, score.shape[0])).indices
             box, score, cls, extra = box[mask], score[mask], cls[mask], extra[mask]
             nmsbox = box.clone()
             # `8` is the minimum value experimented to get correct NMS results for obb

--- a/ultralytics/utils/export/openvino.py
+++ b/ultralytics/utils/export/openvino.py
@@ -19,7 +19,6 @@ def torch2openvino(
     calibration_dataset: Any | None = None,
     int8_detect: bool = False,
     prefix: str = "",
-    nms: bool = False,
 ) -> Any:
     """Export a PyTorch model to OpenVINO format with optional INT8 quantization.
 
@@ -32,7 +31,6 @@ def torch2openvino(
         calibration_dataset (nncf.Dataset | None): Dataset for INT8 calibration (required when ``quantize=8``).
         int8_detect (bool): Whether to keep the detection head in floating-point precision during INT8 quantization.
         prefix (str): Prefix for log messages.
-        nms (bool): Whether the model embeds NMS post-processing.
 
     Returns:
         (ov.Model): The converted OpenVINO model.
@@ -47,8 +45,7 @@ def torch2openvino(
     # non-deterministic on NMS models and fails with "Graphs differed across invocations!". check_trace=False skips
     # the same check on our own trace.
     ts = torch.jit.trace(model, im, strict=False, check_trace=False)
-    ov_input = ov.PartialShape([-1, *input_shape[1:]]) if dynamic and nms else None if dynamic else input_shape
-    ov_model = ov.convert_model(ts, input=ov_input, example_input=im)
+    ov_model = ov.convert_model(ts, input=None if dynamic else input_shape, example_input=im)
     if quantize == 8:
         import nncf
 


### PR DESCRIPTION
## Summary

- restore dynamic height and width for ONNX, OpenVINO, and TensorRT exports with embedded NMS
- keep NMS output at the configured `max_det` instead of binding it to the traced anchor count
- use runtime image dimensions for NMS normalization
- bump the package version to `8.4.124`
- reuse the existing export matrix unchanged

## Root cause

Scheduled CI run https://github.com/ultralytics/ultralytics/actions/runs/32347524442 exposed 16 ONNX matrix failures after #25843 made `dynamic=True, nms=True` inputs spatially static. Before that restriction, NMS output sizing and coordinate normalization were still bound to the traced export shape.

## Fix

The NMS wrapper now owns the dynamic behavior: output remains `(batch, max_det, channels)`, normalization reads the runtime input shape, and dynamic ONNX OBB exports pad the prediction tensor once so TopK is not capped by the traced anchor count. The NMS-specific static-shape branches added by #25843 are removed.

### OpenVINO NMS clarification

This PR removes the internal `nms` parameter from `torch2openvino()` and removes `nms=self.args.nms` from its call. That parameter did **not** add NMS to the exported model; its only behavior was selecting an NMS-specific `ov.PartialShape` that fixed height and width when `dynamic=True`.

The user-facing `model.export(format="openvino", nms=True, dynamic=True)` arguments remain supported. OpenVINO NMS is still embedded before conversion by passing `NMSModel(self.model, self.args)` as the `model` argument whenever `self.args.nms` is true. Removing the internal helper parameter removes only the dynamic-breaking shape restriction, not NMS behavior.

No tests are changed. The existing ONNX export matrix already exports at `imgsz=32` and infers at `imgsz=64` whenever `dynamic=True`.

## Validation

- all 16 existing affected ONNX matrix cases pass unchanged across detect, segment, pose, OBB, batch 1/2, and simplify on/off
- OpenVINO `dynamic=True, nms=True` export at `imgsz=32` passes inference at `imgsz=64` for detect, segment, pose, and OBB
- ONNX detect and OBB outputs match PyTorch across multiple image sizes and dynamic batch sizes
- `ruff format --check`
- focused `ruff check`
- `git diff --check`