### PR TITLE
Read exported head metadata only when the model is a path

### DIFF
--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -82,7 +82,9 @@ class YOLO(Model):
             # Continue with default YOLO initialization
             super().__init__(model=model, task=task, verbose=verbose)
             head = self.model.model[-1]._get_name() if hasattr(self.model, "model") else ""
-            if "RTDETR" in (head or BaseBackend.read_metadata(self.model).get("head", "")):  # if RTDETR head
+            if not head and isinstance(self.model, (str, Path)):  # an exported model keeps its head name in metadata
+                head = BaseBackend.read_metadata(self.model).get("head", "")
+            if "RTDETR" in head:  # if RTDETR head
                 from ultralytics import RTDETR
 
                 new_instance = RTDETR(self)


### PR DESCRIPTION
## summary

- `YOLO(path)` raised `TypeError: expected str, bytes or os.PathLike object, not DistillationModel` for every checkpoint holding a `DistillationModel` — any `last.pt` from an interrupted knowledge-distillation run, and any `save_period` epoch file.
- `DistillationModel` exposes `student_model`/`teacher_model` and no `.model`, so the RT-DETR head check fell through to `BaseBackend.read_metadata(self.model)` with a loaded module where that helper expects a path, and its `Path(file)` sits outside its own `try`.
- The metadata lookup now runs only when the model is a path, matching the `isinstance(model, (str, Path))` guard `nn/tasks.py` already applies before its own `read_metadata` call. Exported models still resolve their head from metadata.
- Existing coverage resumes distillation through `DetectionTrainer(overrides={"resume": ...})` and resumes ordinary training through `YOLO(last).train(resume=True)`, but never crosses the two, which is why the constructor path went untested.

## measured

| case | before | after |
| --- | --- | --- |
| mid-run distillation `.pt` through `YOLO()` | `TypeError` | loads, task `detect`, resumes to completion |
| exported RT-DETR `.onnx` (metadata head `RTDETRDecoder`) | class `RTDETR` | class `RTDETR` |
| exported YOLO `.onnx` (metadata head `Detect`) | class `YOLO` | class `YOLO` |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

YOLO now reads RT-DETR head metadata only for path-based models, preventing loaded `DistillationModel` checkpoints from being passed to path-based metadata handling.

### 📊 Key Changes

- Separates head detection from metadata lookup in `ultralytics/models/yolo/model.py`.
- Reads exported model metadata only when `self.model` is a `str` or `Path`.
- Preserves RT-DETR detection for exported models using the metadata `head` value.
- Prevents `YOLO()` from raising a `TypeError` when loading checkpoints containing a `DistillationModel`.

### 🎯 Purpose & Impact

- Mid-run distillation checkpoints can be loaded through `YOLO()` and resumed without the metadata path error.
- Exported RT-DETR and YOLO models continue resolving to their corresponding model classes from exported head metadata.