### PR TITLE
Report effective training arguments to Platform

### DIFF
--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -497,6 +497,7 @@ def on_train_end(trainer):
     _send(
         "training_complete",
         {
+            "trainArgs": {k: str(v) for k, v in vars(trainer.args).items() if k != "data"},
             "results": {
                 "metrics": {**trainer.metrics, "fitness": trainer.fitness},
                 "bestEpoch": best_epoch,


### PR DESCRIPTION
## Summary

- include the trainer final arguments in the Platform completion payload
- let Platform distinguish values changed during trainer setup, including automatic image-size and batch selection

## Validation

- `.venv/bin/python -m pytest tests/test_python.py -k platform_job_transport -q`
- `.venv/bin/ruff format --check ultralytics/utils/callbacks/platform.py`
- one-epoch CPU training with `imgsz=641 batch=-1`; trainer used `imgsz=672 batch=16` and streamed completion to local Platform

## Consumer

- ultralytics/portal#3738

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

The `training_complete` Platform payload now includes the trainer’s final arguments so Platform can report values applied during training setup.

### 📊 Key Changes

- Added a `trainArgs` field to the `training_complete` payload.
- Populated `trainArgs` from `trainer.args` after setup, converting values to strings.
- Excluded the `data` argument from the reported training arguments.

### 🎯 Purpose & Impact

- Platform can distinguish requested arguments from effective trainer values, including automatically selected image sizes and batch sizes.
- The existing training metrics and completion metadata remain in the payload.