### PR TITLE
Preserve instance axes during scalar indexing

### DIFF
--- a/ultralytics/utils/instance.py
+++ b/ultralytics/utils/instance.py
@@ -325,9 +325,6 @@ class Instances:
         Returns:
             (Instances): A new Instances object containing the selected boxes, segments, and keypoints if present.
 
-        Notes:
-            When using boolean indexing, make sure to provide a boolean array with the same length as the number of
-            instances.
         """
         index = [index] if isinstance(index, (int, np.integer)) else index
         segments = self.segments[index] if len(self.segments) else self.segments

--- a/ultralytics/utils/instance.py
+++ b/ultralytics/utils/instance.py
@@ -324,7 +324,6 @@ class Instances:
 
         Returns:
             (Instances): A new Instances object containing the selected boxes, segments, and keypoints if present.
-
         """
         index = [index] if isinstance(index, (int, np.integer)) else index
         segments = self.segments[index] if len(self.segments) else self.segments

--- a/ultralytics/utils/instance.py
+++ b/ultralytics/utils/instance.py
@@ -329,6 +329,7 @@ class Instances:
             When using boolean indexing, make sure to provide a boolean array with the same length as the number of
             instances.
         """
+        index = [index] if isinstance(index, (int, np.integer)) else index
         segments = self.segments[index] if len(self.segments) else self.segments
         keypoints = self.keypoints[index] if self.keypoints is not None else None
         bboxes = self.bboxes[index]


### PR DESCRIPTION
## Description

Scalar indexing of `Instances` kept the bounding-box axis but removed the leading instance axis from segments and keypoints. A one-instance result therefore reported one box while exposing segment shape `(P, 2)` and keypoint shape `(K, 3)` instead of `(1, P, 2)` and `(1, K, 3)`.

This change converts Python and NumPy scalar integer indices to one-element advanced indices before selecting each aligned field. Slices, integer arrays, and boolean masks retain their existing behavior, including negative scalar indices.

## Validation

A two-instance container indexed with `0` or `np.int64(-1)` now returns one box, segments shaped `(1, P, 2)`, and keypoints shaped `(1, K, 3)`. Current `main` drops both leading axes.

- `py -3.13 -m ruff check ultralytics/utils/instance.py`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Scalar integer indexing in `Instances.__getitem__` now preserves the leading instance axis for segments and keypoints by converting Python and NumPy scalar integers to one-element indices before selecting aligned fields.

### 📊 Key Changes
- Converts Python `int` and NumPy integer scalar indices to one-element lists.
- Applies the normalized index to `segments`, `keypoints`, and `bboxes`.
- Retains existing indexing behavior for slices, integer arrays, boolean masks, and negative scalar indices.

### 🎯 Purpose & Impact
- A scalar-indexed result now keeps consistent one-instance shapes across bounding boxes, segments, and keypoints, including shapes such as `(1, P, 2)` for segments and `(1, K, 3)` for keypoints.