### PR TITLE
Block dataset YAML `download` scripts outside the packaged datasets directory

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1181,15 +1181,11 @@ def test_data_utils(tmp_path):
     data_yaml.write_text("train: images/train\nval: images/val\ntest: images/test\nnames: [item]\n")
     with pytest.raises(FileNotFoundError, match="images not found"):
         check_det_dataset(data_yaml, split="test")
-    # Untrusted YAML `download` scripts must be blocked, not executed (packaged cfg/datasets YAMLs stay trusted)
-    proof = tmp_path / "proof.txt"
+    proof = tmp_path / "proof.txt"  # untrusted YAML download scripts must raise, not execute
     data_yaml.write_text(f"train: images/train\nval: images/val\nnames: [item]\ndownload: open(r'{proof}', 'w')\n")
-    with pytest.raises(PermissionError, match="download script blocked"):
+    with pytest.raises(PermissionError):
         check_det_dataset(data_yaml, autodownload=True)
     assert not proof.exists()
-    from ultralytics.utils.checks import check_file
-
-    assert (ROOT / "cfg" / "datasets") in Path(check_file("VOC.yaml")).resolve().parents  # packaged YAMLs stay trusted
 
     # polygons2masks_overlap must not overflow uint8 on the transient `masks + mask` sum (reaches 2 * i + 1):
     # with more than 128 overlapping instances every instance must keep a distinct index in the overlap mask

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1181,6 +1181,15 @@ def test_data_utils(tmp_path):
     data_yaml.write_text("train: images/train\nval: images/val\ntest: images/test\nnames: [item]\n")
     with pytest.raises(FileNotFoundError, match="images not found"):
         check_det_dataset(data_yaml, split="test")
+    # Untrusted YAML `download` scripts must be blocked, not executed (packaged cfg/datasets YAMLs stay trusted)
+    proof = tmp_path / "proof.txt"
+    data_yaml.write_text(f"train: images/train\nval: images/val\nnames: [item]\ndownload: open(r'{proof}', 'w')\n")
+    with pytest.raises(PermissionError, match="download script blocked"):
+        check_det_dataset(data_yaml, autodownload=True)
+    assert not proof.exists()
+    from ultralytics.utils.checks import check_file
+
+    assert (ROOT / "cfg" / "datasets") in Path(check_file("VOC.yaml")).resolve().parents  # packaged YAMLs stay trusted
 
     # polygons2masks_overlap must not overflow uint8 on the transient `masks + mask` sum (reaches 2 * i + 1):
     # with more than 128 overlapping instances every instance must keep a distinct index in the overlap mask

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -626,14 +626,8 @@ def check_det_dataset(dataset: str, autodownload: bool = True, split: str = "") 
             r = None  # success
             if s.startswith("http") and s.endswith(".zip"):  # URL
                 safe_download(url=s, dir=DATASETS_DIR, delete=True)
-            elif (ROOT / "cfg" / "datasets") not in file.resolve().parents:  # scripts only trusted from packaged YAMLs
-                raise PermissionError(
-                    emojis(
-                        f"Dataset '{name}' download script blocked ❌. 'download' scripts only auto-run from YAMLs "
-                        f"packaged in '{ROOT / 'cfg' / 'datasets'}', but '{file}' is user-supplied. Review its "
-                        f"'download' field, run it manually, and place the dataset in '{DATASETS_DIR}'."
-                    )
-                )
+            elif (ROOT / "cfg" / "datasets") not in file.resolve().parents:  # only packaged YAMLs may run scripts
+                raise PermissionError(f"Dataset '{name}' download script in '{file}' is untrusted, run it manually.")
             elif s.startswith("bash "):  # bash script
                 LOGGER.info(f"Running {s} ...")
                 subprocess.run(s.split(), check=True)

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -626,6 +626,14 @@ def check_det_dataset(dataset: str, autodownload: bool = True, split: str = "") 
             r = None  # success
             if s.startswith("http") and s.endswith(".zip"):  # URL
                 safe_download(url=s, dir=DATASETS_DIR, delete=True)
+            elif (ROOT / "cfg" / "datasets") not in file.resolve().parents:  # scripts only trusted from packaged YAMLs
+                raise PermissionError(
+                    emojis(
+                        f"Dataset '{name}' download script blocked ❌. 'download' scripts only auto-run from YAMLs "
+                        f"packaged in '{ROOT / 'cfg' / 'datasets'}', but '{file}' is user-supplied. Review its "
+                        f"'download' field, run it manually, and place the dataset in '{DATASETS_DIR}'."
+                    )
+                )
             elif s.startswith("bash "):  # bash script
                 LOGGER.info(f"Running {s} ...")
                 subprocess.run(s.split(), check=True)


### PR DESCRIPTION
## Summary

`check_det_dataset()` executed a dataset YAML's `download:` field with `exec()` (or `subprocess.run()` for `bash ` prefixes) for **any** YAML a user loads. A malicious third-party dataset YAML (shared on a forum, GitHub, Kaggle, etc.) therefore gained arbitrary code execution on the victim's machine the moment the referenced images were missing locally — no flags needed, since `autodownload=True` is the default (CWE-95). Reported by @sebastionoss in #24511 — thank you! That PR is being closed in favor of this one as its CLA remained unsigned for 3+ months.

## Fix

Scripts now auto-run only from YAMLs packaged inside `ultralytics/cfg/datasets` — the same trust domain as the installed code itself. All 17 packaged script-based YAMLs (VOC, GlobalWheat2020, Argoverse, …) keep working unchanged, and `download: https://…zip` URL downloads keep working for every YAML. A user-supplied YAML carrying a script now raises an actionable `PermissionError` naming the file and the manual remedy instead of silently executing it.

The guard compares `file.resolve().parents` against the resolved packaged-datasets root, so symlinks, relative paths, lookalike directory prefixes, and Windows case differences are all handled by `pathlib` semantics (Python 3.8-safe — no `is_relative_to`). The check uses the actual loaded file path, not YAML-controlled fields, so file content cannot spoof it. It also closes two indirect vectors: `download:` keys smuggled through NDJSON-converted datasets, and re-entry through `trainer` rewriting `args.data` to an extracted `yaml_file`.

## Validation

- New regression test in `tests/test_python.py::test_data_utils`: an untrusted YAML with a `download:` script raises `PermissionError` and provably does not execute, and packaged YAMLs (`VOC.yaml`) resolve inside the trusted root. Mutation-checked: relocating the trusted root makes the exec fire, proving the guard is the only barrier.
- All 17 packaged `download: |` YAMLs resolve under the trusted root via `check_file(<name>)`.
- `ruff format`/`ruff check` clean; `tests/test_python.py::test_data_utils` passes.

Closes #24511.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Dataset `download:` scripts now run only from YAML files packaged under `ultralytics/cfg/datasets`, preventing untrusted dataset files from executing code automatically.

### 📊 Key Changes
- Added a resolved-path check in `check_det_dataset()` before executing `bash` or Python download scripts.
- Untrusted YAML files now raise an actionable `PermissionError` instead of executing their `download:` script.
- Direct `.zip` URL downloads remain allowed regardless of the YAML file location.
- Added a regression test confirming that an untrusted script raises the error and does not create its target file.

### 🎯 Purpose & Impact
- Packaged script-based datasets continue to use automatic downloads, while user-supplied YAML files must have download scripts run manually.