### PR TITLE
perf(sam): encode each generate() crop once and reuse it across point batches

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1285,14 +1285,14 @@ def test_sam_generate_encodes_each_crop_once(monkeypatch):
 
     calls, original = [], predictor.get_im_features
     monkeypatch.setattr(predictor, "get_im_features", lambda x: calls.append(1) or original(x))
-    with torch.inference_mode():
+    with torch.no_grad():  # torch.inference_mode() needs torch>=1.10, below the repo's 1.8 floor
         predictor.generate(im, crop_n_layers=0, points_stride=2, points_batch_size=1)
 
     assert len(calls) == 1  # 4 point batches (2x2 points, batch_size=1) must share a single encode
 
-    predictor.features = original(im)  # simulate a stale cache left by a prior set_image() call
-    calls.clear()
-    with torch.inference_mode():
+    with torch.no_grad():
+        predictor.features = original(im)  # simulate a stale cache left by a prior set_image() call
+        calls.clear()
         predictor.generate(im, crop_n_layers=1, points_stride=2, points_batch_size=1)
 
     assert len(calls) == 5  # 1 full image + 4 sub-crops, each must re-encode instead of reusing self.features

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1271,33 +1271,6 @@ def test_data_annotator(tmp_path):
     )
 
 
-def test_sam_generate_encodes_each_crop_once(monkeypatch):
-    """generate() must encode each crop once and reuse it across every point batch, not once per batch, and must never
-    fall back to a stale `self.features` left by a prior `set_image()` call on a different crop.
-    """
-    from ultralytics.models.sam import Predictor
-
-    predictor = Predictor(overrides={"model": WEIGHTS_DIR / "mobile_sam.pt", "imgsz": 1024, "verbose": False})
-    predictor.setup_model()
-    predictor.setup_source(np.zeros((64, 64, 3), dtype=np.uint8))
-    predictor.batch = next(iter(predictor.dataset))
-    im = predictor.preprocess(predictor.batch[1])
-
-    calls, original = [], predictor.get_im_features
-    monkeypatch.setattr(predictor, "get_im_features", lambda x: calls.append(1) or original(x))
-    with torch.no_grad():  # torch.inference_mode() needs torch>=1.10, below the repo's 1.8 floor
-        predictor.generate(im, crop_n_layers=0, points_stride=2, points_batch_size=1)
-
-    assert len(calls) == 1  # 4 point batches (2x2 points, batch_size=1) must share a single encode
-
-    with torch.no_grad():
-        predictor.features = original(im)  # simulate a stale cache left by a prior set_image() call
-        calls.clear()
-        predictor.generate(im, crop_n_layers=1, points_stride=2, points_batch_size=1)
-
-    assert len(calls) == 5  # 1 full image + 4 sub-crops, each must re-encode instead of reusing self.features
-
-
 def test_events():
     """Test event sending functionality."""
     from ultralytics.utils.events import Events

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1271,6 +1271,33 @@ def test_data_annotator(tmp_path):
     )
 
 
+def test_sam_generate_encodes_each_crop_once(monkeypatch):
+    """generate() must encode each crop once and reuse it across every point batch, not once per batch, and must never
+    fall back to a stale `self.features` left by a prior `set_image()` call on a different crop.
+    """
+    from ultralytics.models.sam import Predictor
+
+    predictor = Predictor(overrides={"model": WEIGHTS_DIR / "mobile_sam.pt", "imgsz": 1024, "verbose": False})
+    predictor.setup_model()
+    predictor.setup_source(np.zeros((64, 64, 3), dtype=np.uint8))
+    predictor.batch = next(iter(predictor.dataset))
+    im = predictor.preprocess(predictor.batch[1])
+
+    calls, original = [], predictor.get_im_features
+    monkeypatch.setattr(predictor, "get_im_features", lambda x: calls.append(1) or original(x))
+    with torch.inference_mode():
+        predictor.generate(im, crop_n_layers=0, points_stride=2, points_batch_size=1)
+
+    assert len(calls) == 1  # 4 point batches (2x2 points, batch_size=1) must share a single encode
+
+    predictor.features = original(im)  # simulate a stale cache left by a prior set_image() call
+    calls.clear()
+    with torch.inference_mode():
+        predictor.generate(im, crop_n_layers=1, points_stride=2, points_batch_size=1)
+
+    assert len(calls) == 5  # 1 full image + 4 sub-crops, each must re-encode instead of reusing self.features
+
+
 def test_events():
     """Test event sending functionality."""
     from ultralytics.utils.events import Events

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -385,7 +385,6 @@ class Predictor(BasePredictor):
             points_scale = np.array([[w, h]])  # w, h
             # Crop image and interpolate to input size
             crop_im = F.interpolate(im[..., y1:y2, x1:x2], (ih, iw), mode="bilinear", align_corners=False)
-            # Encode each crop once without consulting full-image features cached by set_image().
             crop_features = self.get_im_features(crop_im)
             # (num_points, 2)
             points_for_image = point_grids[layer_idx] * points_scale

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -207,9 +207,7 @@ class Predictor(BasePredictor):
 
         return self.prompt_inference(im, bboxes, points, labels, masks, multimask_output)
 
-    def prompt_inference(
-        self, im, bboxes=None, points=None, labels=None, masks=None, multimask_output=False, features=None
-    ):
+    def prompt_inference(self, im, bboxes=None, points=None, labels=None, masks=None, multimask_output=False):
         """Perform image segmentation inference based on input cues using SAM's specialized architecture.
 
         This internal function leverages the Segment Anything Model (SAM) for prompt-based, real-time segmentation. It
@@ -224,10 +222,6 @@ class Predictor(BasePredictor):
                 0 for background.
             masks (np.ndarray | None): Low-res masks from previous predictions with shape (N, H, W). For SAM, H=W=256.
             multimask_output (bool): Flag to return multiple masks for ambiguous prompts.
-            features (torch.Tensor | dict[str, Any] | None): Precomputed features for `im` (e.g. a crop-local encoding
-                from `generate()`). Takes priority over the cached `self.features`, which belongs to whatever image
-                `set_image()` last encoded and must never be assumed to match `im`.
-
         Returns:
             pred_masks (torch.Tensor): Output masks with shape (C, H, W), where C is the number of generated masks.
             pred_scores (torch.Tensor): Quality scores predicted by the model for each mask, with length C.
@@ -238,9 +232,7 @@ class Predictor(BasePredictor):
             >>> bboxes = [[100, 100, 200, 200]]
             >>> masks, scores = predictor.prompt_inference(im, bboxes=bboxes)
         """
-        if features is None:
-            features = self.get_im_features(im) if self.features is None else self.features
-
+        features = self.get_im_features(im) if self.features is None else self.features
         prompts = self._prepare_prompts(im.shape[2:], self.batch[1][0].shape[:2], bboxes, points, labels, masks)
         return self._inference_features(features, *prompts, multimask_output)
 
@@ -392,17 +384,14 @@ class Predictor(BasePredictor):
             points_scale = np.array([[w, h]])  # w, h
             # Crop image and interpolate to input size
             crop_im = F.interpolate(im[..., y1:y2, x1:x2], (ih, iw), mode="bilinear", align_corners=False)
-            # Encode this crop once and reuse it for every point batch below. Each crop is a distinct image (a
-            # different region resized to `imgsz`), so it must never fall back to `self.features`, which
-            # `set_image()` may have cached for the full, un-cropped image.
+            # Encode each crop once without consulting full-image features cached by set_image().
             crop_features = self.get_im_features(crop_im)
             # (num_points, 2)
             points_for_image = point_grids[layer_idx] * points_scale
             crop_masks, crop_scores, crop_bboxes = [], [], []
             for (points,) in batch_iterator(points_batch_size, points_for_image):
-                pred_mask, pred_score = self.prompt_inference(
-                    crop_im, points=points, multimask_output=True, features=crop_features
-                )
+                prompts = self._prepare_prompts(crop_im.shape[2:], self.batch[1][0].shape[:2], points=points)
+                pred_mask, pred_score = self._inference_features(crop_features, *prompts, multimask_output=True)
                 # Interpolate predicted masks to input size
                 pred_mask = F.interpolate(pred_mask[None], (h, w), mode="bilinear", align_corners=False)[0]
                 idx = pred_score > conf_thres

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -222,6 +222,7 @@ class Predictor(BasePredictor):
                 0 for background.
             masks (np.ndarray | None): Low-res masks from previous predictions with shape (N, H, W). For SAM, H=W=256.
             multimask_output (bool): Flag to return multiple masks for ambiguous prompts.
+
         Returns:
             pred_masks (torch.Tensor): Output masks with shape (C, H, W), where C is the number of generated masks.
             pred_scores (torch.Tensor): Quality scores predicted by the model for each mask, with length C.

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -386,7 +386,6 @@ class Predictor(BasePredictor):
             # Crop image and interpolate to input size
             crop_im = F.interpolate(im[..., y1:y2, x1:x2], (ih, iw), mode="bilinear", align_corners=False)
             crop_features = self.get_im_features(crop_im)
-            # (num_points, 2)
             points_for_image = point_grids[layer_idx] * points_scale
             crop_masks, crop_scores, crop_bboxes = [], [], []
             for (points,) in batch_iterator(points_batch_size, points_for_image):

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -207,7 +207,9 @@ class Predictor(BasePredictor):
 
         return self.prompt_inference(im, bboxes, points, labels, masks, multimask_output)
 
-    def prompt_inference(self, im, bboxes=None, points=None, labels=None, masks=None, multimask_output=False):
+    def prompt_inference(
+        self, im, bboxes=None, points=None, labels=None, masks=None, multimask_output=False, features=None
+    ):
         """Perform image segmentation inference based on input cues using SAM's specialized architecture.
 
         This internal function leverages the Segment Anything Model (SAM) for prompt-based, real-time segmentation. It
@@ -222,6 +224,9 @@ class Predictor(BasePredictor):
                 0 for background.
             masks (np.ndarray | None): Low-res masks from previous predictions with shape (N, H, W). For SAM, H=W=256.
             multimask_output (bool): Flag to return multiple masks for ambiguous prompts.
+            features (torch.Tensor | dict[str, Any] | None): Precomputed features for `im` (e.g. a crop-local encoding
+                from `generate()`). Takes priority over the cached `self.features`, which belongs to whatever image
+                `set_image()` last encoded and must never be assumed to match `im`.
 
         Returns:
             pred_masks (torch.Tensor): Output masks with shape (C, H, W), where C is the number of generated masks.
@@ -233,7 +238,8 @@ class Predictor(BasePredictor):
             >>> bboxes = [[100, 100, 200, 200]]
             >>> masks, scores = predictor.prompt_inference(im, bboxes=bboxes)
         """
-        features = self.get_im_features(im) if self.features is None else self.features
+        if features is None:
+            features = self.get_im_features(im) if self.features is None else self.features
 
         prompts = self._prepare_prompts(im.shape[2:], self.batch[1][0].shape[:2], bboxes, points, labels, masks)
         return self._inference_features(features, *prompts, multimask_output)
@@ -386,11 +392,17 @@ class Predictor(BasePredictor):
             points_scale = np.array([[w, h]])  # w, h
             # Crop image and interpolate to input size
             crop_im = F.interpolate(im[..., y1:y2, x1:x2], (ih, iw), mode="bilinear", align_corners=False)
+            # Encode this crop once and reuse it for every point batch below. Each crop is a distinct image (a
+            # different region resized to `imgsz`), so it must never fall back to `self.features`, which
+            # `set_image()` may have cached for the full, un-cropped image.
+            crop_features = self.get_im_features(crop_im)
             # (num_points, 2)
             points_for_image = point_grids[layer_idx] * points_scale
             crop_masks, crop_scores, crop_bboxes = [], [], []
             for (points,) in batch_iterator(points_batch_size, points_for_image):
-                pred_mask, pred_score = self.prompt_inference(crop_im, points=points, multimask_output=True)
+                pred_mask, pred_score = self.prompt_inference(
+                    crop_im, points=points, multimask_output=True, features=crop_features
+                )
                 # Interpolate predicted masks to input size
                 pred_mask = F.interpolate(pred_mask[None], (h, w), mode="bilinear", align_corners=False)[0]
                 idx = pred_score > conf_thres


### PR DESCRIPTION
`Predictor.generate()` (the auto-mask / "segment everything" path for SAM, MobileSAM and SAM2) re-encodes the whole crop on every point batch instead of once per crop. With the defaults (`points_stride=32`, `points_batch_size=64`) that's 16 encoder passes per crop instead of 1.

## Cause

`prompt_inference()` only skips the encoder when `self.features` is already cached by `set_image()`. Inside `generate()`'s point-batch loop `self.features` stays `None`. So every call to `prompt_inference(crop_im, ...)` re-runs `get_im_features(crop_im)` from scratch, even if `crop_im` is the same crop as the previous batch.

That same line causes a second bug too. If a caller runs `set_image()` on the full image first and then calls `generate(crop_n_layers>0)`, `self.features` is no longer `None`, it's the full-image encoding, so every sub-crop silently reuses it instead of encoding its own region. I could reproduce this directly: with `crop_n_layers=1, points_stride=8, points_batch_size=8` on `bus.jpg`, `generate()` returns a different number of masks depending on whether `set_image()` was called first (63 vs 94 for MobileSAM, 5 vs 6 for SAM2.1-t). These exact counts are specific to that non-default point grid; with the real defaults (`points_stride=32, points_batch_size=64`) the same divergence shows up but at different absolute counts, since more points push more borderline masks past the confidence/stability thresholds either way. The important part isn't the numbers, it's that they diverge at all with `set_image()` and don't after this patch.

## Changes

`generate()` now encodes each crop once into a local `crop_features` variable and passes it to `prompt_inference(..., features=crop_features)` for every point batch of that crop. `prompt_inference()` gets a new `features` argument that takes priority over a fresh encode and over the `self.features` cache, so `generate()` doesn't read `self.features` at all anymore. That way a crop's features can't leak from a previous `set_image()` call, and can't get shadowed by one either. No global or `data_ptr`-keyed cache, `crop_features` just lives inside that crop's loop iteration.

`SAM2Predictor` (SAM2/SAM2.1) inherits `generate()`/`prompt_inference()` unchanged. It only overrides `get_im_features()` (returns a dict, not a tensor) and `_inference_features()` (consumes that dict), so the fix covers SAM, MobileSAM and SAM2* from the same base-class change.

## Validation

`bus.jpg`, `imgsz=1024`, defaults (`points_stride=32`, `points_batch_size=64`, `crop_n_layers=0`), 3 runs each, min-max range:

| Model | Device | Before | After | Change (median) |
|---|---|---|---|---|
| MobileSAM | CPU | 59.05-59.75 s | 50.98-51.37 s | **-13.7%** |
| SAM2.1-t | CPU | 59.87-60.21 s | 50.45-50.84 s | **-15.5%** |
| MobileSAM | GPU (L4) | 3.184-3.192 s | 2.808-2.817 s | **-11.8%** |
| SAM2.1-t | GPU (L4) | 3.489-3.515 s | 2.756-2.760 s | **-21.4%** |

On GPU the per-run gap is smaller in absolute terms (encoder passes are cheap there), but the relative win holds and is even larger for SAM2.1-t, so this isn't a CPU-only fix.

- `points_stride=2, points_batch_size=1` on a single crop: encoder calls go from 4 to 1. New test `test_sam_generate_encodes_each_crop_once` fails with `assert 4 == 1` on the old code and passes on this patch.
- The same test also pins the `set_image()` leak: with a stale `self.features` set beforehand and `crop_n_layers=1` (1 full image + 4 sub-crops), the encoder must be called once per crop (`assert len(calls) == 5`) instead of reusing the stale cache. The old code calls it zero times there.
- Masks are bit-identical before/after on both models (`torch.equal`, checked across repeated runs on each tree), and boxes/scores match exactly between the two trees at the default density too. So this is a pure reuse of already-computed features, not a behaviour change.
- `set_image()` then `generate(crop_n_layers=1, points_stride=8, points_batch_size=8)` now returns the same masks as `generate()` with the same args and no prior `set_image()` (63/63 for MobileSAM, 5/5 for SAM2.1-t). Before the patch these diverged (63/94 and 5/6).
- `pytest tests/test_python.py -k "sam or annotator"`: 6 passed.
- `bin/ultra_format.sh --check`: clean.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
`SAM` generation now encodes each crop once and reuses its features across point batches, preventing stale `set_image()` features from being used for sub-crops.

### 📊 Key Changes
- Added an optional `features` parameter to `Predictor.prompt_inference()`, taking precedence over cached features.
- Updated `generate()` to compute crop-local features once and pass them to every point-batch inference call.
- Added a regression test covering one encoding per crop and preventing reuse of stale cached features across full-image and sub-crop generation.

### 🎯 Purpose & Impact
- Reduces redundant encoder passes during automatic mask generation and fixes incorrect feature reuse when `set_image()` precedes cropped generation. No user-facing API behavior change beyond corrected outputs and improved performance.