### PR TITLE
Link all official Platform datasets from Docs

### DIFF
--- a/docs/en/datasets/classify/caltech101.md
+++ b/docs/en/datasets/classify/caltech101.md
@@ -147,4 +147,4 @@ Caltech-101 has no predefined split. The first time you train, Ultralytics autom
 
 ### Can I use Ultralytics Platform for training models on the Caltech-101 dataset?
 
-Yes. [Ultralytics Platform](https://platform.ultralytics.com) lets you manage datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run Caltech-101 experiments in the cloud, and you can explore more options in our [classification datasets overview](index.md).
+Yes. [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/caltech101) lets you manage datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run Caltech-101 experiments in the cloud, and you can explore more options in our [classification datasets overview](index.md).

--- a/docs/en/datasets/classify/caltech101.md
+++ b/docs/en/datasets/classify/caltech101.md
@@ -14,6 +14,8 @@ keywords: Caltech-101, dataset, image classification, object recognition, machin
 
 The [Caltech-101](https://data.caltech.edu/records/mzrjq-6wc02) dataset is a classic [image classification](https://www.ultralytics.com/glossary/image-classification) benchmark of 9,144 images spanning 101 object categories plus one background class. Each category holds about 40 to 800 images of real-world objects — animals, vehicles, household items, and people — making it a compact yet challenging benchmark for object recognition models.
 
+Explore [Caltech-101 on Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/caltech101) to preview samples, inspect dataset statistics, and clone it for training.
+
 <p align="center">
   <br>
   <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/isc06_9qnM0"
@@ -147,4 +149,4 @@ Caltech-101 has no predefined split. The first time you train, Ultralytics autom
 
 ### Can I use Ultralytics Platform for training models on the Caltech-101 dataset?
 
-Yes. [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/caltech101) lets you manage datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run Caltech-101 experiments in the cloud, and you can explore more options in our [classification datasets overview](index.md).
+Yes. [Ultralytics Platform](https://platform.ultralytics.com) lets you manage datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run Caltech-101 experiments in the cloud, and you can explore more options in our [classification datasets overview](index.md).

--- a/docs/en/datasets/classify/caltech256.md
+++ b/docs/en/datasets/classify/caltech256.md
@@ -14,6 +14,8 @@ keywords: Caltech-256, dataset, image classification, object recognition, machin
 
 The [Caltech-256](https://data.caltech.edu/records/nyy15-4j048) dataset is a classic [image classification](https://www.ultralytics.com/glossary/image-classification) benchmark of 30,607 images spanning 256 object categories plus one background class. Each category holds at least 80 images of real-world objects — animals, vehicles, household items, and people — making it a larger, more challenging successor to [Caltech-101](caltech101.md) for object recognition models.
 
+Explore [Caltech-256 on Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/caltech256) to preview samples, inspect dataset statistics, and clone it for training.
+
 <p align="center">
   <br>
   <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/Y7cfNkqSdMg"
@@ -142,4 +144,4 @@ Caltech-256 has no predefined split. The first time you train, Ultralytics autom
 
 ### Can I use Ultralytics Platform for training models on the Caltech-256 dataset?
 
-Yes. [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/caltech256) lets you manage datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run Caltech-256 experiments in the cloud, and you can explore more options in our [classification datasets overview](index.md).
+Yes. [Ultralytics Platform](https://platform.ultralytics.com) lets you manage datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run Caltech-256 experiments in the cloud, and you can explore more options in our [classification datasets overview](index.md).

--- a/docs/en/datasets/classify/caltech256.md
+++ b/docs/en/datasets/classify/caltech256.md
@@ -142,4 +142,4 @@ Caltech-256 has no predefined split. The first time you train, Ultralytics autom
 
 ### Can I use Ultralytics Platform for training models on the Caltech-256 dataset?
 
-Yes. [Ultralytics Platform](https://platform.ultralytics.com) lets you manage datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run Caltech-256 experiments in the cloud, and you can explore more options in our [classification datasets overview](index.md).
+Yes. [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/caltech256) lets you manage datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run Caltech-256 experiments in the cloud, and you can explore more options in our [classification datasets overview](index.md).

--- a/docs/en/datasets/classify/cifar10.md
+++ b/docs/en/datasets/classify/cifar10.md
@@ -15,6 +15,8 @@ keywords: CIFAR-10, dataset, image classification, object recognition, machine l
 
 The [CIFAR-10](https://cave.cs.toronto.edu/kriz/cifar.html) (Canadian Institute For Advanced Research) dataset is a classic [image classification](https://www.ultralytics.com/glossary/image-classification) benchmark of 60,000 32x32 color images evenly split across 10 classes — airplane, automobile, bird, cat, deer, dog, frog, horse, ship, and truck. It ships with a predefined split of 50,000 training and 10,000 test images (6,000 per class), making it a lightweight, well-balanced starting point for training and benchmarking classification models. For a more fine-grained challenge, see the related [CIFAR-100](cifar100.md) dataset.
 
+Explore [CIFAR-10 on Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/cifar10) to preview samples, inspect dataset statistics, and clone it for training.
+
 <p align="center">
   <br>
   <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/fLBbyhPbWzY"
@@ -144,4 +146,4 @@ CIFAR-10 ships with a predefined split of 50,000 training images and 10,000 test
 
 ### Can I use Ultralytics Platform for training models on the CIFAR-10 dataset?
 
-Yes. [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/cifar10) lets you manage datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run CIFAR-10 experiments in the cloud, and you can explore more options in our [classification datasets overview](index.md).
+Yes. [Ultralytics Platform](https://platform.ultralytics.com) lets you manage datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run CIFAR-10 experiments in the cloud, and you can explore more options in our [classification datasets overview](index.md).

--- a/docs/en/datasets/classify/cifar10.md
+++ b/docs/en/datasets/classify/cifar10.md
@@ -144,4 +144,4 @@ CIFAR-10 ships with a predefined split of 50,000 training images and 10,000 test
 
 ### Can I use Ultralytics Platform for training models on the CIFAR-10 dataset?
 
-Yes. [Ultralytics Platform](https://platform.ultralytics.com) lets you manage datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run CIFAR-10 experiments in the cloud, and you can explore more options in our [classification datasets overview](index.md).
+Yes. [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/cifar10) lets you manage datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run CIFAR-10 experiments in the cloud, and you can explore more options in our [classification datasets overview](index.md).

--- a/docs/en/datasets/classify/cifar100.md
+++ b/docs/en/datasets/classify/cifar100.md
@@ -15,6 +15,8 @@ keywords: CIFAR-100, dataset, image classification, object recognition, machine 
 
 The [CIFAR-100](https://cave.cs.toronto.edu/kriz/cifar.html) (Canadian Institute For Advanced Research) dataset is an [image classification](https://www.ultralytics.com/glossary/image-classification) benchmark of 60,000 32x32 color images spread evenly across 100 fine-grained classes (600 images each), which are in turn grouped into 20 coarse superclasses. Created by Alex Krizhevsky, it ships with a predefined split of 50,000 training and 10,000 test images, making it the harder, more fine-grained sibling of the [CIFAR-10](cifar10.md) dataset.
 
+Explore [CIFAR-100 on Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/cifar100) to preview samples, inspect dataset statistics, and clone it for training.
+
 <p align="center">
   <br>
   <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/6bZeCs0xwO4"
@@ -144,4 +146,4 @@ CIFAR-100 ships with a predefined split of 50,000 training images and 10,000 tes
 
 ### Can I use Ultralytics Platform for training models on the CIFAR-100 dataset?
 
-Yes. [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/cifar100) lets you manage datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run CIFAR-100 experiments in the cloud, and you can explore more options in our [classification datasets overview](index.md).
+Yes. [Ultralytics Platform](https://platform.ultralytics.com) lets you manage datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run CIFAR-100 experiments in the cloud, and you can explore more options in our [classification datasets overview](index.md).

--- a/docs/en/datasets/classify/cifar100.md
+++ b/docs/en/datasets/classify/cifar100.md
@@ -144,4 +144,4 @@ CIFAR-100 ships with a predefined split of 50,000 training images and 10,000 tes
 
 ### Can I use Ultralytics Platform for training models on the CIFAR-100 dataset?
 
-Yes. [Ultralytics Platform](https://platform.ultralytics.com) lets you manage datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run CIFAR-100 experiments in the cloud, and you can explore more options in our [classification datasets overview](index.md).
+Yes. [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/cifar100) lets you manage datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run CIFAR-100 experiments in the cloud, and you can explore more options in our [classification datasets overview](index.md).

--- a/docs/en/datasets/classify/fashion-mnist.md
+++ b/docs/en/datasets/classify/fashion-mnist.md
@@ -15,6 +15,8 @@ keywords: Fashion-MNIST, image classification, Zalando dataset, machine learning
 
 The [Fashion-MNIST](https://github.com/zalandoresearch/fashion-mnist) dataset is an [image classification](https://www.ultralytics.com/glossary/image-classification) benchmark of 70,000 28x28 grayscale images of Zalando's clothing articles, evenly split across 10 classes — T-shirt/top, trouser, pullover, dress, coat, sandal, shirt, sneaker, bag, and ankle boot. It ships with a predefined split of 60,000 training and 10,000 test images (7,000 per class) and serves as a drop-in replacement for the original [MNIST](mnist.md) dataset for benchmarking [machine learning](https://www.ultralytics.com/glossary/machine-learning-ml) algorithms. For the color-image equivalent, see the related [CIFAR-10](cifar10.md) dataset.
 
+Explore [Fashion-MNIST on Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/fashion-mnist) to preview samples, inspect dataset statistics, and clone it for training.
+
 <p align="center">
   <br>
   <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/eX5ad6udQ9Q"
@@ -146,4 +148,4 @@ Fashion-MNIST ships with a predefined split of 60,000 training images and 10,000
 
 ### Can I use Ultralytics Platform for training models on the Fashion-MNIST dataset?
 
-Yes. [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/fashion-mnist) lets you manage datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run Fashion-MNIST experiments in the cloud, and you can explore more options in our [classification datasets overview](index.md).
+Yes. [Ultralytics Platform](https://platform.ultralytics.com) lets you manage datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run Fashion-MNIST experiments in the cloud, and you can explore more options in our [classification datasets overview](index.md).

--- a/docs/en/datasets/classify/fashion-mnist.md
+++ b/docs/en/datasets/classify/fashion-mnist.md
@@ -146,4 +146,4 @@ Fashion-MNIST ships with a predefined split of 60,000 training images and 10,000
 
 ### Can I use Ultralytics Platform for training models on the Fashion-MNIST dataset?
 
-Yes. [Ultralytics Platform](https://platform.ultralytics.com) lets you manage datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run Fashion-MNIST experiments in the cloud, and you can explore more options in our [classification datasets overview](index.md).
+Yes. [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/fashion-mnist) lets you manage datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run Fashion-MNIST experiments in the cloud, and you can explore more options in our [classification datasets overview](index.md).

--- a/docs/en/datasets/classify/imagenette.md
+++ b/docs/en/datasets/classify/imagenette.md
@@ -117,7 +117,7 @@ To use these datasets, simply replace `imagenette` with `imagenette160` or `imag
         yolo classify train data=imagenette320 model=yolo26n-cls.pt epochs=100 imgsz=320
         ```
 
-These smaller versions of the dataset allow for rapid iterations during development while still providing realistic image classification tasks. You can also manage classification datasets and run training in the cloud with [Ultralytics Platform](https://platform.ultralytics.com).
+These smaller versions of the dataset allow for rapid iterations during development while still providing realistic image classification tasks. You can also manage classification datasets and run training in the cloud with [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/imagenette).
 
 ## Citations and Acknowledgments
 

--- a/docs/en/datasets/classify/imagewoof.md
+++ b/docs/en/datasets/classify/imagewoof.md
@@ -100,7 +100,7 @@ To use these variants, simply replace `imagewoof` in the dataset argument with `
         yolo classify train model=yolo26n-cls.pt data=imagewoof320 epochs=100 imgsz=224
         ```
 
-Note that smaller images will likely yield lower classification [accuracy](https://www.ultralytics.com/glossary/accuracy), but they are an excellent way to iterate quickly in the early stages of model development. You can also manage classification datasets and run training in the cloud with [Ultralytics Platform](https://platform.ultralytics.com).
+Note that smaller images will likely yield lower classification [accuracy](https://www.ultralytics.com/glossary/accuracy), but they are an excellent way to iterate quickly in the early stages of model development. You can also manage classification datasets and run training in the cloud with [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/imagewoof).
 
 ## Sample Images and Annotations
 

--- a/docs/en/datasets/classify/mnist.md
+++ b/docs/en/datasets/classify/mnist.md
@@ -157,7 +157,7 @@ The MNIST dataset contains only handwritten digits, whereas the Extended MNIST (
 
 ### Can I use Ultralytics Platform to train models on datasets like MNIST?
 
-Yes. [Ultralytics Platform](https://platform.ultralytics.com) lets you upload datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run MNIST experiments in the cloud — see the [classification datasets overview](index.md) for related options.
+Yes. [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/mnist) lets you upload datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run MNIST experiments in the cloud — see the [classification datasets overview](index.md) for related options.
 
 ### How does MNIST compare to other image classification datasets?
 

--- a/docs/en/datasets/classify/mnist.md
+++ b/docs/en/datasets/classify/mnist.md
@@ -15,6 +15,8 @@ keywords: MNIST, dataset, handwritten digits, image classification, deep learnin
 
 The [MNIST](https://en.wikipedia.org/wiki/MNIST_database) (Modified National Institute of Standards and Technology) dataset is an [image classification](https://www.ultralytics.com/glossary/image-classification) benchmark of 70,000 28x28 grayscale images of handwritten digits spanning 10 classes — the digits 0 through 9. It ships with a predefined split of 60,000 training and 10,000 test images and has long served as the standard benchmark for evaluating [machine learning](https://www.ultralytics.com/glossary/machine-learning-ml) and [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) algorithms. For the harder clothing-image equivalent, see the related [Fashion-MNIST](fashion-mnist.md) dataset; for color images, see [CIFAR-10](cifar10.md).
 
+Explore [MNIST on Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/mnist) to preview samples, inspect dataset statistics, and clone it for training.
+
 ## Key Features
 
 - MNIST contains 60,000 training images and 10,000 test images of handwritten digits, for 70,000 in total.
@@ -157,7 +159,7 @@ The MNIST dataset contains only handwritten digits, whereas the Extended MNIST (
 
 ### Can I use Ultralytics Platform to train models on datasets like MNIST?
 
-Yes. [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/mnist) lets you upload datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run MNIST experiments in the cloud — see the [classification datasets overview](index.md) for related options.
+Yes. [Ultralytics Platform](https://platform.ultralytics.com) lets you upload datasets, train [image classification](../../tasks/classify.md) models, and deploy them without extensive coding. It is a convenient way to run MNIST experiments in the cloud — see the [classification datasets overview](index.md) for related options.
 
 ### How does MNIST compare to other image classification datasets?
 

--- a/docs/en/datasets/depth/depth8.md
+++ b/docs/en/datasets/depth/depth8.md
@@ -10,6 +10,8 @@ keywords: Depth8, Ultralytics, dataset, depth estimation, monocular depth, YOLO2
 
 The [Ultralytics](https://www.ultralytics.com) Depth8 dataset is a compact [monocular depth estimation](index.md) dataset with 8 images sampled from the [SUN RGB-D](sunrgbd.md) dataset: 4 for training and 4 for validation, drawn from its Kinect v1 and Kinect v2 captures (two per sensor in each split) for dense, artifact-free ground-truth depth maps. It is designed for rapid testing, debugging, and experimentation with [YOLO26](../../models/yolo26.md) depth estimation models and training pipelines — the 1.3 MB archive auto-downloads on first use, so `yolo depth train data=depth8.yaml` starts training within seconds.
 
+Explore [Depth8 on Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/depth8) to preview its RGB-depth pairs and clone it for training.
+
 !!! note
 
     Depth8 is for pipeline testing only, not benchmarking — its 8 images are far too few for meaningful depth metrics. Use the full [NYU Depth V2](nyu-depth-v2.md) or [SUN RGB-D](sunrgbd.md) validation sets for representative results.

--- a/docs/en/datasets/depth/nyu-depth-v2.md
+++ b/docs/en/datasets/depth/nyu-depth-v2.md
@@ -8,6 +8,8 @@ keywords: Ultralytics, YOLO, depth estimation, NYU Depth V2, indoor RGB-D, Kinec
 
 [NYU Depth V2](https://cs.nyu.edu/~fergus/datasets/nyu_depth_v2.html) is the standard indoor benchmark for [monocular depth estimation](index.md). It consists of RGB-D video sequences of a wide variety of indoor scenes recorded with a Microsoft Kinect v1. It is the primary benchmark used to report YOLO26-Depth accuracy.
 
+Explore [NYU Depth V2 on Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/nyu-depth) to preview its RGB-depth pairs, inspect dataset statistics, and clone it for training.
+
 ## Key Features
 
 - Captured with a Microsoft Kinect v1 RGB-D sensor.

--- a/docs/en/datasets/depth/sunrgbd.md
+++ b/docs/en/datasets/depth/sunrgbd.md
@@ -8,6 +8,8 @@ keywords: Ultralytics, YOLO, depth estimation, SUN RGB-D, indoor RGB-D, multi-se
 
 [SUN RGB-D](https://rgbd.cs.princeton.edu/) is a real-world indoor scene-understanding benchmark captured with four different RGB-D sensors: Intel RealSense, Asus Xtion, and Microsoft Kinect v1 and v2. Its multi-sensor design makes it a valuable source of real indoor depth diversity for [monocular depth estimation](index.md).
 
+Explore [SUN RGB-D on Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/depth-sunrgbd) to preview its RGB-depth pairs, inspect dataset statistics, and clone it for training.
+
 ## Key Features
 
 - Captured with four different RGB-D sensors (Intel RealSense, Asus Xtion, Microsoft Kinect v1 and v2), providing real multi-sensor variety.

--- a/docs/en/datasets/detect/argoverse.md
+++ b/docs/en/datasets/detect/argoverse.md
@@ -14,6 +14,8 @@ keywords: Argoverse dataset, Argoverse-HD, object detection, 2D detection, auton
 
 The Ultralytics Argoverse dataset (Argoverse-HD) is a 2D [object detection](../../tasks/detect.md) dataset of 54,446 labeled autonomous-driving images — 39,384 for training and 15,062 for validation — across 8 classes: person, bicycle, car, motorcycle, bus, truck, traffic light, and stop sign. The images are captured from a vehicle's ring-front-center camera, and the annotations come from Carnegie Mellon University's streaming-perception project, built on [Argo AI](https://www.argoverse.org/)'s Argoverse 1.1 driving data. It is a large, real-world benchmark for training [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) models to detect road objects in self-driving scenarios.
 
+Explore [Argoverse-HD on Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/argoverse) to preview annotated samples, inspect dataset statistics, and clone it for training.
+
 !!! note "Manual download required"
 
     The Argoverse-HD `*.zip` file (~31.5 GB) needed for training was removed from Amazon S3 after the shutdown of Argo AI by Ford. It is available for manual download from [Google Drive](https://drive.google.com/file/d/1st9qW3BeIwQsnR0t8mRpvbsSWIo16ACi/view?usp=drive_link) — automatic download will not work, so download the archive before training.
@@ -191,4 +193,4 @@ The Argoverse-HD `*.zip` file (~31.5 GB), previously hosted on Amazon S3, can no
 
 ### Can I use the Argoverse dataset with Ultralytics Platform?
 
-Yes. [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/argoverse) lets you upload and version large datasets like Argoverse-HD, then train and deploy [object detection](../../tasks/detect.md) models in the cloud without heavy local setup. You can also browse related datasets in the [detection datasets overview](index.md).
+Yes. [Ultralytics Platform](https://platform.ultralytics.com) lets you upload and version large datasets like Argoverse-HD, then train and deploy [object detection](../../tasks/detect.md) models in the cloud without heavy local setup. You can also browse related datasets in the [detection datasets overview](index.md).

--- a/docs/en/datasets/detect/argoverse.md
+++ b/docs/en/datasets/detect/argoverse.md
@@ -191,4 +191,4 @@ The Argoverse-HD `*.zip` file (~31.5 GB), previously hosted on Amazon S3, can no
 
 ### Can I use the Argoverse dataset with Ultralytics Platform?
 
-Yes. [Ultralytics Platform](https://platform.ultralytics.com) lets you upload and version large datasets like Argoverse-HD, then train and deploy [object detection](../../tasks/detect.md) models in the cloud without heavy local setup. You can also browse related datasets in the [detection datasets overview](index.md).
+Yes. [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/argoverse) lets you upload and version large datasets like Argoverse-HD, then train and deploy [object detection](../../tasks/detect.md) models in the cloud without heavy local setup. You can also browse related datasets in the [detection datasets overview](index.md).

--- a/docs/en/datasets/detect/coco.md
+++ b/docs/en/datasets/detect/coco.md
@@ -61,7 +61,7 @@ A YAML file is used to define the dataset configuration. It contains information
 
 ## Usage
 
-The COCO2017 training and validation data (20.3 GB) downloads automatically the first time you start training. To train a YOLO26n model on COCO for 100 [epochs](https://www.ultralytics.com/glossary/epoch) with an image size of 640, you can use the following code snippets. For a comprehensive list of available arguments, refer to the model [Training](../../modes/train.md) page. You can also run COCO training in the cloud with [Ultralytics Platform](https://platform.ultralytics.com).
+The COCO2017 training and validation data (20.3 GB) downloads automatically the first time you start training. To train a YOLO26n model on COCO for 100 [epochs](https://www.ultralytics.com/glossary/epoch) with an image size of 640, you can use the following code snippets. For a comprehensive list of available arguments, refer to the model [Training](../../modes/train.md) page. You can also run COCO training in the cloud with [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/coco2017).
 
 !!! example "Train Example"
 

--- a/docs/en/datasets/detect/coco12-formats.md
+++ b/docs/en/datasets/detect/coco12-formats.md
@@ -24,7 +24,7 @@ This dataset is invaluable for:
 - **Debugging**: Isolate format-specific issues in training pipelines
 - **Development**: Validate new format additions or changes
 
-When you manage datasets on [Ultralytics Platform](https://platform.ultralytics.com), images in any of these formats are handled automatically—no manual conversion required.
+When you manage datasets on [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/coco12-formats), images in any of these formats are handled automatically—no manual conversion required.
 
 ## Supported Formats
 

--- a/docs/en/datasets/detect/coco128.md
+++ b/docs/en/datasets/detect/coco128.md
@@ -28,7 +28,7 @@ keywords: COCO128, Ultralytics, dataset, object detection, YOLO26, training, val
   <strong>Watch:</strong> Ultralytics COCO Dataset Overview
 </p>
 
-This dataset is intended for use with [Ultralytics Platform](https://platform.ultralytics.com) and [YOLO26](../../models/yolo26.md).
+This dataset is intended for use with [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/coco128) and [YOLO26](../../models/yolo26.md).
 
 ## Dataset Structure
 

--- a/docs/en/datasets/detect/coco8-multispectral.md
+++ b/docs/en/datasets/detect/coco8-multispectral.md
@@ -21,7 +21,7 @@ The [Ultralytics](https://www.ultralytics.com) COCO8-Multispectral dataset is an
   <img width="640" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/coco8-multispectral-overview.avif" alt="Multispectral imaging for object detection">
 </p>
 
-COCO8-Multispectral is fully compatible with [Ultralytics Platform](https://platform.ultralytics.com) and [YOLO26](../../models/yolo26.md), ensuring seamless integration into your [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) workflows.
+COCO8-Multispectral is fully compatible with [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/coco8-multispectral) and [YOLO26](../../models/yolo26.md), ensuring seamless integration into your [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) workflows.
 
 <p align="center">
   <br>

--- a/docs/en/datasets/detect/construction-ppe.md
+++ b/docs/en/datasets/detect/construction-ppe.md
@@ -64,7 +64,7 @@ Construction-PPE powers a variety of safety-focused computer vision applications
 - **Robotics and autonomous systems**: Enable drones or robots to perform PPE checks across large sites, supporting faster and safer inspections.
 - **Research and education**: Provide a real-world dataset for students and researchers exploring workplace safety and human-object interactions.
 
-To label, train, and deploy a PPE detection model without managing local infrastructure, run the full workflow in your browser with [Ultralytics Platform](https://platform.ultralytics.com).
+To label, train, and deploy a PPE detection model without managing local infrastructure, run the full workflow in your browser with [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/construction-ppe).
 
 ## Dataset YAML
 

--- a/docs/en/datasets/detect/globalwheat2020.md
+++ b/docs/en/datasets/detect/globalwheat2020.md
@@ -39,7 +39,7 @@ The Global Wheat Head Dataset is organized into three subsets defined by the `Gl
 
 The Global Wheat Head Dataset is widely used to train and evaluate [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) models for wheat head detection. Its diverse imagery across regions, genotypes, and conditions makes it a valuable resource for [plant phenotyping](https://www.ultralytics.com/blog/from-farm-to-table-how-ai-drives-innovation-in-agriculture) and crop management — supporting yield estimation, crop-health monitoring, and phenotypic analysis.
 
-To annotate field imagery, train, and manage dataset versions in your browser, run the full workflow with [Ultralytics Platform](https://platform.ultralytics.com).
+To annotate field imagery, train, and manage dataset versions in your browser, run the full workflow with [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/globalwheat2020).
 
 ## Dataset YAML
 

--- a/docs/en/datasets/detect/homeobjects-3k.md
+++ b/docs/en/datasets/detect/homeobjects-3k.md
@@ -72,7 +72,7 @@ HomeObjects-3K supports a range of indoor computer vision applications across re
 
 - **Home inventory and asset tracking**: Automatically detect and list home items in photos or videos, useful for managing belongings, organizing spaces, or visualizing furniture in real estate.
 
-To label your own indoor images, train, and manage dataset versions in your browser, run the full workflow with [Ultralytics Platform](https://platform.ultralytics.com).
+To label your own indoor images, train, and manage dataset versions in your browser, run the full workflow with [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/homeobjects-3k).
 
 ## Dataset YAML
 

--- a/docs/en/datasets/detect/kitti.md
+++ b/docs/en/datasets/detect/kitti.md
@@ -66,7 +66,7 @@ The KITTI dataset supports a range of 2D detection applications in autonomous dr
 - **Traffic and road-scene analysis**: Detect and count vehicles and road users to study traffic flow and road safety.
 - **Computer vision benchmarking**: Use KITTI as a standard benchmark for evaluating 2D [object detection](../../tasks/detect.md) and [tracking](../../modes/track.md) models.
 
-To label your own driving imagery, train, and manage dataset versions in your browser, run the full workflow with [Ultralytics Platform](https://platform.ultralytics.com).
+To label your own driving imagery, train, and manage dataset versions in your browser, run the full workflow with [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/kitti).
 
 ## Dataset YAML
 

--- a/docs/en/datasets/detect/lvis.md
+++ b/docs/en/datasets/detect/lvis.md
@@ -53,7 +53,7 @@ The upstream LVIS benchmark also includes a held-out test set of roughly 20,000 
 
 The LVIS dataset is widely used to train and evaluate [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) models for object detection (such as [YOLO](../../models/yolo26.md), [Faster R-CNN](https://arxiv.org/abs/1506.01497), and [SSD](https://arxiv.org/abs/1512.02325)) and instance segmentation (such as [Mask R-CNN](https://arxiv.org/abs/1703.06870)). Its large, long-tailed vocabulary, high annotation volume, and standardized evaluation metrics make it an essential benchmark for measuring how well [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) models handle rare categories.
 
-To label your own images, train, and manage large-vocabulary datasets like LVIS in your browser, run the full workflow with [Ultralytics Platform](https://platform.ultralytics.com).
+Browse the official [LVIS detection](https://platform.ultralytics.com/ultralytics/datasets/lvis) and [LVIS segmentation](https://platform.ultralytics.com/ultralytics/datasets/lvis-seg) datasets on Ultralytics Platform to inspect their annotations, statistics, and classes or clone them for training.
 
 ## Dataset YAML
 

--- a/docs/en/datasets/detect/sku-110k.md
+++ b/docs/en/datasets/detect/sku-110k.md
@@ -54,7 +54,7 @@ The SKU-110K dataset is widely used for training and evaluating [deep learning](
 - Self-checkout systems in stores
 - Robotic picking and sorting in warehouses
 
-To annotate your own shelf images, train, and manage retail-detection datasets in your browser, run the full workflow with [Ultralytics Platform](https://platform.ultralytics.com).
+To annotate your own shelf images, train, and manage retail-detection datasets in your browser, run the full workflow with [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/sku110k).
 
 ## Dataset YAML
 

--- a/docs/en/datasets/detect/tt100k.md
+++ b/docs/en/datasets/detect/tt100k.md
@@ -92,7 +92,7 @@ To train a YOLO26n model on the TT100K dataset for 100 [epochs](https://www.ultr
         yolo detect train data=TT100K.yaml model=yolo26n.pt epochs=100 imgsz=640
         ```
 
-To label additional traffic-sign images and manage TT100K training runs in your browser, use [Ultralytics Platform](https://platform.ultralytics.com).
+To label additional traffic-sign images and manage TT100K training runs in your browser, use [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/tt100k).
 
 ## Sample Data and Annotations
 

--- a/docs/en/datasets/detect/visdrone.md
+++ b/docs/en/datasets/detect/visdrone.md
@@ -103,7 +103,7 @@ To train a YOLO26n model on the VisDrone dataset for 100 [epochs](https://www.ul
         yolo detect train data=VisDrone.yaml model=yolo26n.pt epochs=100 imgsz=640
         ```
 
-To label additional aerial images and manage VisDrone training runs in your browser, use [Ultralytics Platform](https://platform.ultralytics.com).
+To label additional aerial images and manage VisDrone training runs in your browser, use [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/visdrone).
 
 ## Sample Data and Annotations
 

--- a/docs/en/datasets/detect/xview.md
+++ b/docs/en/datasets/detect/xview.md
@@ -105,7 +105,7 @@ To train a model on the xView dataset for 100 [epochs](https://www.ultralytics.c
         yolo detect train data=xView.yaml model=yolo26n.pt epochs=100 imgsz=640
         ```
 
-To label additional satellite images and manage xView training runs in your browser, use [Ultralytics Platform](https://platform.ultralytics.com).
+To label additional satellite images and manage xView training runs in your browser, use [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/xview).
 
 ## Sample Data and Annotations
 

--- a/docs/en/datasets/obb/dota-v2.md
+++ b/docs/en/datasets/obb/dota-v2.md
@@ -15,6 +15,8 @@ keywords: DOTA dataset, object detection, aerial images, oriented bounding boxes
 
 The [DOTA](https://captain-whu.github.io/DOTA/index.html) dataset is a large-scale benchmark for [object detection](https://www.ultralytics.com/glossary/object-detection) in aerial images, released in three versions (v1.0, v1.5, v2.0) with up to 1.7M [Oriented Bounding Box (OBB)](index.md) annotations across 18 categories, captured from diverse aerial sensors and platforms.
 
+Explore the officially hosted [DOTA v1.5](https://platform.ultralytics.com/ultralytics/datasets/dotav1-5) and [DOTA v1.0](https://platform.ultralytics.com/ultralytics/datasets/dotav1) datasets on Ultralytics Platform to preview their oriented annotations, inspect statistics, and clone them for training.
+
 ![DOTA dataset object classes for aerial detection](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/dota-classes-visual.avif)
 
 ## Key Features

--- a/docs/en/datasets/obb/dota128.md
+++ b/docs/en/datasets/obb/dota128.md
@@ -24,7 +24,7 @@ keywords: DOTA128 dataset, Ultralytics, YOLO26, object detection, debugging, tra
 - **Labels**: YOLO-format oriented bounding boxes saved as `.txt` files beside each image.
 - **Download**: 34 MB, fetched automatically from Ultralytics GitHub assets the first time you train.
 
-This dataset is intended for use with [Ultralytics Platform](https://platform.ultralytics.com) and [YOLO26](https://github.com/ultralytics/ultralytics).
+This dataset is intended for use with [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/dota128) and [YOLO26](https://github.com/ultralytics/ultralytics).
 
 ## Dataset YAML
 

--- a/docs/en/datasets/obb/index.md
+++ b/docs/en/datasets/obb/index.md
@@ -94,6 +94,7 @@ Currently, the following datasets with oriented bounding boxes are supported:
 - [DOTA-v1.5](dota-v2.md#dota-v15): An intermediate version of the DOTA dataset, offering additional annotations and improvements over DOTA-v1 for enhanced object detection tasks.
 - [DOTA-v2](dota-v2.md#dota-v20): DOTA (A Large-scale Dataset for Object Detection in Aerial Images) version 2, emphasizes detection from aerial perspectives and contains oriented bounding boxes with 1.7 million instances and 11,268 images.
 - [DOTA8](dota8.md): A small, 8-image subset of the full DOTA dataset suitable for testing workflows and Continuous Integration (CI) checks of OBB training in the `ultralytics` repository.
+- [DOTA8 Multispectral](https://platform.ultralytics.com/ultralytics/datasets/dota8-multispectral): An 8-image, 10-channel TIFF subset for testing multispectral OBB training on Ultralytics Platform.
 - [DOTA128](dota128.md): A 128-image subset of the DOTA dataset with all images in the train folder (used for both train and val), providing a good balance between size and diversity for testing OBB models.
 
 ### Incorporating your own OBB dataset

--- a/docs/en/datasets/pose/coco.md
+++ b/docs/en/datasets/pose/coco.md
@@ -36,7 +36,7 @@ For training and validation, COCO-Pose includes only COCO 2017 images with keypo
 2. **Val2017**: This subset has 2,346 images used for validation purposes during model training.
 3. **Test-dev2017**: A 20,288-image subset of the full 40,670-image test2017 set with withheld ground truth. The dataset YAML links this split to the [COCO test-dev keypoints evaluation server](https://codalab.lisn.upsaclay.fr/competitions/7403).
 
-Training at this scale is where [Ultralytics Platform](https://platform.ultralytics.com) helps most — it manages the compute so you can launch and monitor runs without provisioning your own GPUs.
+Training at this scale is where [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/coco2017-pose) helps most — it manages the compute so you can launch and monitor runs without provisioning your own GPUs.
 
 ## Applications
 

--- a/docs/en/datasets/pose/dog-pose.md
+++ b/docs/en/datasets/pose/dog-pose.md
@@ -32,7 +32,7 @@ Each annotated image includes 24 keypoints with 3 dimensions per keypoint (x, y,
 
 <img src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/ultralytics-dogs.avif" alt="Ultralytics Dog-Pose display image" width="800">
 
-For a specific breed or a different animal altogether, [Ultralytics Platform](https://platform.ultralytics.com) handles uploading, labeling, and training a custom keypoint model on your own data without managing infrastructure.
+For a specific breed or a different animal altogether, [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/dog-pose) handles uploading, labeling, and training a custom keypoint model on your own data without managing infrastructure.
 
 ## Dataset Structure
 

--- a/docs/en/datasets/pose/hand-keypoints.md
+++ b/docs/en/datasets/pose/hand-keypoints.md
@@ -48,7 +48,7 @@ Each hand is annotated with 21 keypoints as follows:
 - **Keypoints**: 21 per hand with `(x, y, visibility)` triplets.
 - **Download size**: ~369 MB.
 
-For a custom gesture vocabulary beyond generic hand landmarks, [Ultralytics Platform](https://platform.ultralytics.com) handles labeling and training your own dataset from the browser.
+For a custom gesture vocabulary beyond generic hand landmarks, [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/hand-keypoints) handles labeling and training your own dataset from the browser.
 
 ## Applications
 

--- a/docs/en/datasets/pose/tiger-pose.md
+++ b/docs/en/datasets/pose/tiger-pose.md
@@ -19,7 +19,7 @@ keywords: Ultralytics, Tiger-Pose, dataset, pose estimation, YOLO26, training da
 
 Despite its manageable training split of 210 images, the Tiger-Pose dataset offers diversity, making it suitable for assessing training pipelines, identifying potential errors, and serving as a valuable preliminary step before working with larger datasets for [pose estimation](../../tasks/pose.md).
 
-Once your pipeline trains clean on this small set, swap in your own animal or object keypoints and scale up training on [Ultralytics Platform](https://platform.ultralytics.com) without leaving the browser.
+Once your pipeline trains clean on this small set, swap in your own animal or object keypoints and scale up training on [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/tiger-pose) without leaving the browser.
 
 ## Dataset Structure
 

--- a/docs/en/datasets/segment/carparts-seg.md
+++ b/docs/en/datasets/segment/carparts-seg.md
@@ -51,7 +51,7 @@ Carparts Segmentation finds applications in various domains including:
 - **Recycling**: Sorting vehicle components for efficient recycling processes.
 - **Smart City Initiatives**: Contributing data for urban planning and traffic management systems within [Smart Cities](https://en.wikipedia.org/wiki/Smart_city).
 
-The complete Carparts Segmentation Dataset can also be browsed and managed on [Ultralytics Platform](https://platform.ultralytics.com).
+The complete Carparts Segmentation Dataset can also be browsed and managed on [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/carparts-seg).
 
 ## Dataset YAML
 

--- a/docs/en/datasets/segment/coco.md
+++ b/docs/en/datasets/segment/coco.md
@@ -39,7 +39,7 @@ For smaller experimentation needs, see the [COCO128-Seg](coco128-seg.md) (128 im
 
 ## Applications
 
-COCO-Seg is widely used for training and evaluating [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) models on [instance segmentation](../../tasks/segment.md), such as the YOLO models. The large number of annotated images, the diversity of object categories, and the standardized evaluation metrics make it an indispensable resource for [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) researchers and practitioners. Full COCO-Seg annotations can also be browsed and managed on [Ultralytics Platform](https://platform.ultralytics.com).
+COCO-Seg is widely used for training and evaluating [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) models on [instance segmentation](../../tasks/segment.md), such as the YOLO models. The large number of annotated images, the diversity of object categories, and the standardized evaluation metrics make it an indispensable resource for [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) researchers and practitioners. Full COCO-Seg annotations can also be browsed and managed on [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/coco2017-seg).
 
 ## Dataset YAML
 

--- a/docs/en/datasets/segment/coco128-seg.md
+++ b/docs/en/datasets/segment/coco128-seg.md
@@ -28,7 +28,7 @@ keywords: COCO128-Seg, Ultralytics, segmentation dataset, YOLO26, COCO 2017, mod
 
     The default YAML points train and val at the same 128 images, so validation metrics measure fit on the training set rather than generalization on held-out data. Duplicate or customize the split if you need a true held-out set.
 
-This dataset is intended for use with [Ultralytics Platform](https://platform.ultralytics.com) and [YOLO26](https://github.com/ultralytics/ultralytics).
+This dataset is intended for use with [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/coco128-seg) and [YOLO26](https://github.com/ultralytics/ultralytics).
 
 ## Dataset YAML
 

--- a/docs/en/datasets/segment/crack-seg.md
+++ b/docs/en/datasets/segment/crack-seg.md
@@ -42,7 +42,7 @@ Crack segmentation supports [infrastructure maintenance](https://www.ultralytics
 
 In industrial settings, crack detection with models like [Ultralytics YOLO26](../../models/yolo26.md) helps verify building integrity in construction, prevents costly downtime in [manufacturing](https://www.ultralytics.com/solutions/computer-vision-in-manufacturing), and makes road inspections safer. Automatically classifying cracks lets maintenance teams prioritize the most urgent repairs.
 
-The complete Crack Segmentation Dataset can also be browsed and managed on [Ultralytics Platform](https://platform.ultralytics.com).
+The complete Crack Segmentation Dataset can also be browsed and managed on [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/crack-seg).
 
 ## Dataset YAML
 

--- a/docs/en/datasets/segment/package-seg.md
+++ b/docs/en/datasets/segment/package-seg.md
@@ -48,7 +48,7 @@ In modern warehouses, [vision AI solutions](https://www.ultralytics.com/solution
 
 Package segmentation models can identify damaged packages by analyzing their shape and appearance. By detecting irregularities or deformations in package outlines, these models help ensure that only intact packages proceed through the supply chain, reducing customer complaints and return rates. This is a key aspect of [quality control in manufacturing](https://www.ultralytics.com/blog/improving-manufacturing-with-computer-vision) and is vital for maintaining product integrity.
 
-The complete Package Segmentation Dataset can also be browsed and managed on [Ultralytics Platform](https://platform.ultralytics.com).
+The complete Package Segmentation Dataset can also be browsed and managed on [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/package-seg).
 
 ## Dataset YAML
 

--- a/docs/en/datasets/semantic/ade20k.md
+++ b/docs/en/datasets/semantic/ade20k.md
@@ -45,7 +45,7 @@ The `masks_dir` field is set to `annotations`, so each image under `images/` is 
 
 ADE20K is widely used for training and evaluating [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) models in semantic segmentation and scene parsing. Its diverse set of categories and complex scenes make it valuable for applications such as autonomous navigation, robotics, augmented reality, and image editing.
 
-The breadth of indoor and outdoor scenes also makes ADE20K a strong benchmark for evaluating model generalization across domains. Pretrained YOLO26 semantic segmentation models reach up to 51.5 mIoU on the ADE20K validation set — see the [semantic segmentation models](../../tasks/semantic.md) page for the full benchmark table. ADE20K-format datasets are also fully compatible with [Ultralytics Platform](https://platform.ultralytics.com) for dataset management and training.
+The breadth of indoor and outdoor scenes also makes ADE20K a strong benchmark for evaluating model generalization across domains. Pretrained YOLO26 semantic segmentation models reach up to 51.5 mIoU on the ADE20K validation set — see the [semantic segmentation models](../../tasks/semantic.md) page for the full benchmark table. ADE20K-format datasets are also fully compatible with [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/ade20k) for dataset management and training.
 
 ## Dataset YAML
 

--- a/docs/en/datasets/semantic/cityscapes8.md
+++ b/docs/en/datasets/semantic/cityscapes8.md
@@ -74,7 +74,7 @@ To train a YOLO26n-sem model on the Cityscapes8 dataset for 100 [epochs](https:/
         yolo semantic train data=cityscapes8.yaml model=yolo26n-sem.pt epochs=100 imgsz=1024
         ```
 
-You can also manage Cityscapes8 and train semantic segmentation models in the cloud with [Ultralytics Platform](https://platform.ultralytics.com).
+You can also manage Cityscapes8 and train semantic segmentation models in the cloud with [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/cityscapes8).
 
 ## Citations, License and Acknowledgments
 


### PR DESCRIPTION
## Summary

- replace generic Platform links with exact official dataset resources across the dataset documentation
- add concise canonical links for newly hosted depth and DOTA resources that had no Platform link
- cover all 52 public datasets currently hosted by the `ultralytics` Platform account

These canonical links are the source-owned contract consumed by ultralytics/portal#3724. Once that renderer change ships, 50 dataset Docs pages will automatically show the corresponding live Platform preview beneath the page title; grouped LVIS and DOTA pages cover the remaining resources without duplicating documentation pages. Relates to ultralytics/portal#3718.

## Validation

- pinned Prettier 3.8.5 over all 39 changed Docs files
- `uv run --isolated --no-project --with-editable . --with minijinja --with zensical python docs/build_docs.py` — strict build passed with no issues
- live Platform API audit: 52/52 current official dataset slugs have an exact canonical link in `docs/en/datasets`
- cross-repository Portal production build: 662 static pages and 54 live preview pages (50 datasets + YOLO26/11/v8/v5)
- local Playwright checks on classification, depth, and grouped DOTA pages at mobile width: exact live embed loaded with zero page errors

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated dataset documentation to link each officially hosted dataset to its exact Ultralytics Platform resource instead of using generic Platform URLs.

### 📊 Key Changes

- Added canonical Platform links for the 52 public datasets hosted under the `ultralytics` Platform account.
- Added new Platform links for depth datasets, including Depth8, NYU Depth V2, and SUN RGB-D.
- Added grouped links for LVIS detection/segmentation and DOTA v1.0/v1.5 resources, including DOTA8 Multispectral.
- Replaced generic Platform links across classification, detection, pose, segmentation, semantic segmentation, and OBB dataset pages.
- Formatted the 39 changed documentation files with Prettier and verified that the strict documentation build passed.

### 🎯 Purpose & Impact

- Dataset documentation now directs readers to the corresponding Platform dataset page for previews, statistics, annotations, and cloning instead of the Platform homepage.
- The canonical dataset URLs provide the source links for the related Portal dataset preview integration.