### PR TITLE
Preserve bounding box format when indexing

### DIFF
--- a/ultralytics/utils/instance.py
+++ b/ultralytics/utils/instance.py
@@ -173,11 +173,11 @@ class Bboxes:
             When using boolean indexing, make sure to provide a boolean array with the same length as the number of
             bounding boxes.
         """
-        if isinstance(index, int):
-            return Bboxes(self.bboxes[index].reshape(1, -1))
         b = self.bboxes[index]
+        if b.ndim == 1:
+            b = b.reshape(1, -1)
         assert b.ndim == 2, f"Indexing on Bboxes with {index} failed to return a matrix!"
-        return Bboxes(b)
+        return Bboxes(b, format=self.format)
 
 
 class Instances:


### PR DESCRIPTION
## Description

`Bboxes.__getitem__` constructed indexed results with the default `xyxy` format. Indexing an `xywh` or `ltwh` container therefore preserved the raw coordinates but changed their interpretation, producing incorrect areas and conversions. NumPy integer indices also returned a one-dimensional array and failed the matrix assertion.

This change restores the instance axis whenever NumPy indexing removes it and passes the source format into the result. Slice and boolean-array behavior remains unchanged.

## Validation

On current `main`, indexing `Bboxes([[1, 2, 3, 4]], format="xywh")` with either `0` or `np.int64(0)` relabeled the result or raised an assertion. After this change, both return shape `(1, 4)`, retain `xywh`, and report the correct area of `12`.

- `py -3.13 -m ruff check ultralytics/utils/instance.py`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated `Bboxes.__getitem__` to preserve the source coordinate format and restore the bounding-box axis when indexing returns a one-dimensional NumPy array, preventing incorrect coordinate interpretation and area calculations.

### 📊 Key Changes
- Reshapes one-dimensional indexed results to a single-row, two-dimensional array.
- Passes `self.format` to newly constructed `Bboxes` results instead of defaulting to `xyxy`.
- Retains the existing matrix assertion for invalid indexing results.
- Preserves existing slice and boolean-array indexing behavior.

### 🎯 Purpose & Impact
- Integer and NumPy integer indexing of `xywh` or `ltwh` containers now returns correctly shaped results with the original format, ensuring accurate conversions and area reporting.