### PR TITLE
Scope the TensorRT INT8 Sigmoid exclusion to the detection head on both quantization paths

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -209,21 +209,6 @@ def test_export_rknn_batch_expansion(monkeypatch, tmp_path):
     assert calls["batch"] == 8
 
 
-def test_modelopt_quantize_onnx_quantizes_sigmoid(monkeypatch):
-    """Check ModelOpt INT8 does not exclude Sigmoid, which SiLU exports as and which fragments the whole graph."""
-    import onnx
-
-    calls = {}
-    graph = SimpleNamespace(input=[SimpleNamespace(name="images")])
-    monkeypatch.setattr("ultralytics.utils.export.engine.check_requirements", lambda *args, **kwargs: None)
-    monkeypatch.setitem(
-        sys.modules, "modelopt.onnx.quantization", SimpleNamespace(quantize=lambda *a, **k: calls.update(k))
-    )
-    monkeypatch.setattr(onnx, "load", lambda *args, **kwargs: SimpleNamespace(graph=graph))
-    modelopt_quantize_onnx("model.onnx", quantize=8, dataset=[{"img": torch.zeros(1, 3, 8, 8)}])
-    assert "op_types_to_exclude" not in calls
-
-
 def test_torch2onnx_serializes_concurrent_exports(monkeypatch, tmp_path):
     """Ensure ONNX exports do not overlap across worker threads."""
     active = 0

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -209,8 +209,8 @@ def test_export_rknn_batch_expansion(monkeypatch, tmp_path):
     assert calls["batch"] == 8
 
 
-def test_modelopt_quantize_onnx_excludes_sigmoid(monkeypatch):
-    """Check ModelOpt INT8 keeps Sigmoid unquantized to preserve confidence calibration (#24668)."""
+def test_modelopt_quantize_onnx_quantizes_sigmoid(monkeypatch):
+    """Check ModelOpt INT8 does not exclude Sigmoid, which SiLU exports as and which fragments the whole graph."""
     import onnx
 
     calls = {}
@@ -221,7 +221,7 @@ def test_modelopt_quantize_onnx_excludes_sigmoid(monkeypatch):
     )
     monkeypatch.setattr(onnx, "load", lambda *args, **kwargs: SimpleNamespace(graph=graph))
     modelopt_quantize_onnx("model.onnx", quantize=8, dataset=[{"img": torch.zeros(1, 3, 8, 8)}])
-    assert calls["op_types_to_exclude"] == ["Sigmoid"]
+    assert "op_types_to_exclude" not in calls
 
 
 def test_torch2onnx_serializes_concurrent_exports(monkeypatch, tmp_path):

--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import types
 from pathlib import Path
 
@@ -185,9 +186,6 @@ def modelopt_quantize_onnx(
             # scales are EP-independent, so the INT8 engine is equivalent and only this one-time step is slower.
             calibration_eps=["cpu"],
             output_path=out_file,
-            # Keep Sigmoid unquantized (it runs in FP16) to preserve confidence-score calibration,
-            # mirroring the OpenVINO IgnoredScope https://github.com/ultralytics/ultralytics/issues/24668
-            op_types_to_exclude=["Sigmoid"],
             **kwargs,
         )
         return out_file
@@ -248,7 +246,7 @@ def onnx2engine(
         calibration uses an ``IInt8Calibrator`` over ``dataset`` and writes a calibration cache, while FP16/INT8 are
         enabled with builder flags. On TensorRT 11 these were removed in favor of strongly-typed networks, so reduced
         precision is baked into the ONNX with NVIDIA ModelOpt before building (FP16 AutoCast, INT8 explicit Q/DQ) by
-        `modelopt_quantize_onnx`. Both INT8 paths keep Sigmoid at higher precision to preserve
+        `modelopt_quantize_onnx`. The TensorRT 7-10 path keeps the Sigmoid layers at higher precision to preserve
         confidence-score calibration (see #24668). Metadata is serialized and written to the engine file if provided.
     """
     # Force re-install TensorRT on CUDA 13 ARM devices to 10.15.x versions for RT-DETR exports
@@ -418,14 +416,22 @@ def onnx2engine(
             cache=str(Path(onnx_file).with_suffix(".cache")),
         )
 
-        # Implicit quantization cannot exclude op types like ModelOpt on TRT 11, so keep Sigmoid (an ACTIVATION
-        # layer named after its ONNX node) in FP32 via per-layer precision constraints to preserve confidence-score
-        # calibration, mirroring the OpenVINO IgnoredScope
-        # https://github.com/ultralytics/ultralytics/issues/24668
+        # Implicit quantization cannot exclude op types like ModelOpt on TRT 11, so keep the head Sigmoid (an
+        # ACTIVATION layer named after its ONNX node) in FP32 via per-layer precision constraints to preserve
+        # confidence-score calibration, mirroring the OpenVINO IgnoredScope
+        # https://github.com/ultralytics/ultralytics/issues/24668. Scope this to the head: every SiLU activation is
+        # also a Sigmoid, and constraining all of them costs INT8 speed across backbone and neck.
+        names = [network.get_layer(i).name for i in range(network.num_layers)]
+        indices = [int(m.group(1)) for n in names if (m := re.match(r"/model\.(\d+)/", n))]
+        head = f"/model.{max(indices)}/" if indices else "/"
         count = 0
         for i in range(network.num_layers):
             layer = network.get_layer(i)
-            if layer.type == trt.LayerType.ACTIVATION and "sigmoid" in layer.name.lower():
+            if (
+                layer.type == trt.LayerType.ACTIVATION
+                and "sigmoid" in layer.name.lower()
+                and layer.name.startswith(head)
+            ):
                 layer.precision = trt.float32
                 for j in range(layer.num_outputs):
                     layer.set_output_type(j, trt.float32)
@@ -437,7 +443,7 @@ def onnx2engine(
                 else trt.BuilderFlag.STRICT_TYPES
             )
             config.set_flag(flag)  # OBEY_PRECISION_CONSTRAINTS replaced STRICT_TYPES in TensorRT 8.2
-            LOGGER.info(f"{prefix} keeping {count} Sigmoid layers in FP32 for INT8 accuracy")
+            LOGGER.info(f"{prefix} keeping {count} head Sigmoid layers in FP32 for INT8 accuracy")
 
     elif use_fp16 and not is_trt11:
         config.set_flag(trt.BuilderFlag.FP16)


### PR DESCRIPTION
`nn.SiLU` exports to ONNX as `Sigmoid` and `Mul`, so excluding Sigmoid matched all 88 activations in YOLO26n detect instead of the one head Sigmoid #24668 asked for. The TensorRT 11 ModelOpt path drops the exclusion, since ModelOpt never quantizes Sigmoid and it only fragmented the graph. The TensorRT 7 to 10 calibrator path scopes the FP32 constraint to the head rather than deleting it, because with no constraint TensorRT fuses Conv and SiLU in the segment proto branch and has no INT8 kernel for the fused node.

## TensorRT 11, YOLO26n at 640 px, batch 1

| task | MB before | MB after | FPS before | FPS after | speedup |
|---|---|---|---|---|---|
| detect | 48.0 | 24.0 | 1147 | 1353 | +17.9% |
| segment | 49.2 | 30.4 | 1001 | 1169 | +16.8% |
| semantic | 44.3 | 21.8 | 1591 | 1866 | +17.3% |
| depth | 73.3 | 54.8 | 1072 | 1244 | +16.0% |
| pose | 49.2 | 24.6 | 1094 | 1282 | +17.2% |
| obb | 48.6 | 24.2 | 1108 | 1285 | +16.0% |

## TensorRT 10, YOLO26n at 640 px, batch 1

| task | MB before | MB after | FPS before | FPS after | speedup |
|---|---|---|---|---|---|
| detect | 4.3 | 4.4 | 1303 | 1474 | +13.2% |
| segment | 4.8 | 5.0 | 1139 | 1247 | +9.4% |
| semantic | 2.7 | 2.9 | 1798 | 2060 | +14.6% |
| depth | 6.7 | 6.9 | 1216 | 1332 | +9.6% |
| pose | 4.9 | 5.1 | 1250 | 1412 | +12.9% |
| obb | 4.4 | 4.6 | 1267 | 1417 | +11.9% |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

TensorRT INT8 Sigmoid handling now targets only the detection head on TensorRT 7–10, while TensorRT 11 ModelOpt quantization no longer excludes Sigmoid operators.

### 📊 Key Changes

- Removed `op_types_to_exclude=["Sigmoid"]` from `modelopt_quantize_onnx`.
- Updated the TensorRT 7–10 calibrator to identify the highest `/model.<index>/` module and constrain only matching head Sigmoid activation layers to FP32.
- Preserved FP32 precision and output types for the selected head Sigmoid layers, while allowing other Sigmoid layers to use INT8.
- Updated logging and documentation to describe head-only Sigmoid handling.
- Removed the test that expected ModelOpt quantization to exclude all Sigmoid operators.

### 🎯 Purpose & Impact

- TensorRT 11 ModelOpt no longer fragments the graph by applying a global Sigmoid exclusion.
- TensorRT 7–10 retains the FP32 constraint needed for the head while avoiding constraints on backbone and neck SiLU-derived Sigmoid activations.
- The change narrows higher-precision processing to the intended detection head and allows broader INT8 optimization elsewhere.