### PR TITLE
Report progress bar frames as state, not log lines

### DIFF
--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -303,12 +303,12 @@ def on_pretrain_routine_start(trainer):
     trainer.platform = ctx
 
     # Create callback to send console output to Platform
-    def send_console_output(content, line_count, chunk_id):
-        """Send batched console output to Platform webhook."""
+    def send_console_output(content, line_count, chunk_id, progress):
+        """Send batched console output and live progress bar frames to Platform webhook."""
         _executor.submit(
             _send,
             "console_output",
-            {"chunkId": chunk_id, "content": content, "lineCount": line_count},
+            {"chunkId": chunk_id, "content": content, "lineCount": line_count, "progress": progress},
             project,
             name,
             ctx["model_id"],

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -303,12 +303,17 @@ def on_pretrain_routine_start(trainer):
     trainer.platform = ctx
 
     # Create callback to send console output to Platform
-    def send_console_output(content, line_count, chunk_id, progress):
+    def send_console_output(content, line_count, chunk_id):
         """Send batched console output and live progress bar frames to Platform webhook."""
         _executor.submit(
             _send,
             "console_output",
-            {"chunkId": chunk_id, "content": content, "lineCount": line_count, "progress": progress},
+            {
+                "chunkId": chunk_id,
+                "content": content,
+                "lineCount": line_count,
+                "progress": ctx["console_logger"].progress_sent,
+            },
             project,
             name,
             ctx["model_id"],

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -93,8 +93,8 @@ class ConsoleLogger:
             return
 
         self.active = True
-        sys.stdout = self._ConsoleCapture(self.original_stdout, self._queue_log)
-        sys.stderr = self._ConsoleCapture(self.original_stderr, self._queue_log)
+        self.stdout_capture = sys.stdout = self._ConsoleCapture(self.original_stdout, self._queue_log)
+        self.stderr_capture = sys.stderr = self._ConsoleCapture(self.original_stderr, self._queue_log)
 
         # Hook Ultralytics logger
         try:
@@ -113,7 +113,7 @@ class ConsoleLogger:
         if not self.active:
             return
 
-        sys.stdout.callback = sys.stderr.callback = None
+        self.stdout_capture.callback = self.stderr_capture.callback = None
         self.active = False
         sys.stdout = self.original_stdout
         sys.stderr = self.original_stderr

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -105,8 +105,9 @@ class ConsoleLogger:
             pass
 
         # Background flush thread: carries live progress frames in every mode, batched lines when batching
-        self.flush_thread = threading.Thread(target=self._flush_worker, daemon=True)
-        self.flush_thread.start()
+        if not (self.flush_thread and self.flush_thread.is_alive()):  # a worker still sleeping resumes on its own
+            self.flush_thread = threading.Thread(target=self._flush_worker, daemon=True)
+            self.flush_thread.start()
 
     def stop_capture(self):
         """Stop capturing console output and flush remaining buffer."""

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -38,8 +38,8 @@ class ConsoleLogger:
         >>> logger.start_capture()
 
         Custom callback with batching:
-        >>> def my_handler(content, line_count, chunk_id):
-        ...     print(f"Received {line_count} lines")
+        >>> def my_handler(content, line_count, chunk_id, progress):
+        ...     print(f"Received {line_count} lines and {len(progress)} live progress bars")
         >>> logger = ConsoleLogger(on_flush=my_handler, batch_size=5)
         >>> logger.start_capture()
     """
@@ -51,7 +51,8 @@ class ConsoleLogger:
             destination (str | Path | None): API endpoint URL (http/https), local file path, or None.
             batch_size (int): Lines to accumulate before flush (1 = immediate, higher = batched).
             flush_interval (float): Max seconds between flushes when batching.
-            on_flush (callable | None): Callback(content: str, line_count: int, chunk_id: int) for custom handling.
+            on_flush (callable | None): Callback(content, line_count, chunk_id, progress) where progress maps live
+                progress bar ids to their latest frame.
         """
         if isinstance(destination, str) and destination.startswith("http://"):
             LOGGER.warning("ConsoleLogger destination uses plaintext HTTP; captured logs are sent unencrypted.")
@@ -80,8 +81,7 @@ class ConsoleLogger:
         # Deduplication state
         self.last_line = ""
         self.last_time = 0.0
-        self.last_progress_time = 0.0
-        self.progress_interval = 1.0
+        self.progress = {}  # live progress bar frames by bar id, held as state instead of buffered as log lines
 
     def start_capture(self):
         """Start capturing console output and redirect stdout/stderr.
@@ -93,8 +93,8 @@ class ConsoleLogger:
             return
 
         self.active = True
-        sys.stdout = self._ConsoleCapture(self.original_stdout, self._queue_log)
-        sys.stderr = self._ConsoleCapture(self.original_stderr, self._queue_log)
+        sys.stdout = self._ConsoleCapture(self.original_stdout, self._queue_log, self._queue_progress)
+        sys.stderr = self._ConsoleCapture(self.original_stderr, self._queue_log, self._queue_progress)
 
         # Hook Ultralytics logger
         try:
@@ -148,12 +148,6 @@ class ConsoleLogger:
             if not (line := line.rstrip()):
                 continue  # a bare newline carries nothing once timestamped
 
-            # Rate-limit progress bar redraws, always keeping the completed bar
-            if any(pair in line for pair in ("──", "━─", "━╸", "╸─")):  # an unfilled cell inside the bar
-                if current_time - self.last_progress_time < self.progress_interval:
-                    continue
-                self.last_progress_time = current_time
-
             # General deduplication
             if line == self.last_line and current_time - self.last_time < 0.1:
                 continue
@@ -177,6 +171,16 @@ class ConsoleLogger:
             if should_flush:
                 self._flush_buffer()
 
+    def _queue_progress(self, bar_id, frame):
+        """Hold a live progress bar frame as state, promoting the last frame to a log line when the bar closes."""
+        with self.buffer_lock:
+            if frame is not None:
+                self.progress[str(bar_id)] = frame.split("\r")[-1].replace("\x1b[K", "").rstrip()
+                return
+            frame = self.progress.pop(str(bar_id), None)  # bar closed
+        if frame:
+            self._queue_log(frame + "\n")  # the completed bar is real log content
+
     def _flush_worker(self):
         """Background worker that flushes buffer periodically."""
         while self.active:
@@ -185,12 +189,13 @@ class ConsoleLogger:
                 self._flush_buffer()
 
     def _flush_buffer(self):
-        """Flush buffered lines to destination and/or callback."""
+        """Flush buffered lines and current progress bar frames to destination and/or callback."""
         with self.buffer_lock:
-            if not self.buffer:
+            if not self.buffer and not self.progress:
                 return
             lines = self.buffer.copy()
             self.buffer.clear()
+            progress = dict(self.progress)
             self.chunk_id += 1
             chunk_id = self.chunk_id  # Capture under lock to avoid race
 
@@ -200,12 +205,12 @@ class ConsoleLogger:
         # Call custom callback if provided
         if self.on_flush:
             try:
-                self.on_flush(content, line_count, chunk_id)
+                self.on_flush(content, line_count, chunk_id, progress)
             except Exception:
                 pass  # Silently ignore callback errors to avoid flooding stderr
 
         # Write to destination (file or API)
-        if self.destination is not None:
+        if self.destination is not None and lines:
             self._write_destination(content)
 
     def _write_destination(self, content):
@@ -226,17 +231,23 @@ class ConsoleLogger:
     class _ConsoleCapture:
         """Lightweight stdout/stderr capture."""
 
-        __slots__ = ("callback", "original")
+        __slots__ = ("callback", "original", "progress_callback")
 
-        def __init__(self, original, callback):
+        def __init__(self, original, callback, progress_callback):
             """Initialize a stream wrapper that redirects writes to a callback while preserving the original."""
             self.original = original
             self.callback = callback
+            self.progress_callback = progress_callback
 
         def write(self, text):
             """Write text to the original stream and forward it to the capture callback."""
             self.original.write(text)
             self.callback(text)
+
+        def progress(self, bar_id, frame):
+            """Write a TQDM frame to the original stream and report it as bar state instead of a log line."""
+            self.original.write(frame or "")
+            self.progress_callback(bar_id, frame)
 
         def flush(self):
             """Flush the wrapped stream to propagate buffered output promptly during console capture."""

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -38,8 +38,8 @@ class ConsoleLogger:
         >>> logger.start_capture()
 
         Custom callback with batching:
-        >>> def my_handler(content, line_count, chunk_id, progress):
-        ...     print(f"Received {line_count} lines and {len(progress)} live progress bars")
+        >>> def my_handler(content, line_count, chunk_id):
+        ...     print(f"Received {line_count} lines")
         >>> logger = ConsoleLogger(on_flush=my_handler, batch_size=5)
         >>> logger.start_capture()
     """
@@ -51,8 +51,7 @@ class ConsoleLogger:
             destination (str | Path | None): API endpoint URL (http/https), local file path, or None.
             batch_size (int): Lines to accumulate before flush (1 = immediate, higher = batched).
             flush_interval (float): Max seconds between flushes when batching.
-            on_flush (callable | None): Callback(content, line_count, chunk_id, progress) where progress maps live
-                progress bar ids to their latest frame.
+            on_flush (callable | None): Callback(content: str, line_count: int, chunk_id: int) for custom handling.
         """
         if isinstance(destination, str) and destination.startswith("http://"):
             LOGGER.warning("ConsoleLogger destination uses plaintext HTTP; captured logs are sent unencrypted.")
@@ -114,6 +113,7 @@ class ConsoleLogger:
         if not self.active:
             return
 
+        sys.stdout.callback = sys.stderr.callback = None
         self.active = False
         sys.stdout = self.original_stdout
         sys.stderr = self.original_stderr
@@ -194,7 +194,7 @@ class ConsoleLogger:
                 return  # nothing new: an idle bar must not flush a chunk of its own
             lines = self.buffer.copy()
             self.buffer.clear()
-            progress = self.progress_sent = dict(self.progress)
+            self.progress_sent = dict(self.progress)
             self.chunk_id += 1
             chunk_id = self.chunk_id  # Capture under lock to avoid race
 
@@ -204,7 +204,7 @@ class ConsoleLogger:
         # Call custom callback if provided
         if self.on_flush:
             try:
-                self.on_flush(content, line_count, chunk_id, progress)
+                self.on_flush(content, line_count, chunk_id)
             except Exception:
                 pass  # Silently ignore callback errors to avoid flooding stderr
 
@@ -240,12 +240,14 @@ class ConsoleLogger:
         def write(self, text):
             """Write text to the original stream and forward it to the capture callback."""
             self.original.write(text)
-            self.callback(text, None)
+            if self.callback:
+                self.callback(text, None)
 
         def progress(self, bar_id, frame):
             """Write a TQDM frame to the original stream and report it as bar state instead of a log line."""
             self.original.write(frame)
-            self.callback(frame, bar_id)
+            if self.callback:
+                self.callback(frame, bar_id)
 
         def flush(self):
             """Flush the wrapped stream to propagate buffered output promptly during console capture."""

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -103,10 +103,9 @@ class ConsoleLogger:
         except Exception:
             pass
 
-        # Start background flush thread for batched mode
-        if self.batch_size > 1:
-            self.flush_thread = threading.Thread(target=self._flush_worker, daemon=True)
-            self.flush_thread.start()
+        # Background flush thread: carries live progress frames in every mode, batched lines when batching
+        self.flush_thread = threading.Thread(target=self._flush_worker, daemon=True)
+        self.flush_thread.start()
 
     def stop_capture(self):
         """Stop capturing console output and flush remaining buffer."""

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -94,8 +94,8 @@ class ConsoleLogger:
             return
 
         self.active = True
-        sys.stdout = self._ConsoleCapture(self.original_stdout, self._queue_log, self._queue_progress)
-        sys.stderr = self._ConsoleCapture(self.original_stderr, self._queue_log, self._queue_progress)
+        sys.stdout = self._ConsoleCapture(self.original_stdout, self._queue_log)
+        sys.stderr = self._ConsoleCapture(self.original_stderr, self._queue_log)
 
         # Hook Ultralytics logger
         try:
@@ -130,8 +130,8 @@ class ConsoleLogger:
         self.progress.clear()
         self._flush_buffer()
 
-    def _queue_log(self, text):
-        """Queue console text with deduplication and timestamp processing."""
+    def _queue_log(self, text, bar_id):
+        """Queue console text with deduplication and timestamp processing, holding bar frames as state."""
         if not self.active:
             return
 
@@ -141,6 +141,13 @@ class ConsoleLogger:
         if "\r" in text:
             text = text.split("\r")[-1]
         text = text.replace("\x1b[K", "")
+
+        if bar_id is not None:  # a redraw is bar state, so only the frame a bar closed with becomes a log line
+            with self.buffer_lock:
+                if text:
+                    self.progress[str(bar_id)] = text.rstrip()
+                    return
+                text = self.progress.pop(str(bar_id), "")
 
         lines = text.split("\n")
         if lines and lines[-1] == "":
@@ -172,18 +179,6 @@ class ConsoleLogger:
             # Flush outside lock to avoid deadlock
             if should_flush:
                 self._flush_buffer()
-
-    def _queue_progress(self, bar_id, frame):
-        """Hold a live progress bar frame as state, promoting the last frame to a log line when the bar closes."""
-        if not self.active:
-            return  # a bar outliving the capture must not repopulate the state
-        with self.buffer_lock:
-            if frame is not None:
-                self.progress[str(bar_id)] = frame.split("\r")[-1].replace("\x1b[K", "").rstrip()
-                return
-            frame = self.progress.pop(str(bar_id), None)  # bar closed
-        if frame:
-            self._queue_log(frame + "\n")  # the completed bar is real log content
 
     def _flush_worker(self):
         """Background worker that flushes buffer periodically."""
@@ -235,23 +230,22 @@ class ConsoleLogger:
     class _ConsoleCapture:
         """Lightweight stdout/stderr capture."""
 
-        __slots__ = ("callback", "original", "progress_callback")
+        __slots__ = ("callback", "original")
 
-        def __init__(self, original, callback, progress_callback):
+        def __init__(self, original, callback):
             """Initialize a stream wrapper that redirects writes to a callback while preserving the original."""
             self.original = original
             self.callback = callback
-            self.progress_callback = progress_callback
 
         def write(self, text):
             """Write text to the original stream and forward it to the capture callback."""
             self.original.write(text)
-            self.callback(text)
+            self.callback(text, None)
 
         def progress(self, bar_id, frame):
             """Write a TQDM frame to the original stream and report it as bar state instead of a log line."""
-            self.original.write(frame or "")
-            self.progress_callback(bar_id, frame)
+            self.original.write(frame)
+            self.callback(frame, bar_id)
 
         def flush(self):
             """Flush the wrapped stream to propagate buffered output promptly during console capture."""
@@ -273,7 +267,7 @@ class ConsoleLogger:
 
         def emit(self, record):
             """Format and forward LogRecord messages to the capture callback for unified log streaming."""
-            self.callback(self.format(record) + "\n")
+            self.callback(self.format(record) + "\n", None)
 
 
 class _DriveInfo:

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -82,6 +82,7 @@ class ConsoleLogger:
         self.last_line = ""
         self.last_time = 0.0
         self.progress = {}  # live progress bar frames by bar id, held as state instead of buffered as log lines
+        self.progress_sent = {}
 
     def start_capture(self):
         """Start capturing console output and redirect stdout/stderr.
@@ -190,11 +191,11 @@ class ConsoleLogger:
     def _flush_buffer(self):
         """Flush buffered lines and current progress bar frames to destination and/or callback."""
         with self.buffer_lock:
-            if not self.buffer and not self.progress:
-                return
+            if not self.buffer and self.progress == self.progress_sent:
+                return  # nothing new: an idle bar must not flush a chunk of its own
             lines = self.buffer.copy()
             self.buffer.clear()
-            progress = dict(self.progress)
+            progress = self.progress_sent = dict(self.progress)
             self.chunk_id += 1
             chunk_id = self.chunk_id  # Capture under lock to avoid race
 

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -126,7 +126,8 @@ class ConsoleLogger:
                 pass
             self._log_handler = None
 
-        # Final flush
+        # Final flush, without the frames of any bar that outlived the capture
+        self.progress.clear()
         self._flush_buffer()
 
     def _queue_log(self, text):
@@ -174,6 +175,8 @@ class ConsoleLogger:
 
     def _queue_progress(self, bar_id, frame):
         """Hold a live progress bar frame as state, promoting the last frame to a log line when the bar closes."""
+        if not self.active:
+            return  # a bar outliving the capture must not repopulate the state
         with self.buffer_lock:
             if frame is not None:
                 self.progress[str(bar_id)] = frame.split("\r")[-1].replace("\x1b[K", "").rstrip()

--- a/ultralytics/utils/tqdm.py
+++ b/ultralytics/utils/tqdm.py
@@ -302,7 +302,11 @@ class TQDM:
                     width = shutil.get_terminal_size().columns - 1  # COLUMNS env, else sys.__stdout__
                 progress_str = self._fit(f"{self._fit(self.desc, width - len(fields) - 2)}: {fields}", width)
             # Non-interactive environments avoid the carriage return which creates empty lines
-            self.file.write(progress_str if self.noninteractive else f"\r\033[K{progress_str}")
+            frame = progress_str if self.noninteractive else f"\r\033[K{progress_str}"
+            if progress := getattr(self.file, "progress", None):
+                progress(id(self), frame)  # a redraw is bar state, so log consumers keep it out of their log
+            else:
+                self.file.write(frame)
             self.file.flush()
         except Exception:
             pass
@@ -341,6 +345,9 @@ class TQDM:
                     self._display(final=True)
             else:
                 self._display(final=True)
+
+            if progress := getattr(self.file, "progress", None):
+                progress(id(self), None)  # bar closed: the last frame is now log content
 
             # Cleanup
             if self.leave:

--- a/ultralytics/utils/tqdm.py
+++ b/ultralytics/utils/tqdm.py
@@ -347,7 +347,7 @@ class TQDM:
                 self._display(final=True)
 
             if progress := getattr(self.file, "progress", None):
-                progress(id(self), None)  # bar closed: the last frame is now log content
+                progress(id(self), "")  # bar closed: the last frame is now log content
 
             # Cleanup
             if self.leave:


### PR DESCRIPTION
This is a contract change. It wouldn't break the consumers completely if it is merged. It will just stop showing live progress and only show completed progress bars (same as how it was before #25900) until the consumers update themselves to read the new payload. The main benefit is that consumer no longer need to do ugly heuristical gymnastics on the logs to find out whether it's a progress bar or not. It just knows from the demarcation in payload.

A progress bar redraw is state, not a log line, but `_queue_log` appended each frame into the same buffer as real log lines, so consumers had to guess which lines were bar frames and dedupe them again on their side.

**Three changes:**

1. `TQDM._display` hands the frame to the output stream through a `progress(bar_id, frame)` hook when the stream has one, else writes as before. `close()` sends an empty frame to say the bar is done.
2. `ConsoleLogger` keeps live frames in `self.progress`, a dict of bar id to latest frame, and never puts them in the log buffer. `on_flush` gets it as a 4th argument. When a bar closes, its last frame is promoted to one real log line, so the completed bar still stays in the log.
3. Deleted the bar detection `any(pair in line for pair in ("──", "━─", "━╸", "╸─"))` and the `progress_interval` rate limiter. No text heuristic is left, so a log line that happens to contain `──` is no longer treated as a bar.

Bar ids are exact, so a consumer no longer needs to build a key from the rendered text to tell two bars apart.

**Payload** now carries `progress` next to `content`. The backend has to read that field to show the live bar. Until it does, the bar shows only when it completes, same as before #25900.

Live frames are sent on flush, so the rate is `flush_interval`, 5s, instead of the old 1s limiter. Frames no longer count toward `batch_size`.

Bar rendering in the terminal is unchanged: the raw frame still goes to the real stream first.

**Cost**, measured over 60s of one live bar with `batch_size=5` and `flush_interval=5.0`, using a normal training row as the description:

| Per minute of one live bar | Before | After | Change |
| -------------------------- | -----: | ----: | -----: |
| Callback flushes | 13 | 13 | same |
| Payload bytes | 12,483 | 3,239 | -74% |
| Bar lines kept in the log | 61 | 1 | -98% |

Same number of requests, they just stop carrying 5 redraw lines each. Over a one hour run that is about 730 KB against 190 KB, and 3,660 stored bar lines against one line per closed bar.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Progress-bar redraws are now reported as structured state in the `console_output` payload instead of buffered as log lines, reducing duplicate log data and removing text-based bar detection.

### 📊 Key Changes

- `TQDM._display` sends frames through a stream `progress(bar_id, frame)` hook when available, while preserving terminal rendering; `close()` sends an empty frame to mark completion.
- `ConsoleLogger` stores the latest live frame per bar ID in `progress`, excludes active frames from log buffering, and promotes the final frame to one log line when the bar closes.
- The `console_output` payload now includes `progress` alongside `content`, using exact bar IDs for consumers to identify individual bars.
- Removed progress-bar text heuristics and the separate one-second `progress_interval` limiter; live progress updates are sent when progress state changes during flushes.
- Capture now maintains a background flush worker for progress updates even when regular log batching is disabled.

### 🎯 Purpose & Impact

- Consumers must read the new `progress` payload field to display live progress bars; without that update, bars appear only when they complete.
- Active redraws no longer inflate stored log content, while each completed bar remains as one log line.
- Log messages containing characters previously associated with progress bars are no longer misclassified.