### PR TITLE
Skip disk cleanup for Jetson builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -107,6 +107,7 @@ jobs:
       new_release: ${{ steps.check_tag.outputs.new_release }}
     steps:
       - name: Cleanup disk space
+        if: ${{ !startsWith(matrix.dockerfile, 'Dockerfile-jetson-') }}
         uses: ultralytics/actions/cleanup-disk@main
 
       - name: Checkout repo


### PR DESCRIPTION
## Summary

- retain disk cleanup for the general, Python, ARM64, and NVIDIA ARM64 images
- skip cleanup only for JetPack 4/5/6 matrix entries so native ARM Jetson builds keep runner swap available
- address the hosted-runner disconnect in [Docker run 32789191130](https://github.com/ultralytics/ultralytics/actions/runs/32789191130/attempts/1) without masking Docker or test failures

The shared cleanup itself is hardened by ultralytics/actions#893.

## Validation

- [no-push JetPack 5 Docker run 32844264268](https://github.com/ultralytics/ultralytics/actions/runs/32844264268): cleanup skipped; image build, environment check, and full tests passed
- `actionlint .github/workflows/docker.yml`
- Ruby YAML parse
- `npx prettier@3.8.5 --print-width 120 --check .github/workflows/docker.yml`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the Docker workflow to skip disk cleanup for JetPack 4, 5, and 6 Jetson builds so native ARM Jetson builds retain runner swap availability.

### 📊 Key Changes
- Added a condition to the shared `Cleanup disk space` step that excludes Dockerfiles beginning with `Dockerfile-jetson-`.
- Retained disk cleanup for general, Python, ARM64, and NVIDIA ARM64 image builds.
- Applied the change across the Jetson matrix entries without altering the Docker build, environment-check, or test steps.

### 🎯 Purpose & Impact
- Jetson builds no longer run the shared disk-cleanup action, preserving runner resources needed during native ARM builds.
- Other Docker build variants continue using disk cleanup.
- The workflow continues to expose Docker or test failures rather than masking them.