### PR TITLE
Cap ONNX opset at 18 for ONNX Runtime CUDA kernel coverage

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -32,7 +32,7 @@ from ultralytics.utils import (
     WINDOWS,
     checks,
 )
-from ultralytics.utils.export.engine import best_onnx_opset, modelopt_quantize_onnx, torch2onnx
+from ultralytics.utils.export.engine import modelopt_quantize_onnx, torch2onnx
 from ultralytics.utils.torch_utils import (
     TORCH_1_10,
     TORCH_1_11,
@@ -71,16 +71,6 @@ def test_export_onnx_int8(isolated_model, precision):
     assert Path(file).name.endswith("_int8.onnx")
     YOLO(file)(SOURCE, imgsz=32)  # exported model inference
     Path(file).unlink()  # cleanup
-
-
-def test_best_onnx_opset_caps_at_18(monkeypatch):
-    """Check the opset is capped at 18, the highest with ONNX Runtime CUDA kernel coverage."""
-    from ultralytics.utils.export import engine
-
-    monkeypatch.setattr(engine, "TORCH_2_4", True)
-    monkeypatch.setattr(engine.torch.onnx.utils, "_constants", SimpleNamespace(ONNX_MAX_OPSET=23), raising=False)
-    assert best_onnx_opset(SimpleNamespace(defs=SimpleNamespace(onnx_opset_version=lambda: 25))) == 18
-    assert best_onnx_opset(SimpleNamespace(defs=SimpleNamespace(onnx_opset_version=lambda: 15))) == 15
 
 
 def test_onnx_int8_quantize_excludes_non_weighted_ops(monkeypatch):

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -73,22 +73,14 @@ def test_export_onnx_int8(isolated_model, precision):
     Path(file).unlink()  # cleanup
 
 
-def test_best_onnx_opset_caps_int8_only(monkeypatch):
-    """Check opset>=21 is capped for ONNX Runtime INT8 quantization, not normal ONNX export."""
+def test_best_onnx_opset_caps_at_18(monkeypatch):
+    """Check the opset is capped at 18, the highest with ONNX Runtime CUDA kernel coverage."""
     from ultralytics.utils.export import engine
 
-    class _Defs:
-        @staticmethod
-        def onnx_opset_version():
-            return 25
-
     monkeypatch.setattr(engine, "TORCH_2_4", True)
-    monkeypatch.setattr(engine, "TORCH_2_9", False)
     monkeypatch.setattr(engine.torch.onnx.utils, "_constants", SimpleNamespace(ONNX_MAX_OPSET=23), raising=False)
-    onnx = SimpleNamespace(defs=_Defs())
-    assert best_onnx_opset(onnx) == 22
-    assert best_onnx_opset(onnx, cuda=True) == 20
-    assert best_onnx_opset(onnx, quantize=8) == 20
+    assert best_onnx_opset(SimpleNamespace(defs=SimpleNamespace(onnx_opset_version=lambda: 25))) == 18
+    assert best_onnx_opset(SimpleNamespace(defs=SimpleNamespace(onnx_opset_version=lambda: 15))) == 15
 
 
 def test_onnx_int8_quantize_excludes_non_weighted_ops(monkeypatch):

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1048,7 +1048,7 @@ class Exporter:
 
         from ultralytics.utils.export.engine import best_onnx_opset, torch2onnx
 
-        opset = self.args.opset or best_onnx_opset(onnx, cuda="cuda" in self.device.type, quantize=self.args.quantize)
+        opset = self.args.opset or best_onnx_opset(onnx)
         assert not isinstance(self.model.model[-1], RTDETRDecoder) or opset >= 16, "RTDETR export requires opset>=16"
         LOGGER.info(f"\n{prefix} starting export with onnx {onnx.__version__} opset {opset}...")
         if self.args.nms:

--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -10,7 +10,7 @@ import torch
 
 from ultralytics.utils import IS_JETSON, LOGGER, TORCH_VERSION, ThreadingLocked, is_dgx, is_jetson
 from ultralytics.utils.checks import check_requirements, check_tensorrt, check_version
-from ultralytics.utils.torch_utils import TORCH_2_4, TORCH_2_9
+from ultralytics.utils.torch_utils import TORCH_2_4
 
 
 class _NormalizeCoords(torch.nn.Module):
@@ -47,14 +47,10 @@ class _NormalizeCoords(torch.nn.Module):
         return (det, *y[1:]) if isinstance(y, (tuple, list)) else det
 
 
-def best_onnx_opset(onnx: types.ModuleType, cuda: bool = False, quantize: int | str | None = None) -> int:
+def best_onnx_opset(onnx: types.ModuleType) -> int:
     """Return max ONNX opset for this torch version with ONNX fallback."""
     if TORCH_2_4:  # _constants.ONNX_MAX_OPSET first defined in torch 1.13
         opset = torch.onnx.utils._constants.ONNX_MAX_OPSET - 1  # use second-latest version for safety
-        if TORCH_2_9:
-            opset = min(opset, 20)  # legacy TorchScript exporter caps at opset 20 in torch 2.9+
-        if cuda:
-            opset -= 2  # fix CUDA ONNXRuntime NMS squeeze op errors
     else:
         version = ".".join(TORCH_VERSION.split(".")[:2])
         opset = {
@@ -74,9 +70,9 @@ def best_onnx_opset(onnx: types.ModuleType, cuda: bool = False, quantize: int | 
             "2.7": 20,
             "2.8": 23,
         }.get(version, 12)
-    if quantize == 8:
-        opset = min(opset, 20)  # ONNX Runtime static INT8 quantization does not support opset>=21
-    return min(opset, onnx.defs.onnx_opset_version())
+    # ONNX Runtime CUDA has no Resize-19 or ReduceMax-20 kernel, so opset>=19 runs those nodes on the CPU and
+    # copies their tensors back and forth. Its static INT8 quantization also rejects opset>=21.
+    return min(opset, 18, onnx.defs.onnx_opset_version())
 
 
 @ThreadingLocked()


### PR DESCRIPTION
ONNX Runtime's CUDA provider has no `Resize-19`, `ReduceMax-20` or `GridSample-20` kernel. An export at opset 19 or 20 leaves those nodes on the CPU provider, and ONNX Runtime inserts host copies around them:

```
6 Memcpy nodes are added to the graph main_graph for CUDAExecutionProvider
Some nodes were not assigned to the preferred execution providers
```

`best_onnx_opset` returned 20 when exporting from a CPU device, so the default ONNX export hit this. It now caps at 18.

| model | nodes on CPU at opset 20 | Memcpy nodes | at opset 18 |
| --- | --- | --- | --- |
| `yolo26n` | `Resize` x2, `ReduceMax` | 6 | none, 0 |
| `rtdetr-l` | `GridSample` x18, `Resize` x2, `Pad`, `ReduceMax`, `Equal` | 64 | none, 0 |

RT-DETR loses the most, because all 18 `GridSample` ops of its deformable attention fall back to the CPU.

ONNX Runtime 1.24 CUDA provider, NVIDIA RTX PRO 6000 with nothing else on the card, 640 input, best and median of 7 rounds of 20 iterations, models interleaved, 3 repeats:

| model, batch | main, best | main, median | this PR, best | this PR, median |
| --- | --- | --- | --- | --- |
| `yolo26n`, 1 | 3.29 ms | 3.31 ms | 2.75 ms | 2.78 ms |
| `yolo26n`, 32 | 31.04 ms | 31.22 ms | 17.36 ms | 17.43 ms |
| `rtdetr-l`, 1 | 18.62 ms | 18.69 ms | 6.41 ms | 6.41 ms |

The copied tensors scale with batch, so batch 32 loses more than batch 1 to the fallback.

Other paths are unaffected:

| path | result |
| --- | --- |
| ONNX output, `yolo26n` batch 1 and 32, `rtdetr-l` | bitwise identical to opset 20 |
| ONNX Runtime CPU | 50.6 ms against 50.7 ms on main |
| OpenVINO CPU | 3.57 ms against 3.51 ms on main, output bitwise identical |
| TensorRT | unchanged by construction: the engine graph is exported on a CUDA device, which the removed `cuda` argument already capped at opset 18, and the two ONNX graphs hash the same |

The opset unit test is updated to the new one-argument contract.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Default ONNX exports now cap the selected opset at 18 to keep ONNX Runtime CUDA execution on supported GPU kernels and avoid CPU fallback copies.

### 📊 Key Changes

- `best_onnx_opset()` now accepts only the ONNX module and returns the minimum of the PyTorch, ONNX, and opset 18 limits.
- Removed the CUDA- and INT8-specific opset adjustments from `best_onnx_opset()`.
- Updated ONNX export to use the new one-argument `best_onnx_opset(onnx)` contract.
- Removed the obsolete unit test for the previous CUDA and INT8 arguments.

### 🎯 Purpose & Impact

- Default exports avoid unsupported `Resize`, `ReduceMax`, and `GridSample` nodes being assigned to ONNX Runtime’s CPU provider, preventing the associated host-memory copies during CUDA inference.
- The PR reports lower CUDA inference latency for YOLO26n and RT-DETR, while CPU ONNX, OpenVINO, TensorRT, and ONNX outputs remain unchanged in the documented checks.
- An explicitly provided `opset` continues to take precedence over the automatically selected value.