### PR TITLE
Make GT side clamp in select_candidates_in_gts monotonic

### DIFF
--- a/ultralytics/utils/tal.py
+++ b/ultralytics/utils/tal.py
@@ -297,7 +297,7 @@ class TaskAlignedAssigner(nn.Module):
             - Bounding box format: [x_min, y_min, x_max, y_max].
         """
         gt_bboxes_xywh = xyxy2xywh(gt_bboxes)
-        wh_mask = gt_bboxes_xywh[..., 2:] < self.stride[0]  # the smallest stride
+        wh_mask = gt_bboxes_xywh[..., 2:] < self.stride_val  # floor tiny sides so the pool grows monotonically
         gt_bboxes_xywh[..., 2:] = torch.where(
             (wh_mask * mask_gt).bool(),
             torch.tensor(self.stride_val, dtype=gt_bboxes_xywh.dtype, device=gt_bboxes_xywh.device),
@@ -366,7 +366,7 @@ class RotatedTaskAlignedAssigner(TaskAlignedAssigner):
             (torch.Tensor): Boolean mask of positive anchors with shape (b, n_boxes, h*w).
         """
         gt_bboxes_clone = gt_bboxes.clone()
-        wh_mask = gt_bboxes_clone[..., 2:4] < self.stride[0]
+        wh_mask = gt_bboxes_clone[..., 2:4] < self.stride_val
         gt_bboxes_clone[..., 2:4] = torch.where(
             (wh_mask * mask_gt).bool(),
             torch.tensor(self.stride_val, dtype=gt_bboxes_clone.dtype, device=gt_bboxes_clone.device),


### PR DESCRIPTION
The threshold used stride[0] (8px) while the replacement used stride_val (stride[1], 16px), so a side of 7.9px was raised to 16px while 8.1px was left alone. Sides in [8, 16) therefore got a smaller candidate pool than sides below 8 -- averaged over random box positions on a 640px grid, a 7.9px square drew 5.28 candidate anchors and an 8.0px square only 1.32.

Comparing against stride_val makes the operation a plain floor to 16px, which is monotonic in box size. Applied to the rotated assigner too.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated candidate selection in the standard and rotated assigners to clamp tiny ground-truth box sides using `self.stride_val`, preserving a monotonic candidate pool as box size increases.

### 📊 Key Changes
- Changed the ground-truth side threshold in both `select_candidates_in_gts` implementations from `self.stride[0]` to `self.stride_val`.
- Applied the same clamp behavior to axis-aligned and rotated candidate assignment.
- Retained replacement of undersized sides with `self.stride_val` while respecting the ground-truth mask and tensor device/dtype.

### 🎯 Purpose & Impact
- Prevents box sides in the range below `self.stride_val` from receiving inconsistent candidate pools due to the previous threshold, improving monotonic candidate selection for small objects.