### PR TITLE
Use correct OpenVINO throughput hint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,14 +342,17 @@ jobs:
         uses: ultralytics/actions/retry@main
         with:
           shell: bash # for Windows compatibility
-          # -n 2 limits parallelism for resource-heavy base export tests on shared runners. The ARM runner is
-          # single-process to avoid xdist worker overhead and runner disconnects during long slow-test runs.
+          # Keep OpenVINO exports isolated from concurrent CPU-heavy tests on Ubuntu to avoid native runtime crashes.
+          # The ARM runner is single-process to avoid xdist worker overhead and runner disconnects.
           run: |
-            pytest_args=(-vv -s --slow --durations=50 --durations-min=1 tests/ --export-env base)
+            pytest_args=(-vv -s --slow --durations=50 --durations-min=1 --export-env base)
             if [[ "${{ matrix.os }}" == "ubuntu-24.04-arm" ]]; then
-              PYTHONFAULTHANDLER=1 PYTHONUNBUFFERED=1 pytest "${pytest_args[@]}"
+              PYTHONFAULTHANDLER=1 PYTHONUNBUFFERED=1 pytest "${pytest_args[@]}" tests/
+            elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+              PYTHONFAULTHANDLER=1 PYTHONUNBUFFERED=1 pytest -n 2 --dist=loadfile "${pytest_args[@]}" tests/ --ignore=tests/test_exports.py
+              PYTHONFAULTHANDLER=1 PYTHONUNBUFFERED=1 pytest "${pytest_args[@]}" tests/test_exports.py
             else
-              PYTHONFAULTHANDLER=1 PYTHONUNBUFFERED=1 pytest -n 2 --dist=loadfile "${pytest_args[@]}"
+              PYTHONFAULTHANDLER=1 PYTHONUNBUFFERED=1 pytest -n 2 --dist=loadfile "${pytest_args[@]}" tests/
             fi
           retries: 1 # Retry once after initial attempt (2 total runs)
           timeout_minutes: 120

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,17 +342,14 @@ jobs:
         uses: ultralytics/actions/retry@main
         with:
           shell: bash # for Windows compatibility
-          # Keep OpenVINO exports isolated from concurrent CPU-heavy tests on Ubuntu to avoid native runtime crashes.
-          # The ARM runner is single-process to avoid xdist worker overhead and runner disconnects.
+          # -n 2 limits parallelism for resource-heavy base export tests on shared runners. The ARM runner is
+          # single-process to avoid xdist worker overhead and runner disconnects during long slow-test runs.
           run: |
-            pytest_args=(-vv -s --slow --durations=50 --durations-min=1 --export-env base)
+            pytest_args=(-vv -s --slow --durations=50 --durations-min=1 tests/ --export-env base)
             if [[ "${{ matrix.os }}" == "ubuntu-24.04-arm" ]]; then
-              PYTHONFAULTHANDLER=1 PYTHONUNBUFFERED=1 pytest "${pytest_args[@]}" tests/
-            elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-              PYTHONFAULTHANDLER=1 PYTHONUNBUFFERED=1 pytest -n 2 --dist=loadfile "${pytest_args[@]}" tests/ --ignore=tests/test_exports.py
-              PYTHONFAULTHANDLER=1 PYTHONUNBUFFERED=1 pytest "${pytest_args[@]}" tests/test_exports.py
+              PYTHONFAULTHANDLER=1 PYTHONUNBUFFERED=1 pytest "${pytest_args[@]}"
             else
-              PYTHONFAULTHANDLER=1 PYTHONUNBUFFERED=1 pytest -n 2 --dist=loadfile "${pytest_args[@]}" tests/
+              PYTHONFAULTHANDLER=1 PYTHONUNBUFFERED=1 pytest -n 2 --dist=loadfile "${pytest_args[@]}"
             fi
           retries: 1 # Retry once after initial attempt (2 total runs)
           timeout_minutes: 120

--- a/ultralytics/nn/backends/openvino.py
+++ b/ultralytics/nn/backends/openvino.py
@@ -57,8 +57,11 @@ class OpenVINOBackend(BaseBackend):
             self.apply_metadata(YAML.load(metadata_file))
 
         # Set inference mode
-        throughput_mode = "CUMULATIVE_THROUGHPUT" if device_name == "AUTO" else "THROUGHPUT"
-        self.inference_mode = throughput_mode if self.dynamic and self.batch > 1 else "LATENCY"
+        self.inference_mode = (
+            ("CUMULATIVE_THROUGHPUT" if device_name == "AUTO" else "THROUGHPUT")
+            if self.dynamic and self.batch > 1
+            else "LATENCY"
+        )
         config = {"PERFORMANCE_HINT": self.inference_mode}
         if LINUX and ARM64 and device_name == "CPU":
             config["EXECUTION_MODE_HINT"] = ov.properties.hint.ExecutionMode.ACCURACY

--- a/ultralytics/nn/backends/openvino.py
+++ b/ultralytics/nn/backends/openvino.py
@@ -57,7 +57,8 @@ class OpenVINOBackend(BaseBackend):
             self.apply_metadata(YAML.load(metadata_file))
 
         # Set inference mode
-        self.inference_mode = "CUMULATIVE_THROUGHPUT" if self.dynamic and self.batch > 1 else "LATENCY"
+        throughput_mode = "CUMULATIVE_THROUGHPUT" if device_name == "AUTO" else "THROUGHPUT"
+        self.inference_mode = throughput_mode if self.dynamic and self.batch > 1 else "LATENCY"
         config = {"PERFORMANCE_HINT": self.inference_mode}
         if LINUX and ARM64 and device_name == "CPU":
             config["EXECUTION_MODE_HINT"] = ov.properties.hint.ExecutionMode.ACCURACY


### PR DESCRIPTION
### Summary

- use `THROUGHPUT` for dynamic batched inference on a single OpenVINO device
- reserve `CUMULATIVE_THROUGHPUT` for AUTO multi-device execution
- leave pytest parallelism unchanged

### Motivation

Scheduled CI run https://github.com/ultralytics/ultralytics/actions/runs/32561344345 segfaulted twice in adjacent dynamic INT8 OpenVINO detection cases. The same failure occurred in scheduled run https://github.com/ultralytics/ultralytics/actions/runs/32231215311 on a different PyTorch version. Both enter the dynamic batch-2 async path on a CPU-only runner.

The backend currently applies `CUMULATIVE_THROUGHPUT` to all dynamic batches. OpenVINO documents `THROUGHPUT` for single-device multi-stream execution and `CUMULATIVE_THROUGHPUT` for AUTO execution across multiple devices:
- https://docs.openvino.ai/2026/openvino-workflow/running-inference/inference-devices-and-modes/cpu-device.html
- https://docs.openvino.ai/2026/openvino-workflow/running-inference/inference-devices-and-modes/auto-device-selection.html

### Validation

- Ruff format and lint passed
- Python compileall passed
- `git diff --check` passed
- PR CI runs the existing OpenVINO export coverage with unchanged pytest parallelism

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated OpenVINO dynamic batch inference to use the device-appropriate performance hint, using `THROUGHPUT` for single-device execution and retaining `CUMULATIVE_THROUGHPUT` for `AUTO`.

### 📊 Key Changes
- Changed dynamic batches larger than one on non-`AUTO` devices to use the `THROUGHPUT` performance hint.
- Kept `CUMULATIVE_THROUGHPUT` for dynamic batches larger than one when `device_name` is `AUTO`.
- Preserved `LATENCY` for non-dynamic or single-item inference.
- Left the existing ARM64 CPU execution-mode configuration and pytest parallelism unchanged.

### 🎯 Purpose & Impact
- OpenVINO now receives `THROUGHPUT` for multi-stream inference on a single device and `CUMULATIVE_THROUGHPUT` only for `AUTO` multi-device execution.