### PR TITLE
Route exported models by embedded metadata

### DIFF
--- a/docs/en/reference/nn/backends/base.md
+++ b/docs/en/reference/nn/backends/base.md
@@ -18,4 +18,8 @@ keywords: Ultralytics, BaseBackend, inference backend, abstract class, model loa
 
 ## ::: ultralytics.nn.backends.base.read_tflite_metadata
 
+<br><br><hr><br>
+
+## ::: ultralytics.nn.backends.base.read_export_metadata
+
 <br><br>

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -13,6 +13,7 @@ from ultralytics.data.build import load_inference_source
 from ultralytics.engine.model import Model
 from ultralytics.models import yolo
 from ultralytics.nn.autobackend import check_class_names
+from ultralytics.nn.backends.base import read_export_metadata
 from ultralytics.nn.tasks import (
     ClassificationModel,
     DepthModel,
@@ -80,7 +81,9 @@ class YOLO(Model):
         else:
             # Continue with default YOLO initialization
             super().__init__(model=model, task=task, verbose=verbose)
-            if hasattr(self.model, "model") and "RTDETR" in self.model.model[-1]._get_name():  # if RTDETR head
+            module = getattr(self.model, "model", None)  # exported models are held as a path instead
+            head = module[-1]._get_name() if module else read_export_metadata(self.model).get("head")
+            if head == "RTDETRDecoder":  # if RTDETR head
                 from ultralytics import RTDETR
 
                 new_instance = RTDETR(self)

--- a/ultralytics/nn/backends/ascend.py
+++ b/ultralytics/nn/backends/ascend.py
@@ -7,9 +7,9 @@ from pathlib import Path
 import numpy as np
 import torch
 
-from ultralytics.utils import LOGGER, YAML
+from ultralytics.utils import LOGGER
 
-from .base import BaseBackend
+from .base import BaseBackend, read_export_metadata
 
 
 class AscendBackend(BaseBackend):
@@ -46,10 +46,7 @@ class AscendBackend(BaseBackend):
 
         self.model = InferSession(getattr(self.device, "index", None) or 0, str(found))
 
-        # Load metadata
-        metadata_file = found.parent / "metadata.yaml"
-        if metadata_file.exists():
-            self.apply_metadata(YAML.load(metadata_file))
+        self.apply_metadata(read_export_metadata(found))
 
     def __del__(self):
         """Release the Ascend device-side resources held by the inference session."""

--- a/ultralytics/nn/backends/axelera.py
+++ b/ultralytics/nn/backends/axelera.py
@@ -8,7 +8,7 @@ import torch
 
 from ultralytics.utils.checks import check_requirements
 
-from .base import BaseBackend
+from .base import BaseBackend, read_export_metadata
 
 
 class AxeleraBackend(BaseBackend):
@@ -40,12 +40,7 @@ class AxeleraBackend(BaseBackend):
 
         self.model = op.load(str(found)).optimized()
 
-        # Load metadata
-        metadata_file = found.parent / "metadata.yaml"
-        if metadata_file.exists():
-            from ultralytics.utils import YAML
-
-            self.apply_metadata(YAML.load(metadata_file))
+        self.apply_metadata(read_export_metadata(found))
 
     def forward(self, im: torch.Tensor) -> list:
         """Run inference on the Axelera hardware accelerator.

--- a/ultralytics/nn/backends/base.py
+++ b/ultralytics/nn/backends/base.py
@@ -9,6 +9,8 @@ from typing import Any
 
 import torch
 
+from ultralytics.utils import YAML
+
 
 def read_tflite_metadata(file: str | Path) -> dict | None:
     """Read Ultralytics metadata embedded in a ``.tflite`` file.
@@ -36,6 +38,45 @@ def read_tflite_metadata(file: str | Path) -> dict | None:
     except (zipfile.BadZipFile, SyntaxError, ValueError, KeyError, json.JSONDecodeError):
         return None
     return None
+
+
+def read_export_metadata(file: str | Path) -> dict:
+    """Read the metadata an Ultralytics export embeds, resolving a model's task and head without its filename.
+
+    Args:
+        file (str | Path): Path to an exported model file or directory.
+
+    Returns:
+        (dict): Export metadata, empty when the file carries none.
+    """
+    import json
+    import zipfile
+
+    path = Path(file)
+    try:
+        if path.suffix == ".engine":  # length-prefixed JSON header
+            with open(path, "rb") as f:
+                return json.loads(f.read(int.from_bytes(f.read(4), "little", signed=True)))
+        if path.suffix == ".tflite":
+            return read_tflite_metadata(path) or {}
+        if path.suffix == ".torchscript":  # extra file written by torch.jit.save
+            with zipfile.ZipFile(path) as zf:
+                return json.loads(zf.read(next(n for n in zf.namelist() if n.endswith("extra/config.txt"))))
+        if path.suffix == ".onnx" or path.name.endswith("_imx_model"):  # IMX packages its ONNX in a directory
+            import onnx
+
+            model = onnx.load(str(next(path.glob("*.onnx"), path) if path.is_dir() else path), load_external_data=False)
+            return {prop.key: prop.value for prop in model.metadata_props}
+        if path.suffix in {".mlpackage", ".mlmodel"}:
+            import coremltools as ct
+
+            return dict(ct.utils.load_spec(str(path)).description.metadata.userDefined)
+    except Exception:  # third-party, truncated or pre-metadata exports carry no header, so fall back to the filename
+        return {}
+    sidecar = (path if path.is_dir() else path.parent) / "metadata.yaml"  # openvino, paddle, ncnn, saved_model, ...
+    if path.suffix == ".pb":  # a frozen graph keeps its metadata in the sibling saved_model directory
+        sidecar = next(path.resolve().parent.rglob(f"{path.stem}_saved_model*/metadata.yaml"), sidecar)
+    return YAML.load(sidecar) if sidecar.exists() else {}
 
 
 class BaseBackend(ABC):

--- a/ultralytics/nn/backends/base.py
+++ b/ultralytics/nn/backends/base.py
@@ -10,6 +10,7 @@ from typing import Any
 import torch
 
 from ultralytics.utils import YAML
+from ultralytics.utils.checks import check_requirements
 
 
 def read_tflite_metadata(file: str | Path) -> dict | None:
@@ -63,6 +64,7 @@ def read_export_metadata(file: str | Path) -> dict:
             with zipfile.ZipFile(path) as zf:
                 return json.loads(zf.read(next(n for n in zf.namelist() if n.endswith("extra/config.txt"))))
         if path.suffix == ".onnx" or path.name.endswith("_imx_model"):  # IMX packages its ONNX in a directory
+            check_requirements("onnx")  # the ONNX backend requires it alongside onnxruntime
             import onnx
 
             model = onnx.load(str(next(path.glob("*.onnx"), path) if path.is_dir() else path), load_external_data=False)

--- a/ultralytics/nn/backends/deepx.py
+++ b/ultralytics/nn/backends/deepx.py
@@ -9,7 +9,7 @@ import torch
 
 from ultralytics.utils import LOGGER
 
-from .base import BaseBackend
+from .base import BaseBackend, read_export_metadata
 
 
 class DeepXBackend(BaseBackend):
@@ -45,12 +45,7 @@ class DeepXBackend(BaseBackend):
 
         self.model = InferenceEngine(str(found))
 
-        # Load metadata
-        metadata_file = found.parent / "metadata.yaml"
-        if metadata_file.exists():
-            from ultralytics.utils import YAML
-
-            self.apply_metadata(YAML.load(metadata_file))
+        self.apply_metadata(read_export_metadata(found))
 
     def forward(self, im: torch.Tensor) -> np.ndarray | list[np.ndarray]:
         """Run inference on the DEEPX NPU.

--- a/ultralytics/nn/backends/executorch.py
+++ b/ultralytics/nn/backends/executorch.py
@@ -9,7 +9,7 @@ import torch
 from ultralytics.utils import LOGGER
 from ultralytics.utils.checks import check_executorch_requirements
 
-from .base import BaseBackend
+from .base import BaseBackend, read_export_metadata
 
 
 class ExecuTorchBackend(BaseBackend):
@@ -31,21 +31,9 @@ class ExecuTorchBackend(BaseBackend):
         from executorch.runtime import Runtime
 
         w = Path(weight)
-        if w.is_dir():
-            model_file = next(w.rglob("*.pte"))
-            metadata_file = w / "metadata.yaml"
-        else:
-            model_file = w
-            metadata_file = w.parent / "metadata.yaml"
-
-        program = Runtime.get().load_program(str(model_file))
+        program = Runtime.get().load_program(str(next(w.rglob("*.pte")) if w.is_dir() else w))
         self.model = program.load_method("forward")
-
-        # Load metadata
-        if metadata_file.exists():
-            from ultralytics.utils import YAML
-
-            self.apply_metadata(YAML.load(metadata_file))
+        self.apply_metadata(read_export_metadata(w))
 
     def forward(self, im: torch.Tensor) -> list:
         """Run inference using the ExecuTorch runtime.

--- a/ultralytics/nn/backends/hailo.py
+++ b/ultralytics/nn/backends/hailo.py
@@ -11,7 +11,7 @@ import torch
 
 from ultralytics.utils import LOGGER
 
-from .base import BaseBackend
+from .base import BaseBackend, read_export_metadata
 
 
 class HailoBackend(BaseBackend):
@@ -42,11 +42,7 @@ class HailoBackend(BaseBackend):
             raise FileNotFoundError(f"No .hef file found in: {w}")
 
         LOGGER.info(f"Loading {hef_file} for Hailo inference...")
-        metadata_file = hef_file.parent / "metadata.yaml"
-        if metadata_file.exists():
-            from ultralytics.utils import YAML
-
-            self.apply_metadata(YAML.load(metadata_file))
+        self.apply_metadata(read_export_metadata(hef_file))
         if self.task and self.task not in {"detect", "segment", "pose", "obb", "classify", "semantic", "depth"}:
             raise ValueError(
                 f"Hailo inference only supports detect, segment, pose, obb, classify, semantic and depth tasks, "

--- a/ultralytics/nn/backends/ncnn.py
+++ b/ultralytics/nn/backends/ncnn.py
@@ -10,7 +10,7 @@ import torch
 from ultralytics.utils import LOGGER
 from ultralytics.utils.checks import check_requirements
 
-from .base import BaseBackend
+from .base import BaseBackend, read_export_metadata
 
 
 class NCNNBackend(BaseBackend):
@@ -48,12 +48,7 @@ class NCNNBackend(BaseBackend):
         self.net.load_param(str(w))
         self.net.load_model(str(w.with_suffix(".bin")))
 
-        # Load metadata
-        metadata_file = w.parent / "metadata.yaml"
-        if metadata_file.exists():
-            from ultralytics.utils import YAML
-
-            self.apply_metadata(YAML.load(metadata_file))
+        self.apply_metadata(read_export_metadata(w))
 
     def forward(self, im: torch.Tensor) -> list[np.ndarray]:
         """Run inference using the NCNN runtime.

--- a/ultralytics/nn/backends/openvino.py
+++ b/ultralytics/nn/backends/openvino.py
@@ -10,7 +10,7 @@ import torch
 from ultralytics.utils import ARM64, LINUX, LOGGER
 from ultralytics.utils.checks import check_requirements
 
-from .base import BaseBackend
+from .base import BaseBackend, read_export_metadata
 
 
 class OpenVINOBackend(BaseBackend):
@@ -49,12 +49,7 @@ class OpenVINOBackend(BaseBackend):
         if ov_model.get_parameters()[0].get_layout().empty:
             ov_model.get_parameters()[0].set_layout(ov.Layout("NCHW"))
 
-        # Load metadata
-        metadata_file = w.parent / "metadata.yaml"
-        if metadata_file.exists():
-            from ultralytics.utils import YAML
-
-            self.apply_metadata(YAML.load(metadata_file))
+        self.apply_metadata(read_export_metadata(w))
 
         # Set inference mode
         self.inference_mode = (

--- a/ultralytics/nn/backends/paddle.py
+++ b/ultralytics/nn/backends/paddle.py
@@ -10,7 +10,7 @@ import torch
 from ultralytics.utils import ARM64, LOGGER
 from ultralytics.utils.checks import check_requirements
 
-from .base import BaseBackend
+from .base import BaseBackend, read_export_metadata
 
 
 class PaddleBackend(BaseBackend):
@@ -58,12 +58,7 @@ class PaddleBackend(BaseBackend):
         self.input_handle = self.predictor.get_input_handle(self.predictor.get_input_names()[0])
         self.output_names = self.predictor.get_output_names()
 
-        # Load metadata
-        metadata_file = (w if w.is_dir() else w.parent) / "metadata.yaml"
-        if metadata_file.exists():
-            from ultralytics.utils import YAML
-
-            self.apply_metadata(YAML.load(metadata_file))
+        self.apply_metadata(read_export_metadata(w))
 
     def forward(self, im: torch.Tensor) -> list[np.ndarray]:
         """Run Baidu PaddlePaddle inference.

--- a/ultralytics/nn/backends/rknn.py
+++ b/ultralytics/nn/backends/rknn.py
@@ -9,7 +9,7 @@ import torch
 from ultralytics.utils import LOGGER
 from ultralytics.utils.checks import check_requirements, is_rockchip
 
-from .base import BaseBackend
+from .base import BaseBackend, read_export_metadata
 
 
 class RKNNBackend(BaseBackend):
@@ -49,12 +49,7 @@ class RKNNBackend(BaseBackend):
         if ret != 0:
             raise RuntimeError(f"Failed to init RKNN runtime: {ret}")
 
-        # Load metadata
-        metadata_file = w.parent / "metadata.yaml"
-        if metadata_file.exists():
-            from ultralytics.utils import YAML
-
-            self.apply_metadata(YAML.load(metadata_file))
+        self.apply_metadata(read_export_metadata(w))
 
     def forward(self, im: torch.Tensor) -> list:
         """Run inference on the Rockchip NPU.

--- a/ultralytics/nn/backends/tensorflow.py
+++ b/ultralytics/nn/backends/tensorflow.py
@@ -10,7 +10,7 @@ import torch
 
 from ultralytics.utils import LOGGER
 
-from .base import BaseBackend, read_tflite_metadata
+from .base import BaseBackend, read_export_metadata, read_tflite_metadata
 
 
 class TensorFlowBackend(BaseBackend):
@@ -45,12 +45,7 @@ class TensorFlowBackend(BaseBackend):
         if self.format == "saved_model":
             LOGGER.info(f"Loading {weight} for TensorFlow SavedModel inference...")
             self.model = tf.saved_model.load(weight)
-            # Load metadata
-            metadata_file = Path(weight) / "metadata.yaml"
-            if metadata_file.exists():
-                from ultralytics.utils import YAML
-
-                self.apply_metadata(YAML.load(metadata_file))
+            self.apply_metadata(read_export_metadata(weight))
         elif self.format == "pb":
             LOGGER.info(f"Loading {weight} for TensorFlow GraphDef inference...")
             from ultralytics.utils.export.tensorflow import gd_outputs
@@ -65,17 +60,7 @@ class TensorFlowBackend(BaseBackend):
             with open(weight, "rb") as f:
                 gd.ParseFromString(f.read())
             self.frozen_func = wrap_frozen_graph(gd, inputs="x:0", outputs=gd_outputs(gd))
-
-            # Try to find metadata
-            try:
-                metadata_file = next(
-                    Path(weight).resolve().parent.rglob(f"{Path(weight).stem}_saved_model*/metadata.yaml")
-                )
-                from ultralytics.utils import YAML
-
-                self.apply_metadata(YAML.load(metadata_file))
-            except StopIteration:
-                pass
+            self.apply_metadata(read_export_metadata(weight))
         else:  # edgetpu
             try:
                 from tflite_runtime.interpreter import Interpreter, load_delegate

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -2253,8 +2253,12 @@ def guess_model_task(model):
             elif isinstance(m, (Detect, WorldDetect, YOLOEDetect, v10Detect)):
                 return "detect"
 
-    # Guess from model filename
     if isinstance(model, (str, Path)):
+        from ultralytics.nn.backends.base import read_export_metadata
+
+        if task := read_export_metadata(model).get("task"):  # exports embed their task, i.e. best.onnx
+            return task
+        # Guess from model filename
         model = Path(model)
         if "-sem" in model.stem or "semantic" in model.parts:
             return "semantic"


### PR DESCRIPTION
Training writes `best.pt`, so its exports (`best.onnx`, `best.engine`, `best.torchscript`, `best_openvino_model/`, ...) carry no task in their filename, and `guess_model_task` then falls back to `detect`: a segmentation export returns no masks, a pose export no keypoints, and an RT-DETR export is handed the YOLO detect predictor, which misreads its normalized `cxcywh` queries as pixel `xyxy`.

Every export already embeds the `Exporter` metadata (`task`, `head`, ...), so this reads it back before the task and model family are resolved, with the filename kept as the fallback for files that carry none:

- `read_export_metadata()` in `nn/backends/base.py` reads the TensorRT header, the TorchScript extra file, the TFLite zip entry, ONNX `metadata_props` (also for `_imx_model/` directories), CoreML `userDefined`, and the `metadata.yaml` sidecar of the directory formats, including the `_saved_model/` sibling of a frozen `.pb`. It reuses `onnx` and `coremltools`, which those backends already require, instead of a bespoke protobuf parser. MNN keeps its metadata in a flatbuffer `bizCode` and Triton serves it over HTTP, so those still resolve from the filename.
- `guess_model_task()` consults it first for path inputs, and `YOLO.__init__` uses its `head` to route exported RT-DETR models to `RTDETR`.
- The eleven backends that each duplicated the `metadata.yaml` sidecar lookup now call the shared reader, a net deletion.

```python
from ultralytics import YOLO

path = YOLO("yolo26n-seg.pt").export(format="onnx")  # rename to best.onnx
YOLO("best.onnx").predict("https://ultralytics.com/images/bus.jpg")  # task=segment, masks present, no warning
```

Verified locally with `yolo26n-seg.pt` and `yolo26n.pt` exported to ONNX and TorchScript and renamed to `best.*` (segment/detect resolve correctly via Python and CLI), reading a 94 MB ONNX takes 8 ms, and `tests/test_python.py::test_model_methods`, `tests/test_exports.py::test_export_onnx` and `::test_export_torchscript` pass.

Supersedes #25886. Thank you @artest08 for surfacing the problem and for the original implementation.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Exported models now resolve their task and model head from embedded metadata before using filename-based detection, allowing renamed exports such as `best.onnx` to load with the correct behavior.

### 📊 Key Changes

- Added `read_export_metadata()` in `ultralytics/nn/backends/base.py` to read metadata from TensorRT, TorchScript, TFLite, ONNX, IMX, CoreML, and directory-based export formats, including frozen TensorFlow graph sidecars.
- Updated `guess_model_task()` to prioritize embedded export task metadata and retain filename-based detection as a fallback.
- Updated `YOLO.__init__` to use the embedded `head` metadata and route exported `RTDETRDecoder` models to `RTDETR`.
- Replaced duplicated `metadata.yaml` loading in the export backends with the shared metadata reader.

### 🎯 Purpose & Impact

- Renamed segmentation, pose, and other exports can retain their correct task without relying on task-specific filenames.
- Exported RT-DETR models are routed to the RT-DETR implementation instead of the YOLO detection predictor.
- Backends continue to resolve metadata from existing sidecar files when embedded metadata is unavailable.