### PR TITLE
Add classes to a trained detector without changing existing predictions

### DIFF
--- a/docs/en/guides/finetuning-guide.md
+++ b/docs/en/guides/finetuning-guide.md
@@ -193,6 +193,37 @@ This is known as catastrophic forgetting - the model loses previously learned kn
 - **Merge datasets**: include examples of the original classes alongside the new classes during fine-tuning. This is the only reliable way to prevent forgetting.
 - **Freeze backbone and neck**: freezing both the backbone and neck so only the detection head trains helps for short fine-tuning runs with a very low learning rate.
 - **Train for fewer epochs**: the longer the model trains on new data exclusively, the more forgetting increases.
+- **Add the classes instead**: `AddClassesTrainer` leaves the pretrained classes bit-identical, see below.
+
+### Adding Classes Without Forgetting
+
+`AddClassesTrainer` adds classes to a trained detection model while the boxes and scores of every pretrained class stay exactly as they were. Each classification branch gets a copy of itself that ends in a fresh conv for the new classes, and the rest of the model is frozen, so the new classes are learned from the features the pretrained model already has. This works when a new class looks like something the model has seen, such as a rhino on a COCO model that knows elephants and cows, and poorly for a domain the backbone has never encountered.
+
+The dataset YAML must list the pretrained classes first, in their original order, followed by the new ones. Label files only need boxes for the new classes:
+
+```yaml
+# rhino.yaml
+path: ../datasets/rhino
+train: images/train
+val: images/val
+
+names:
+    0: person
+    1: bicycle
+    # ... the remaining COCO names, unchanged ...
+    79: toothbrush
+    80: rhino # the new class
+```
+
+```python
+from ultralytics import YOLO
+from ultralytics.models.yolo.detect import AddClassesTrainer
+
+model = YOLO("yolo26n.pt")
+model.train(data="rhino.yaml", epochs=50, trainer=AddClassesTrainer)
+```
+
+The result is a normal checkpoint that predicts, validates and exports as usual. Training it again with a dataset that adds further classes stacks another branch and freezes the earlier ones, so classes can be added in several sessions. Pass `trainer=AddClassesTrainer` again when resuming or continuing such a run; the default trainer would train the whole model and lose the guarantee. Pass `classes=[80]` to `val` or `train` to report metrics for the new classes only.
 
 ## FAQ
 
@@ -214,4 +245,4 @@ It depends on the dataset size and domain similarity. For small datasets with a 
 
 ### How do I prevent catastrophic forgetting when fine-tuning YOLO on new classes?
 
-Include examples of the original classes in the training data alongside the new classes. If that is not possible, freezing more layers (`freeze=10` or higher) and using a lower learning rate helps preserve the pretrained knowledge. See [Performance degrades on original classes](#performance-degrades-on-original-classes-after-fine-tuning) for more details.
+Train with `AddClassesTrainer`, which keeps the predictions of the pretrained classes bit-identical, see [Adding Classes Without Forgetting](#adding-classes-without-forgetting). To fine-tune every layer instead, include examples of the original classes in the training data alongside the new classes.

--- a/docs/en/reference/models/yolo/detect/train.md
+++ b/docs/en/reference/models/yolo/detect/train.md
@@ -14,4 +14,8 @@ keywords: Ultralytics, YOLO, DetectionTrainer, training, object detection, machi
 
 ## ::: ultralytics.models.yolo.detect.train.DetectionTrainer
 
+<br><br><hr><br>
+
+## ::: ultralytics.models.yolo.detect.train.AddClassesTrainer
+
 <br><br>

--- a/docs/en/reference/nn/modules/conv.md
+++ b/docs/en/reference/nn/modules/conv.md
@@ -64,6 +64,10 @@ keywords: Ultralytics, convolution modules, Conv, LightConv, GhostConv, YOLO, de
 
 <br><br><hr><br>
 
+## ::: ultralytics.nn.modules.conv.Parallel
+
+<br><br><hr><br>
+
 ## ::: ultralytics.nn.modules.conv.Index
 
 <br><br><hr><br>

--- a/ultralytics/models/yolo/detect/__init__.py
+++ b/ultralytics/models/yolo/detect/__init__.py
@@ -1,7 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from .predict import DetectionPredictor
-from .train import DetectionTrainer
+from .train import AddClassesTrainer, DetectionTrainer
 from .val import DetectionValidator
 
-__all__ = "DetectionPredictor", "DetectionTrainer", "DetectionValidator"
+__all__ = "AddClassesTrainer", "DetectionPredictor", "DetectionTrainer", "DetectionValidator"

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 import random
-from copy import copy
+from copy import copy, deepcopy
 from typing import Any
 
 import numpy as np
@@ -14,6 +14,7 @@ from torch import nn
 from ultralytics.data import build_dataloader, build_yolo_dataset
 from ultralytics.engine.trainer import BaseTrainer
 from ultralytics.models import yolo
+from ultralytics.nn.modules import Parallel
 from ultralytics.nn.tasks import DetectionModel
 from ultralytics.utils import DEFAULT_CFG, LOGGER, RANK
 from ultralytics.utils.patches import override_configs
@@ -251,3 +252,50 @@ class DetectionTrainer(BaseTrainer):
         n = len(train_dataset)
         del train_dataset  # free memory
         return super().auto_batch(max_num_obj, dataset_size=n)
+
+
+class AddClassesTrainer(DetectionTrainer):
+    """Add classes to a trained detection model while every existing class keeps its exact predictions.
+
+    Each classification branch gets a copy of itself that ends in a fresh conv for the classes the dataset adds, and the
+    rest of the model is frozen, so the boxes and the scores of the pretrained classes stay bit-identical. The dataset
+    YAML must list the pretrained classes first, in their original order, followed by the new ones. Training an already
+    extended model adds another copy and freezes the earlier ones. Pass the trainer again when resuming.
+
+    Examples:
+        >>> from ultralytics import YOLO
+        >>> from ultralytics.models.yolo.detect import AddClassesTrainer
+        >>> model = YOLO("yolo26n.pt")  # data.yaml lists the 80 COCO names followed by the new class "rhino"
+        >>> model.train(data="data.yaml", epochs=50, trainer=AddClassesTrainer)
+    """
+
+    def get_model(self, cfg: str | None = None, weights: str | None = None, verbose: bool = True):
+        """Return the pretrained model with a classification branch added for the classes the dataset introduces."""
+        assert isinstance(weights, nn.Module), f"{self.__class__.__name__} requires a trained detection model"
+        head, names, old = weights.model[-1], self.data["names"], weights.names
+        nc, new = len(names), len(names) - len(old)
+        assert all(names.get(i) == old[i] for i in range(len(old))), "the dataset must list the pretrained classes first"
+        assert new > 0 or isinstance(head.cv3[0], Parallel), "the dataset adds no classes"
+        if new:
+            for cv3 in (head.cv3, getattr(head, "one2one_cv3", None)):
+                for i, seq in enumerate(cv3 or ()):
+                    branch = deepcopy(seq[-1] if isinstance(seq, Parallel) else seq)  # copy of the latest cls branch
+                    branch[-1] = nn.Conv2d(branch[-1].in_channels, new, 1)
+                    branch[-1].bias.data[:] = math.log(5 / nc / (640 / head.stride[i]) ** 2)  # Detect.bias_init
+                    cv3[i] = seq.append(branch) if isinstance(seq, Parallel) else Parallel([seq, branch])
+            head.nc, head.no = nc, nc + 4 * head.reg_max
+        return weights
+
+    def setup_model(self):
+        """Freeze everything but the classification branch added last."""
+        ckpt = super().setup_model()
+        model = unwrap_model(self.model)
+        head, i = model.model[-1], len(model.model) - 1
+        freeze = [str(j) for j in range(i)]  # backbone and neck
+        for name, m in head.named_children():
+            if "cv3" in name:  # cls branches, the last module of each is the one being trained
+                freeze += [f"{i}.{name}.{s}.{k}" for s in range(head.nl) for k in range(len(m[s]) - 1)]
+            else:
+                freeze.append(f"{i}.{name}")
+        self.args.freeze = freeze
+        return ckpt

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -119,6 +119,7 @@ class DetectionValidator(BaseValidator):
             preds,
             self.args.conf,
             self.args.iou,
+            classes=self.args.classes,
             nc=0 if self.args.task == "detect" else self.nc,
             multi_label=True,
             agnostic=self.args.single_cls or self.args.agnostic_nms,

--- a/ultralytics/nn/modules/__init__.py
+++ b/ultralytics/nn/modules/__init__.py
@@ -73,6 +73,7 @@ from .conv import (
     GhostConv,
     Index,
     LightConv,
+    Parallel,
     RepConv,
     SpatialAttention,
 )
@@ -168,6 +169,7 @@ __all__ = (
     "MLPBlock",
     "MSDeformAttn",
     "MaxSigmoidAttnBlock",
+    "Parallel",
     "Pose",
     "Pose26",
     "Proto",

--- a/ultralytics/nn/modules/conv.py
+++ b/ultralytics/nn/modules/conv.py
@@ -22,6 +22,7 @@ __all__ = (
     "GhostConv",
     "Index",
     "LightConv",
+    "Parallel",
     "RepConv",
     "SpatialAttention",
 )
@@ -640,6 +641,14 @@ class Concat(nn.Module):
             (torch.Tensor): Concatenated tensor.
         """
         return torch.cat(x, self.d)
+
+
+class Parallel(nn.ModuleList):
+    """Apply every module to the same input and concatenate their outputs along the channel dimension."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the modules side by side on x and concatenate the results."""
+        return torch.cat([m(x) for m in self], 1)
 
 
 class Index(nn.Module):


### PR DESCRIPTION
Adds `AddClassesTrainer`, which adds classes to a trained detection model while the boxes and scores of every pretrained class stay bit-identical.

```python
from ultralytics import YOLO
from ultralytics.models.yolo.detect import AddClassesTrainer

model = YOLO("yolo26n.pt")  # data.yaml lists the 80 COCO names followed by "rhino"
model.train(data="data.yaml", epochs=50, trainer=AddClassesTrainer)
```

How it works, in 50 lines on top of existing owners:

- `get_model` takes the pretrained module and gives each classification branch (`cv3`, `one2one_cv3`) a copy of itself ending in a fresh conv for the new classes, wrapped in a new 5-line `Parallel` module that concatenates the branch outputs. The pretrained branch, `cv2` and the whole backbone/neck are untouched.
- `setup_model` builds `args.freeze` so only the newest branch trains; BaseTrainer does the freezing and keeps the frozen BatchNorm layers in eval mode.
- No gradient masking, weight restoring, EMA handling, class remapping or head subclass is needed: nothing that produces the old outputs can move.
- Training an already extended model with a dataset that adds more classes stacks another branch and freezes the earlier ones. Resume works by passing the trainer again.
- `DetectionValidator` now passes `classes` to NMS, matching the predictor, so `classes=[80]` on val reports metrics for the new classes only.

Validation on CPU (`yolo26n.pt`, `imgsz=320`):

- coco8 with `orange` relabelled as new class 80, then `bowl` as 81 in a second session: `bus.jpg` confidences and boxes `torch.equal` to the base model after both sessions, the first branch stays frozen in the second session, ONNX export and predict work, resume and re-training on the same names continue the last branch, and a dataset missing pretrained classes fails with a clear assertion.
- Fused cost per added session on YOLO26n: 2.409M to 2.472M parameters (+2.6%).
- `rhino` added to COCO YOLO26n from African Wildlife, 10 epochs, CPU: `rhino` 0.985 mAP50 / 0.908 mAP50-95, while `elephant` (0.840 / 0.704) and `zebra` (0.946 / 0.772) are identical to the base model on the same val set.

Docs: a new section in the fine-tuning guide.

Supersedes #25609. Thank you @Y-T-G for surfacing the problem and for the experiments there; this is a smaller design that reaches the same guarantee through the existing trainer freeze path.

Resolves #690
Resolves #3066
Resolves #4029
Resolves #4282
Resolves #12728
Resolves #13316
Resolves #13485
Resolves #13965
Resolves #14985
Resolves #17897
Resolves #18250
Resolves #20135
Resolves #20879
Resolves #21399
Resolves #24592
Resolves #24601

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Added `AddClassesTrainer` to extend trained detection models with new classes while preserving existing class predictions, using frozen pretrained branches and trainable classification branches for the additions.

### 📊 Key Changes
- Added `AddClassesTrainer`, which validates that pretrained class names remain first and creates new classification branches for added classes.
- Added the `Parallel` module to run original and new classification branches on the same features and concatenate their outputs.
- Configured training to freeze the backbone, neck, regression layers, and earlier classification branches, leaving only the newest branch trainable.
- Exported `AddClassesTrainer` and `Parallel`, and documented their APIs and usage in the fine-tuning guide.
- Updated `DetectionValidator` to pass `classes` to NMS, enabling validation metrics for selected added classes.

### 🎯 Purpose & Impact
- Users can add classes across multiple training sessions while retaining the existing detection branches and using the same checkpoint for prediction, validation, export, resume, and further class additions.
- Dataset names must preserve the pretrained classes in their original order, followed by new classes; the added-class workflow is available through `trainer=AddClassesTrainer`.
- Passing `classes=[...]` to validation or training filters reported detection results to those class IDs.