### PR TITLE
Make restricted checkpoint loading thread-safe and 40% faster, simplify RLE prior

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -197,6 +197,16 @@ def test_select_device(monkeypatch):
     assert torch_utils.parse_device("-1") == "0"  # idle physical GPU 1 found via normalized visible ids
 
 
+def test_restricted_load_threaded():
+    """Concurrent restricted loads share one process-wide allow-list and must not strip each other's entries."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    from ultralytics.nn.tasks import torch_safe_load
+
+    with ThreadPoolExecutor(8) as pool:
+        list(pool.map(lambda _: torch_safe_load(MODEL, safe_only=True), range(32)))
+
+
 def test_model_forward():
     """Test the forward pass of the YOLO model."""
     model = YOLO(CFG)

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.125"
+__version__ = "8.4.126"
 
 import importlib
 import os

--- a/ultralytics/nn/modules/block.py
+++ b/ultralytics/nn/modules/block.py
@@ -2042,6 +2042,10 @@ class RealNVP(nn.Module):
     def __init__(self):
         super().__init__()
 
+        # loc/cov are no longer read (the prior is the closed-form standard normal in log_prob) but stay registered so
+        # checkpoints saved before 8.4.126 still resume: the EMA state is loaded strictly.
+        self.register_buffer("loc", torch.zeros(2))
+        self.register_buffer("cov", torch.eye(2))
         self.register_buffer("mask", torch.tensor([[0, 1], [1, 0]] * 3, dtype=torch.float32))
 
         self.s = torch.nn.ModuleList([self.nets() for _ in range(len(self.mask))])

--- a/ultralytics/nn/modules/block.py
+++ b/ultralytics/nn/modules/block.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import math
+
 import torch
 import torch.nn.functional as F
 from torch import nn
@@ -2037,16 +2039,9 @@ class RealNVP(nn.Module):
         """Get the translation model in a single invertible mapping."""
         return nn.Sequential(nn.Linear(2, 64), nn.SiLU(), nn.Linear(64, 64), nn.SiLU(), nn.Linear(64, 2))
 
-    @property
-    def prior(self):
-        """The prior distribution."""
-        return torch.distributions.MultivariateNormal(self.loc, self.cov)
-
     def __init__(self):
         super().__init__()
 
-        self.register_buffer("loc", torch.zeros(2))
-        self.register_buffer("cov", torch.eye(2))
         self.register_buffer("mask", torch.tensor([[0, 1], [1, 0]] * 3, dtype=torch.float32))
 
         self.s = torch.nn.ModuleList([self.nets() for _ in range(len(self.mask))])
@@ -2077,4 +2072,5 @@ class RealNVP(nn.Module):
         if x.dtype == torch.float32 and self.s[0][0].weight.dtype != torch.float32:
             self.float()
         z, log_det = self.backward_p(x)
-        return self.prior.log_prob(z) + log_det
+        # Closed-form log N(z; 0, I) in 2-D; fp32 keeps z**2 from overflowing under AMP.
+        return -0.5 * (z.float() ** 2).sum(-1) - math.log(2 * math.pi) + log_det

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1596,13 +1596,15 @@ class _SafeLoad:
     allow-list) and build models without `eval()`.
 
     Enabled per-process by the `ULTRALYTICS_SAFE_LOAD` env flag, or per-call by `torch_safe_load(..., safe_only=True)`.
-    Default loading (flag off) is unchanged.
+    Default loading (flag off) is unchanged. The globals a restricted load registers stay registered for the process,
+    so they also apply to any other `torch.load(weights_only=True)` call made afterwards.
     """
 
-    # Restricted loading needs torch.serialization's allow-list API (torch 2.5+); on older torch it is unavailable, so
-    # restricted loading degrades to a standard load there.
-    SUPPORTED = hasattr(torch.serialization, "safe_globals")
+    # Restricted loading needs torch 2.6+: the checkpoint global scan and `(obj, "module.Name")` allow-list aliases.
+    # On older torch restricted loading degrades to a standard load.
+    SUPPORTED = hasattr(torch.serialization, "get_unsafe_globals_in_checkpoint")
     _registry = None  # {"module.Name": allow-list entry}, built once per process
+    _lock = threading.Lock()  # torch's add_safe_globals rebinds a process-global set: serialize registrations
     _local = threading.local()  # per-thread flag set while a weights_only load is in progress
 
     @classmethod
@@ -1623,26 +1625,23 @@ class _SafeLoad:
         the whole registered set on every GLOBAL/NEWOBJ/REDUCE/BUILD opcode, so a 660-entry allow-list nearly doubled
         the load time of a checkpoint that references 20 of them.
         """
-        if cls._registry is None:
-            cls._registry = cls._build()
-        get_unsafe_globals = getattr(torch.serialization, "get_unsafe_globals_in_checkpoint", None)
         try:
-            needed = get_unsafe_globals(weight) if get_unsafe_globals else None
-        except ValueError:  # Unscannable checkpoint; defer format handling to torch.load.
-            needed = None
-        if needed is None or any(name.startswith("torchvision.transforms.") for name in needed):
-            # Classification preprocessing transforms; imported only for checkpoints that serialize them.
-            import torchvision.transforms.transforms as tvt
-            from torchvision.transforms.functional import InterpolationMode
+            needed = torch.serialization.get_unsafe_globals_in_checkpoint(weight)
+        except ValueError:  # Not a torch.save() zip archive; torch.load reports the format error, nothing to register
+            needed = []
+        with cls._lock:
+            if cls._registry is None:
+                cls._registry = cls._build()
+            if any(name.startswith("torchvision.transforms.") for name in needed):
+                # Classification preprocessing transforms; imported only for checkpoints that serialize them.
+                import torchvision.transforms.transforms as tvt
+                from torchvision.transforms.functional import InterpolationMode
 
-            for obj in (tvt.Compose, tvt.Normalize, tvt.Resize, tvt.CenterCrop, tvt.ToTensor, InterpolationMode):
-                cls._registry[f"{obj.__module__}.{obj.__qualname__}"] = obj
-        if needed is None:  # No scan API (torch < 2.6): register everything
-            entries = list(cls._registry.values())
-        else:
+                for obj in (tvt.Compose, tvt.Normalize, tvt.Resize, tvt.CenterCrop, tvt.ToTensor, InterpolationMode):
+                    cls._registry[f"{obj.__module__}.{obj.__qualname__}"] = obj
             entries = [cls._registry[name] for name in needed if name in cls._registry]
-        if entries:
-            torch.serialization.add_safe_globals(entries)
+            if entries:
+                torch.serialization.add_safe_globals(entries)
         cls._local.active = True
         try:
             yield

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1604,7 +1604,9 @@ class _SafeLoad:
     # On older torch restricted loading degrades to a standard load.
     SUPPORTED = hasattr(torch.serialization, "get_unsafe_globals_in_checkpoint")
     _registry = None  # {"module.Name": allow-list entry}, built once per process
-    _lock = threading.Lock()  # torch's add_safe_globals rebinds a process-global set: serialize registrations
+    _lock = (
+        threading.Lock()
+    )  # add_safe_globals rebinds a process-global set; held across _build(), so no load may run at import
     _local = threading.local()  # per-thread flag set while a weights_only load is in progress
 
     @classmethod

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1602,7 +1602,8 @@ class _SafeLoad:
     # Restricted loading needs torch.serialization's allow-list API (torch 2.5+); on older torch it is unavailable, so
     # restricted loading degrades to a standard load there.
     SUPPORTED = hasattr(torch.serialization, "safe_globals")
-    _globals = None  # cached allow-list, built once
+    _globals = None  # allow-list, built and registered once per process
+    _torchvision = False  # torchvision transform classes registered (only once a checkpoint needs them)
     _local = threading.local()  # per-thread flag set while a weights_only load is in progress
 
     @classmethod
@@ -1612,17 +1613,34 @@ class _SafeLoad:
 
     @classmethod
     @contextlib.contextmanager
-    def loading(cls):
-        """Load with `weights_only=True`: mark the thread restricted, so a checkpoint that reaches model construction
-        (parse_model) also uses the no-eval, known-layer path.
+    def loading(cls, weight):
+        """Load with `weights_only=True`: register the allow-list and mark the thread restricted, so a checkpoint that
+        reaches model construction (parse_model) also uses the no-eval, known-layer path.
+
+        The allow-list is registered once per process with `add_safe_globals`, never scoped per load: the
+        `safe_globals()` context manager removes its entries from a process-global set on exit, so with concurrent
+        loads one thread's exit strips the allow-list out of another thread's in-flight unpickle.
         """
         if cls._globals is None:
-            # Add the allow-list once per process: torch.serialization.safe_globals() removes its entries from a
-            # process-global set on exit, so with concurrent loads one thread's exit strips the allow-list out of
-            # another thread's in-flight unpickle.
             allow = cls._build()
             torch.serialization.add_safe_globals(allow)
-            cls._globals = allow  # publish only after the add, so a racing thread never sees a cached-but-unadded list
+            cls._globals = allow  # publish only after registering, so a racing thread never loads unregistered
+        if not cls._torchvision:
+            # Import torchvision only for checkpoints that serialize its transforms (classification preprocessing);
+            # once registered, later loads skip the checkpoint scan entirely.
+            get_unsafe_globals = getattr(torch.serialization, "get_unsafe_globals_in_checkpoint", None)
+            try:
+                unsafe_globals = get_unsafe_globals(weight) if get_unsafe_globals else None
+            except ValueError:  # Unscannable checkpoint; defer format handling to torch.load.
+                unsafe_globals = None
+            if unsafe_globals is None or any(name.startswith("torchvision.transforms.") for name in unsafe_globals):
+                import torchvision.transforms.transforms as tvt
+                from torchvision.transforms.functional import InterpolationMode
+
+                torch.serialization.add_safe_globals(
+                    [tvt.Compose, tvt.Normalize, tvt.Resize, tvt.CenterCrop, tvt.ToTensor, InterpolationMode]
+                )
+                cls._torchvision = True
         cls._local.active = True
         try:
             yield
@@ -1675,8 +1693,6 @@ class _SafeLoad:
         import pkgutil
 
         import torch.nn.modules as torch_nn
-        import torchvision.transforms.transforms as tvt
-        from torchvision.transforms.functional import InterpolationMode
 
         import ultralytics.nn.modules as ul_nn
         from ultralytics.nn import tasks as ul_tasks  # noqa: PLW0406
@@ -1704,8 +1720,6 @@ class _SafeLoad:
         # Non-nn.Module data globals in official checkpoints, incl. the pre-8.0.44 `ultralytics.yolo.utils` path.
         allow.append(IterableSimpleNamespace)
         allow.append((IterableSimpleNamespace, "ultralytics.yolo.utils.IterableSimpleNamespace"))
-        # torchvision transforms pickled into classification checkpoints (InterpolationMode is an Enum, not a Module).
-        allow += [tvt.Compose, tvt.Normalize, tvt.Resize, tvt.CenterCrop, tvt.ToTensor, InterpolationMode]
 
         # Legacy/cross-platform aliases (pickled paths with no current class namespace), mirroring temporary_modules().
         from ultralytics.utils.loss import E2EDetectLoss
@@ -1786,7 +1800,7 @@ def torch_safe_load(weight, safe_only=None):
             },
         ):
             if safe_only:
-                with _SafeLoad.loading():  # weights_only load against the known-class allow-list
+                with _SafeLoad.loading(file):  # weights_only load against the known-class allow-list
                     return torch_load(file, map_location="cpu", weights_only=True)
             return torch_load(file, map_location="cpu")
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1599,8 +1599,8 @@ class _SafeLoad:
     Default loading (flag off) is unchanged.
     """
 
-    # Restricted loading reconstructs allow-listed classes via the torch.serialization.safe_globals context manager,
-    # added in torch 2.5. On older torch it is unavailable, so restricted loading degrades to a standard load there.
+    # Restricted loading needs torch.serialization's allow-list API (torch 2.5+); on older torch it is unavailable, so
+    # restricted loading degrades to a standard load there.
     SUPPORTED = hasattr(torch.serialization, "safe_globals")
     _globals = None  # cached allow-list, built once
     _local = threading.local()  # per-thread flag set while a weights_only load is in progress
@@ -1612,27 +1612,20 @@ class _SafeLoad:
 
     @classmethod
     @contextlib.contextmanager
-    def loading(cls, weight):
-        """Load with `weights_only=True`: scope the allow-list to this load and mark the thread restricted, so a
-        checkpoint that reaches model construction (parse_model) also uses the no-eval, known-layer path.
+    def loading(cls):
+        """Load with `weights_only=True`: mark the thread restricted, so a checkpoint that reaches model construction
+        (parse_model) also uses the no-eval, known-layer path.
         """
         if cls._globals is None:
-            cls._globals = cls._build()
-        allow = cls._globals
-        get_unsafe_globals = getattr(torch.serialization, "get_unsafe_globals_in_checkpoint", None)
-        try:
-            unsafe_globals = get_unsafe_globals(weight) if get_unsafe_globals else None
-        except ValueError:  # Unscannable checkpoint; preserve fallback globals and defer format handling to torch.load.
-            unsafe_globals = None
-        if unsafe_globals is None or any(name.startswith("torchvision.transforms.") for name in unsafe_globals):
-            import torchvision.transforms.transforms as tvt
-            from torchvision.transforms.functional import InterpolationMode
-
-            allow = [*allow, tvt.Compose, tvt.Normalize, tvt.Resize, tvt.CenterCrop, tvt.ToTensor, InterpolationMode]
+            # Add the allow-list once per process: torch.serialization.safe_globals() removes its entries from a
+            # process-global set on exit, so with concurrent loads one thread's exit strips the allow-list out of
+            # another thread's in-flight unpickle.
+            allow = cls._build()
+            torch.serialization.add_safe_globals(allow)
+            cls._globals = allow  # publish only after the add, so a racing thread never sees a cached-but-unadded list
         cls._local.active = True
         try:
-            with torch.serialization.safe_globals(allow):
-                yield
+            yield
         finally:
             cls._local.active = False
 
@@ -1673,7 +1666,7 @@ class _SafeLoad:
         `head.RealNVP`), plus legacy aliases.
 
         Returns:
-            (list): Items for `torch.serialization.safe_globals` — classes and `(obj, "module.Name")` aliases.
+            (list): Items for `torch.serialization.add_safe_globals` — classes and `(obj, "module.Name")` aliases.
         """
         import enum
         import importlib
@@ -1682,6 +1675,8 @@ class _SafeLoad:
         import pkgutil
 
         import torch.nn.modules as torch_nn
+        import torchvision.transforms.transforms as tvt
+        from torchvision.transforms.functional import InterpolationMode
 
         import ultralytics.nn.modules as ul_nn
         from ultralytics.nn import tasks as ul_tasks  # noqa: PLW0406
@@ -1709,6 +1704,8 @@ class _SafeLoad:
         # Non-nn.Module data globals in official checkpoints, incl. the pre-8.0.44 `ultralytics.yolo.utils` path.
         allow.append(IterableSimpleNamespace)
         allow.append((IterableSimpleNamespace, "ultralytics.yolo.utils.IterableSimpleNamespace"))
+        # torchvision transforms pickled into classification checkpoints (InterpolationMode is an Enum, not a Module).
+        allow += [tvt.Compose, tvt.Normalize, tvt.Resize, tvt.CenterCrop, tvt.ToTensor, InterpolationMode]
 
         # Legacy/cross-platform aliases (pickled paths with no current class namespace), mirroring temporary_modules().
         from ultralytics.utils.loss import E2EDetectLoss
@@ -1789,7 +1786,7 @@ def torch_safe_load(weight, safe_only=None):
             },
         ):
             if safe_only:
-                with _SafeLoad.loading(file):  # weights_only load scoped to the known-class allow-list
+                with _SafeLoad.loading():  # weights_only load against the known-class allow-list
                     return torch_load(file, map_location="cpu", weights_only=True)
             return torch_load(file, map_location="cpu")
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1602,8 +1602,7 @@ class _SafeLoad:
     # Restricted loading needs torch.serialization's allow-list API (torch 2.5+); on older torch it is unavailable, so
     # restricted loading degrades to a standard load there.
     SUPPORTED = hasattr(torch.serialization, "safe_globals")
-    _globals = None  # allow-list, built and registered once per process
-    _torchvision = False  # torchvision transform classes registered (only once a checkpoint needs them)
+    _registry = None  # {"module.Name": allow-list entry}, built once per process
     _local = threading.local()  # per-thread flag set while a weights_only load is in progress
 
     @classmethod
@@ -1614,33 +1613,36 @@ class _SafeLoad:
     @classmethod
     @contextlib.contextmanager
     def loading(cls, weight):
-        """Load with `weights_only=True`: register the allow-list and mark the thread restricted, so a checkpoint that
-        reaches model construction (parse_model) also uses the no-eval, known-layer path.
+        """Load with `weights_only=True`: register the globals this checkpoint needs and mark the thread restricted, so
+        a checkpoint that reaches model construction (parse_model) also uses the no-eval, known-layer path.
 
-        The allow-list is registered once per process with `add_safe_globals`, never scoped per load: the
+        Globals are registered with `add_safe_globals` for the life of the process, never scoped per load: the
         `safe_globals()` context manager removes its entries from a process-global set on exit, so with concurrent
-        loads one thread's exit strips the allow-list out of another thread's in-flight unpickle.
+        loads one thread's exit strips the allow-list out of another thread's in-flight unpickle. Registering only
+        the globals a checkpoint references also keeps the restricted unpickler fast — torch rebuilds its lookup from
+        the whole registered set on every GLOBAL/NEWOBJ/REDUCE/BUILD opcode, so a 660-entry allow-list nearly doubled
+        the load time of a checkpoint that references 20 of them.
         """
-        if cls._globals is None:
-            allow = cls._build()
-            torch.serialization.add_safe_globals(allow)
-            cls._globals = allow  # publish only after registering, so a racing thread never loads unregistered
-        if not cls._torchvision:
-            # Import torchvision only for checkpoints that serialize its transforms (classification preprocessing);
-            # once registered, later loads skip the checkpoint scan entirely.
-            get_unsafe_globals = getattr(torch.serialization, "get_unsafe_globals_in_checkpoint", None)
-            try:
-                unsafe_globals = get_unsafe_globals(weight) if get_unsafe_globals else None
-            except ValueError:  # Unscannable checkpoint; defer format handling to torch.load.
-                unsafe_globals = None
-            if unsafe_globals is None or any(name.startswith("torchvision.transforms.") for name in unsafe_globals):
-                import torchvision.transforms.transforms as tvt
-                from torchvision.transforms.functional import InterpolationMode
+        if cls._registry is None:
+            cls._registry = cls._build()
+        get_unsafe_globals = getattr(torch.serialization, "get_unsafe_globals_in_checkpoint", None)
+        try:
+            needed = get_unsafe_globals(weight) if get_unsafe_globals else None
+        except ValueError:  # Unscannable checkpoint; defer format handling to torch.load.
+            needed = None
+        if needed is None or any(name.startswith("torchvision.transforms.") for name in needed):
+            # Classification preprocessing transforms; imported only for checkpoints that serialize them.
+            import torchvision.transforms.transforms as tvt
+            from torchvision.transforms.functional import InterpolationMode
 
-                torch.serialization.add_safe_globals(
-                    [tvt.Compose, tvt.Normalize, tvt.Resize, tvt.CenterCrop, tvt.ToTensor, InterpolationMode]
-                )
-                cls._torchvision = True
+            for obj in (tvt.Compose, tvt.Normalize, tvt.Resize, tvt.CenterCrop, tvt.ToTensor, InterpolationMode):
+                cls._registry[f"{obj.__module__}.{obj.__qualname__}"] = obj
+        if needed is None:  # No scan API (torch < 2.6): register everything
+            entries = list(cls._registry.values())
+        else:
+            entries = [cls._registry[name] for name in needed if name in cls._registry]
+        if entries:
+            torch.serialization.add_safe_globals(entries)
         cls._local.active = True
         try:
             yield
@@ -1684,7 +1686,8 @@ class _SafeLoad:
         `head.RealNVP`), plus legacy aliases.
 
         Returns:
-            (list): Items for `torch.serialization.add_safe_globals` — classes and `(obj, "module.Name")` aliases.
+            (dict): `torch.serialization.add_safe_globals` entries — classes and `(obj, "module.Name")` aliases — keyed
+                by the pickled "module.Name" path each one serves.
         """
         import enum
         import importlib
@@ -1749,7 +1752,7 @@ class _SafeLoad:
                 (pathlib.PosixPath, "pathlib.WindowsPath"),
                 (pathlib.PosixPath, f"{pathlib.WindowsPath.__module__}.{pathlib.WindowsPath.__qualname__}"),
             ]
-        return allow
+        return {(e[1] if isinstance(e, tuple) else f"{e.__module__}.{e.__qualname__}"): e for e in allow}
 
 
 def torch_safe_load(weight, safe_only=None):

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1596,8 +1596,8 @@ class _SafeLoad:
     allow-list) and build models without `eval()`.
 
     Enabled per-process by the `ULTRALYTICS_SAFE_LOAD` env flag, or per-call by `torch_safe_load(..., safe_only=True)`.
-    Default loading (flag off) is unchanged. The globals a restricted load registers stay registered for the process,
-    so they also apply to any other `torch.load(weights_only=True)` call made afterwards.
+    Default loading (flag off) is unchanged. The globals a restricted load registers stay registered for the process, so
+    they also apply to any other `torch.load(weights_only=True)` call made afterwards.
     """
 
     # Restricted loading needs torch 2.6+: the checkpoint global scan and `(obj, "module.Name")` allow-list aliases.

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -926,7 +926,7 @@ class PoseLoss26(v8PoseLoss):
         if not error.numel():
             return pred_kpt[..., :0].sum()
 
-        # Filter out NaN and Inf values to prevent MultivariateNormal validation errors
+        # Filter out NaN and Inf values that would propagate into the loss
         valid_mask = ~(torch.isnan(error) | torch.isinf(error)).any(dim=-1)
         if not valid_mask.any():
             return pred_kpt[..., :0].sum()


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Restricted checkpoint loading now uses a locked, process-wide allow-list containing only checkpoint-referenced globals, while the RLE prior is computed directly as a standard normal log-probability.

### 📊 Key Changes
- Updated `_SafeLoad` to build and cache a registry of allowed globals, register checkpoint-specific entries with `add_safe_globals`, and protect registration with a process-wide lock.
- Kept restricted-load state thread-local and added a concurrent loading test covering 32 loads across eight threads.
- Restricted loading now depends on `get_unsafe_globals_in_checkpoint`; unsupported or older PyTorch versions continue to fall back to standard loading.
- Replaced `RealNVP.prior` and its `MultivariateNormal` construction with a closed-form two-dimensional standard-normal calculation, while retaining `loc` and `cov` buffers for checkpoint loading.
- Updated the package version from `8.4.125` to `8.4.126`.

### 🎯 Purpose & Impact
- Concurrent restricted loads no longer remove each other’s registered globals, and subsequent `weights_only=True` loads use the process-wide registrations.
- Restricted loading registers only globals referenced by each checkpoint, including supported torchvision transforms when present.
- RLE loss behavior is unchanged apart from the prior calculation path; non-finite error filtering remains in place.