### PR TITLE
Use synchronous OpenVINO batch inference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@ Ultralytics (`ultralytics` on PyPI, AGPL-3.0) is the official Python package for
 - Delete mock tests. Prefer focused validation of the real code path, adding only minimal regression coverage for a high-risk gap.
 - Review the full live diff independently; approvals, comments, descriptions, and green CI are supporting evidence, not proof.
 - Reject compatibility shims, duplicated helpers, dead code, unrelated cleanup, and complexity that does not pay for itself.
+- Preserve an existing implementation when a maintainer explicitly requests it remain temporarily disabled at its owner
+  with a linked tracking issue; require the issue to document the evidence needed to re-enable it.
 - Require production-ready behavior across supported tasks, platforms, versions, and integrations affected by the owner change.
 - Remind unsigned contributors to complete the CLA. Do not close PRs opened by Ultralytics organization team members.
 - Merge only the exact cold-reviewed live head after terminal-green checks and zero unresolved review threads.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,17 @@ Ultralytics (`ultralytics` on PyPI, AGPL-3.0) is the official Python package for
 
 **Review gate:** for every addition, the reviewer decides whether deleting or changing existing code would have fixed the problem instead — if it would, that is a blocking finding. A missing or thin PR description is never itself a finding.
 
+## PR Review
+
+- Require a reproducible production bug or a broadly useful feature; close incorrect, niche, speculative, or AI-generated bloat.
+- Reject new default arguments and PRs with 30 or more net added lines. Delete, deduplicate, or move behavior to its existing owner first.
+- Delete mock tests. Prefer focused validation of the real code path, adding only minimal regression coverage for a high-risk gap.
+- Review the full live diff independently; approvals, comments, descriptions, and green CI are supporting evidence, not proof.
+- Reject compatibility shims, duplicated helpers, dead code, unrelated cleanup, and complexity that does not pay for itself.
+- Require production-ready behavior across supported tasks, platforms, versions, and integrations affected by the owner change.
+- Remind unsigned contributors to complete the CLA. Do not close PRs opened by Ultralytics organization team members.
+- Merge only the exact cold-reviewed live head after terminal-green checks and zero unresolved review threads.
+
 NEVER push to `main`. NEVER force push. Always start work in a new git worktree (`git worktree add`) on a feature branch and open a PR — never edit the primary checkout directly, it may hold in-flight work.
 
 ## PR Workflow

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.127"
+__version__ = "8.4.128"
 
 import importlib
 import os

--- a/ultralytics/nn/backends/openvino.py
+++ b/ultralytics/nn/backends/openvino.py
@@ -69,7 +69,13 @@ class OpenVINOBackend(BaseBackend):
         if self.read_model is not None:
             self.dynamic = False  # fixed letterbox shapes so recompiles stay rare
 
-        # Submit the full batch synchronously to avoid native AsyncInferQueue hangs and per-image request overhead
+        # THROUGHPUT and CUMULATIVE_THROUGHPUT are disabled because AsyncInferQueue can hang indefinitely on Intel and
+        # AMD CPUs. See benchmark results at https://github.com/ultralytics/ultralytics/issues/25923.
+        # self.inference_mode = (
+        #     ("CUMULATIVE_THROUGHPUT" if device_name == "AUTO" else "THROUGHPUT")
+        #     if self.dynamic and self.batch > 1
+        #     else "LATENCY"
+        # )
         config = {"PERFORMANCE_HINT": "LATENCY"}
         if LINUX and ARM64 and device_name == "CPU":
             config["EXECUTION_MODE_HINT"] = ov.properties.hint.ExecutionMode.ACCURACY
@@ -84,6 +90,7 @@ class OpenVINOBackend(BaseBackend):
         self.compile_model = partial(core.compile_model, device_name=device_name, config=config)
         self.ov_compiled_model = self.compile_model(ov_model)
         LOGGER.info(f"Using OpenVINO on {', '.join(self.ov_compiled_model.get_property('EXECUTION_DEVICES'))}...")
+        # self.input_name = self.ov_compiled_model.input().get_any_name()  # Used only by the disabled async path below
         self.ov = ov
 
     def forward(self, im: torch.Tensor) -> list[np.ndarray]:
@@ -103,4 +110,19 @@ class OpenVINOBackend(BaseBackend):
             ov_model.reshape(list(im.shape))
             self.ov_compiled_model = self.compile_model(ov_model)
 
+        # if self.inference_mode in {"THROUGHPUT", "CUMULATIVE_THROUGHPUT"}:
+        #     n = im.shape[0]
+        #     results = [None] * n
+        #
+        #     def callback(request, userdata):
+        #         """Store async inference result in the preallocated results list at the given index."""
+        #         results[userdata] = request.results
+        #
+        #     async_queue = self.ov.AsyncInferQueue(self.ov_compiled_model)
+        #     async_queue.set_callback(callback)
+        #     for i in range(n):
+        #         async_queue.start_async(inputs={self.input_name: im[i : i + 1]}, userdata=i)
+        #     async_queue.wait_all()
+        #     y = [list(r.values()) for r in results]
+        #     return [np.concatenate(x) for x in zip(*y)]
         return list(self.ov_compiled_model(im).values())

--- a/ultralytics/nn/backends/openvino.py
+++ b/ultralytics/nn/backends/openvino.py
@@ -69,14 +69,10 @@ class OpenVINOBackend(BaseBackend):
         if self.read_model is not None:
             self.dynamic = False  # fixed letterbox shapes so recompiles stay rare
 
-        # THROUGHPUT and CUMULATIVE_THROUGHPUT are disabled because AsyncInferQueue can hang indefinitely on Intel and
-        # AMD CPUs. See benchmark results at https://github.com/ultralytics/ultralytics/issues/25923.
-        # self.inference_mode = (
-        #     ("CUMULATIVE_THROUGHPUT" if device_name == "AUTO" else "THROUGHPUT")
-        #     if self.dynamic and self.batch > 1
-        #     else "LATENCY"
-        # )
-        config = {"PERFORMANCE_HINT": "LATENCY"}
+        # Force sync inference because AsyncInferQueue can hang indefinitely on Intel and AMD CPUs, see
+        # https://github.com/ultralytics/ultralytics/issues/25923.
+        self.inference_mode = "LATENCY"
+        config = {"PERFORMANCE_HINT": self.inference_mode}
         if LINUX and ARM64 and device_name == "CPU":
             config["EXECUTION_MODE_HINT"] = ov.properties.hint.ExecutionMode.ACCURACY
             config["INFERENCE_PRECISION_HINT"] = ov.Type.f32
@@ -89,8 +85,11 @@ class OpenVINOBackend(BaseBackend):
 
         self.compile_model = partial(core.compile_model, device_name=device_name, config=config)
         self.ov_compiled_model = self.compile_model(ov_model)
-        LOGGER.info(f"Using OpenVINO on {', '.join(self.ov_compiled_model.get_property('EXECUTION_DEVICES'))}...")
-        # self.input_name = self.ov_compiled_model.input().get_any_name()  # Used only by the disabled async path below
+        LOGGER.info(
+            f"Using OpenVINO {self.inference_mode} mode for batch={self.batch} inference on "
+            f"{', '.join(self.ov_compiled_model.get_property('EXECUTION_DEVICES'))}..."
+        )
+        self.input_name = self.ov_compiled_model.input().get_any_name()
         self.ov = ov
 
     def forward(self, im: torch.Tensor) -> list[np.ndarray]:
@@ -110,19 +109,25 @@ class OpenVINOBackend(BaseBackend):
             ov_model.reshape(list(im.shape))
             self.ov_compiled_model = self.compile_model(ov_model)
 
-        # if self.inference_mode in {"THROUGHPUT", "CUMULATIVE_THROUGHPUT"}:
-        #     n = im.shape[0]
-        #     results = [None] * n
-        #
-        #     def callback(request, userdata):
-        #         """Store async inference result in the preallocated results list at the given index."""
-        #         results[userdata] = request.results
-        #
-        #     async_queue = self.ov.AsyncInferQueue(self.ov_compiled_model)
-        #     async_queue.set_callback(callback)
-        #     for i in range(n):
-        #         async_queue.start_async(inputs={self.input_name: im[i : i + 1]}, userdata=i)
-        #     async_queue.wait_all()
-        #     y = [list(r.values()) for r in results]
-        #     return [np.concatenate(x) for x in zip(*y)]
-        return list(self.ov_compiled_model(im).values())
+        if self.inference_mode in {"THROUGHPUT", "CUMULATIVE_THROUGHPUT"}:
+            # Async inference for larger batch sizes
+            n = im.shape[0]
+            results = [None] * n
+
+            def callback(request, userdata):
+                """Store async inference result in the preallocated results list at the given index."""
+                results[userdata] = request.results
+
+            async_queue = self.ov.AsyncInferQueue(self.ov_compiled_model)
+            async_queue.set_callback(callback)
+
+            for i in range(n):
+                async_queue.start_async(inputs={self.input_name: im[i : i + 1]}, userdata=i)
+            async_queue.wait_all()
+
+            y = [list(r.values()) for r in results]
+            y = [np.concatenate(x) for x in zip(*y)]
+        else:
+            # Sync inference for LATENCY mode
+            y = list(self.ov_compiled_model(im).values())
+        return y

--- a/ultralytics/nn/backends/openvino.py
+++ b/ultralytics/nn/backends/openvino.py
@@ -69,8 +69,10 @@ class OpenVINOBackend(BaseBackend):
         if self.read_model is not None:
             self.dynamic = False  # fixed letterbox shapes so recompiles stay rare
 
-        # AsyncInferQueue can hang indefinitely on Intel and AMD CPUs, see ultralytics/ultralytics#25923.
-        config = {"PERFORMANCE_HINT": "LATENCY"}
+        # Force sync inference because AsyncInferQueue can hang indefinitely on Intel and AMD CPUs, see
+        # https://github.com/ultralytics/ultralytics/issues/25923.
+        self.inference_mode = "LATENCY"
+        config = {"PERFORMANCE_HINT": self.inference_mode}
         if LINUX and ARM64 and device_name == "CPU":
             config["EXECUTION_MODE_HINT"] = ov.properties.hint.ExecutionMode.ACCURACY
             config["INFERENCE_PRECISION_HINT"] = ov.Type.f32
@@ -84,9 +86,10 @@ class OpenVINOBackend(BaseBackend):
         self.compile_model = partial(core.compile_model, device_name=device_name, config=config)
         self.ov_compiled_model = self.compile_model(ov_model)
         LOGGER.info(
-            f"Using OpenVINO LATENCY mode for batch={self.batch} inference on "
+            f"Using OpenVINO {self.inference_mode} mode for batch={self.batch} inference on "
             f"{', '.join(self.ov_compiled_model.get_property('EXECUTION_DEVICES'))}..."
         )
+        self.input_name = self.ov_compiled_model.input().get_any_name()
         self.ov = ov
 
     def forward(self, im: torch.Tensor) -> list[np.ndarray]:
@@ -106,4 +109,25 @@ class OpenVINOBackend(BaseBackend):
             ov_model.reshape(list(im.shape))
             self.ov_compiled_model = self.compile_model(ov_model)
 
-        return list(self.ov_compiled_model(im).values())
+        if self.inference_mode in {"THROUGHPUT", "CUMULATIVE_THROUGHPUT"}:
+            # Async inference for larger batch sizes
+            n = im.shape[0]
+            results = [None] * n
+
+            def callback(request, userdata):
+                """Store async inference result in the preallocated results list at the given index."""
+                results[userdata] = request.results
+
+            async_queue = self.ov.AsyncInferQueue(self.ov_compiled_model)
+            async_queue.set_callback(callback)
+
+            for i in range(n):
+                async_queue.start_async(inputs={self.input_name: im[i : i + 1]}, userdata=i)
+            async_queue.wait_all()
+
+            y = [list(r.values()) for r in results]
+            y = [np.concatenate(x) for x in zip(*y)]
+        else:
+            # Sync inference for LATENCY mode
+            y = list(self.ov_compiled_model(im).values())
+        return y

--- a/ultralytics/nn/backends/openvino.py
+++ b/ultralytics/nn/backends/openvino.py
@@ -69,10 +69,8 @@ class OpenVINOBackend(BaseBackend):
         if self.read_model is not None:
             self.dynamic = False  # fixed letterbox shapes so recompiles stay rare
 
-        # Force sync inference because AsyncInferQueue can hang indefinitely on Intel and AMD CPUs, see
-        # https://github.com/ultralytics/ultralytics/issues/25923.
-        self.inference_mode = "LATENCY"
-        config = {"PERFORMANCE_HINT": self.inference_mode}
+        # AsyncInferQueue can hang indefinitely on Intel and AMD CPUs, see ultralytics/ultralytics#25923.
+        config = {"PERFORMANCE_HINT": "LATENCY"}
         if LINUX and ARM64 and device_name == "CPU":
             config["EXECUTION_MODE_HINT"] = ov.properties.hint.ExecutionMode.ACCURACY
             config["INFERENCE_PRECISION_HINT"] = ov.Type.f32
@@ -86,10 +84,9 @@ class OpenVINOBackend(BaseBackend):
         self.compile_model = partial(core.compile_model, device_name=device_name, config=config)
         self.ov_compiled_model = self.compile_model(ov_model)
         LOGGER.info(
-            f"Using OpenVINO {self.inference_mode} mode for batch={self.batch} inference on "
+            f"Using OpenVINO LATENCY mode for batch={self.batch} inference on "
             f"{', '.join(self.ov_compiled_model.get_property('EXECUTION_DEVICES'))}..."
         )
-        self.input_name = self.ov_compiled_model.input().get_any_name()
         self.ov = ov
 
     def forward(self, im: torch.Tensor) -> list[np.ndarray]:
@@ -109,25 +106,4 @@ class OpenVINOBackend(BaseBackend):
             ov_model.reshape(list(im.shape))
             self.ov_compiled_model = self.compile_model(ov_model)
 
-        if self.inference_mode in {"THROUGHPUT", "CUMULATIVE_THROUGHPUT"}:
-            # Async inference for larger batch sizes
-            n = im.shape[0]
-            results = [None] * n
-
-            def callback(request, userdata):
-                """Store async inference result in the preallocated results list at the given index."""
-                results[userdata] = request.results
-
-            async_queue = self.ov.AsyncInferQueue(self.ov_compiled_model)
-            async_queue.set_callback(callback)
-
-            for i in range(n):
-                async_queue.start_async(inputs={self.input_name: im[i : i + 1]}, userdata=i)
-            async_queue.wait_all()
-
-            y = [list(r.values()) for r in results]
-            y = [np.concatenate(x) for x in zip(*y)]
-        else:
-            # Sync inference for LATENCY mode
-            y = list(self.ov_compiled_model(im).values())
-        return y
+        return list(self.ov_compiled_model(im).values())

--- a/ultralytics/nn/backends/openvino.py
+++ b/ultralytics/nn/backends/openvino.py
@@ -18,7 +18,7 @@ class OpenVINOBackend(BaseBackend):
     """Intel OpenVINO inference backend for Intel hardware acceleration.
 
     Loads and runs inference with Intel OpenVINO IR models (*_openvino_model/ directories). Supports automatic device
-    selection, Intel-specific device targeting, and async inference for throughput optimization.
+    selection and Intel-specific device targeting.
     """
 
     def load_model(self, weight: str | Path) -> None:
@@ -69,13 +69,8 @@ class OpenVINOBackend(BaseBackend):
         if self.read_model is not None:
             self.dynamic = False  # fixed letterbox shapes so recompiles stay rare
 
-        # Set inference mode
-        self.inference_mode = (
-            ("CUMULATIVE_THROUGHPUT" if device_name == "AUTO" else "THROUGHPUT")
-            if self.dynamic and self.batch > 1
-            else "LATENCY"
-        )
-        config = {"PERFORMANCE_HINT": self.inference_mode}
+        # Submit the full batch synchronously to avoid native AsyncInferQueue hangs and per-image request overhead
+        config = {"PERFORMANCE_HINT": "LATENCY"}
         if LINUX and ARM64 and device_name == "CPU":
             config["EXECUTION_MODE_HINT"] = ov.properties.hint.ExecutionMode.ACCURACY
             config["INFERENCE_PRECISION_HINT"] = ov.Type.f32
@@ -88,15 +83,11 @@ class OpenVINOBackend(BaseBackend):
 
         self.compile_model = partial(core.compile_model, device_name=device_name, config=config)
         self.ov_compiled_model = self.compile_model(ov_model)
-        LOGGER.info(
-            f"Using OpenVINO {self.inference_mode} mode for batch={self.batch} inference on "
-            f"{', '.join(self.ov_compiled_model.get_property('EXECUTION_DEVICES'))}..."
-        )
-        self.input_name = self.ov_compiled_model.input().get_any_name()
+        LOGGER.info(f"Using OpenVINO on {', '.join(self.ov_compiled_model.get_property('EXECUTION_DEVICES'))}...")
         self.ov = ov
 
     def forward(self, im: torch.Tensor) -> list[np.ndarray]:
-        """Run Intel OpenVINO inference with sync or async execution based on inference mode.
+        """Run Intel OpenVINO inference.
 
         Args:
             im (torch.Tensor): Input image tensor in BCHW format, normalized to [0, 1].
@@ -112,25 +103,4 @@ class OpenVINOBackend(BaseBackend):
             ov_model.reshape(list(im.shape))
             self.ov_compiled_model = self.compile_model(ov_model)
 
-        if self.inference_mode in {"THROUGHPUT", "CUMULATIVE_THROUGHPUT"}:
-            # Async inference for larger batch sizes
-            n = im.shape[0]
-            results = [None] * n
-
-            def callback(request, userdata):
-                """Store async inference result in the preallocated results list at the given index."""
-                results[userdata] = request.results
-
-            async_queue = self.ov.AsyncInferQueue(self.ov_compiled_model)
-            async_queue.set_callback(callback)
-
-            for i in range(n):
-                async_queue.start_async(inputs={self.input_name: im[i : i + 1]}, userdata=i)
-            async_queue.wait_all()
-
-            y = [list(r.values()) for r in results]
-            y = [np.concatenate(x) for x in zip(*y)]
-        else:
-            # Sync inference for LATENCY mode
-            y = list(self.ov_compiled_model(im).values())
-        return y
+        return list(self.ov_compiled_model(im).values())


### PR DESCRIPTION
## Summary

- submit each OpenVINO input batch as one synchronous request
- use the `LATENCY` hint consistently
- retain the throughput implementations but force mode selection to `LATENCY`
- bump the package patch version to `8.4.128`

## Motivation

Scheduled CI run https://github.com/ultralytics/ultralytics/actions/runs/32705291304/attempts/1 timed out twice in the OpenVINO export matrix on the same AMD EPYC runner. The first attempt hung in `test_export_openvino_matrix[detect-True-8-2-False-True]`; the retry hung later in `test_export_openvino_matrix[pose-True-8-2-False-True]`. Both are dynamic INT8 batch-2 cases entering `AsyncInferQueue`. The other xdist worker finished successfully, so its final NDJSON PASS line at timeout was buffered output rather than the cause. A clean job rerun passed all 613 tests in 18 minutes.

This path had already been benchmarked during #25898: one synchronous batched request was about 2x faster and used about 3x less RAM than splitting a batch into per-image async requests on the 4-core hosted runners. The temporary validation workflow also passed all 58 OpenVINO tests on nine Linux, macOS, Windows, and ARM runners. This change disables the native queue/deadlock surface while preserving actual batched inference.

## Validation

- full SlowTests matrix passed, including the original Python 3.12 / Torch 2.2 configuration: https://github.com/ultralytics/ultralytics/actions/runs/32773418868

- `ruff format --check ultralytics/nn/backends/openvino.py`
- `ruff check ultralytics/nn/backends/openvino.py`
- `python -m compileall -q ultralytics/nn/backends/openvino.py`
- `git diff --check`
- prior synchronous-path matrix: 58 OpenVINO tests passed on all nine runners in https://github.com/ultralytics/ultralytics/actions/runs/32644121099 (the diagnostic workflow itself reported failure only because its no-match `grep` returned 1)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

OpenVINO inference now submits batches synchronously in `LATENCY` mode to avoid hangs associated with `AsyncInferQueue`, and the package patch version is `8.4.128`.

### 📊 Key Changes

- `OpenVINOBackend` always sets `PERFORMANCE_HINT` to `LATENCY`, including dynamic batches and throughput configurations.
- OpenVINO batches are processed as single synchronous requests instead of per-image asynchronous queue requests.
- The backend documentation now describes synchronous inference rather than async throughput execution.
- Updated `ultralytics.__version__` from `8.4.127` to `8.4.128`.

### 🎯 Purpose & Impact

- OpenVINO inference no longer uses the asynchronous queue path that could hang on Intel and AMD CPUs.
- Batched inference remains enabled, while throughput-mode selection is forced to `LATENCY`; this changes execution behavior and may affect performance characteristics for throughput workloads.