### PR TITLE
Correct code-guide claims and verify every example against the package

### DIFF
--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -1,20 +1,21 @@
 ---
+title: "Customize the YOLO & RT-DETR Trainer"
 comments: true
-description: Learn how to customize the Ultralytics YOLO trainer with custom metrics, class-weighted loss, custom model saving, backbone freezing, per-layer learning rates, SyncBatchNorm, and gradient clipping.
-keywords: Ultralytics, YOLO, Custom Trainer, DetectionTrainer, BaseTrainer, Custom Metrics, F1 Score, Class Weights, Backbone Freezing, Per-Layer Learning Rate, SyncBatchNorm, Gradient Clipping, Multi-GPU Training, Fine-Tuning, Transfer Learning
+description: Subclass DetectionTrainer or RTDETRTrainer to log F1, weight rare classes, save best.pt by a custom metric, freeze backbones, and set per-layer learning rates.
+keywords: Ultralytics, YOLO, custom trainer, DetectionTrainer, RTDETRTrainer, BaseTrainer, custom metrics, class weights, backbone freezing, per-layer learning rate, SyncBatchNorm, gradient clipping, multi-GPU training
 ---
 
-# Customizing Trainer
+# Customizing the Ultralytics YOLO and RT-DETR Trainer
 
-The Ultralytics training pipeline is built around `BaseTrainer` and task-specific trainers like `DetectionTrainer`. These classes handle the training loop, validation, checkpointing, and logging out of the box. When you need more control — tracking custom metrics, adjusting loss weighting, or implementing learning rate schedules — you can subclass the trainer and override specific methods.
+**Ultralytics YOLO26** training is built around `BaseTrainer` and task-specific trainers such as `DetectionTrainer` and `RTDETRTrainer`. These classes handle the training loop, validation, checkpointing, and logging out of the box. When you need more control — tracking custom metrics, adjusting loss weighting, or setting per-layer learning rates — you subclass the trainer and override specific methods.
 
-This guide walks through seven common customizations:
+This guide walks through seven customizations, shown on YOLO26 and, where the recipe differs, on [RT-DETR](../models/rtdetr.md):
 
 1. [Logging custom metrics (F1 score)](#logging-custom-metrics) at the end of each [epoch](https://www.ultralytics.com/glossary/epoch)
-2. [Adding class weights](#adding-class-weights) to handle class imbalance
+2. [Adding class weights](#adding-class-weights) beyond what the `cls_pw` argument gives you
 3. [Saving the best model](#saving-the-best-model-by-custom-metric) based on a different metric
 4. [Freezing the backbone](#freezing-and-unfreezing-the-backbone) for the first N epochs, then unfreezing
-5. [Specifying per-layer learning rates](#per-layer-learning-rates)
+5. [Specifying per-layer learning rates](#per-layer-learning-rates), including an [RT-DETR variant](#rt-detr-variant) with weight, BatchNorm and bias groups
 6. [Synchronizing BatchNorm across GPUs](#synchronized-batchnorm-for-multi-gpu-training) for multi-GPU training
 7. [Configuring gradient clipping](#configurable-gradient-clipping) for stability tuning
 
@@ -41,7 +42,13 @@ model = YOLO("yolo26n.pt")
 model.train(data="coco8.yaml", epochs=10, trainer=CustomTrainer)
 ```
 
-Your custom trainer inherits all functionality from `DetectionTrainer`, so you only need to override the specific methods you want to customize.
+Your custom trainer inherits all functionality from `DetectionTrainer`, so you only need to override the specific methods you want to customize. To change the network itself rather than how it trains, edit the architecture instead — see the [model YAML configuration reference](model-yaml-config.md).
+
+!!! warning "What a custom trainer does and does not reach"
+
+    The `trainer` argument applies to **that one `train()` call**. The class is not recorded in the checkpoint, so `YOLO("last.pt").train(resume=True)` silently reverts to the stock trainer and every customization on this page is lost mid-run — pass `trainer=` again when you resume. Subsequent `model.val()` and `model.export()` calls are unaffected by it either way.
+
+    Under [multi-GPU training](../modes/train.md#multi-gpu-training), Ultralytics re-launches your script through `torchrun` and generates a launcher that imports the trainer by name — `from <your module> import <YourTrainer>`. A class defined in the launch script resolves to `__main__`, which the new process does not carry, so put custom trainer and model classes in their own importable module for any run with more than one device.
 
 ## Logging Custom Metrics
 
@@ -105,9 +112,15 @@ This logs the mean F1 score across all classes and a per-class breakdown after e
 
 ## Adding Class Weights
 
-If your dataset has imbalanced classes (e.g., a rare defect in manufacturing inspection), you can upweight underrepresented classes in the [loss function](https://www.ultralytics.com/glossary/loss-function). This makes the model penalize misclassifications on rare classes more heavily.
+!!! tip "Try the `cls_pw` argument first"
 
-To customize the loss, subclass the loss classes, model, and trainer:
+    Ultralytics already ships inverse-frequency class weighting. Setting `cls_pw` between `0.0` and `1.0` makes the trainer count instances per class in your dataset, raise the inverse frequency to that power, normalize the result to mean 1.0, and multiply the classification loss by it — no custom code at all. See [how to train on an imbalanced dataset](../modes/train.md#how-do-i-train-a-model-on-an-imbalanced-dataset).
+
+    Subclass only when you need something `cls_pw` cannot express, such as hand-chosen per-class weights that do not follow the frequency distribution. That is what the rest of this section shows.
+
+If your dataset has imbalanced classes (e.g., a rare defect in manufacturing inspection), you can upweight specific classes in the [loss function](https://www.ultralytics.com/glossary/loss-function). This makes the model penalize misclassifications on those classes more heavily.
+
+To set weights the frequency-based argument cannot produce, subclass the loss classes, model, and trainer:
 
 ```python
 import torch
@@ -161,7 +174,9 @@ class WeightedTrainer(DetectionTrainer):
 
     def get_model(self, cfg=None, weights=None, verbose=True):
         """Return a WeightedDetectionModel."""
-        model = WeightedDetectionModel(cfg, nc=self.data["nc"], verbose=verbose and RANK == -1)
+        model = self.set_model_names_for_load(  # keeps cls_remap working; dropping it transfers head rows positionally
+            WeightedDetectionModel(cfg, nc=self.data["nc"], ch=self.data["channels"], verbose=verbose and RANK == -1)
+        )
         if weights:
             model.load(weights)
         return model
@@ -171,19 +186,26 @@ model = YOLO("yolo26n.pt")
 model.train(data="coco8.yaml", epochs=10, trainer=WeightedTrainer)
 ```
 
+!!! warning "Pick indices your dataset actually contains"
+
+    Weights only change the loss for classes that appear in the **training** split. The `coco8.yaml` used above contains no instances of class 0 or class 1 in its train images, so the two weights set here leave the loss bit-identical. Check your label distribution and weight indices that are present, or the example runs cleanly and does nothing.
+
 !!! tip "Computing Weights from Dataset"
 
     You can compute class weights automatically from your dataset's label distribution. A common approach is inverse frequency weighting:
 
     ```python
     import numpy as np
+    import torch
 
     # class_counts: number of instances per class
     class_counts = np.array([5000, 200, 3000])
     # Inverse frequency: rarer classes get higher weight
-    class_weights = max(class_counts) / class_counts
-    # Result: [1.0, 25.0, 1.67]
+    class_weights = torch.from_numpy(class_counts.max() / class_counts).float()
+    # tensor([ 1.0000, 25.0000,  1.6667])
     ```
+
+    The `.float()` tensor is what `init_criterion` above expects — a raw NumPy array has no `.to(self.device)`.
 
 !!! note "Loading a model with custom classes"
 
@@ -224,11 +246,12 @@ class CustomSaveTrainer(DetectionTrainer):
 
     def validate(self):
         """Override fitness to use mAP@0.5 for best model selection."""
+        prev_best = self.best_fitness  # BaseTrainer.validate() overwrites this with the default fitness
         metrics, fitness = super().validate()
-        if metrics:
-            fitness = metrics.get("metrics/mAP50(B)", fitness)
-            if self.best_fitness is None or fitness > self.best_fitness:
-                self.best_fitness = fitness
+        if metrics is None:
+            return metrics, fitness
+        fitness = metrics["metrics/mAP50(B)"]
+        self.best_fitness = fitness if prev_best is None else max(prev_best, fitness)
         return metrics, fitness
 
 
@@ -236,9 +259,13 @@ model = YOLO("yolo26n.pt")
 model.train(data="coco8.yaml", epochs=20, trainer=CustomSaveTrainer)
 ```
 
+!!! warning "Capture `best_fitness` before calling `super().validate()`"
+
+    `BaseTrainer.validate()` sets `self.best_fitness` from the **default** fitness before your override runs, and `save_model()` writes `best.pt` only when `self.best_fitness == self.fitness`. Reading `self.best_fitness` after the `super()` call therefore compares your metric against a number on a different scale. With mAP@0.5 the mistake is hidden, because mAP@0.5 is always at least mAP@0.5:0.95. With a metric that can sit **below** default fitness — recall, for instance — `best.pt` instead tracks whichever epoch first beat the *default* fitness, so it marks the wrong checkpoint, and on a run where the custom metric never crosses that running maximum it is not written at all.
+
 !!! note "Available Metrics"
 
-    Common metrics available in `self.metrics` after validation include:
+    Use the `metrics` dict returned by `super().validate()`, as the code above does. The trainer's own `self.metrics` is assigned only *after* `validate()` returns, so inside the override it still holds the previous epoch's values. Its keys are:
 
     | Key | Description |
     |---|---|
@@ -312,12 +339,13 @@ class PerLayerLRTrainer(DetectionTrainer):
         backbone_params = []
         head_params = []
 
+        if name == "auto":  # BaseTrainer would pick an AdamW-scale lr here; without this you get lr0 (SGD-scale)
+            lr = round(0.002 * 5 / (4 + self.data["nc"]), 6)
+
         unwrapped = unwrap_model(model)
         backbone_len = len(unwrapped.yaml["backbone"])  # YOLO26 backbone spans layers 0-10 (C2PSA at layer 10)
 
-        for k, v in unwrapped.named_parameters():
-            if not v.requires_grad:
-                continue
+        for k, v in unwrapped.named_parameters():  # no requires_grad filter, so frozen layers can be unfrozen later
             is_backbone = any(k.startswith(f"model.{i}.") for i in range(backbone_len))
             if is_backbone:
                 backbone_params.append(v)
@@ -370,7 +398,7 @@ class RTDETRBackboneLRTrainer(RTDETRTrainer):
         name = {x.lower(): x for x in canonical}.get(name.lower(), name)
         if name == "auto":
             name, lr, momentum = "AdamW", 1e-4, 0.9
-        self.args.warmup_bias_lr = 0.0  # RT-DETR warms biases from 0, unlike YOLO's 0.1
+        self.args.warmup_bias_lr = 0.0  # optimizer="auto" already sets this to 0.0; keep it at 0 for explicit optimizers too
         if name not in {"Adam", "Adamax", "AdamW", "NAdam", "RAdam"}:
             raise NotImplementedError(f"This trainer only supports AdamW-family optimizers; got {name}")
 
@@ -436,7 +464,7 @@ model.train(data="coco8.yaml", epochs=20, trainer=RTDETRBackboneLRTrainer)
 
 !!! tip "Combining Techniques"
 
-    These customizations can be combined into a single trainer class by overriding multiple methods and adding callbacks as needed.
+    These customizations can be combined into a single trainer class by overriding multiple methods and adding callbacks as needed. One pairing needs care: `BaseTrainer.build_optimizer` deliberately does **not** filter on `requires_grad`, which is exactly why the [freeze and unfreeze](#freezing-and-unfreezing-the-backbone) recipe works — frozen parameters are still in a param group, so they resume training the moment the callback unfreezes them. A custom `build_optimizer` that skips them leaves those parameters with no optimizer state, and the backbone never trains again however many epochs remain. The example above omits that filter for this reason.
 
 ## Synchronized BatchNorm for Multi-GPU Training
 
@@ -525,6 +553,12 @@ Pass your custom trainer class (not an instance) to the `trainer` parameter in `
 
 ```python
 from ultralytics import YOLO
+from ultralytics.models.yolo.detect import DetectionTrainer
+
+
+class MyCustomTrainer(DetectionTrainer):
+    """A custom trainer that extends DetectionTrainer with additional functionality."""
+
 
 model = YOLO("yolo26n.pt")
 model.train(data="coco8.yaml", trainer=MyCustomTrainer)
@@ -558,7 +592,12 @@ Yes, for simpler customizations, [callbacks](../usage/callbacks.md) are often su
 If your change is simpler (such as adjusting loss gains), you can modify the [hyperparameters](https://www.ultralytics.com/glossary/hyperparameter-tuning) directly:
 
 ```python
+from ultralytics import YOLO
+
+model = YOLO("yolo26n.pt")
 model.train(data="coco8.yaml", box=10.0, cls=1.5, dfl=2.0)
 ```
 
-For structural changes to the loss (such as adding class weights), you need to subclass the loss and model as shown in the [class weights section](#adding-class-weights).
+On YOLO26 the `dfl` gain still applies, but not to a distribution focal loss: YOLO26 ships `reg_max: 1`, so there is no DFL term and the gain scales the `l1_loss` column you see in the training log instead. On YOLOv8 and YOLO11, which use `reg_max: 16`, it scales the `dfl_loss` term as the name suggests.
+
+For structural changes to the loss (such as arbitrary class weights), subclass the loss and model as shown in the [class weights section](#adding-class-weights). For inverse-frequency weighting, use the `cls_pw` argument instead of any of this.

--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -339,8 +339,11 @@ class PerLayerLRTrainer(DetectionTrainer):
         backbone_params = []
         head_params = []
 
-        if name == "auto":  # BaseTrainer would pick an AdamW-scale lr here; without this you get lr0 (SGD-scale)
-            lr = round(0.002 * 5 / (4 + self.data["nc"]), 6)
+        if name == "auto":  # BaseTrainer fits an AdamW-scale lr here; without this you inherit lr0, an SGD-scale value
+            name, lr = "AdamW", round(0.002 * 5 / (4 + self.data["nc"]), 6)
+        optimizer_cls = getattr(torch.optim, name, None)
+        if optimizer_cls is None:
+            raise NotImplementedError(f"optimizer={name!r} is not in torch.optim; pass Adam, AdamW, SGD, RMSprop or auto")
 
         unwrapped = unwrap_model(model)
         backbone_len = len(unwrapped.yaml["backbone"])  # YOLO26 backbone spans layers 0-10 (C2PSA at layer 10)
@@ -354,15 +357,14 @@ class PerLayerLRTrainer(DetectionTrainer):
 
         backbone_lr = lr * 0.1
 
-        optimizer = torch.optim.AdamW(
-            [
-                {"params": backbone_params, "lr": backbone_lr, "weight_decay": decay},
-                {"params": head_params, "lr": lr, "weight_decay": decay},
-            ],
-        )
+        groups = [
+            {"params": backbone_params, "lr": backbone_lr, "weight_decay": decay},
+            {"params": head_params, "lr": lr, "weight_decay": decay},
+        ]
+        optimizer = optimizer_cls(groups, momentum=momentum) if name in {"SGD", "RMSprop"} else optimizer_cls(groups)
 
         LOGGER.info(
-            f"PerLayerLR optimizer: backbone ({len(backbone_params)} params, lr={backbone_lr}) "
+            f"PerLayerLR {name}: backbone ({len(backbone_params)} params, lr={backbone_lr}) "
             f"| head ({len(head_params)} params, lr={lr})"
         )
         return optimizer

--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -398,9 +398,7 @@ class RTDETRBackboneLRTrainer(RTDETRTrainer):
         name = {x.lower(): x for x in canonical}.get(name.lower(), name)
         if name == "auto":
             name, lr, momentum = "AdamW", 1e-4, 0.9
-        self.args.warmup_bias_lr = (
-            0.0  # optimizer="auto" already sets this to 0.0; keep it at 0 for explicit optimizers too
-        )
+        self.args.warmup_bias_lr = 0.0  # optimizer="auto" sets this too; keep it for explicit optimizers
         if name not in {"Adam", "Adamax", "AdamW", "NAdam", "RAdam"}:
             raise NotImplementedError(f"This trainer only supports AdamW-family optimizers; got {name}")
 

--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -343,7 +343,9 @@ class PerLayerLRTrainer(DetectionTrainer):
             name, lr = "AdamW", round(0.002 * 5 / (4 + self.data["nc"]), 6)
         optimizer_cls = getattr(torch.optim, name, None)
         if optimizer_cls is None:
-            raise NotImplementedError(f"optimizer={name!r} is not in torch.optim; pass Adam, AdamW, SGD, RMSprop or auto")
+            raise NotImplementedError(
+                f"optimizer={name!r} is not in torch.optim; pass Adam, AdamW, SGD, RMSprop or auto"
+            )
 
         unwrapped = unwrap_model(model)
         backbone_len = len(unwrapped.yaml["backbone"])  # YOLO26 backbone spans layers 0-10 (C2PSA at layer 10)

--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -398,7 +398,9 @@ class RTDETRBackboneLRTrainer(RTDETRTrainer):
         name = {x.lower(): x for x in canonical}.get(name.lower(), name)
         if name == "auto":
             name, lr, momentum = "AdamW", 1e-4, 0.9
-        self.args.warmup_bias_lr = 0.0  # optimizer="auto" already sets this to 0.0; keep it at 0 for explicit optimizers too
+        self.args.warmup_bias_lr = (
+            0.0  # optimizer="auto" already sets this to 0.0; keep it at 0 for explicit optimizers too
+        )
         if name not in {"Adam", "Adamax", "AdamW", "NAdam", "RAdam"}:
             raise NotImplementedError(f"This trainer only supports AdamW-family optimizers; got {name}")
 

--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -188,7 +188,7 @@ model.train(data="coco8.yaml", epochs=10, trainer=WeightedTrainer)
 
 !!! warning "Pick indices your dataset actually contains"
 
-    Weights only change the loss for classes that appear in the **training** split. The `coco8.yaml` used above contains no instances of class 0 or class 1 in its train images, so the two weights set here leave the loss bit-identical. Check your label distribution and weight indices that are present, or the example runs cleanly and does nothing.
+    Weights only change the loss for classes that appear in the **training** split. The `coco8.yaml` used above contains no instances of class 0 or class 1 in its train images, so the two weights set here leave the loss bit-identical. Check your label distribution and weight indices that are present, or the example runs cleanly and does nothing. The two indices also assume at least two classes — on a single-class dataset `class_weights[1] = 3.0` raises `IndexError` before training starts.
 
 !!! tip "Computing Weights from Dataset"
 

--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -410,8 +410,6 @@ class RTDETRBackboneLRTrainer(RTDETRTrainer):
 
         for module_name, module in unwrapped.named_modules():
             for param_name, param in module.named_parameters(recurse=False):
-                if not param.requires_grad:
-                    continue
                 fullname = f"{module_name}.{param_name}" if module_name else param_name
                 parts = fullname.split(".")
                 section = (
@@ -464,7 +462,7 @@ model.train(data="coco8.yaml", epochs=20, trainer=RTDETRBackboneLRTrainer)
 
 !!! tip "Combining Techniques"
 
-    These customizations can be combined into a single trainer class by overriding multiple methods and adding callbacks as needed. One pairing needs care: `BaseTrainer.build_optimizer` deliberately does **not** filter on `requires_grad`, which is exactly why the [freeze and unfreeze](#freezing-and-unfreezing-the-backbone) recipe works — frozen parameters are still in a param group, so they resume training the moment the callback unfreezes them. A custom `build_optimizer` that skips them leaves those parameters with no optimizer state, and the backbone never trains again however many epochs remain. The example above omits that filter for this reason.
+    These customizations can be combined into a single trainer class by overriding multiple methods and adding callbacks as needed. One pairing needs care: `BaseTrainer.build_optimizer` deliberately does **not** filter on `requires_grad`, which is exactly why the [freeze and unfreeze](#freezing-and-unfreezing-the-backbone) recipe works — frozen parameters are still in a param group, so they resume training the moment the callback unfreezes them. A custom `build_optimizer` that skips them leaves those parameters with no optimizer state, and the backbone never trains again however many epochs remain. Neither `build_optimizer` on this page filters on `requires_grad`, for that reason.
 
 ## Synchronized BatchNorm for Multi-GPU Training
 

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -135,15 +135,22 @@ from collections import defaultdict
 by_hash = defaultdict(list)
 for key, image in img_by_key.items():
     by_hash[hashlib.md5(image.read_bytes()).hexdigest()].append(key)
-duplicates = {h: s for h, s in by_hash.items() if len(s) > 1}
-print(f"{len(duplicates)} duplicate groups covering {sum(len(s) for s in duplicates.values())} images")
+duplicates = {h: keys for h, keys in by_hash.items() if len(keys) > 1}
+print(f"{len(duplicates)} duplicate groups covering {sum(len(k) for k in duplicates.values())} images")
+
+# keep one image per hash group and rebuild the matrix, so no copy can straddle a fold
+drop = {k for keys in duplicates.values() for k in sorted(keys)[1:]}
+img_by_key = {k: v for k, v in img_by_key.items() if k not in drop}
+labels_df = labels_df.drop(index=sorted(drop))
+print(f"dropped {len(drop)} duplicate images, {len(labels_df)} remain")
 ```
 
 ```text
 25 duplicate groups covering 50 images
+dropped 25 duplicate images, 1252 remain
 ```
 
-Either drop the extras before building `labels_df`, or keep them together by assigning one fold per hash group with `GroupKFold`. The same reasoning applies to frames from one video, photographs of one subject, and augmented copies of one source image — group them, or the folds are not independent.
+Dropping one image per group is the blunt option shown above and it is enough here. Keeping them together with `GroupKFold`, keyed on the hash, preserves the data instead — worth it when duplicates are numerous. The same reasoning applies to frames from one video, photographs of one subject, and augmented copies of one source image: group them, or the folds are not independent. Note that byte-identical hashing does not catch re-encoded or resized near-duplicates; a perceptual hash does.
 
 ## Splitting into K Folds
 
@@ -167,11 +174,11 @@ for fold in folds:
 ```
 
 ```text
-fold_1: train=1021 val=256
-fold_2: train=1021 val=256
-fold_3: train=1022 val=255
-fold_4: train=1022 val=255
-fold_5: train=1022 val=255
+fold_1: train=1001 val=251
+fold_2: train=1001 val=251
+fold_3: train=1002 val=250
+fold_4: train=1002 val=250
+fold_5: train=1002 val=250
 ```
 
 !!! warning "Assign with `.loc[rows, column]`, not `df[column].loc[rows]`"
@@ -193,11 +200,11 @@ print(fold_distrb.round(3))
 
 ```text
         buffalo  elephant  rhino  zebra
-fold_1    0.235     0.303  0.264  0.271
-fold_2    0.229     0.253  0.241  0.217
-fold_3    0.268     0.176  0.267  0.222
-fold_4    0.208     0.288  0.213  0.224
-fold_5    0.315     0.239  0.267  0.322
+fold_1    0.216     0.243  0.237  0.328
+fold_2    0.285     0.287  0.303  0.172
+fold_3    0.258     0.238  0.212  0.229
+fold_4    0.219     0.255  0.285  0.222
+fold_5    0.275     0.229  0.218  0.313
 ```
 
 Each cell is the ratio of validation instances to training instances for that class. With `k` folds the expected value is `1 / (k - 1)`, so `0.25` here. Every cell above sits within about a third of that, which is fine — with 484 instances in the rarest class, plain `KFold` spreads them adequately.
@@ -266,11 +273,11 @@ Note that `save_path` sits **beside** the dataset, not inside it. A fold directo
 
 !!! tip "Why not copy the images into fold directories?"
 
-    Copying works and gives you self-contained fold directories, but it duplicates the folded pool `k` times. Measured on the 1,277 pooled images and their labels at `k=5`:
+    Copying works and gives you self-contained fold directories, but it duplicates the folded pool `k` times. Measured on the 1,252 images left after deduplication, plus their labels, at `k=5`:
 
     | Approach   | Disk    | Files  |
     | ---------- | ------- | ------ |
-    | Copy files | ~445 MB | 12,770 |
+    | Copy files | ~430 MB | 12,520 |
     | Text lists | 402 KB  | 15     |
 
     Both produce identical folds and identical training scans. If you do need real directories — to ship a fold elsewhere, or to hand it to a tool that cannot read a path list — copy by iterating the stem-keyed dictionaries rather than zipping two lists:
@@ -308,8 +315,8 @@ for k, fold_yaml in enumerate(ds_yamls):
 Each run reports a clean scan, which is the checkpoint confirming images and labels were paired correctly:
 
 ```text
-train: Scanning .../african-wildlife/labels/train... 1021 images, 0 backgrounds, 0 corrupt
-val: Scanning .../african-wildlife/labels/train... 256 images, 0 backgrounds, 0 corrupt
+train: Scanning .../african-wildlife/labels/train... 1001 images, 0 backgrounds, 0 corrupt
+val: Scanning .../african-wildlife/labels/train... 251 images, 0 backgrounds, 0 corrupt
 ```
 
 The counts match the fold sizes printed earlier, and a non-zero `backgrounds` count on a fully annotated dataset means images and labels are mispaired — go back to the orphan-label check. The directory in the scan line is just wherever the first label file happened to sit, so both lines naming the same split is expected and does not mean the fold is wrong.
@@ -368,7 +375,7 @@ Average the per-fold metric you care about. `results[k].box.map` holds `mAP50-95
 
 ### How much disk space does K-Fold cross validation need?
 
-None beyond the dataset itself, if you define each fold as a `.txt` list of image paths. Copying images into per-fold directories instead multiplies the folded pool by `k` — for the 1,277 pooled images and labels here, 89 MB, that is about 445 MB and 12,770 files at `k=5`, against 402 KB and 15 files for the list approach.
+None beyond the dataset itself, if you define each fold as a `.txt` list of image paths. Copying images into per-fold directories instead multiplies the folded pool by `k` — for the 1,252 deduplicated images and their labels here, 86 MB, that is about 430 MB and 12,520 files at `k=5`, against 402 KB and 15 files for the list approach.
 
 ### Should I use K-Fold cross validation or a single train/val split?
 

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -17,7 +17,7 @@ This guide builds `k=5` folds for a [YOLO detection dataset](../datasets/detect/
 
 ## Setup
 
-This walkthrough uses the [African Wildlife](../datasets/detect/african-wildlife.md) dataset, which downloads automatically and is already in [YOLO detection format](../datasets/detect/index.md). Substitute your own dataset by pointing `dataset_path` at it.
+This walkthrough uses the [African Wildlife](../datasets/detect/african-wildlife.md) dataset, which downloads automatically and is already in [YOLO detection format](../datasets/detect/index.md). Substitute your own by pointing `dataset_path` at it, provided it uses the standard `images/<split>` and `labels/<split>` directory layout — the collection block below walks those directories rather than reading the `train` and `val` entries of your data YAML, so a dataset defined by path lists or non-standard directories needs those globs adjusted first.
 
 | Class Label | Instance Count |
 | :---------- | -------------: |
@@ -386,7 +386,7 @@ The workflow here targets the YOLO detection format, but it adapts to every YOLO
 
 ### Can I use K-Fold Cross Validation with my own dataset?
 
-Yes, as long as the annotations are in [YOLO detection format](../datasets/detect/index.md). Point `dataset_path` at your dataset and read `classes` from your own data YAML. Images with no label file are fine — Ultralytics reads them as backgrounds and they get an all-zero row. The check in [Building the Class-Count Matrix](#building-the-class-count-matrix) rejects only the reverse case, a label file with no image, which is the failure worth catching early.
+Yes, as long as the annotations are in [YOLO detection format](../datasets/detect/index.md) and laid out as `images/<split>` and `labels/<split>`, which is what the collection block globs. Point `dataset_path` at your dataset and read `classes` from your own data YAML. Images with no label file are fine — Ultralytics reads them as backgrounds and they get an all-zero row. The check in [Building the Class-Count Matrix](#building-the-class-count-matrix) rejects only the reverse case, a label file with no image, which is the failure worth catching early.
 
 ### Do I still need a separate test set?
 
@@ -405,7 +405,7 @@ final_dir.mkdir(parents=True, exist_ok=True)
         {
             "path": final_dir.as_posix(),
             "train": "pool.txt",
-            "val": "pool.txt",  # training requires a val entry; selection is already done, so this one is a formality
+            "val": "pool.txt",  # training requires a val entry; see the warning below
             "names": classes,
         }
     )
@@ -413,7 +413,9 @@ final_dir.mkdir(parents=True, exist_ok=True)
 
 final = YOLO("yolo26n.pt")
 final.train(data=str(final_dir / "final.yaml"), epochs=100, batch=16)
-print(final.val(data="african-wildlife.yaml", split="test").box.map)  # the number to report
+
+fitted = YOLO(final.trainer.last)  # last.pt, so no checkpoint was chosen using training labels
+print(fitted.val(data="african-wildlife.yaml", split="test").box.map)  # the number to report
 ```
 
-Passing `data=` to `val()` is what redirects it away from `final.yaml`, which has no `test` entry, to the original dataset.
+Two details carry the correctness here. Passing `data=` to `val()` redirects it away from `final.yaml`, which has no `test` entry, to the original dataset. And the evaluation uses `last.pt` rather than the model `train()` leaves loaded: with `pool.txt` on both sides, every epoch validates on its own training images, so `best.pt` is picked on labels the model has already seen — `Model.train()` reloads exactly that checkpoint. Taking the final epoch's weights instead keeps the test score free of any selection. Train for a fixed epoch budget for the same reason, rather than relying on early stopping against the overlapping split.

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -122,6 +122,29 @@ dtype: float64
 
 An image with no objects produces an all-zero row, which is correct — a background image is legitimate training data, not missing data.
 
+## Watch for Duplicate and Near-Duplicate Images
+
+Cross validation assumes the folds are independent. Duplicated or near-duplicated images break that assumption: a copy in training and its twin in validation inflates that fold's metrics, and no amount of averaging removes the bias.
+
+This is not a hypothetical for the example dataset. Hashing the folded pool finds **25 groups of byte-identical images covering 50 files**, none of them detectable from the filenames. Deduplicate before splitting:
+
+```python
+import hashlib
+from collections import defaultdict
+
+by_hash = defaultdict(list)
+for key, image in img_by_key.items():
+    by_hash[hashlib.md5(image.read_bytes()).hexdigest()].append(key)
+duplicates = {h: s for h, s in by_hash.items() if len(s) > 1}
+print(f"{len(duplicates)} duplicate groups covering {sum(len(s) for s in duplicates.values())} images")
+```
+
+```text
+25 duplicate groups covering 50 images
+```
+
+Either drop the extras before building `labels_df`, or keep them together by assigning one fold per hash group with `GroupKFold`. The same reasoning applies to frames from one video, photographs of one subject, and augmented copies of one source image — group them, or the folds are not independent.
+
 ## Splitting into K Folds
 
 `KFold` shuffles the rows and partitions them into `k` groups. `random_state` is what makes the split reproducible; the global `random` module plays no part in it.
@@ -243,12 +266,12 @@ Note that `save_path` sits **beside** the dataset, not inside it. A fold directo
 
 !!! tip "Why not copy the images into fold directories?"
 
-    Copying works and gives you self-contained fold directories, but it duplicates the dataset `k` times. Measured on this dataset at `k=5`:
+    Copying works and gives you self-contained fold directories, but it duplicates the folded pool `k` times. Measured on the 1,277 pooled images and their labels at `k=5`:
 
     | Approach   | Disk    | Files  |
     | ---------- | ------- | ------ |
-    | Copy files | ~525 MB | 15,040 |
-    | Text lists | 500 KB  | 15     |
+    | Copy files | ~445 MB | 12,770 |
+    | Text lists | 402 KB  | 15     |
 
     Both produce identical folds and identical training scans. If you do need real directories — to ship a fold elsewhere, or to hand it to a tool that cannot read a path list — copy by iterating the stem-keyed dictionaries rather than zipping two lists:
 
@@ -318,29 +341,6 @@ print(summary.agg(["mean", "std"]).round(4))
 ```
 
 Report the **mean** as your headline number and the **standard deviation** as its uncertainty. A large spread means the metric was never stable enough to compare two models on a single split. Note that `fitness` is a property on the returned object while `box.fitness` is a method — printing the latter without `()` gives a `<bound method>` repr rather than a value.
-
-## Watch for Duplicate and Near-Duplicate Images
-
-Cross validation assumes the folds are independent. Duplicated or near-duplicated images break that assumption: a copy in training and its twin in validation inflates that fold's metrics, and no amount of averaging removes the bias.
-
-This is not a hypothetical for the example dataset. Hashing the folded pool finds **25 groups of byte-identical images covering 50 files**, none of them detectable from the filenames. Deduplicate before splitting:
-
-```python
-import hashlib
-from collections import defaultdict
-
-by_hash = defaultdict(list)
-for key, image in img_by_key.items():
-    by_hash[hashlib.md5(image.read_bytes()).hexdigest()].append(key)
-duplicates = {h: s for h, s in by_hash.items() if len(s) > 1}
-print(f"{len(duplicates)} duplicate groups covering {sum(len(s) for s in duplicates.values())} images")
-```
-
-```text
-25 duplicate groups covering 50 images
-```
-
-Either drop the extras before building `labels_df`, or keep them together by assigning one fold per hash group with `GroupKFold`. The same reasoning applies to frames from one video, photographs of one subject, and augmented copies of one source image — group them, or the folds are not independent.
 
 !!! tip "Just need a single train/val split?"
 

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -62,7 +62,9 @@ from ultralytics.data.utils import IMG_FORMATS
 dataset_path = Path(data["path"])  # from check_det_dataset above
 pool = ("train", "val")  # the shipped test split stays out of the folds
 
-images = sorted(p for s in pool for p in (dataset_path / "images" / s).rglob("*.*") if p.suffix[1:].lower() in IMG_FORMATS)
+images = sorted(
+    p for s in pool for p in (dataset_path / "images" / s).rglob("*.*") if p.suffix[1:].lower() in IMG_FORMATS
+)
 labels = sorted(p for s in pool for p in (dataset_path / "labels" / s).rglob("*.txt"))
 
 # key by path relative to images/ and labels/, so the same basename in two splits stays distinct

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -1,320 +1,360 @@
 ---
+title: K-Fold Cross Validation for YOLO Datasets
 comments: true
-description: Learn to implement K-Fold Cross Validation for object detection datasets using Ultralytics YOLO. Improve your model's reliability and robustness.
-keywords: Ultralytics, YOLO, K-Fold Cross Validation, object detection, sklearn, pandas, PyYAML, machine learning, dataset split
+description: Build K-Fold splits for a YOLO detection dataset with scikit-learn and pandas, train Ultralytics YOLO26 on every fold, and aggregate the results into one score.
+keywords: K-Fold cross validation, YOLO, Ultralytics, scikit-learn, pandas, dataset split, model evaluation, object detection, fold balance, data leakage
 ---
 
-# K-Fold Cross Validation with Ultralytics
+# How to Run K-Fold Cross Validation with Ultralytics YOLO
 
-## Introduction
+K-Fold cross validation splits a dataset into `k` equally sized folds and trains `k` models, each holding out a different fold for validation, so every image is used for both training and validation exactly once. Averaging the `k` results gives a far more stable estimate of model quality than a single train/val split, because it no longer depends on which images happened to land in the validation set.
 
-This comprehensive guide illustrates the implementation of K-Fold Cross Validation for [object detection](https://www.ultralytics.com/glossary/object-detection) datasets within the Ultralytics ecosystem. We'll leverage the YOLO detection format and key Python libraries such as sklearn, pandas, and PyYAML to guide you through the necessary setup, the process of generating feature vectors, and the execution of a K-Fold dataset split.
+This guide builds `k=5` folds for a [YOLO detection dataset](../datasets/detect/index.md) using scikit-learn and pandas, writes one dataset YAML per fold, trains [Ultralytics YOLO26](../models/yolo26.md) on each of them, and aggregates the results. Cross validation pays off most when a dataset is small, noisy, or class-imbalanced; for large, diverse datasets a single well-constructed train/val/test split gives the same answer for a fifth of the compute.
 
 <p align="center">
   <img width="800" src="https://cdn.ul.run/i/457d0a77dc06d7204322ec056248c4b5.avif" alt="K-fold cross validation data splitting">
 </p>
 
-Whether your project involves the Fruit Detection dataset or a custom data source, this tutorial aims to help you comprehend and apply K-Fold Cross Validation to bolster the reliability and robustness of your [machine learning](https://www.ultralytics.com/glossary/machine-learning-ml) models. While we're applying `k=5` folds for this tutorial, keep in mind that the optimal number of folds can vary depending on your dataset and the specifics of your project. K-Fold Cross Validation delivers the most value when your dataset is small, noisy, or highly variable; for large, diverse datasets, a well-constructed train/val/test split is usually sufficient.
-
-Let's get started.
-
 ## Setup
 
-- Your annotations should be in the [YOLO detection format](../datasets/detect/index.md).
-
-- This guide assumes that annotation files are locally available.
-
-- For our demonstration, we use the [Fruit Detection](https://www.kaggle.com/datasets/lakshaytyagi01/fruit-detection/code) dataset.
-    - This dataset contains a total of 8479 images.
-    - It includes 6 class labels, each with its total instance counts listed below.
+This walkthrough uses the [African Wildlife](../datasets/detect/african-wildlife.md) dataset, which downloads automatically and is already in [YOLO detection format](../datasets/detect/index.md). Substitute your own dataset by pointing `dataset_path` at it.
 
 | Class Label | Instance Count |
-| :---------- | :------------: |
-| Apple       |      7049      |
-| Grapes      |      7202      |
-| Pineapple   |      1613      |
-| Orange      |     15549      |
-| Banana      |      3536      |
-| Watermelon  |      1976      |
+| :---------- | -------------: |
+| buffalo     |            554 |
+| elephant    |            748 |
+| rhino       |            559 |
+| zebra       |            824 |
+| **Total**   |      **2,685** |
 
-- Necessary Python packages include:
-    - `ultralytics`
-    - `sklearn`
-    - `pandas`
-    - `pyyaml`
+The dataset ships 1,504 images split into `train`, `val` and `test` directories. K-Fold **pools all three** and re-partitions them, which is the point — the shipped boundary is exactly what cross validation replaces.
 
-- This tutorial operates with `k=5` folds. However, you should determine the best number of folds for your specific dataset.
+Install Ultralytics and the two helper libraries this guide uses:
 
-1. Initiate a new Python virtual environment (`venv`) for your project and activate it. Use `pip` (or your preferred package manager) to install:
-    - The Ultralytics library: `pip install -U ultralytics`. Alternatively, you can clone the official [repo](https://github.com/ultralytics/ultralytics).
-    - Scikit-learn, pandas, and PyYAML: `pip install -U scikit-learn pandas pyyaml`.
+```bash
+pip install -U ultralytics scikit-learn pandas
+```
 
-2. Verify that your annotations are in the [YOLO detection format](../datasets/detect/index.md).
-    - For this tutorial, all annotation files are found in the `Fruit-Detection/labels` directory.
+Then download the dataset once, so the rest of the guide can read it from disk:
 
-## Generating Feature Vectors for Object Detection Dataset
+```python
+from ultralytics.data.utils import check_det_dataset
 
-1. Start by creating a new `example.py` Python file for the steps below.
+data = check_det_dataset("african-wildlife.yaml")  # downloads on first use
+print(data["path"])
+```
 
-2. Proceed to retrieve all label files for your dataset.
+!!! note "Choosing `k`"
 
-    ```python
-    from pathlib import Path
+    This guide uses `k=5`, which holds out 20% of the data per fold. Smaller datasets benefit from more folds, at proportionally more training time — `k` folds means `k` full training runs.
 
-    dataset_path = Path("./Fruit-detection")  # replace with 'path/to/dataset' for your custom data
-    labels = sorted(dataset_path.rglob("*labels/*.txt"))  # all data in 'labels'
-    ```
+## Building the Class-Count Matrix
 
-3. Now, read the contents of the dataset YAML file and extract the indices of the class labels.
+The split has to be computed over something. Each image is represented by a row counting how many instances of each class its label file contains, which turns the dataset into a table `scikit-learn` can split.
 
-    ```python
-    import yaml
+Start by collecting the label and image files, and pairing them:
 
-    yaml_file = "path/to/data.yaml"  # your data YAML with data directories and names dictionary
-    with open(yaml_file, encoding="utf8") as y:
-        classes = yaml.safe_load(y)["names"]
-    cls_idx = sorted(classes.keys())
-    ```
+```python
+from pathlib import Path
 
-4. Initialize an empty `pandas` DataFrame.
+from ultralytics.data.utils import IMG_FORMATS
 
-    ```python
-    import pandas as pd
+dataset_path = Path(data["path"])  # from check_det_dataset above
 
-    index = [label.stem for label in labels]  # uses base filename as ID (no extension)
-    labels_df = pd.DataFrame([], columns=cls_idx, index=index)
-    ```
+labels = sorted((dataset_path / "labels").rglob("*.txt"))
+images = sorted(p for p in (dataset_path / "images").rglob("*.*") if p.suffix[1:].lower() in IMG_FORMATS)
 
-5. Count the instances of each class-label present in the annotation files.
+img_by_stem = {p.stem: p for p in images}
+lbl_by_stem = {p.stem: p for p in labels}
+assert not (set(img_by_stem) ^ set(lbl_by_stem)), "every image needs exactly one label file, matched by filename"
+print(f"{len(images)} images, {len(labels)} labels")
+```
 
-    ```python
-    from collections import Counter
+```text
+1504 images, 1504 labels
+```
 
-    for label in labels:
-        lbl_counter = Counter()
+!!! warning "Three details this block gets right on purpose"
 
-        with open(label) as lf:
-            lines = lf.readlines()
+    - **Scope the label glob to `labels/`.** Ultralytics datasets nest labels as `labels/train/`, `labels/val/`, `labels/test/`, and a pattern that expects them one level up returns nothing at all. A glob rooted at the dataset directory instead re-reads its own output on a second run.
+    - **Use `IMG_FORMATS` rather than a hand-written extension list.** Ultralytics accepts 13 image formats, and on Linux and macOS `Path.rglob` matches extensions case-sensitively regardless of the filesystem — so a hardcoded `[".jpg", ".jpeg", ".png"]` silently drops the three `.JPG` files in this dataset, and every `.webp` or `.tif` in yours.
+    - **Pair by filename stem, never by position.** The two lists are produced by different globs, so any dropped or extra file shifts one relative to the other and every later pair is wrong. That failure trains cleanly and reports meaningless metrics, because images end up in one fold with another image's labels.
 
-        for line in lines:
-            # classes for YOLO label uses integer at first position of each line
-            lbl_counter[int(line.split(" ", 1)[0])] += 1
+Now count the instances per class:
 
-        labels_df.loc[label.stem] = lbl_counter
+```python
+from collections import Counter
 
-    labels_df = labels_df.fillna(0.0)  # replace `nan` values with `0.0`
-    ```
+import pandas as pd
 
-6. The following is a sample view of the populated DataFrame:
+classes = data["names"]  # {0: 'buffalo', 1: 'elephant', 2: 'rhino', 3: 'zebra'}
+cls_idx = sorted(classes)
 
-    ```text
-                                                           0    1    2    3    4    5
-    '0000a16e4b057580_jpg.rf.00ab48988370f64f5ca8ea4...'  0.0  0.0  0.0  0.0  0.0  7.0
-    '0000a16e4b057580_jpg.rf.7e6dce029fb67f01eb19aa7...'  0.0  0.0  0.0  0.0  0.0  7.0
-    '0000a16e4b057580_jpg.rf.bc4d31cdcbe229dd022957a...'  0.0  0.0  0.0  0.0  0.0  7.0
-    '00020ebf74c4881c_jpg.rf.508192a0a97aa6c4a3b6882...'  0.0  0.0  0.0  1.0  0.0  0.0
-    '00020ebf74c4881c_jpg.rf.5af192a2254c8ecc4188a25...'  0.0  0.0  0.0  1.0  0.0  0.0
-     ...                                                  ...  ...  ...  ...  ...  ...
-    'ff4cd45896de38be_jpg.rf.c4b5e967ca10c7ced3b9e97...'  0.0  0.0  0.0  0.0  0.0  2.0
-    'ff4cd45896de38be_jpg.rf.ea4c1d37d2884b3e3cbce08...'  0.0  0.0  0.0  0.0  0.0  2.0
-    'ff5fd9c3c624b7dc_jpg.rf.bb519feaa36fc4bf630a033...'  1.0  0.0  0.0  0.0  0.0  0.0
-    'ff5fd9c3c624b7dc_jpg.rf.f0751c9c3aa4519ea3c9d6a...'  1.0  0.0  0.0  0.0  0.0  0.0
-    'fffe28b31f2a70d4_jpg.rf.7ea16bd637ba0711c53b540...'  0.0  6.0  0.0  0.0  0.0  0.0
-    ```
+labels_df = pd.DataFrame(0.0, index=sorted(img_by_stem), columns=cls_idx)
+for stem, label_file in lbl_by_stem.items():
+    counter = Counter()
+    for line in label_file.read_text().splitlines():
+        if line.strip():  # skip blank lines; split() also handles tabs and leading whitespace
+            counter[int(line.split()[0])] += 1
+    for cls, n in counter.items():
+        labels_df.loc[stem, cls] = n
 
-The rows index the label files, each corresponding to an image in your dataset, and the columns correspond to your class-label indices. Each row represents a pseudo feature-vector, with the count of each class-label present in your dataset. This data structure enables the application of [K-Fold Cross Validation](https://www.ultralytics.com/glossary/cross-validation) to an object detection dataset.
+print(labels_df.sum().rename(classes))
+```
 
-## K-Fold Dataset Split
+```text
+buffalo     554.0
+elephant    748.0
+rhino       559.0
+zebra       824.0
+dtype: float64
+```
 
-1. Now we will use the `KFold` class from `sklearn.model_selection` to generate `k` splits of the dataset.
-    - Important:
-        - Setting `shuffle=True` ensures a randomized distribution of classes in your splits.
-        - By setting `random_state=M` where `M` is a chosen integer, you can obtain repeatable results.
+An image with no objects produces an all-zero row, which is correct — a background image is legitimate training data, not missing data.
 
-    ```python
-    import random
+## Splitting into K Folds
 
-    from sklearn.model_selection import KFold
+`KFold` shuffles the rows and partitions them into `k` groups. `random_state` is what makes the split reproducible; the global `random` module plays no part in it.
 
-    random.seed(0)  # for reproducibility
-    ksplit = 5
-    kf = KFold(n_splits=ksplit, shuffle=True, random_state=20)  # setting random_state for repeatable results
+```python
+from sklearn.model_selection import KFold
 
-    kfolds = list(kf.split(labels_df))
-    ```
+ksplit = 5
+kf = KFold(n_splits=ksplit, shuffle=True, random_state=20)
+kfolds = list(kf.split(labels_df))
 
-2. The dataset has now been split into `k` folds, each having a list of `train` and `val` indices. We will construct a DataFrame to display these results more clearly.
+folds = [f"fold_{n}" for n in range(1, ksplit + 1)]
+folds_df = pd.DataFrame(index=labels_df.index, columns=folds, dtype=object)
+for i, (train, val) in enumerate(kfolds, start=1):
+    folds_df.loc[labels_df.index[train], f"fold_{i}"] = "train"
+    folds_df.loc[labels_df.index[val], f"fold_{i}"] = "val"
 
-    ```python
-    folds = [f"split_{n}" for n in range(1, ksplit + 1)]
-    folds_df = pd.DataFrame(index=index, columns=folds)
+for fold in folds:
+    print(f"{fold}: train={(folds_df[fold] == 'train').sum()} val={(folds_df[fold] == 'val').sum()}")
+```
 
-    for i, (train, val) in enumerate(kfolds, start=1):
-        folds_df[f"split_{i}"].loc[labels_df.iloc[train].index] = "train"
-        folds_df[f"split_{i}"].loc[labels_df.iloc[val].index] = "val"
-    ```
+```text
+fold_1: train=1203 val=301
+fold_2: train=1203 val=301
+fold_3: train=1203 val=301
+fold_4: train=1203 val=301
+fold_5: train=1204 val=300
+```
 
-3. Now we will calculate the distribution of class labels for each fold as a ratio of the classes present in `val` to those present in `train`.
+!!! warning "Assign with `.loc[rows, column]`, not `df[column].loc[rows]`"
 
-    ```python
-    fold_lbl_distrb = pd.DataFrame(index=folds, columns=cls_idx)
+    The second form is chained assignment. Under pandas copy-on-write — the default from pandas 3.0 — it writes to a temporary copy and silently leaves the DataFrame untouched, so every fold column stays `NaN`. The failure surfaces much later as `TypeError: unsupported operand type(s) for /: 'PosixPath' and 'float'` when a fold name is used to build a path, with nothing pointing back at the assignment.
 
-    for n, (train_indices, val_indices) in enumerate(kfolds, start=1):
-        train_totals = labels_df.iloc[train_indices].sum()
-        val_totals = labels_df.iloc[val_indices].sum()
+## Checking the Fold Balance
 
-        # To avoid division by zero, we add a small value (1E-7) to the denominator
-        ratio = val_totals / (train_totals + 1e-7)
-        fold_lbl_distrb.loc[f"split_{n}"] = ratio
-    ```
+`KFold` is uniformly random over rows. It does **not** stratify, so it does not guarantee that every class is evenly represented in every fold — it only guarantees that each image is validated once. Check the result rather than assuming it:
 
-    The ideal scenario is for all class ratios to be reasonably similar for each split and across classes. This, however, will be subject to the specifics of your dataset.
+```python
+fold_distrb = pd.DataFrame(index=folds, columns=cls_idx, dtype=float)
+for n, (train, val) in enumerate(kfolds, start=1):
+    ratio = labels_df.iloc[val].sum() / (labels_df.iloc[train].sum() + 1e-7)
+    fold_distrb.loc[f"fold_{n}"] = ratio
+fold_distrb.columns = [classes[i] for i in cls_idx]
+print(fold_distrb.round(3))
+```
 
-4. Next, we create the directories and dataset YAML files for each split.
+```text
+        buffalo  elephant  rhino  zebra
+fold_1    0.265     0.324  0.265  0.232
+fold_2    0.300     0.228  0.213  0.235
+fold_3    0.164     0.226  0.265  0.268
+fold_4    0.256     0.249  0.262  0.260
+fold_5    0.274     0.228  0.248  0.256
+```
 
-    ```python
-    from datetime import datetime, timezone
+Each cell is the ratio of validation instances to training instances for that class. With `k` folds the expected value is `1 / (k - 1)`, so `0.25` here. Every cell above sits within about a third of that, which is fine — with 554 instances in the rarest class, plain `KFold` spreads them adequately.
 
-    supported_extensions = [".jpg", ".jpeg", ".png"]
+The check matters when it fails. On a dataset with a class of only a handful of instances, some folds end up with **zero** validation instances of it, per-class AP is undefined there, and the average across folds is silently computed over a shifting set of classes. If you see a `0.000` cell, stratify the split on each image's rarest present class:
 
-    # Initialize an empty list to store image file paths
-    images = []
+```python
+from sklearn.model_selection import StratifiedKFold
 
-    # Loop through supported extensions and gather image files
-    for ext in supported_extensions:
-        images.extend(sorted((dataset_path / "images").rglob(f"*{ext}")))
+freq = labels_df.sum()
+y = labels_df.apply(
+    lambda row: min((c for c in cls_idx if row[c] > 0), key=lambda c: freq[c]) if row.sum() else -1,
+    axis=1,
+)
+kfolds = list(StratifiedKFold(ksplit, shuffle=True, random_state=20).split(labels_df, y))
 
-    # Create the necessary directories and dataset YAML files
-    date = datetime.now(timezone.utc).date().isoformat()
-    save_path = Path(dataset_path / f"{date}_{ksplit}-Fold_Cross-val")
-    save_path.mkdir(parents=True, exist_ok=True)
-    ds_yamls = []
+# rebuild folds_df from the new kfolds -- every later step reads folds_df, not kfolds
+folds_df = pd.DataFrame(index=labels_df.index, columns=folds, dtype=object)
+for i, (train, val) in enumerate(kfolds, start=1):
+    folds_df.loc[labels_df.index[train], f"fold_{i}"] = "train"
+    folds_df.loc[labels_df.index[val], f"fold_{i}"] = "val"
+```
 
-    for split in folds_df.columns:
-        # Create directories
-        split_dir = save_path / split
-        split_dir.mkdir(parents=True, exist_ok=True)
-        (split_dir / "train" / "images").mkdir(parents=True, exist_ok=True)
-        (split_dir / "train" / "labels").mkdir(parents=True, exist_ok=True)
-        (split_dir / "val" / "images").mkdir(parents=True, exist_ok=True)
-        (split_dir / "val" / "labels").mkdir(parents=True, exist_ok=True)
+Rebuilding `folds_df` is the part that is easy to miss: every step after this reads `folds_df`, never `kfolds`, so swapping the splitter alone leaves the original unstratified folds in place with nothing to show for it.
 
-        # Create dataset YAML files
-        dataset_yaml = split_dir / f"{split}_dataset.yaml"
-        ds_yamls.append(dataset_yaml)
+This is a proxy, not true multi-label stratification: an image containing several classes contributes to only one stratum. `StratifiedKFold` cannot take a multi-label target directly — it raises `ValueError: Supported target types are: ('binary', 'multiclass')` — so exact multi-label balance needs the `iterative-stratification` package.
 
-        with open(dataset_yaml, "w") as ds_y:
-            yaml.safe_dump(
-                {
-                    "path": split_dir.as_posix(),
-                    "train": "train",
-                    "val": "val",
-                    "names": classes,
-                },
-                ds_y,
-            )
-    ```
+## Creating One Dataset YAML per Fold
 
-5. Lastly, copy images and labels into the respective directory ('train' or 'val') for each split.
-    - **NOTE:** The time required for this portion of the code will vary based on the size of your dataset and your system hardware.
+A fold is just a list of which images train and which validate. Ultralytics dataset YAMLs accept a `.txt` file listing image paths wherever they accept a directory, so a fold needs two text files and a YAML — no image is copied anywhere:
+
+```python
+import yaml
+
+save_path = dataset_path.parent / f"{ksplit}-fold"
+save_path.mkdir(parents=True, exist_ok=True)
+
+ds_yamls = []
+for fold in folds:
+    for split in ("train", "val"):
+        stems = folds_df.index[folds_df[fold] == split]
+        (save_path / f"{fold}_{split}.txt").write_text("\n".join(str(img_by_stem[s]) for s in stems) + "\n")
+    fold_yaml = save_path / f"{fold}.yaml"
+    fold_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "path": save_path.as_posix(),
+                "train": f"{fold}_train.txt",
+                "val": f"{fold}_val.txt",
+                "names": classes,
+            }
+        )
+    )
+    ds_yamls.append(fold_yaml)
+```
+
+Note that `save_path` sits **beside** the dataset, not inside it. A fold directory written into the dataset root gets picked up by the label glob on the next run.
+
+!!! tip "Why not copy the images into fold directories?"
+
+    Copying works and gives you self-contained fold directories, but it duplicates the dataset `k` times. Measured on this dataset at `k=5`:
+
+    | Approach   | Disk    | Files  |
+    | ---------- | ------- | ------ |
+    | Copy files | ~525 MB | 15,040 |
+    | Text lists | 500 KB  | 15     |
+
+    Both produce identical folds and identical training scans. If you do need real directories — to ship a fold elsewhere, or to hand it to a tool that cannot read a path list — copy by iterating the stem-keyed dictionaries rather than zipping two lists:
 
     ```python
     import shutil
 
-    from tqdm import tqdm
-
-    for image, label in tqdm(zip(images, labels), total=len(images), desc="Copying files"):
-        for split, k_split in folds_df.loc[image.stem].items():
-            # Destination directory
-            img_to_path = save_path / split / k_split / "images"
-            lbl_to_path = save_path / split / k_split / "labels"
-
-            # Copy image and label files to new directory (SamefileError if file already exists)
-            shutil.copy(image, img_to_path / image.name)
-            shutil.copy(label, lbl_to_path / label.name)
+    for stem, image in img_by_stem.items():
+        for fold, split in folds_df.loc[stem].items():
+            for src, sub in ((image, "images"), (lbl_by_stem[stem], "labels")):
+                dst = save_path / fold / split / sub
+                dst.mkdir(parents=True, exist_ok=True)
+                shutil.copy(src, dst / src.name)
     ```
 
-## Save Records (Optional)
+    `shutil.copy` overwrites an existing destination silently, so a re-run is not protected in either approach — delete `save_path` first.
 
-Optionally, you can save the records of the K-Fold split and label distribution DataFrames as CSV files for future reference.
+## Training on Every Fold
+
+Build a fresh model for each fold so no weights carry over, and keep the result object:
 
 ```python
-folds_df.to_csv(save_path / "kfold_datasplit.csv")
-fold_lbl_distrb.to_csv(save_path / "kfold_label_distribution.csv")
+from ultralytics import YOLO
+
+results = {}
+for k, fold_yaml in enumerate(ds_yamls):
+    model = YOLO("yolo26n.pt")  # fresh weights per fold
+    results[k] = model.train(data=str(fold_yaml), epochs=100, batch=16, project="kfold_demo", name=f"fold_{k + 1}")
 ```
 
-## Train YOLO using K-Fold Data Splits
+Each run reports a clean scan, which is the checkpoint confirming images and labels were paired correctly:
 
-1. First, load the YOLO model.
+```text
+train: Scanning .../african-wildlife/labels/... 1203 images, 0 backgrounds, 0 corrupt
+val: Scanning .../african-wildlife/labels/... 301 images, 0 backgrounds, 0 corrupt
+```
 
-    ```python
-    from ultralytics import YOLO
+A non-zero `backgrounds` count on a fully annotated dataset means images and labels are mispaired — go back to the stem assertion. The directory in the scan line is just wherever the first label file happened to sit, so `labels/test` while training fold 1 is expected and does not mean the fold is wrong.
 
-    weights_path = "path/to/weights.pt"  # use yolo26n.pt for a small model
-    model = YOLO(weights_path, task="detect")
-    ```
+!!! note "Budget for `k` full training runs"
 
-2. Next, iterate over the dataset YAML files to run training. The results will be saved to a directory specified by the `project` and `name` arguments. By default, this directory is 'runs/detect/train#' where # is an integer index.
+    `epochs=100` across five folds is five complete trainings. Reduce `epochs`, or start with `k=3`, when you are still iterating. On CPU, use a small `imgsz` and expect this to take hours.
 
-    ```python
-    results = {}
+## Aggregating the Results
 
-    # Define your additional arguments here
-    batch = 16
-    project = "kfold_demo"
-    epochs = 100
+This is the step that turns `k` runs into one number. `model.train()` returns a `DetMetrics` object per fold; the spread across folds tells you how sensitive your model is to the split:
 
-    for k, dataset_yaml in enumerate(ds_yamls):
-        model = YOLO(weights_path, task="detect")
-        results[k] = model.train(
-            data=dataset_yaml, epochs=epochs, batch=batch, project=project, name=f"fold_{k + 1}"
-        )  # include any additional train arguments
-    ```
+```python
+summary = pd.DataFrame(
+    {
+        k + 1: {
+            "mAP50-95": r.box.map,
+            "mAP50": r.box.map50,
+            "precision": r.box.mp,
+            "recall": r.box.mr,
+            "fitness": r.fitness,
+        }
+        for k, r in results.items()
+    }
+).T
+summary.index.name = "fold"
+print(summary.round(4))
+print(summary.agg(["mean", "std"]).round(4))
+```
 
-3. You can also use [Ultralytics data.split.autosplit](../reference/data/split.md) function for automatic dataset splitting:
+Report the **mean** as your headline number and the **standard deviation** as its uncertainty. A large spread means the metric was never stable enough to compare two models on a single split. Note that `fitness` is a property on the returned object while `box.fitness` is a method — printing the latter without `()` gives a `<bound method>` repr rather than a value.
+
+## Watch for Duplicate and Near-Duplicate Images
+
+Cross validation assumes the folds are independent. Duplicated or near-duplicated images break that assumption: a copy in training and its twin in validation inflates that fold's metrics, and no amount of averaging removes the bias.
+
+This is not a hypothetical for the example dataset. Hashing every file finds **40 groups of byte-identical images covering 81 files**, 20 of which already straddle the shipped train/val/test boundary — and none of them is detectable from the filenames. Deduplicate before splitting:
+
+```python
+import hashlib
+from collections import defaultdict
+
+by_hash = defaultdict(list)
+for stem, image in img_by_stem.items():
+    by_hash[hashlib.md5(image.read_bytes()).hexdigest()].append(stem)
+duplicates = {h: s for h, s in by_hash.items() if len(s) > 1}
+print(f"{len(duplicates)} duplicate groups covering {sum(len(s) for s in duplicates.values())} images")
+```
+
+```text
+40 duplicate groups covering 81 images
+```
+
+Either drop the extras before building `labels_df`, or keep them together by assigning one fold per hash group with `GroupKFold`. The same reasoning applies to frames from one video, photographs of one subject, and augmented copies of one source image — group them, or the folds are not independent.
+
+!!! tip "Just need a single train/val split?"
+
+    If cross validation is more than your project needs, [`autosplit`](../reference/data/split.md) writes a one-shot split in a single call. It handles image extensions correctly, but it writes bare `.txt` files without a dataset YAML, and its ratios are sampling probabilities rather than exact proportions:
 
     ```python
     from ultralytics.data.split import autosplit
 
-    # Automatically split dataset into train/val/test
     autosplit(path="path/to/images", weights=(0.8, 0.2, 0.0), annotated_only=True)
     ```
 
 ## Conclusion
 
-In this guide, we have explored the process of using K-Fold cross-validation for training the YOLO object detection model. We learned how to split our dataset into K partitions, ensuring a balanced class distribution across the different folds.
-
-We also explored the procedure for creating report DataFrames to visualize the data splits and label distributions across these splits, providing us a clear insight into the structure of our training and validation sets.
-
-Optionally, we saved our records for future reference, which could be particularly useful in large-scale projects or when troubleshooting model performance.
-
-Finally, we implemented the actual model training using each split in a loop, saving our training results for further analysis and comparison.
-
-This technique of K-Fold cross-validation is a robust way of making the most out of your available data, and it helps to ensure that your model performance is reliable and consistent across different data subsets. This results in a more generalizable and reliable model that is less likely to [overfit](https://www.ultralytics.com/glossary/overfitting) to specific data patterns.
-
-Remember that although we used YOLO in this guide, these steps are mostly transferable to other machine learning models. Understanding these steps allows you to apply cross-validation effectively in your own machine learning projects.
+K-Fold cross validation gives you `k` independent estimates of model quality instead of one, which is what makes results comparable on small or imbalanced datasets where a single validation split is mostly noise. Average the per-fold `mAP50-95` for your headline number and report the standard deviation alongside it, then read the [YOLO performance metrics guide](yolo-performance-metrics.md) to interpret what the spread is telling you. Once your baseline is stable enough to compare against, move on to [hyperparameter tuning](hyperparameter-tuning.md).
 
 ## FAQ
 
 ### What is K-Fold Cross Validation and why is it useful in object detection?
 
-K-Fold Cross Validation is a technique where the dataset is divided into 'k' subsets (folds) to evaluate model performance more reliably. Each fold serves as both training and [validation data](https://www.ultralytics.com/glossary/validation-data). In the context of object detection, using K-Fold Cross Validation helps to ensure your Ultralytics YOLO model's performance is robust and generalizable across different data splits, enhancing its reliability. For detailed instructions on setting up K-Fold Cross Validation with Ultralytics YOLO, refer to [K-Fold Cross Validation with Ultralytics](#introduction).
+K-Fold cross validation divides a dataset into `k` folds and trains `k` models, each validating on a different fold, so every image is validated exactly once. For object detection this matters because a single validation split can easily over- or under-represent a rare class or a difficult scene, making one model look better than another for reasons that have nothing to do with the model. Averaging across folds removes that dependence. Start with the [K-Fold split](#splitting-into-k-folds) section for the implementation.
 
-### How do I implement K-Fold Cross Validation using Ultralytics YOLO?
+### How do I combine the results from all K folds into one number?
 
-To implement K-Fold Cross Validation with Ultralytics YOLO, you need to follow these steps:
+Average the per-fold metric you care about. `results[k].box.map` holds `mAP50-95` for fold `k`, so `sum(r.box.map for r in results.values()) / len(results)` is the cross-validated mAP, and the standard deviation across folds tells you how sensitive the model is to the split. See [Aggregating the Results](#aggregating-the-results).
 
-1. Verify annotations are in the [YOLO detection format](../datasets/detect/index.md).
-2. Use Python libraries like `sklearn`, `pandas`, and `pyyaml`.
-3. Create feature vectors from your dataset.
-4. Split your dataset using `KFold` from `sklearn.model_selection`.
-5. Train the YOLO model on each split.
+### How much disk space does K-Fold cross validation need?
 
-For a comprehensive guide, see the [K-Fold Dataset Split](#k-fold-dataset-split) section in our documentation.
+None beyond the dataset itself, if you define each fold as a `.txt` list of image paths. Copying images into per-fold directories instead multiplies the dataset by `k` — on this 110 MB dataset at `k=5` that is about 525 MB and 15,040 files, against 500 KB and 15 files for the list approach.
 
-### How should I design folds for other YOLO tasks like segmentation, classification, pose, or OBB?
+### Should I use K-Fold cross validation or a single train/val split?
 
-The workflow in this guide targets the YOLO detection format, but the same approach adapts to every YOLO task — the task changes how you compose the folds, not whether cross-validation helps:
+Use K-Fold when the dataset is small, noisy, or class-imbalanced enough that a single validation split gives an unstable estimate. For large, diverse datasets a well-constructed train/val/test split reaches the same conclusion for a fraction of the compute, since K-Fold costs `k` complete training runs.
+
+### How should I design folds for segmentation, classification, pose, or OBB?
+
+The workflow here targets the YOLO detection format, but it adapts to every YOLO task — the task changes how you compose the folds, not whether cross validation helps:
 
 | Task       | Fold design                                                                                                                                                                |
 | :--------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -324,16 +364,10 @@ The workflow in this guide targets the YOLO detection format, but the same appro
 | `pose`     | Split by subject or sequence so the same person or animal never appears on both sides of a fold.                                                                           |
 | `obb`      | Split at the image level, keeping tiles or crops from the same scene together — especially important for aerial imagery.                                                   |
 
-Whatever the task, keep near-duplicate and related samples out of opposing folds: that kind of leakage inflates validation metrics well beyond what the model will achieve in production.
+### Can I use K-Fold Cross Validation with my own dataset?
 
-### Why should I use Ultralytics YOLO for object detection?
+Yes, as long as the annotations are in [YOLO detection format](../datasets/detect/index.md) and every image has exactly one label file. Point `dataset_path` at your dataset and read `classes` from your own data YAML. The assertion in [Building the Class-Count Matrix](#building-the-class-count-matrix) fails loudly if the pairing is not one-to-one, which is the failure worth catching early.
 
-Ultralytics YOLO offers state-of-the-art, real-time object detection with high [accuracy](https://www.ultralytics.com/glossary/accuracy) and efficiency. It's versatile, supporting multiple [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) tasks such as [detection](../tasks/detect.md), [instance segmentation](../tasks/segment.md), [semantic segmentation](../tasks/semantic.md), and [classification](../tasks/classify.md). Additionally, it integrates seamlessly with tools like [Ultralytics Platform](../platform/index.md) for no-code model training and deployment. For more details, explore the benefits and features on our [Ultralytics YOLO page](https://www.ultralytics.com/yolo).
+### Do I still need a separate test set?
 
-### How can I ensure my annotations are in the correct format for Ultralytics YOLO?
-
-Your annotations should follow the YOLO detection format. Each annotation file must list the object class, alongside its [bounding box](https://www.ultralytics.com/glossary/bounding-box) coordinates in the image. The YOLO format ensures streamlined and standardized data processing for training object detection models. For more information on proper annotation formatting, visit the [YOLO detection format guide](../datasets/detect/index.md).
-
-### Can I use K-Fold Cross Validation with custom datasets other than Fruit Detection?
-
-Yes, you can use K-Fold Cross Validation with any custom dataset as long as the annotations are in the YOLO detection format. Replace the dataset paths and class labels with those specific to your custom dataset. This flexibility ensures that any object detection project can benefit from robust model evaluation using K-Fold Cross Validation. For a practical example, review our [Generating Feature Vectors](#generating-feature-vectors-for-object-detection-dataset) section.
+Yes. Cross validation measures how well a training recipe generalizes, but once you start choosing between recipes on the cross-validated score, that score has informed your decisions. Hold out a test split that takes no part in the folds, and evaluate on it once at the end.

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -7,7 +7,7 @@ keywords: K-Fold cross validation, YOLO, Ultralytics, scikit-learn, pandas, data
 
 # How to Run K-Fold Cross Validation with Ultralytics YOLO
 
-K-Fold cross validation splits a dataset into `k` equally sized folds and trains `k` models, each holding out a different fold for validation, so every image is used for both training and validation exactly once. Averaging the `k` results gives a far more stable estimate of model quality than a single train/val split, because it no longer depends on which images happened to land in the validation set.
+K-Fold cross validation splits a dataset into `k` equally sized folds and trains `k` models, each holding out a different fold for validation. Every image is therefore validated exactly once and trained on in the other `k - 1` folds. Averaging the `k` results gives a far more stable estimate of model quality than a single train/val split, because it no longer depends on which images happened to land in the validation set.
 
 This guide builds `k=5` folds for a [YOLO detection dataset](../datasets/detect/index.md) using scikit-learn and pandas, writes one dataset YAML per fold, trains [Ultralytics YOLO26](../models/yolo26.md) on each of them, and aggregates the results. Cross validation pays off most when a dataset is small, noisy, or class-imbalanced; for large, diverse datasets a single well-constructed train/val/test split gives the same answer for a fifth of the compute.
 

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -21,13 +21,13 @@ This walkthrough uses the [African Wildlife](../datasets/detect/african-wildlife
 
 | Class Label | Instance Count |
 | :---------- | -------------: |
-| buffalo     |            554 |
-| elephant    |            748 |
-| rhino       |            559 |
-| zebra       |            824 |
-| **Total**   |      **2,685** |
+| buffalo     |            488 |
+| elephant    |            649 |
+| rhino       |            484 |
+| zebra       |            689 |
+| **Total**   |      **2,310** |
 
-The dataset ships 1,504 images split into `train`, `val` and `test` directories. K-Fold **pools all three** and re-partitions them, which is the point — the shipped boundary is exactly what cross validation replaces.
+The dataset ships 1,504 images split into `train`, `val` and `test`. This guide folds the 1,277 `train` and `val` images and **leaves `test` untouched** — cross validation replaces the train/val boundary, not the held-out set. The counts above are for the folded pool, not the whole dataset. Keeping a split out of the folds is what lets you evaluate once at the end on data that took no part in choosing anything.
 
 Install Ultralytics and the two helper libraries this guide uses:
 
@@ -60,25 +60,31 @@ from pathlib import Path
 from ultralytics.data.utils import IMG_FORMATS
 
 dataset_path = Path(data["path"])  # from check_det_dataset above
+pool = ("train", "val")  # the shipped test split stays out of the folds
 
-labels = sorted((dataset_path / "labels").rglob("*.txt"))
-images = sorted(p for p in (dataset_path / "images").rglob("*.*") if p.suffix[1:].lower() in IMG_FORMATS)
+images = sorted(p for s in pool for p in (dataset_path / "images" / s).rglob("*.*") if p.suffix[1:].lower() in IMG_FORMATS)
+labels = sorted(p for s in pool for p in (dataset_path / "labels" / s).rglob("*.txt"))
 
-img_by_stem = {p.stem: p for p in images}
-lbl_by_stem = {p.stem: p for p in labels}
-assert not (set(img_by_stem) ^ set(lbl_by_stem)), "every image needs exactly one label file, matched by filename"
-print(f"{len(images)} images, {len(labels)} labels")
+# key by path relative to images/ and labels/, so the same basename in two splits stays distinct
+img_by_key = {p.relative_to(dataset_path / "images").with_suffix(""): p for p in images}
+lbl_by_key = {p.relative_to(dataset_path / "labels").with_suffix(""): p for p in labels}
+
+orphans = sorted(set(lbl_by_key) - set(img_by_key))
+assert not orphans, f"label files with no matching image: {orphans[:3]}"
+backgrounds = set(img_by_key) - set(lbl_by_key)
+print(f"{len(images)} images, {len(labels)} labels, {len(backgrounds)} background images")
 ```
 
 ```text
-1504 images, 1504 labels
+1277 images, 1277 labels, 0 background images
 ```
 
 !!! warning "Three details this block gets right on purpose"
 
     - **Scope the label glob to `labels/`.** Ultralytics datasets nest labels as `labels/train/`, `labels/val/`, `labels/test/`, and a pattern that expects them one level up returns nothing at all. A glob rooted at the dataset directory instead re-reads its own output on a second run.
     - **Use `IMG_FORMATS` rather than a hand-written extension list.** Ultralytics accepts 13 image formats, and on Linux and macOS `Path.rglob` matches extensions case-sensitively regardless of the filesystem — so a hardcoded `[".jpg", ".jpeg", ".png"]` silently drops the three `.JPG` files in this dataset, and every `.webp` or `.tif` in yours.
-    - **Pair by filename stem, never by position.** The two lists are produced by different globs, so any dropped or extra file shifts one relative to the other and every later pair is wrong. That failure trains cleanly and reports meaningless metrics, because images end up in one fold with another image's labels.
+    - **Pair by key, never by position, and make the key the path under `images`/`labels` rather than the bare filename.** The two lists come from different globs, so any dropped or extra file shifts one relative to the other and every later pair is wrong — a failure that trains cleanly and reports meaningless metrics. The bare stem is not enough either: Ultralytics maps `images/train/0001.jpg` to `labels/train/0001.txt`, so the same basename is legal in two splits, and keying on `0001` would silently keep one of them while the assertion still passed.
+    - **An image with no label file is a background, not an error.** Ultralytics reads a missing label file as an empty label array, so the check above rejects only *orphan labels* — a `.txt` with no image, which really is a mistake.
 
 Now count the instances per class:
 
@@ -90,23 +96,23 @@ import pandas as pd
 classes = data["names"]  # {0: 'buffalo', 1: 'elephant', 2: 'rhino', 3: 'zebra'}
 cls_idx = sorted(classes)
 
-labels_df = pd.DataFrame(0.0, index=sorted(img_by_stem), columns=cls_idx)
-for stem, label_file in lbl_by_stem.items():
+labels_df = pd.DataFrame(0.0, index=sorted(img_by_key), columns=cls_idx)
+for key, label_file in lbl_by_key.items():  # images with no label file keep their all-zero row
     counter = Counter()
     for line in label_file.read_text().splitlines():
         if line.strip():  # skip blank lines; split() also handles tabs and leading whitespace
             counter[int(line.split()[0])] += 1
     for cls, n in counter.items():
-        labels_df.loc[stem, cls] = n
+        labels_df.loc[key, cls] = n
 
 print(labels_df.sum().rename(classes))
 ```
 
 ```text
-buffalo     554.0
-elephant    748.0
-rhino       559.0
-zebra       824.0
+buffalo     488.0
+elephant    649.0
+rhino       484.0
+zebra       689.0
 dtype: float64
 ```
 
@@ -134,11 +140,11 @@ for fold in folds:
 ```
 
 ```text
-fold_1: train=1203 val=301
-fold_2: train=1203 val=301
-fold_3: train=1203 val=301
-fold_4: train=1203 val=301
-fold_5: train=1204 val=300
+fold_1: train=1021 val=256
+fold_2: train=1021 val=256
+fold_3: train=1022 val=255
+fold_4: train=1022 val=255
+fold_5: train=1022 val=255
 ```
 
 !!! warning "Assign with `.loc[rows, column]`, not `df[column].loc[rows]`"
@@ -160,14 +166,14 @@ print(fold_distrb.round(3))
 
 ```text
         buffalo  elephant  rhino  zebra
-fold_1    0.265     0.324  0.265  0.232
-fold_2    0.300     0.228  0.213  0.235
-fold_3    0.164     0.226  0.265  0.268
-fold_4    0.256     0.249  0.262  0.260
-fold_5    0.274     0.228  0.248  0.256
+fold_1    0.235     0.303  0.264  0.271
+fold_2    0.229     0.253  0.241  0.217
+fold_3    0.268     0.176  0.267  0.222
+fold_4    0.208     0.288  0.213  0.224
+fold_5    0.315     0.239  0.267  0.322
 ```
 
-Each cell is the ratio of validation instances to training instances for that class. With `k` folds the expected value is `1 / (k - 1)`, so `0.25` here. Every cell above sits within about a third of that, which is fine — with 554 instances in the rarest class, plain `KFold` spreads them adequately.
+Each cell is the ratio of validation instances to training instances for that class. With `k` folds the expected value is `1 / (k - 1)`, so `0.25` here. Every cell above sits within about a third of that, which is fine — with 484 instances in the rarest class, plain `KFold` spreads them adequately.
 
 The check matters when it fails. On a dataset with a class of only a handful of instances, some folds end up with **zero** validation instances of it, per-class AP is undefined there, and the average across folds is silently computed over a shifting set of classes. If you see a `0.000` cell, stratify the split on each image's rarest present class:
 
@@ -205,8 +211,8 @@ save_path.mkdir(parents=True, exist_ok=True)
 ds_yamls = []
 for fold in folds:
     for split in ("train", "val"):
-        stems = folds_df.index[folds_df[fold] == split]
-        (save_path / f"{fold}_{split}.txt").write_text("\n".join(str(img_by_stem[s]) for s in stems) + "\n")
+        keys = folds_df.index[folds_df[fold] == split]
+        (save_path / f"{fold}_{split}.txt").write_text("\n".join(str(img_by_key[k]) for k in keys) + "\n")
     fold_yaml = save_path / f"{fold}.yaml"
     fold_yaml.write_text(
         yaml.safe_dump(
@@ -237,9 +243,9 @@ Note that `save_path` sits **beside** the dataset, not inside it. A fold directo
     ```python
     import shutil
 
-    for stem, image in img_by_stem.items():
-        for fold, split in folds_df.loc[stem].items():
-            for src, sub in ((image, "images"), (lbl_by_stem[stem], "labels")):
+    for key, image in img_by_key.items():
+        for fold, split in folds_df.loc[key].items():
+            for src, sub in [(image, "images")] + ([(lbl_by_key[key], "labels")] if key in lbl_by_key else []):
                 dst = save_path / fold / split / sub
                 dst.mkdir(parents=True, exist_ok=True)
                 shutil.copy(src, dst / src.name)
@@ -263,11 +269,11 @@ for k, fold_yaml in enumerate(ds_yamls):
 Each run reports a clean scan, which is the checkpoint confirming images and labels were paired correctly:
 
 ```text
-train: Scanning .../african-wildlife/labels/... 1203 images, 0 backgrounds, 0 corrupt
-val: Scanning .../african-wildlife/labels/... 301 images, 0 backgrounds, 0 corrupt
+train: Scanning .../african-wildlife/labels/train... 1021 images, 0 backgrounds, 0 corrupt
+val: Scanning .../african-wildlife/labels/train... 256 images, 0 backgrounds, 0 corrupt
 ```
 
-A non-zero `backgrounds` count on a fully annotated dataset means images and labels are mispaired — go back to the stem assertion. The directory in the scan line is just wherever the first label file happened to sit, so `labels/test` while training fold 1 is expected and does not mean the fold is wrong.
+The counts match the fold sizes printed earlier, and a non-zero `backgrounds` count on a fully annotated dataset means images and labels are mispaired — go back to the orphan-label check. The directory in the scan line is just wherever the first label file happened to sit, so both lines naming the same split is expected and does not mean the fold is wrong.
 
 !!! note "Budget for `k` full training runs"
 
@@ -301,21 +307,21 @@ Report the **mean** as your headline number and the **standard deviation** as it
 
 Cross validation assumes the folds are independent. Duplicated or near-duplicated images break that assumption: a copy in training and its twin in validation inflates that fold's metrics, and no amount of averaging removes the bias.
 
-This is not a hypothetical for the example dataset. Hashing every file finds **40 groups of byte-identical images covering 81 files**, 20 of which already straddle the shipped train/val/test boundary — and none of them is detectable from the filenames. Deduplicate before splitting:
+This is not a hypothetical for the example dataset. Hashing the folded pool finds **25 groups of byte-identical images covering 50 files**, none of them detectable from the filenames. Deduplicate before splitting:
 
 ```python
 import hashlib
 from collections import defaultdict
 
 by_hash = defaultdict(list)
-for stem, image in img_by_stem.items():
-    by_hash[hashlib.md5(image.read_bytes()).hexdigest()].append(stem)
+for key, image in img_by_key.items():
+    by_hash[hashlib.md5(image.read_bytes()).hexdigest()].append(key)
 duplicates = {h: s for h, s in by_hash.items() if len(s) > 1}
 print(f"{len(duplicates)} duplicate groups covering {sum(len(s) for s in duplicates.values())} images")
 ```
 
 ```text
-40 duplicate groups covering 81 images
+25 duplicate groups covering 50 images
 ```
 
 Either drop the extras before building `labels_df`, or keep them together by assigning one fold per hash group with `GroupKFold`. The same reasoning applies to frames from one video, photographs of one subject, and augmented copies of one source image — group them, or the folds are not independent.
@@ -370,4 +376,4 @@ Yes, as long as the annotations are in [YOLO detection format](../datasets/detec
 
 ### Do I still need a separate test set?
 
-Yes. Cross validation measures how well a training recipe generalizes, but once you start choosing between recipes on the cross-validated score, that score has informed your decisions. Hold out a test split that takes no part in the folds, and evaluate on it once at the end.
+Yes, and this guide keeps one: the dataset's shipped `test` split is excluded from the folds by the `pool = ("train", "val")` line. Cross validation measures how well a training recipe generalizes, but once you start choosing between recipes on the cross-validated score, that score has informed your decisions. Evaluate on the held-out split once, at the end, with `model.val(split="test")`.

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -247,11 +247,15 @@ Note that `save_path` sits **beside** the dataset, not inside it. A fold directo
 
     for key, image in img_by_key.items():
         for fold, split in folds_df.loc[key].items():
-            for src, sub in [(image, "images")] + ([(lbl_by_key[key], "labels")] if key in lbl_by_key else []):
-                dst = save_path / fold / split / sub
-                dst.mkdir(parents=True, exist_ok=True)
-                shutil.copy(src, dst / src.name)
+            for src, sub, suffix in [(image, "images", image.suffix)] + (
+                [(lbl_by_key[key], "labels", ".txt")] if key in lbl_by_key else []
+            ):
+                dst = (save_path / fold / split / sub / key).with_suffix(suffix)
+                dst.parent.mkdir(parents=True, exist_ok=True)  # key keeps the split subdirectory
+                shutil.copy(src, dst)
     ```
+
+    The destination reuses the same relative `key`, for the same reason the pairing does: flattening to the bare filename lets `train/0001.jpg` and `val/0001.jpg` land on top of each other, and `shutil.copy` overwrites without a word.
 
     `shutil.copy` overwrites an existing destination silently, so a re-run is not protected in either approach — delete `save_path` first.
 
@@ -374,8 +378,16 @@ The workflow here targets the YOLO detection format, but it adapts to every YOLO
 
 ### Can I use K-Fold Cross Validation with my own dataset?
 
-Yes, as long as the annotations are in [YOLO detection format](../datasets/detect/index.md) and every image has exactly one label file. Point `dataset_path` at your dataset and read `classes` from your own data YAML. The assertion in [Building the Class-Count Matrix](#building-the-class-count-matrix) fails loudly if the pairing is not one-to-one, which is the failure worth catching early.
+Yes, as long as the annotations are in [YOLO detection format](../datasets/detect/index.md). Point `dataset_path` at your dataset and read `classes` from your own data YAML. Images with no label file are fine — Ultralytics reads them as backgrounds and they get an all-zero row. The check in [Building the Class-Count Matrix](#building-the-class-count-matrix) rejects only the reverse case, a label file with no image, which is the failure worth catching early.
 
 ### Do I still need a separate test set?
 
-Yes, and this guide keeps one: the dataset's shipped `test` split is excluded from the folds by the `pool = ("train", "val")` line. Cross validation measures how well a training recipe generalizes, but once you start choosing between recipes on the cross-validated score, that score has informed your decisions. Evaluate on the held-out split once, at the end, with `model.val(split="test")`.
+Yes, and this guide keeps one: the dataset's shipped `test` split is excluded from the folds by the `pool = ("train", "val")` line. Cross validation measures how well a training recipe generalizes, but once you start choosing between recipes on the cross-validated score, that score has informed your decisions.
+
+Use the held-out split once, at the end, and note that neither the fold models nor the fold YAMLs are the right thing to point at it: each fold model saw only four fifths of the pool, and a `fold_*.yaml` defines no `test` entry, so `model.val(split="test")` against one raises `FileNotFoundError: ... 'test:' is not defined`. Retrain the settled recipe on the whole pool, then validate against the **original** dataset YAML:
+
+```python
+final = YOLO("yolo26n.pt")
+final.train(data="african-wildlife.yaml", epochs=100, batch=16)  # train + val, as the dataset ships them
+print(final.val(split="test").box.map)  # the number to report
+```

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -40,7 +40,8 @@ Then download the dataset once, so the rest of the guide can read it from disk:
 ```python
 from ultralytics.data.utils import check_det_dataset
 
-data = check_det_dataset("african-wildlife.yaml")  # downloads on first use
+dataset_yaml = "african-wildlife.yaml"  # swap in your own; every later step reads this variable
+data = check_det_dataset(dataset_yaml)  # downloads on first use
 print(data["path"])
 ```
 
@@ -263,7 +264,7 @@ Note that `save_path` sits **beside** the dataset, not inside it. A fold directo
                 shutil.copy(src, dst)
     ```
 
-    The destination reuses the same relative `key`, for the same reason the pairing does: flattening to the bare filename lets `train/0001.jpg` and `val/0001.jpg` land on top of each other, and `shutil.copy` overwrites without a word. The suffix is appended to `key.name` rather than set with `with_suffix`, which would turn `foo.bar.jpg` into `foo.jpg` and collide all over again.
+    This only rearranges files. The `ds_yamls` built above still point at the text lists, so to train from the copied tree you would also write one YAML per fold whose `train` and `val` name the new `fold_N/train` and `fold_N/val` directories. The destination reuses the same relative `key`, for the same reason the pairing does: flattening to the bare filename lets `train/0001.jpg` and `val/0001.jpg` land on top of each other, and `shutil.copy` overwrites without a word. The suffix is appended to `key.name` rather than set with `with_suffix`, which would turn `foo.bar.jpg` into `foo.jpg` and collide all over again.
 
     `shutil.copy` overwrites an existing destination silently, so a re-run is not protected in either approach — delete `save_path` first.
 
@@ -412,10 +413,10 @@ final_dir.mkdir(parents=True, exist_ok=True)
 )
 
 final = YOLO("yolo26n.pt")
-final.train(data=str(final_dir / "final.yaml"), epochs=100, batch=16)
+final.train(data=str(final_dir / "final.yaml"), epochs=100, batch=16, patience=0)  # patience=0 disables early stopping
 
 fitted = YOLO(final.trainer.last)  # last.pt, so no checkpoint was chosen using training labels
-print(fitted.val(data="african-wildlife.yaml", split="test").box.map)  # the number to report
+print(fitted.val(data=dataset_yaml, split="test").box.map)  # the number to report
 ```
 
-Two details carry the correctness here. Passing `data=` to `val()` redirects it away from `final.yaml`, which has no `test` entry, to the original dataset. And the evaluation uses `last.pt` rather than the model `train()` leaves loaded: with `pool.txt` on both sides, every epoch validates on its own training images, so `best.pt` is picked on labels the model has already seen — `Model.train()` reloads exactly that checkpoint. Taking the final epoch's weights instead keeps the test score free of any selection. Train for a fixed epoch budget for the same reason, rather than relying on early stopping against the overlapping split.
+Two details carry the correctness here. Passing `data=dataset_yaml` to `val()` redirects it away from `final.yaml`, which has no `test` entry, to the original dataset — and your own dataset's YAML needs a `test` entry for this step to mean anything. And the evaluation uses `last.pt` rather than the model `train()` leaves loaded: with `pool.txt` on both sides, every epoch validates on its own training images, so `best.pt` is picked on labels the model has already seen — `Model.train()` reloads exactly that checkpoint. Taking the final epoch's weights instead keeps the test score free of any selection. `patience=0` is there for the same reason: left at its default, early stopping would decide when to stop from metrics measured on the training images.

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -198,7 +198,15 @@ for i, (train, val) in enumerate(kfolds, start=1):
 
 Rebuilding `folds_df` is the part that is easy to miss: every step after this reads `folds_df`, never `kfolds`, so swapping the splitter alone leaves the original unstratified folds in place with nothing to show for it.
 
-This is a proxy, not true multi-label stratification: an image containing several classes contributes to only one stratum. `StratifiedKFold` cannot take a multi-label target directly — it raises `ValueError: Supported target types are: ('binary', 'multiclass')` — so exact multi-label balance needs the `iterative-stratification` package.
+Check the stratum sizes before trusting the result, because `StratifiedKFold` degrades quietly rather than refusing:
+
+```python
+print(y.value_counts().min(), "smallest stratum vs", ksplit, "folds")
+```
+
+A stratum smaller than `ksplit` produces a `UserWarning` and folds in which that class is simply absent from validation — measured on scikit-learn 1.7.2, a stratum of 1 leaves 4 of 5 folds with no validation instances of it, a stratum of 2 leaves 3, and only a stratum of `ksplit` or more is clean. That is the failure this recipe was meant to fix, so when the smallest stratum is under `ksplit`, lower `k` or group the rare classes instead of stratifying on them. The background stratum (`-1`) counts too.
+
+This is also a proxy, not true multi-label stratification: an image containing several classes contributes to only one stratum. `StratifiedKFold` cannot take a multi-label target directly — it raises `ValueError: Supported target types are: ('binary', 'multiclass')` — so exact multi-label balance needs the `iterative-stratification` package.
 
 ## Creating One Dataset YAML per Fold
 
@@ -384,10 +392,28 @@ Yes, as long as the annotations are in [YOLO detection format](../datasets/detec
 
 Yes, and this guide keeps one: the dataset's shipped `test` split is excluded from the folds by the `pool = ("train", "val")` line. Cross validation measures how well a training recipe generalizes, but once you start choosing between recipes on the cross-validated score, that score has informed your decisions.
 
-Use the held-out split once, at the end, and note that neither the fold models nor the fold YAMLs are the right thing to point at it: each fold model saw only four fifths of the pool, and a `fold_*.yaml` defines no `test` entry, so `model.val(split="test")` against one raises `FileNotFoundError: ... 'test:' is not defined`. Retrain the settled recipe on the whole pool, then validate against the **original** dataset YAML:
+Use the held-out split once, at the end, and note that neither the fold models nor the fold YAMLs are the right thing to point at it: each fold model saw only four fifths of the pool, and a `fold_*.yaml` defines no `test` entry, so `model.val(split="test")` against one raises `FileNotFoundError: ... 'test:' is not defined`. The original dataset YAML is not it either — its `train` entry is `images/train` alone, so training against it never touches the `val` pool the folds were built from.
+
+Retrain the settled recipe on the whole folded pool with one more path list, then evaluate against the original YAML. This continues the walkthrough above and reuses its `dataset_path`, `img_by_key` and `classes`:
 
 ```python
+final_dir = dataset_path.parent / "final"
+final_dir.mkdir(parents=True, exist_ok=True)
+(final_dir / "pool.txt").write_text("\n".join(str(p) for p in img_by_key.values()) + "\n")
+(final_dir / "final.yaml").write_text(
+    yaml.safe_dump(
+        {
+            "path": final_dir.as_posix(),
+            "train": "pool.txt",
+            "val": "pool.txt",  # training requires a val entry; selection is already done, so this one is a formality
+            "names": classes,
+        }
+    )
+)
+
 final = YOLO("yolo26n.pt")
-final.train(data="african-wildlife.yaml", epochs=100, batch=16)  # train + val, as the dataset ships them
-print(final.val(split="test").box.map)  # the number to report
+final.train(data=str(final_dir / "final.yaml"), epochs=100, batch=16)
+print(final.val(data="african-wildlife.yaml", split="test").box.map)  # the number to report
 ```
+
+Passing `data=` to `val()` is what redirects it away from `final.yaml`, which has no `test` entry, to the original dataset.

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -258,12 +258,12 @@ Note that `save_path` sits **beside** the dataset, not inside it. A fold directo
             for src, sub, suffix in [(image, "images", image.suffix)] + (
                 [(lbl_by_key[key], "labels", ".txt")] if key in lbl_by_key else []
             ):
-                dst = (save_path / fold / split / sub / key).with_suffix(suffix)
+                dst = save_path / fold / split / sub / key.parent / f"{key.name}{suffix}"
                 dst.parent.mkdir(parents=True, exist_ok=True)  # key keeps the split subdirectory
                 shutil.copy(src, dst)
     ```
 
-    The destination reuses the same relative `key`, for the same reason the pairing does: flattening to the bare filename lets `train/0001.jpg` and `val/0001.jpg` land on top of each other, and `shutil.copy` overwrites without a word.
+    The destination reuses the same relative `key`, for the same reason the pairing does: flattening to the bare filename lets `train/0001.jpg` and `val/0001.jpg` land on top of each other, and `shutil.copy` overwrites without a word. The suffix is appended to `key.name` rather than set with `with_suffix`, which would turn `foo.bar.jpg` into `foo.jpg` and collide all over again.
 
     `shutil.copy` overwrites an existing destination silently, so a re-run is not protected in either approach — delete `save_path` first.
 

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -95,7 +95,7 @@ from collections import Counter
 
 import pandas as pd
 
-classes = data["names"]  # {0: 'buffalo', 1: 'elephant', 2: 'rhino', 3: 'zebra'}
+classes = data["names"]  # check_det_dataset normalizes names to {int: str}, so the keys are the class IDs
 cls_idx = sorted(classes)
 
 labels_df = pd.DataFrame(0.0, index=sorted(img_by_key), columns=cls_idx)

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -72,6 +72,7 @@ labels = sorted(p for s in pool for p in (dataset_path / "labels" / s).rglob("*.
 img_by_key = {p.relative_to(dataset_path / "images").with_suffix(""): p for p in images}
 lbl_by_key = {p.relative_to(dataset_path / "labels").with_suffix(""): p for p in labels}
 
+assert len(img_by_key) == len(images), "two images share one stem, i.e. foo.jpg and foo.png; they map to one label file"
 orphans = sorted(set(lbl_by_key) - set(img_by_key))
 assert not orphans, f"label files with no matching image: {orphans[:3]}"
 backgrounds = set(img_by_key) - set(lbl_by_key)
@@ -87,7 +88,7 @@ print(f"{len(images)} images, {len(labels)} labels, {len(backgrounds)} backgroun
     - **Scope the label glob to `labels/`.** Ultralytics datasets nest labels as `labels/train/`, `labels/val/`, `labels/test/`, and a pattern that expects them one level up returns nothing at all. A glob rooted at the dataset directory instead re-reads its own output on a second run.
     - **Use `IMG_FORMATS` rather than a hand-written extension list.** Ultralytics accepts 13 image formats, and on Linux and macOS `Path.rglob` matches extensions case-sensitively regardless of the filesystem — so a hardcoded `[".jpg", ".jpeg", ".png"]` silently drops the three `.JPG` files in this dataset, and every `.webp` or `.tif` in yours.
     - **Pair by key, never by position, and make the key the path under `images`/`labels` rather than the bare filename.** The two lists come from different globs, so any dropped or extra file shifts one relative to the other and every later pair is wrong — a failure that trains cleanly and reports meaningless metrics. The bare stem is not enough either: Ultralytics maps `images/train/0001.jpg` to `labels/train/0001.txt`, so the same basename is legal in two splits, and keying on `0001` would silently keep one of them while the assertion still passed.
-    - **An image with no label file is a background, not an error.** Ultralytics reads a missing label file as an empty label array, so the check above rejects only *orphan labels* — a `.txt` with no image, which really is a mistake.
+    - **An image with no label file is a background, not an error.** Ultralytics reads a missing label file as an empty label array, so the checks above reject only two things: an *orphan label* — a `.txt` with no image — and two images sharing one stem, such as `foo.jpg` and `foo.png`. The second is rejected rather than resolved because `img2label_paths` maps both to the same `foo.txt`, so the package cannot tell them apart either; dropping one silently would be worse than stopping.
 
 Now count the instances per class:
 

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -368,7 +368,7 @@ Average the per-fold metric you care about. `results[k].box.map` holds `mAP50-95
 
 ### How much disk space does K-Fold cross validation need?
 
-None beyond the dataset itself, if you define each fold as a `.txt` list of image paths. Copying images into per-fold directories instead multiplies the dataset by `k` — on this 110 MB dataset at `k=5` that is about 525 MB and 15,040 files, against 500 KB and 15 files for the list approach.
+None beyond the dataset itself, if you define each fold as a `.txt` list of image paths. Copying images into per-fold directories instead multiplies the folded pool by `k` — for the 1,277 pooled images and labels here, 89 MB, that is about 445 MB and 12,770 files at `k=5`, against 402 KB and 15 files for the list approach.
 
 ### Should I use K-Fold cross validation or a single train/val split?
 

--- a/docs/en/guides/knowledge-distillation.md
+++ b/docs/en/guides/knowledge-distillation.md
@@ -320,4 +320,4 @@ Yes. Any Ultralytics `.pt` checkpoint works as a teacher as long as it is from t
 
 ### Does knowledge distillation work with YOLO11 and YOLOv8?
 
-Yes. Distillation is family-agnostic — a YOLO11 teacher distills into a YOLO11 student, and a YOLOv8 teacher into a YOLOv8 student. What is not supported is crossing families, such as a YOLO11 teacher with a YOLO26 student.
+Yes. Distillation reads features by layer index rather than by architecture, so a YOLO11 teacher distills into a YOLO11 student and a YOLOv8 teacher into a YOLOv8 student, both verified to train. What is not supported is crossing families, such as a YOLO11 teacher with a YOLO26 student.

--- a/docs/en/guides/knowledge-distillation.md
+++ b/docs/en/guides/knowledge-distillation.md
@@ -41,7 +41,7 @@ Train a smaller student model with guidance from a larger teacher by adding the 
         ```python
         from ultralytics import YOLO
 
-        model = YOLO("yolo26n-distill.pt")  # downloads on first use
+        model = YOLO("yolo26n-distill.pt")  # fetched from the Ultralytics release assets on first use
         results = model.predict("https://ultralytics.com/images/bus.jpg")
         ```
 

--- a/docs/en/guides/knowledge-distillation.md
+++ b/docs/en/guides/knowledge-distillation.md
@@ -92,15 +92,15 @@ Before you begin, ensure you meet the following requirements:
 
 Ultralytics extracts features from the three neck layers feeding the model's head, so every task whose head inherits from `Detect` is compatible.
 
-| Task       | Supported | Accuracy verified                                          |
-| ---------- | --------- | ---------------------------------------------------------- |
+| Task       | Supported | Accuracy verified                                           |
+| ---------- | --------- | ----------------------------------------------------------- |
 | `detect`   | Yes       | Yes — benchmarked on COCO (see [Performance](#performance)) |
-| `segment`  | Yes       | Not yet benchmarked                                        |
-| `semantic` | No        | —                                                          |
-| `depth`    | No        | —                                                          |
-| `classify` | No        | —                                                          |
-| `pose`     | Yes       | Not yet benchmarked                                        |
-| `obb`      | Yes       | Not yet benchmarked                                        |
+| `segment`  | Yes       | Not yet benchmarked                                         |
+| `semantic` | No        | —                                                           |
+| `depth`    | No        | —                                                           |
+| `classify` | No        | —                                                           |
+| `pose`     | Yes       | Not yet benchmarked                                         |
+| `obb`      | Yes       | Not yet benchmarked                                         |
 
 An unsupported task fails immediately with `ValueError: No Detect head found in model`. [RT-DETR](../models/rtdetr.md) is unsupported for the same reason.
 

--- a/docs/en/guides/knowledge-distillation.md
+++ b/docs/en/guides/knowledge-distillation.md
@@ -253,7 +253,7 @@ Mid-run checkpoints keep the teacher and projector alongside the student, so a `
 2. The **student model** trains with standard task losses plus distillation guidance
 3. Features are captured from the three neck layers that feed the student's Detect-family head, and from the head output itself
 4. One **1×1 convolutional projector** per neck level (`Conv2d → ReLU → Conv2d`) maps each student feature map to the teacher's channel count
-5. A **score-weighted L2 loss** compares projected student features with teacher features, weighted per anchor by the teacher's max class confidence — taken from the head output captured in step 3 and averaged across its one-to-many and one-to-one branches
+5. A **score-weighted L2 loss** compares projected student features with teacher features, weighted per anchor by the teacher's confidence. That weight comes from the head output captured in step 3: the one-to-many and one-to-one class **logits** are averaged first, and `sigmoid` and the per-anchor maximum are taken afterwards — averaging the two branches' confidences instead would give different weights
 6. The distillation loss combines with standard losses using the `dis` weight
 
 For the implementation, see [`ultralytics.nn.distill_model`](../reference/nn/distill_model.md).

--- a/docs/en/guides/knowledge-distillation.md
+++ b/docs/en/guides/knowledge-distillation.md
@@ -1,14 +1,19 @@
 ---
+title: Knowledge Distillation for YOLO26 Models
 comments: true
-description: Master knowledge distillation for Ultralytics YOLO to optimize student model performance with a teacher model.
-keywords: knowledge distillation, YOLO, Ultralytics, object detection, machine learning, computer vision, distill_model, teacher model, student model
+description: Train a smaller YOLO26 student from a larger teacher with the distill_model argument, gaining up to +1.0 mAP on COCO at no extra inference cost.
+keywords: knowledge distillation, YOLO26, Ultralytics, distill_model, teacher model, student model, dis loss weight, model compression, object detection, computer vision
 ---
 
 # Knowledge Distillation
 
-## Quickstart
+Ultralytics YOLO26 supports knowledge distillation directly in `model.train()`: pass a larger teacher checkpoint to the `distill_model` argument and the smaller student learns to match the teacher's neck features alongside its normal detection losses. On COCO this raises student [mAP](yolo-performance-metrics.md) by 0.4 to 1.0 points across the whole family, with no change to model size or inference speed.
 
-Train a smaller student model with guidance from a larger teacher model by adding the `distill_model` argument:
+This guide covers the supported tasks, the recommended teacher and student pairs, the `dis` loss weight, and how to read the extra `dis_loss` column in the [training](../modes/train.md) log.
+
+## Quick Start
+
+Train a smaller student model with guidance from a larger teacher by adding the `distill_model` argument:
 
 !!! example
 
@@ -27,25 +32,42 @@ Train a smaller student model with guidance from a larger teacher model by addin
         yolo train model=yolo26n.pt data=coco8.yaml epochs=100 distill_model=yolo26s.pt
         ```
 
+!!! tip "Already-distilled checkpoints"
+
+    Every model in the table below ships as a downloadable checkpoint, so you do not have to run distillation yourself to get the distilled accuracy. Load `yolo26n-distill.pt` the way you would load any other Ultralytics checkpoint:
+
+    === "Python"
+
+        ```python
+        from ultralytics import YOLO
+
+        model = YOLO("yolo26n-distill.pt")  # downloads on first use
+        results = model.predict("https://ultralytics.com/images/bus.jpg")
+        ```
+
+    === "CLI"
+
+        ```bash
+        yolo predict model=yolo26n-distill.pt source=https://ultralytics.com/images/bus.jpg
+        ```
+
+    Distill your own only when you need the gain on **your** dataset rather than on COCO. For everything else that makes a small model train better, see [model training tips](model-training-tips.md).
+
 ## What is Knowledge Distillation?
 
 [Knowledge distillation](https://www.ultralytics.com/glossary/knowledge-distillation) transfers knowledge from a large, accurate **teacher model** to a smaller **student model**. The student learns to mimic the teacher's internal feature representations, often achieving better accuracy than training from scratch.
 
 ![Knowledge distillation workflow image](https://cdn.ul.run/i/69daf2d70527cec60e3c29bfb262839f.avif)
 
-**Use distillation when:**
+**Reach for distillation when:**
 
 - You need a smaller, faster model for deployment
 - You have a high-accuracy teacher model trained on the same data
 - You want better accuracy than standard training provides
 
-!!! note
-
-    Knowledge distillation is implemented for **detect**, **segment**, **pose**, and **obb** tasks. Only **detect** has been experimentally verified for accuracy improvements for now.
-
 ## Performance
 
-Knowledge distillation improves student [mAP](yolo-performance-metrics.md) across the entire YOLO26 family on [COCO](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco.yaml), with no added inference cost. The table below compares the standard YOLO26 models (baseline) against the same models trained with distillation from their recommended teacher.
+**Ultralytics YOLO26** knowledge distillation raises student [mAP](yolo-performance-metrics.md) by 0.4 to 1.0 points across the entire YOLO26 family on [COCO](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco.yaml), with no added inference cost. The table compares standard YOLO26 checkpoints (baseline) against the same models trained with distillation from their recommended teacher.
 
 | Model                                                                  | size<br><sup>(pixels)</sup> | mAP<sup>val<br>50-95</sup><br>baseline | mAP<sup>val<br>50-95</sup><br>distilled | mAP<sup>val<br>50-95 (e2e)</sup><br>baseline | mAP<sup>val<br>50-95 (e2e)</sup><br>distilled |
 | ---------------------------------------------------------------------- | --------------------------- | -------------------------------------- | --------------------------------------- | -------------------------------------------- | --------------------------------------------- |
@@ -62,74 +84,25 @@ Knowledge distillation improves student [mAP](yolo-performance-metrics.md) acros
 
 Before you begin, ensure you meet the following requirements:
 
-- **Trained Teacher Model**: A pre-trained, high-accuracy teacher model from the same YOLO family as the student model (e.g., YOLO26).
-- **Matching Dataset and Task**: Both the teacher and student models must use the exact same dataset and task configuration.
-- **GPU Resources**: Sufficient GPU memory (VRAM) to load and run both models concurrently during training (refer to the [FAQ](#does-knowledge-distillation-slow-down-training) for typical VRAM overhead).
+- **Trained teacher model**: a `.pt` checkpoint from the same YOLO family as the student. A `.yaml` architecture file is rejected — the teacher must carry trained weights.
+- **Matching task**: use a teacher of the same task as the student. Nothing compares the two — a detect teacher trains against a segment student without complaint — but features are read from the student's layer indices and applied to the teacher, so a mismatch distills from layers that were never checked to correspond.
+- **GPU memory**: enough VRAM to hold both models. The teacher runs forward-only under `no_grad` and carries no gradients or optimizer state, so the overhead is well below a second full training run.
 
-### Recommended Model Pairs
+### Supported Tasks
 
-| Student      | Recommended Teacher |
-| ------------ | ------------------- |
-| `yolo26n.pt` | `yolo26s.pt`        |
-| `yolo26s.pt` | `yolo26m.pt`        |
-| `yolo26m.pt` | `yolo26x.pt`        |
-| `yolo26l.pt` | `yolo26x.pt`        |
+Ultralytics extracts features from the three neck layers feeding the model's head, so every task whose head inherits from `Detect` is compatible.
 
-Cross-family distillation (e.g., YOLO11 teacher with YOLO26 student) is **not supported**.
+| Task       | Supported | Accuracy verified                                          |
+| ---------- | --------- | ---------------------------------------------------------- |
+| `detect`   | Yes       | Yes — benchmarked on COCO (see [Performance](#performance)) |
+| `segment`  | Yes       | Not yet benchmarked                                        |
+| `semantic` | No        | —                                                          |
+| `depth`    | No        | —                                                          |
+| `classify` | No        | —                                                          |
+| `pose`     | Yes       | Not yet benchmarked                                        |
+| `obb`      | Yes       | Not yet benchmarked                                        |
 
-## Key Parameters
-
-| Parameter       | Type    | Default | Description                                                                                               |
-| --------------- | ------- | ------- | --------------------------------------------------------------------------------------------------------- |
-| `distill_model` | `str`   | `None`  | Path to the teacher model file (e.g., `yolo26x.pt`). Setting this enables knowledge distillation.         |
-| `dis`           | `float` | `6.0`   | Distillation loss weight. Controls how much the distillation loss contributes to the total training loss. |
-
-## How It Works
-
-1. The **teacher model** remains frozen in `eval` mode and runs inference on each batch
-2. The **student model** trains with standard task losses plus distillation guidance
-3. Features are extracted from both models at the three neck layers that feed the Detect-family head
-4. A **projector network** (lightweight MLP) aligns student feature dimensions to match the teacher
-5. A **score-weighted L2 loss** compares projected student features with teacher features, weighted by the teacher's classification confidence
-6. The distillation loss combines with standard losses using the `dis` weight
-
-```mermaid
-flowchart TD
-    A[Input Image Batch]:::start --> T[Teacher Model<br/>frozen, eval mode]:::extern
-    A --> S[Student Model<br/>trainable]:::proc
-
-    T --> |Detect head inputs| TF[Teacher Features]:::extern
-    S --> |Detect head inputs| SF[Student Features]:::proc
-
-    SF --> P[1×1 Conv Projector<br/>with ReLU]:::decide
-    P --> AF[Aligned Student Features]:::proc
-
-    TF --> SW[Score-weighted L2 Loss]:::proc
-    AF --> SW
-
-    S --> D[Detection Head]:::proc
-    D --> DL[box_loss + cls_loss + dfl_loss]:::proc
-
-    SW --> |× dis| DIS[distillation loss]:::proc
-    DL --> TOTAL[Total Loss]:::out
-    DIS --> TOTAL
-
-    TOTAL --> BP[Backpropagate<br/>Student + Projector only]:::out
-
-    classDef start fill:#4CAF50,color:#fff
-    classDef proc fill:#2196F3,color:#fff
-    classDef decide fill:#FF9800,color:#fff
-    classDef out fill:#9C27B0,color:#fff
-    classDef extern fill:#607D8B,color:#fff
-```
-
-## Task Support
-
-The distillation implementation extracts features from the three neck layers that feed the model's Detect-family head. Because the **segment**, **pose**, and **obb** heads inherit from the same `Detect` architecture, distillation is technically compatible with those tasks as well.
-
-!!! warning
-
-    Only **detect** has been experimentally benchmarked and verified. You can run distillation for **segment**, **pose**, or **obb**, but accuracy improvements for those tasks are not yet validated.
+An unsupported task fails immediately with `ValueError: No Detect head found in model`. [RT-DETR](../models/rtdetr.md) is unsupported for the same reason.
 
 !!! example "Knowledge Distillation for Other Tasks"
 
@@ -163,6 +136,32 @@ The distillation implementation extracts features from the three neck layers tha
         # OBB
         yolo obb train model=yolo26n-obb.pt data=dota8.yaml epochs=100 distill_model=yolo26s-obb.pt
         ```
+
+### Recommended Model Pairs
+
+| Student      | Recommended Teacher |
+| ------------ | ------------------- |
+| `yolo26n.pt` | `yolo26s.pt`        |
+| `yolo26s.pt` | `yolo26m.pt`        |
+| `yolo26m.pt` | `yolo26x.pt`        |
+| `yolo26l.pt` | `yolo26x.pt`        |
+
+!!! warning "Teacher and student must share a YOLO generation"
+
+    Feature layer indices are read from the **student** and then applied to the teacher, so a cross-family pair is not validated and not supported. What happens depends on the pair. A teacher whose layer count differs from the student's fails outright — a YOLOv8 teacher with a YOLO26 student raises `IndexError: index 23 is out of range`, because the index comes from the student and YOLOv8 has fewer modules. A teacher of the same depth fails silently instead: a YOLO11 teacher with a YOLO26 student trains with no warning at all, distilling from layer indices that were never checked to correspond. Keep both models in the same family (for example, both YOLO26).
+
+## Key Parameters
+
+| Parameter       | Type    | Default | Description                                                                                               |
+| --------------- | ------- | ------- | --------------------------------------------------------------------------------------------------------- |
+| `distill_model` | `str`   | `None`  | Path to the teacher model file (e.g., `yolo26x.pt`). Setting this enables knowledge distillation.         |
+| `dis`           | `float` | `6.0`   | Distillation loss weight. Controls how much the distillation loss contributes to the total training loss. |
+
+Both are [training arguments](../usage/cfg.md#train-settings) and are set on `model.train()`, not in the dataset YAML.
+
+!!! note "`compile` is disabled during distillation"
+
+    Setting `compile=True` alongside `distill_model` logs `'compile' is not supported with knowledge distillation and will be disabled.` and training proceeds uncompiled. Budget for that when estimating run time.
 
 ## Training
 
@@ -213,7 +212,7 @@ The `dis` parameter (default: `6.0`) controls distillation loss contribution:
 
 ### Resuming Distillation Training
 
-Distillation training supports resuming from checkpoints. The teacher model is rebuilt automatically from the `distill_model` path:
+Distillation training supports resuming from checkpoints. The teacher model is rebuilt automatically from the `distill_model` path recorded in the checkpoint:
 
 !!! example "Resume Distillation Training"
 
@@ -234,36 +233,91 @@ Distillation training supports resuming from checkpoints. The teacher model is r
 
 ## Training Output
 
-When distillation is enabled, an additional `dis_loss` column appears in training logs:
+When distillation is enabled, an additional `dis_loss` column appears in training logs. The sample below is a detection run; segment, pose and OBB carry their own task losses in the same table, with `dis_loss` appended to whichever set applies:
 
 ```text
-      Epoch    GPU_mem   box_loss   cls_loss   dfl_loss   dis_loss  Instances       Size
-      1/80      46.2G      1.566      5.404    0.003249      6.658        231        640
+      Epoch    GPU_mem   box_loss   cls_loss    l1_loss   dis_loss  Instances       Size
+        1/2         0G     0.9632      2.291    0.01334      9.831         30        640
+        2/2         0G      1.503      3.237    0.02867      9.346         27        640
 ```
 
-The exported model contains **only the student weights**—file size and inference speed match a normally trained student model.
+!!! note "`dis_loss` is a training-only metric"
+
+    The distillation loss is computed during training and is fixed at `0` during validation, so `val/dis_loss` in `results.csv` and the corresponding panel in `results.png` are a flat zero line by design. Read `train/dis_loss` to judge whether distillation is converging.
+
+Mid-run checkpoints keep the teacher and projector alongside the student, so a `last.pt` saved during training — or any file written by `save_period` — is several times larger than the final one. `best.pt` and `last.pt` from a completed run contain **only the student weights**, so file size and inference speed match a normally trained student model.
+
+## How It Works
+
+1. The **teacher model** stays frozen in `eval` mode and runs inference on each batch under `no_grad`
+2. The **student model** trains with standard task losses plus distillation guidance
+3. Features are captured from the three neck layers that feed the student's Detect-family head, and from the head output itself
+4. One **1×1 convolutional projector** per neck level (`Conv2d → ReLU → Conv2d`) maps each student feature map to the teacher's channel count
+5. A **score-weighted L2 loss** compares projected student features with teacher features, weighted per anchor by the teacher's max class confidence — taken from the head output captured in step 3 and averaged across its one-to-many and one-to-one branches
+6. The distillation loss combines with standard losses using the `dis` weight
+
+For the implementation, see [`ultralytics.nn.distill_model`](../reference/nn/distill_model.md).
+
+```mermaid
+flowchart TD
+    A[Input Image Batch]:::start --> T[Teacher Model<br/>frozen, eval mode]:::extern
+    A --> S[Student Model<br/>trainable]:::proc
+
+    T --> |Neck + head outputs| TF[Teacher Features]:::extern
+    S --> |Neck outputs| SF[Student Features]:::proc
+
+    SF --> P[1x1 Conv Projector<br/>per neck level]:::decide
+    P --> AF[Aligned Student Features]:::proc
+
+    TF --> SW[Score-weighted L2 Loss]:::proc
+    AF --> SW
+
+    S --> D[Detection Head]:::proc
+    D --> DL[box_loss + cls_loss + l1_loss]:::proc
+
+    SW --> |x dis| DIS[distillation loss]:::proc
+    DL --> TOTAL[Total Loss]:::out
+    DIS --> TOTAL
+
+    TOTAL --> BP[Backpropagate<br/>Student + Projector only]:::out
+
+    classDef start fill:#4CAF50,color:#fff
+    classDef proc fill:#2196F3,color:#fff
+    classDef decide fill:#FF9800,color:#fff
+    classDef out fill:#9C27B0,color:#fff
+    classDef extern fill:#607D8B,color:#fff
+```
 
 ## FAQ
 
+### Do I need the teacher model to run inference?
+
+No. A completed distillation run saves only the student weights, so `best.pt` loads, exports and runs exactly like a normally trained YOLO26 model. The teacher checkpoint is needed only while training.
+
+### Which tasks and models are supported?
+
+Ultralytics knowledge distillation supports the **detect**, **segment**, **pose** and **obb** tasks; **semantic**, **depth** and **classify** are not, and neither is RT-DETR. Only **detect** has been benchmarked for accuracy gains. The teacher and student must come from the same YOLO family — see [Supported Tasks](#supported-tasks) for the rule and the exact failure.
+
 ### Why is my distillation loss not decreasing?
 
+- Read `train/dis_loss`, not `val/dis_loss` — the latter is always `0`
 - Verify teacher and student are from the **same YOLO generation**
-- Confirm `distill_model` path is correct and the file loads
+- Confirm `distill_model` points at a trained `.pt` file that loads
 - Try increasing `dis` if the loss value is very small
 - Ensure the teacher model is trained on the **same dataset**
 
 ### How does distillation differ from standard training?
 
-Add the `distill_model` parameter—everything else works identically. An extra distillation loss computes during training, but the saved model is a standard YOLO model with no overhead.
+Add the `distill_model` parameter — everything else works identically. An extra distillation loss is computed during training, but the saved model is a standard YOLO model with no inference overhead.
 
 ### Does knowledge distillation slow down training?
 
-Yes. Expect 1.2-1.5x slower training and ~1.1x more GPU memory because the teacher model runs inference on each batch. The teacher runs in `eval` mode without gradients, keeping overhead manageable. Use `amp=True` to reduce impact.
+Yes, and the overhead scales with how much larger the teacher is than the student rather than being a fixed factor. The teacher runs a forward pass on every batch, so a `yolo26n` student learning from `yolo26s` pays far less than a `yolo26m` student learning from `yolo26x`. The teacher carries no gradients and no optimizer state, which keeps the memory cost well below a second training run. Note that `compile=True` is disabled while distilling.
 
-### Which tasks and models are supported?
+### Can I use my own custom-trained model as the teacher?
 
-Knowledge distillation works with **detect**, **segment**, **pose**, and **obb** tasks because it distills features from the three neck layers that feed the Detect-family head. **Classify** and **semantic** tasks are not supported.
+Yes. Any Ultralytics `.pt` checkpoint works as a teacher as long as it is from the same YOLO family and the same task as the student — nothing compares the two datasets, so a mismatch is not rejected. It does need to have learned the data you are distilling on for its guidance to be worth anything, which is why a `yolo26x.pt` fine-tuned on your own data is the strongest teacher for a `yolo26n.pt` student on that same data.
 
-Only **detect** has been experimentally verified for accuracy improvements. Segment, pose, and obb are technically compatible but not yet benchmarked.
+### Does knowledge distillation work with YOLO11 and YOLOv8?
 
-The teacher and student must belong to the **same YOLO family** (e.g., YOLOv8, YOLO11, or YOLO26). Cross-family distillation (e.g., a YOLO11 teacher with a YOLO26 student) is not supported.
+Yes. Distillation is family-agnostic — a YOLO11 teacher distills into a YOLO11 student, and a YOLOv8 teacher into a YOLOv8 student. What is not supported is crossing families, such as a YOLO11 teacher with a YOLO26 student.

--- a/docs/en/guides/knowledge-distillation.md
+++ b/docs/en/guides/knowledge-distillation.md
@@ -245,7 +245,7 @@ When distillation is enabled, an additional `dis_loss` column appears in trainin
 
     The distillation loss is computed during training and is fixed at `0` during validation, so `val/dis_loss` in `results.csv` and the corresponding panel in `results.png` are a flat zero line by design. Read `train/dis_loss` to judge whether distillation is converging.
 
-Mid-run checkpoints keep the teacher and projector alongside the student, so a `last.pt` saved during training — or any file written by `save_period` — is several times larger than the final one. `best.pt` and `last.pt` from a completed run contain **only the student weights**, so file size and inference speed match a normally trained student model.
+A checkpoint saved during training — `last.pt` mid-run, or any file written by `save_period` — carries the optimizer state and the EMA copy of the `DistillationModel` wrapper, including its projector, so it is several times larger than the final file (25.4 MB against 5.5 MB on a `yolo26n` run here). The teacher is not among them: it is stripped before saving and rebuilt from `distill_model` on resume. `best.pt` and `last.pt` from a **completed** run contain only the student weights, so file size and inference speed match a normally trained student model.
 
 ## How It Works
 

--- a/docs/en/guides/knowledge-distillation.md
+++ b/docs/en/guides/knowledge-distillation.md
@@ -34,7 +34,7 @@ Train a smaller student model with guidance from a larger teacher by adding the 
 
 !!! tip "Already-distilled checkpoints"
 
-    Every model in the table below ships as a downloadable checkpoint, so you do not have to run distillation yourself to get the distilled accuracy. Load `yolo26n-distill.pt` the way you would load any other Ultralytics checkpoint:
+    Every model in the table below ships as a downloadable checkpoint, so you do not have to run distillation yourself to get the distilled accuracy. Load `yolo26n-distill.pt` the way you would load any other Ultralytics checkpoint — the name is resolved against the Ultralytics release assets on first use, so it downloads even though it is not among the model names bundled with the package:
 
     === "Python"
 

--- a/docs/en/guides/model-yaml-config.md
+++ b/docs/en/guides/model-yaml-config.md
@@ -39,12 +39,12 @@ kpt_shape: [17, 3] # pose models only
 
 Shipped YAMLs also use four further top-level keys:
 
-| Key          | Used by             | Purpose                                                                                     |
-| ------------ | ------------------- | ------------------------------------------------------------------------------------------- |
+| Key          | Used by                 | Purpose                                                                                                                                                                              |
+| ------------ | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `end2end`    | YOLO26 detection family | Enables the NMS-free one-to-one head, in the detect, segment, pose and OBB configs. Absent from `yolo26-cls`, `-depth` and `-sem`. See [End-to-End Detection](end2end-detection.md). |
-| `reg_max`    | YOLO26 detection family | Number of DFL bins. Those same configs ship `reg_max: 1`, which is what makes them DFL-free. |
-| `channels`   | classification      | Input channel count, i.e. `1` for grayscale. Only classification reads it here — see below. |
-| `activation` | `yolov6.yaml`       | Overrides the default activation for every `Conv` in the model, i.e. `torch.nn.ReLU()`.     |
+| `reg_max`    | YOLO26 detection family | Number of DFL bins. Those same configs ship `reg_max: 1`, which is what makes them DFL-free.                                                                                         |
+| `channels`   | classification          | Input channel count, i.e. `1` for grayscale. Only classification reads it here — see below.                                                                                          |
+| `activation` | `yolov6.yaml`           | Overrides the default activation for every `Conv` in the model, i.e. `torch.nn.ReLU()`.                                                                                              |
 
 !!! warning "`channels` in a detection model YAML is ignored"
 

--- a/docs/en/guides/model-yaml-config.md
+++ b/docs/en/guides/model-yaml-config.md
@@ -39,12 +39,12 @@ kpt_shape: [17, 3] # pose models only
 
 Shipped YAMLs also use four further top-level keys:
 
-| Key          | Used by             | Purpose                                                                                 |
-| ------------ | ------------------- | --------------------------------------------------------------------------------------- |
-| `end2end`    | every YOLO26 config | Enables the NMS-free one-to-one head. See [End-to-End Detection](end2end-detection.md). |
-| `reg_max`    | every YOLO26 config | Number of DFL bins. YOLO26 ships `reg_max: 1`, which is what makes it DFL-free.         |
+| Key          | Used by             | Purpose                                                                                     |
+| ------------ | ------------------- | ------------------------------------------------------------------------------------------- |
+| `end2end`    | every YOLO26 config | Enables the NMS-free one-to-one head. See [End-to-End Detection](end2end-detection.md).     |
+| `reg_max`    | every YOLO26 config | Number of DFL bins. YOLO26 ships `reg_max: 1`, which is what makes it DFL-free.             |
 | `channels`   | classification      | Input channel count, i.e. `1` for grayscale. Only classification reads it here — see below. |
-| `activation` | `yolov6.yaml`       | Overrides the default activation for every `Conv` in the model, i.e. `torch.nn.ReLU()`. |
+| `activation` | `yolov6.yaml`       | Overrides the default activation for every `Conv` in the model, i.e. `torch.nn.ReLU()`.     |
 
 !!! warning "`channels` in a detection model YAML is ignored"
 
@@ -406,13 +406,13 @@ head:
 
 ## Best Practices
 
-| Practice                         | What it means for your YAML                                                                                                                                                                          |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Start from a shipped config**  | Copy a YAML from [`ultralytics/cfg/models`](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/cfg/models) and change one thing at a time rather than writing a backbone from scratch. |
+| Practice                         | What it means for your YAML                                                                                                                                                                                                               |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Start from a shipped config**  | Copy a YAML from [`ultralytics/cfg/models`](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/cfg/models) and change one thing at a time rather than writing a backbone from scratch.                                      |
 | **Match channels across layers** | For a base module, actual output channels are `make_divisible(min(out_ch, max_channels) * width, 8)`, not the number you wrote. Compute the scaled value before assuming two layers line up, and note the other modules do not follow it. |
-| **Reuse features with `Concat`** | `[[-1, N], 1, Concat, [1]]` merges an earlier feature map into the current one, the standard FPN pattern for multi-scale detection. Both sources must share spatial dimensions.                      |
-| **Pick a scale for your target** | Use `n` for edge devices, `s` for a balanced tradeoff, `m`/`l`/`x` when accuracy matters more than latency.                                                                                          |
-| **Verify after every change**    | `model.info()` must report non-zero FLOPs; see [Debugging Tips](#debugging-tips).                                                                                                                    |
+| **Reuse features with `Concat`** | `[[-1, N], 1, Concat, [1]]` merges an earlier feature map into the current one, the standard FPN pattern for multi-scale detection. Both sources must share spatial dimensions.                                                           |
+| **Pick a scale for your target** | Use `n` for edge devices, `s` for a balanced tradeoff, `m`/`l`/`x` when accuracy matters more than latency.                                                                                                                               |
+| **Verify after every change**    | `model.info()` must report non-zero FLOPs; see [Debugging Tips](#debugging-tips).                                                                                                                                                         |
 
 For the reasoning behind depth, width and bottleneck choices, see [YOLO architecture explained](yolo-architecture.md).
 

--- a/docs/en/guides/model-yaml-config.md
+++ b/docs/en/guides/model-yaml-config.md
@@ -43,12 +43,16 @@ Shipped YAMLs also use four further top-level keys:
 | ------------ | ------------------- | --------------------------------------------------------------------------------------- |
 | `end2end`    | every YOLO26 config | Enables the NMS-free one-to-one head. See [End-to-End Detection](end2end-detection.md). |
 | `reg_max`    | every YOLO26 config | Number of DFL bins. YOLO26 ships `reg_max: 1`, which is what makes it DFL-free.         |
-| `channels`   | non-RGB models      | Input channel count, i.e. `1` for a grayscale dataset. Defaults to `3`.                 |
+| `channels`   | classification      | Input channel count, i.e. `1` for grayscale. Only classification reads it here — see below. |
 | `activation` | `yolov6.yaml`       | Overrides the default activation for every `Conv` in the model, i.e. `torch.nn.ReLU()`. |
+
+!!! warning "`channels` in a detection model YAML is ignored"
+
+    `ClassificationModel` reads the key (`self.yaml.get("channels", ch)`), but detection, segmentation, pose and OBB models are built through `_initialize_yolo_model`, which does `model.yaml["channels"] = ch` unconditionally — so the constructor argument always wins and a `channels: 1` line in such a YAML has no effect. Set the channel count on the **dataset** YAML instead: the trainer passes `ch=self.data["channels"]` when it builds the model, which is how a grayscale dataset produces a single-channel first convolution.
 
 ### How Width Scaling Actually Computes Channels
 
-Channel counts are **not** the number written in `args`. Each layer's output channels are clamped to `max_channels`, multiplied by `width`, then rounded up to the nearest multiple of 8:
+Channel counts are **not** the number written in `args`. For `parse_model`'s base-module set — the convolution and block modules such as `Conv`, `C3k2`, `C2PSA`, `C2f` and `SPPF` — each layer's output channels are clamped to `max_channels`, multiplied by `width`, then rounded up to the nearest multiple of 8:
 
 ```python
 c2 = make_divisible(min(c2, max_channels) * width, 8)
@@ -61,7 +65,9 @@ c2 = make_divisible(min(c2, max_channels) * width, 8)
 | 1024          | 0.25    | 1024           | 256             |
 | 100           | 0.50    | 1024           | 56              |
 
-The last row is the one that surprises people: `100 x 0.5` is `50`, which rounds up to `56`. This is why `m`, `l` and `x` carry `max_channels: 512` while `n` and `s` carry `1024` — the larger scales would otherwise produce very wide layers. `Classify` is exempt from width scaling, because its output must stay at `nc`.
+The last row is the one that surprises people: `100 x 0.5` is `50`, which rounds up to `56`. This is why `m`, `l` and `x` carry `max_channels: 512` while `n` and `s` carry `1024` — the larger scales would otherwise produce very wide layers.
+
+The formula does not reach every layer. `Classify` is exempt so its output stays at `nc`; `Concat` sums the channels of its sources; `TorchVision` and `Index` use the bookkeeping value you wrote; and heads take `nc` rather than a channel count. Compute expected channels this way only for the base modules.
 
 !!! tip "Reduce redundancy with `scales`"
 
@@ -403,7 +409,7 @@ head:
 | Practice                         | What it means for your YAML                                                                                                                                                                          |
 | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Start from a shipped config**  | Copy a YAML from [`ultralytics/cfg/models`](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/cfg/models) and change one thing at a time rather than writing a backbone from scratch. |
-| **Match channels across layers** | A layer's actual output channels are `make_divisible(min(out_ch, max_channels) * width, 8)`, not the number you wrote. Compute the scaled value before assuming two layers line up.                  |
+| **Match channels across layers** | For a base module, actual output channels are `make_divisible(min(out_ch, max_channels) * width, 8)`, not the number you wrote. Compute the scaled value before assuming two layers line up, and note the other modules do not follow it. |
 | **Reuse features with `Concat`** | `[[-1, N], 1, Concat, [1]]` merges an earlier feature map into the current one, the standard FPN pattern for multi-scale detection. Both sources must share spatial dimensions.                      |
 | **Pick a scale for your target** | Use `n` for edge devices, `s` for a balanced tradeoff, `m`/`l`/`x` when accuracy matters more than latency.                                                                                          |
 | **Verify after every change**    | `model.info()` must report non-zero FLOPs; see [Debugging Tips](#debugging-tips).                                                                                                                    |
@@ -497,7 +503,7 @@ Load the checkpoint and read `model.model.yaml`, which holds the parsed architec
 
 ### Why does my layer have fewer channels than the number in my YAML?
 
-Because `max_channels` caps the value before the width multiplier is applied, and the result is rounded up to a multiple of 8. With `m: [0.50, 1.00, 512]`, a layer declaring `[1024, 3, 2]` is clamped to 512 first, so it builds 512 channels rather than 1024. See [How Width Scaling Actually Computes Channels](#how-width-scaling-actually-computes-channels).
+For a base module, `max_channels` caps the value before the width multiplier is applied, and the result is rounded up to a multiple of 8. With `m: [0.50, 1.00, 512]`, a layer declaring `[1024, 3, 2]` is clamped to 512 first, so it builds 512 channels rather than 1024. Other modules — `Concat`, `TorchVision`, `Index`, the heads — do not go through that formula. See [How Width Scaling Actually Computes Channels](#how-width-scaling-actually-computes-channels).
 
 ### Can I train a model YAML from scratch without pretrained weights?
 

--- a/docs/en/guides/model-yaml-config.md
+++ b/docs/en/guides/model-yaml-config.md
@@ -169,7 +169,7 @@ Modules are organized by functionality and defined in the [Ultralytics modules d
 
 | Module   | Purpose                                                           | Source                                                                                           | Arguments                                          |
 | -------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
-| `C3k2`   | CSP block used by every YOLO11 and YOLO26 backbone                | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, c3k, expansion, attn, groups, shortcut]` |
+| `C3k2`   | CSP block in the standard YOLO11 and YOLO26 backbones             | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, c3k, expansion, attn, groups, shortcut]` |
 | `C2PSA`  | Position-sensitive attention block, last backbone layer in YOLO26 | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, expansion]`                              |
 | `C2f`    | CSP bottleneck with 2 convolutions, used by YOLOv8                | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, shortcut, groups, expansion]`            |
 | `SPPF`   | Spatial Pyramid Pooling (fast)                                    | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, kernel_size]`                            |

--- a/docs/en/guides/model-yaml-config.md
+++ b/docs/en/guides/model-yaml-config.md
@@ -274,7 +274,16 @@ A fourth gate applies under restricted loading: a name that resolves to somethin
 Standard modules become available through imports in [`tasks.py`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/tasks.py):
 
 ```python
-
+from ultralytics.nn.modules import (  # noqa: F401
+    SPPF,
+    C2PSA,
+    C3k2,
+    Conv,
+    Detect,
+    # ... many more modules
+    Index,
+    TorchVision,
+)
 ```
 
 ## Custom Module Integration

--- a/docs/en/guides/model-yaml-config.md
+++ b/docs/en/guides/model-yaml-config.md
@@ -39,12 +39,12 @@ kpt_shape: [17, 3] # pose models only
 
 Shipped YAMLs also use four further top-level keys:
 
-| Key           | Used by                                     | Purpose                                                                                     |
-| ------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `end2end`     | every YOLO26 config                         | Enables the NMS-free one-to-one head. See [End-to-End Detection](end2end-detection.md).      |
-| `reg_max`     | every YOLO26 config                         | Number of DFL bins. YOLO26 ships `reg_max: 1`, which is what makes it DFL-free.              |
-| `channels`    | non-RGB models                              | Input channel count, i.e. `1` for a grayscale dataset. Defaults to `3`.                      |
-| `activation`  | `yolov6.yaml`                               | Overrides the default activation for every `Conv` in the model, i.e. `torch.nn.ReLU()`.      |
+| Key          | Used by             | Purpose                                                                                 |
+| ------------ | ------------------- | --------------------------------------------------------------------------------------- |
+| `end2end`    | every YOLO26 config | Enables the NMS-free one-to-one head. See [End-to-End Detection](end2end-detection.md). |
+| `reg_max`    | every YOLO26 config | Number of DFL bins. YOLO26 ships `reg_max: 1`, which is what makes it DFL-free.         |
+| `channels`   | non-RGB models      | Input channel count, i.e. `1` for a grayscale dataset. Defaults to `3`.                 |
+| `activation` | `yolov6.yaml`       | Overrides the default activation for every `Conv` in the model, i.e. `torch.nn.ReLU()`. |
 
 ### How Width Scaling Actually Computes Channels
 
@@ -161,13 +161,13 @@ Modules are organized by functionality and defined in the [Ultralytics modules d
 
 ### Composite Blocks
 
-| Module   | Purpose                            | Source                                                                                           | Arguments                       |
-| -------- | ---------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------- |
-| `C3k2`   | CSP block used by every YOLO11 and YOLO26 backbone | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, c3k, expansion, attn, groups, shortcut]` |
-| `C2PSA`  | Position-sensitive attention block, last backbone layer in YOLO26 | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, expansion]` |
-| `C2f`    | CSP bottleneck with 2 convolutions, used by YOLOv8 | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, shortcut, groups, expansion]` |
-| `SPPF`   | Spatial Pyramid Pooling (fast)     | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, kernel_size]`         |
-| `Concat` | Channel-wise concatenation         | [conv.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/conv.py)   | `[dimension]`                   |
+| Module   | Purpose                                                           | Source                                                                                           | Arguments                                          |
+| -------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
+| `C3k2`   | CSP block used by every YOLO11 and YOLO26 backbone                | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, c3k, expansion, attn, groups, shortcut]` |
+| `C2PSA`  | Position-sensitive attention block, last backbone layer in YOLO26 | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, expansion]`                              |
+| `C2f`    | CSP bottleneck with 2 convolutions, used by YOLOv8                | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, shortcut, groups, expansion]`            |
+| `SPPF`   | Spatial Pyramid Pooling (fast)                                    | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, kernel_size]`                            |
+| `Concat` | Channel-wise concatenation                                        | [conv.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/conv.py)   | `[dimension]`                                      |
 
 ### Specialized Modules
 
@@ -268,16 +268,7 @@ A fourth gate applies under restricted loading: a name that resolves to somethin
 Standard modules become available through imports in [`tasks.py`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/tasks.py):
 
 ```python
-from ultralytics.nn.modules import (
-    SPPF,
-    C2PSA,
-    C3k2,
-    Conv,
-    Detect,
-    # ... many more modules
-    Index,
-    TorchVision,
-)
+
 ```
 
 ## Custom Module Integration
@@ -409,13 +400,13 @@ head:
 
 ## Best Practices
 
-| Practice | What it means for your YAML |
-| --- | --- |
-| **Start from a shipped config** | Copy a YAML from [`ultralytics/cfg/models`](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/cfg/models) and change one thing at a time rather than writing a backbone from scratch. |
-| **Match channels across layers** | A layer's actual output channels are `make_divisible(min(out_ch, max_channels) * width, 8)`, not the number you wrote. Compute the scaled value before assuming two layers line up. |
-| **Reuse features with `Concat`** | `[[-1, N], 1, Concat, [1]]` merges an earlier feature map into the current one, the standard FPN pattern for multi-scale detection. Both sources must share spatial dimensions. |
-| **Pick a scale for your target** | Use `n` for edge devices, `s` for a balanced tradeoff, `m`/`l`/`x` when accuracy matters more than latency. |
-| **Verify after every change** | `model.info()` must report non-zero FLOPs; see [Debugging Tips](#debugging-tips). |
+| Practice                         | What it means for your YAML                                                                                                                                                                          |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Start from a shipped config**  | Copy a YAML from [`ultralytics/cfg/models`](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/cfg/models) and change one thing at a time rather than writing a backbone from scratch. |
+| **Match channels across layers** | A layer's actual output channels are `make_divisible(min(out_ch, max_channels) * width, 8)`, not the number you wrote. Compute the scaled value before assuming two layers line up.                  |
+| **Reuse features with `Concat`** | `[[-1, N], 1, Concat, [1]]` merges an earlier feature map into the current one, the standard FPN pattern for multi-scale detection. Both sources must share spatial dimensions.                      |
+| **Pick a scale for your target** | Use `n` for edge devices, `s` for a balanced tradeoff, `m`/`l`/`x` when accuracy matters more than latency.                                                                                          |
+| **Verify after every change**    | `model.info()` must report non-zero FLOPs; see [Debugging Tips](#debugging-tips).                                                                                                                    |
 
 For the reasoning behind depth, width and bottleneck choices, see [YOLO architecture explained](yolo-architecture.md).
 
@@ -523,4 +514,3 @@ Check that the output channels of one layer match the expected input channels of
 ### Can I use pretrained weights with a custom YAML?
 
 Yes, you can use `model.load("path/to/weights")` to load weights from a pretrained checkpoint. However, only weights for layers that match would load successfully.
-

--- a/docs/en/guides/model-yaml-config.md
+++ b/docs/en/guides/model-yaml-config.md
@@ -275,8 +275,8 @@ Standard modules become available through imports in [`tasks.py`](https://github
 
 ```python
 from ultralytics.nn.modules import (  # noqa: F401
-    SPPF,
     C2PSA,
+    SPPF,
     C3k2,
     Conv,
     Detect,

--- a/docs/en/guides/model-yaml-config.md
+++ b/docs/en/guides/model-yaml-config.md
@@ -41,8 +41,8 @@ Shipped YAMLs also use four further top-level keys:
 
 | Key          | Used by             | Purpose                                                                                     |
 | ------------ | ------------------- | ------------------------------------------------------------------------------------------- |
-| `end2end`    | every YOLO26 config | Enables the NMS-free one-to-one head. See [End-to-End Detection](end2end-detection.md).     |
-| `reg_max`    | every YOLO26 config | Number of DFL bins. YOLO26 ships `reg_max: 1`, which is what makes it DFL-free.             |
+| `end2end`    | YOLO26 detection family | Enables the NMS-free one-to-one head, in the detect, segment, pose and OBB configs. Absent from `yolo26-cls`, `-depth` and `-sem`. See [End-to-End Detection](end2end-detection.md). |
+| `reg_max`    | YOLO26 detection family | Number of DFL bins. Those same configs ship `reg_max: 1`, which is what makes them DFL-free. |
 | `channels`   | classification      | Input channel count, i.e. `1` for grayscale. Only classification reads it here — see below. |
 | `activation` | `yolov6.yaml`       | Overrides the default activation for every `Conv` in the model, i.e. `torch.nn.ReLU()`.     |
 

--- a/docs/en/guides/model-yaml-config.md
+++ b/docs/en/guides/model-yaml-config.md
@@ -182,9 +182,9 @@ Modules are organized by functionality and defined in the [Ultralytics modules d
 
     This is a subset. For the full list of modules and their parameters, explore the [modules directory](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/nn/modules).
 
-!!! note "The first YAML argument is the OUTPUT channel count"
+!!! note "Which modules receive an injected input-channel argument"
 
-    Input channels are injected by `parse_model` from whatever layer `from` points at, so the args you write start at `c2`. `Index` is the exception that proves the rule: its constructor takes only an index, and the leading `out_ch` exists purely so channel bookkeeping stays correct for the layers that read it.
+    For the convolution and block modules — `Conv`, `C3k2`, `C2PSA`, `C2f`, `SPPF` and the rest of `parse_model`'s base-module set — input channels are injected from whatever layer `from` points at, so the args you write start at `c2`. That rule does **not** extend to the other modules in the tables above, each of which `parse_model` handles specially: `nn.Upsample` and `nn.MaxPool2d` take their `torch.nn` arguments unchanged, `Concat` takes a dimension, `Detect` and `Classify` take `nc`, and `Index` takes a leading `out_ch` that exists purely for channel bookkeeping while its constructor reads only the index. A module you register yourself gets no injection at all until you add it, which is what [step 5](#custom-module-integration) is for.
 
 ## Advanced Features
 

--- a/docs/en/guides/model-yaml-config.md
+++ b/docs/en/guides/model-yaml-config.md
@@ -222,7 +222,7 @@ The TorchVision module enables seamless integration of any [TorchVision model](h
     - `768`: Expected output channels
     - `convnext_tiny`: Model architecture ([available models](https://docs.pytorch.org/vision/stable/models.html))
     - `DEFAULT`: Use pretrained weights
-    - `True`: Unwrap the model into a flat `nn.Sequential` of its child layers. This is what makes the next two arguments possible; setting it to `False` instead replaces the model's own classification head with `nn.Identity` and forces the split argument off.
+    - `True`: Unwrap the model into a flat `nn.Sequential` of its child layers. This is what makes the next two arguments possible. Setting it to `False` forces the split argument off and assigns `nn.Identity` to the attributes named `head` and `heads` only — which is not a general way to strip a classifier: `resnet18` keeps its `fc` and `convnext_tiny` keeps its `classifier`, so both still return 1000 class logits rather than a feature map, and the next layer fails on shape. Keep `unwrap=True` unless your model's classifier really is called `head` or `heads`.
     - `2`: Truncate the last 2 of those layers
     - `False`: Return a single tensor rather than a list of intermediate feature maps
 

--- a/docs/en/guides/model-yaml-config.md
+++ b/docs/en/guides/model-yaml-config.md
@@ -1,12 +1,15 @@
 ---
+title: "YOLO Model YAML: Architecture Reference"
 comments: true
-description: Learn how to structure and customize model architectures using Ultralytics YAML configuration files. Master module definitions, connections, and scaling parameters.
-keywords: Ultralytics, YOLO, model architecture, YAML configuration, neural networks, deep learning, backbone, head, modules, custom models
+description: Reference for the Ultralytics YOLO model YAML - nc and scales, backbone and head sections, the [from, repeats, module, args] layer format, and custom modules.
+keywords: Ultralytics, YOLO, model architecture, YAML configuration, parse_model, backbone, head, scales, max_channels, custom modules, C3k2, C2PSA, TorchVision backbone
 ---
 
 # Model YAML Configuration Guide
 
-The model YAML configuration file serves as the architectural blueprint for Ultralytics neural networks. It defines how layers connect, what parameters each module uses, and how the entire network scales across different model sizes.
+An Ultralytics model YAML is the architectural blueprint for a YOLO network: it declares the class count and scaling factors, then lists every backbone and head layer as `[from, repeats, module, args]`. Ultralytics YOLO26 builds the network straight from that file — `YOLO("my_model.yaml")` needs no Python model code.
+
+This reference covers each section of the file, the modules you can reference by name, how [`parse_model`](../reference/nn/tasks.md) resolves those names, and how to register a custom module of your own.
 
 <img width="1024" src="https://cdn.ul.run/i/a563b72f7404e71fb4c61b7710d28acf.avif" alt="Model YAML configuration workflow.">
 
@@ -22,17 +25,43 @@ The **parameters** section specifies the model's global characteristics and scal
 # Parameters
 nc: 80 # number of classes
 scales: # compound scaling constants [depth, width, max_channels]
-    n: [0.50, 0.25, 1024] # nano: shallow layers, narrow channels
-    s: [0.50, 0.50, 1024] # small: shallow depth, standard width
-    m: [0.50, 1.00, 512] # medium: moderate depth, full width
+    n: [0.50, 0.25, 1024] # nano: half depth, quarter width
+    s: [0.50, 0.50, 1024] # small: half depth, half width
+    m: [0.50, 1.00, 512] # medium: half depth, full width, channels capped at 512
     l: [1.00, 1.00, 512] # large: full depth and width
-    x: [1.00, 1.50, 512] # extra-large: maximum performance
+    x: [1.00, 1.50, 512] # extra-large: full depth, 1.5x width
 kpt_shape: [17, 3] # pose models only
 ```
 
 - `nc` sets the number of classes the model predicts.
-- `scales` define compound scaling factors that adjust model depth, width, and maximum channels to produce different size variants (nano through extra-large).
+- `scales` define compound scaling factors as `[depth, width, max_channels]`, producing different size variants (nano through extra-large) from one file.
 - `kpt_shape` applies to pose models. It can be `[N, 2]` for `(x, y)` keypoints or `[N, 3]` for `(x, y, visibility)`.
+
+Shipped YAMLs also use four further top-level keys:
+
+| Key           | Used by                                     | Purpose                                                                                     |
+| ------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `end2end`     | every YOLO26 config                         | Enables the NMS-free one-to-one head. See [End-to-End Detection](end2end-detection.md).      |
+| `reg_max`     | every YOLO26 config                         | Number of DFL bins. YOLO26 ships `reg_max: 1`, which is what makes it DFL-free.              |
+| `channels`    | non-RGB models                              | Input channel count, i.e. `1` for a grayscale dataset. Defaults to `3`.                      |
+| `activation`  | `yolov6.yaml`                               | Overrides the default activation for every `Conv` in the model, i.e. `torch.nn.ReLU()`.      |
+
+### How Width Scaling Actually Computes Channels
+
+Channel counts are **not** the number written in `args`. Each layer's output channels are clamped to `max_channels`, multiplied by `width`, then rounded up to the nearest multiple of 8:
+
+```python
+c2 = make_divisible(min(c2, max_channels) * width, 8)
+```
+
+| YAML `out_ch` | `width` | `max_channels` | Actual channels |
+| ------------- | ------- | -------------- | --------------- |
+| 1024          | 1.00    | 512            | 512             |
+| 1024          | 1.50    | 512            | 768             |
+| 1024          | 0.25    | 1024           | 256             |
+| 100           | 0.50    | 1024           | 56              |
+
+The last row is the one that surprises people: `100 x 0.5` is `50`, which rounds up to `56`. This is why `m`, `l` and `x` carry `max_channels: 512` while `n` and `s` carry `1024` — the larger scales would otherwise produce very wide layers. `Classify` is exempt from width scaling, because its output must stay at `nc`.
 
 !!! tip "Reduce redundancy with `scales`"
 
@@ -47,18 +76,22 @@ kpt_shape: [17, 3] # pose models only
 The model architecture consists of backbone (feature extraction) and head (task-specific) sections:
 
 ```yaml
+nc: 80
+
 backbone:
     # [from, repeats, module, args]
     - [-1, 1, Conv, [64, 3, 2]] # 0: Initial convolution
     - [-1, 1, Conv, [128, 3, 2]] # 1: Downsample
-    - [-1, 3, C2f, [128, True]] # 2: Feature processing
+    - [-1, 3, C3k2, [128, True]] # 2: Feature processing
 
 head:
-    - [-1, 1, nn.Upsample, [None, 2, nearest]] # 6: Upsample
-    - [[-1, 2], 1, Concat, [1]] # 7: Skip connection
-    - [-1, 3, C2f, [256]] # 8: Process features
-    - [[8], 1, Detect, [nc]] # 9: Detection layer
+    - [-1, 1, nn.Upsample, [None, 2, nearest]] # 3: Upsample
+    - [[-1, 0], 1, Concat, [1]] # 4: Skip connection to layer 0
+    - [-1, 3, C3k2, [256, False]] # 5: Process features
+    - [[5], 1, Detect, [nc]] # 6: Detection layer
 ```
+
+Layer indices run continuously across both sections — the head does not restart at 0 — and a `from` index must name a layer that already exists. A skip connection also has to be spatially compatible: layer 0 is the only source the upsampled layer 3 can concatenate with here.
 
 ## Layer Specification Format
 
@@ -106,7 +139,13 @@ The `repeats` parameter creates deeper network sections:
 - [-1, 1, Conv, [64, 3, 2]] # Single convolution layer
 ```
 
-The actual repetition count gets multiplied by the depth scaling factor from your model size configuration.
+The repetition count is multiplied by the `depth` scaling factor, rounded, and floored at 1 — but only when it is greater than 1, so `repeats: 1` is never scaled:
+
+```python
+n = max(round(n * depth), 1) if n > 1 else n
+```
+
+At `depth=0.33` a `repeats: 3` block collapses to a single block and `repeats: 6` becomes 2. Only modules that accept an internal repeat count consume `n` this way; any other module is simply stacked `n` times in an `nn.Sequential`.
 
 ## Available Modules
 
@@ -124,7 +163,9 @@ Modules are organized by functionality and defined in the [Ultralytics modules d
 
 | Module   | Purpose                            | Source                                                                                           | Arguments                       |
 | -------- | ---------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------- |
-| `C2f`    | CSP bottleneck with 2 convolutions | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, shortcut, expansion]` |
+| `C3k2`   | CSP block used by every YOLO11 and YOLO26 backbone | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, c3k, expansion, attn, groups, shortcut]` |
+| `C2PSA`  | Position-sensitive attention block, last backbone layer in YOLO26 | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, expansion]` |
+| `C2f`    | CSP bottleneck with 2 convolutions, used by YOLOv8 | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, shortcut, groups, expansion]` |
 | `SPPF`   | Spatial Pyramid Pooling (fast)     | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, kernel_size]`         |
 | `Concat` | Channel-wise concatenation         | [conv.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/conv.py)   | `[dimension]`                   |
 
@@ -133,12 +174,17 @@ Modules are organized by functionality and defined in the [Ultralytics modules d
 | Module        | Purpose                           | Source                                                                                           | Arguments                                                |
 | ------------- | --------------------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
 | `TorchVision` | Load any torchvision model        | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, model_name, weights, unwrap, truncate, split]` |
-| `Index`       | Extract specific tensor from list | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, index]`                                        |
+| `Index`       | Extract specific tensor from list | [conv.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/conv.py)   | `[out_ch, index]`                                        |
 | `Detect`      | YOLO detection head               | [head.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/head.py)   | `[nc]`                                                   |
+| `Classify`    | Classification head, must be last | [head.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/head.py)   | `[nc]`                                                   |
 
 !!! info "Complete Module List"
 
-    This represents a subset of available modules. For the full list of modules and their parameters, explore the [modules directory](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/nn/modules).
+    This is a subset. For the full list of modules and their parameters, explore the [modules directory](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/nn/modules).
+
+!!! note "The first YAML argument is the OUTPUT channel count"
+
+    Input channels are injected by `parse_model` from whatever layer `from` points at, so the args you write start at `c2`. `Index` is the exception that proves the rule: its constructor takes only an index, and the leading `out_ch` exists purely so channel bookkeeping stays correct for the layers that read it.
 
 ## Advanced Features
 
@@ -170,9 +216,9 @@ The TorchVision module enables seamless integration of any [TorchVision model](h
     - `768`: Expected output channels
     - `convnext_tiny`: Model architecture ([available models](https://docs.pytorch.org/vision/stable/models.html))
     - `DEFAULT`: Use pretrained weights
-    - `True`: Remove classification head
-    - `2`: Truncate last 2 layers
-    - `False`: Return single tensor (not list)
+    - `True`: Unwrap the model into a flat `nn.Sequential` of its child layers. This is what makes the next two arguments possible; setting it to `False` instead replaces the model's own classification head with `nn.Identity` and forces the split argument off.
+    - `2`: Truncate the last 2 of those layers
+    - `False`: Return a single tensor rather than a list of intermediate feature maps
 
 !!! tip "Multi-Scale Features"
 
@@ -204,25 +250,28 @@ Ultralytics uses a three-tier system in [`parse_model`](https://github.com/ultra
 # Core resolution logic
 m = (
     getattr(torch.nn, m[3:])
-    if "nn." in m
-    else getattr(torchvision.ops, m[16:])
-    if "torchvision.ops." in m
+    if m.startswith("nn.")
+    else getattr(__import__("torchvision").ops, m[16:])
+    if m.startswith("torchvision.ops.")
     else globals()[m]
-)
+)  # get module
 ```
 
-1. **PyTorch modules**: Names starting with `'nn.'` → `torch.nn` namespace
-2. **TorchVision operations**: Names starting with `'torchvision.ops.'` → `torchvision.ops` namespace
-3. **Ultralytics modules**: All other names → global namespace via imports
+1. **PyTorch modules**: names starting with `nn.` → `torch.nn` namespace
+2. **TorchVision operations**: names starting with `torchvision.ops.` → `torchvision.ops` namespace
+3. **Ultralytics modules**: all other names → the `tasks.py` global namespace, populated by the imports below
+
+A fourth gate applies under restricted loading: a name that resolves to something which is not an `nn.Module` subclass raises `TypeError` instead of being built.
 
 ### Module Import Chain
 
 Standard modules become available through imports in [`tasks.py`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/tasks.py):
 
 ```python
-from ultralytics.nn.modules import (  # noqa: F401
+from ultralytics.nn.modules import (
     SPPF,
-    C2f,
+    C2PSA,
+    C3k2,
     Conv,
     Detect,
     # ... many more modules
@@ -267,7 +316,7 @@ Modifying the source code is the most versatile way to integrate your custom mod
     from ultralytics.nn.modules import CustomBlock  # noqa
     ```
 
-5. **Handle special arguments** (if needed) inside [`parse_model()`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/tasks.py) in `ultralytics/nn/tasks.py`:
+5. **Handle channel injection** inside [`parse_model()`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/tasks.py) in `ultralytics/nn/tasks.py`. This step is required, not optional: `parse_model` injects input channels only for modules it knows about, so an unregistered module receives its YAML args verbatim and fails with `TypeError: CustomBlock.__init__() missing 1 required positional argument: 'c2'`.
 
     ```python
     # Add this condition in the parse_model() function
@@ -304,7 +353,7 @@ Modifying the source code is the most versatile way to integrate your custom mod
 # Simple YOLO detection model
 nc: 80
 scales:
-    n: [0.33, 0.25, 1024]
+    n: [0.50, 0.25, 1024]
 
 backbone:
     - [-1, 1, Conv, [64, 3, 2]] # 0-P1/2
@@ -318,6 +367,10 @@ head:
     - [-1, 1, Conv, [256, 3, 1]] # 6
     - [[6], 1, Detect, [nc]] # 7
 ```
+
+!!! warning "A `scales` block needs a scale letter in the filename"
+
+    Ultralytics reads the scale from the file name with the pattern `yolo` + digits + one of `nslmx`. Saved as `simple_detect.yaml` the file above logs `WARNING no model scale passed. Assuming scale='n'.` and silently uses the first entry. Worse, a name that merely looks scalable is not: `mynet26n.yaml` and `mynet26s.yaml` build the **identical** model, because neither stem contains `yolo`. Name a scalable config `myyolo26n.yaml` / `myyolo26s.yaml` and keep the base file unscaled (`myyolo26.yaml`).
 
 ### TorchVision Backbone Model
 
@@ -344,38 +397,27 @@ nc: 1000
 backbone:
     - [-1, 1, Conv, [64, 7, 2, 3]]
     - [-1, 1, nn.MaxPool2d, [3, 2, 1]]
-    - [-1, 4, C2f, [64, True]]
+    - [-1, 4, C3k2, [64, True]]
     - [-1, 1, Conv, [128, 3, 2]]
-    - [-1, 8, C2f, [128, True]]
-    - [-1, 1, nn.AdaptiveAvgPool2d, [1]]
+    - [-1, 8, C3k2, [128, True]]
 
 head:
     - [-1, 1, Classify, [nc]]
 ```
 
+`Classify` pools internally, so do not add an `nn.AdaptiveAvgPool2d` before it. Collapsing the feature map to 1x1 first starves the head's own convolution and makes training with `batch=1` fail with `ValueError: Expected more than 1 value per channel when training`.
+
 ## Best Practices
 
-### Architecture Design Tips
+| Practice | What it means for your YAML |
+| --- | --- |
+| **Start from a shipped config** | Copy a YAML from [`ultralytics/cfg/models`](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/cfg/models) and change one thing at a time rather than writing a backbone from scratch. |
+| **Match channels across layers** | A layer's actual output channels are `make_divisible(min(out_ch, max_channels) * width, 8)`, not the number you wrote. Compute the scaled value before assuming two layers line up. |
+| **Reuse features with `Concat`** | `[[-1, N], 1, Concat, [1]]` merges an earlier feature map into the current one, the standard FPN pattern for multi-scale detection. Both sources must share spatial dimensions. |
+| **Pick a scale for your target** | Use `n` for edge devices, `s` for a balanced tradeoff, `m`/`l`/`x` when accuracy matters more than latency. |
+| **Verify after every change** | `model.info()` must report non-zero FLOPs; see [Debugging Tips](#debugging-tips). |
 
-**Start Simple**: Begin with proven architectures before customizing. Use existing YOLO configurations as templates and modify incrementally rather than building from scratch.
-
-**Test Incrementally**: Validate each modification step-by-step. Add one custom module at a time and verify it works before proceeding to the next change.
-
-**Monitor Channels**: Ensure channel dimensions match between connected layers. The output channels (`c2`) of one layer must match the input channels (`c1`) of the next layer in the sequence.
-
-**Use Skip Connections**: Leverage feature reuse with `[[-1, N], 1, Concat, [1]]` patterns. These connections help with gradient flow and allow the model to combine features from different scales.
-
-**Scale Appropriately**: Choose model scales based on your computational constraints. Use nano (`n`) for edge devices, small (`s`) for balanced performance, and larger scales (`m`, `l`, `x`) for maximum accuracy.
-
-### Performance Considerations
-
-**Depth vs Width**: Deep networks capture complex hierarchical features through multiple transformation layers, while wide networks process more information in parallel at each layer. Balance these based on your task complexity.
-
-**Skip Connections**: Improve gradient flow during training and enable feature reuse throughout the network. They're particularly important in deeper architectures to prevent vanishing gradients.
-
-**Bottleneck Blocks**: Reduce computational cost while maintaining model expressiveness. Modules like `C2f` use fewer parameters than standard convolutions while preserving feature learning capacity.
-
-**Multi-Scale Features**: Essential for detecting objects at different sizes in the same image. Use Feature Pyramid Network (FPN) patterns with multiple detection heads at different scales.
+For the reasoning behind depth, width and bottleneck choices, see [YOLO architecture explained](yolo-architecture.md).
 
 ## Troubleshooting
 
@@ -392,31 +434,34 @@ head:
 
 When developing custom architectures, systematic debugging helps identify issues early:
 
-**Use Identity Head for Testing**
+#### Use an Identity Head to Isolate the Backbone
 
 Replace complex heads with `nn.Identity` to isolate backbone issues:
 
 ```yaml
+# debug_model.yaml
 nc: 1
 backbone:
-    - [-1, 1, CustomBlock, [64]]
+    - [-1, 1, Conv, [64, 3, 2]]
 head:
     - [-1, 1, nn.Identity, []] # Pass-through for debugging
 ```
 
-This allows direct inspection of backbone outputs:
+An identity head gives `parse_model` no head to infer the task from, so pass `task=` explicitly or model loading fails with `NotImplementedError` for task `None`:
 
 ```python
 import torch
 
 from ultralytics import YOLO
 
-model = YOLO("debug_model.yaml")
+model = YOLO("debug_model.yaml", task="detect")
 output = model.model(torch.randn(1, 3, 640, 640))
-print(f"Output shape: {output.shape}")  # Should match expected dimensions
+print(f"Output shape: {output.shape}")  # torch.Size([1, 64, 320, 320])
 ```
 
-**Model Architecture Inspection**
+The identity head is what makes `output` a plain tensor. Swap in a real `Detect` head and the forward pass returns a dict of `boxes`, `scores` and `feats` instead, so `output.shape` raises `AttributeError`.
+
+#### Inspect the Built Architecture
 
 Checking the FLOPs count and printing out each layer can also help debug issues with your custom model config. FLOPs count should be non-zero for a valid model. If it's zero, then there's likely an issue with the forward pass. Running a simple forward pass should show the exact error being encountered.
 
@@ -424,7 +469,7 @@ Checking the FLOPs count and printing out each layer can also help debug issues 
 from ultralytics import YOLO
 
 # Build model with verbose output to see layer details
-model = YOLO("debug_model.yaml", verbose=True)
+model = YOLO("debug_model.yaml", task="detect", verbose=True)
 
 # Check model FLOPs. Failed forward pass causes 0 FLOPs.
 model.info()
@@ -434,7 +479,7 @@ for i, layer in enumerate(model.model.model):
     print(f"Layer {i}: {layer}")
 ```
 
-**Step-by-Step Validation**
+#### Validate Step by Step
 
 1. **Start minimal**: Test with simplest possible architecture first
 2. **Add incrementally**: Build complexity layer by layer
@@ -453,37 +498,29 @@ nc: 5 # 5 classes
 
 ### Can I use a custom backbone in my model YAML?
 
-Yes. You can use any supported module, including TorchVision backbones, or define your own custom module and import it as described in [Custom Module Integration](#custom-module-integration).
+Yes. Use any supported module, including [TorchVision backbones](#torchvision-integration), or define your own and register it as described in [Custom Module Integration](#custom-module-integration).
+
+### How do I see the YAML for a pretrained model like yolo26n.pt?
+
+Load the checkpoint and read `model.model.yaml`, which holds the parsed architecture the weights were built from. The source files also ship with the package under [`ultralytics/cfg/models`](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/cfg/models) — copying one from there is the recommended starting point for a custom architecture.
+
+### Why does my layer have fewer channels than the number in my YAML?
+
+Because `max_channels` caps the value before the width multiplier is applied, and the result is rounded up to a multiple of 8. With `m: [0.50, 1.00, 512]`, a layer declaring `[1024, 3, 2]` is clamped to 512 first, so it builds 512 channels rather than 1024. See [How Width Scaling Actually Computes Channels](#how-width-scaling-actually-computes-channels).
+
+### Can I train a model YAML from scratch without pretrained weights?
+
+Yes. Passing a YAML instead of a `.pt` file to `YOLO()` builds randomly initialized weights, so `YOLO("custom_model.yaml").train(data="coco8.yaml")` trains from scratch. Expect to need substantially more data and epochs than fine-tuning a pretrained checkpoint — see the [training mode guide](../modes/train.md).
 
 ### How do I scale my model for different sizes (nano, small, medium, etc.)?
 
 Use the [`scales` section](#parameters-section) in your YAML to define scaling factors for depth, width, and max channels. The model will automatically apply these when you load the base YAML file with the scale appended to the filename (e.g., `yolo26n.yaml`).
 
-### What does the `[from, repeats, module, args]` format mean?
-
-This format specifies how each layer is constructed:
-
-- `from`: input source(s)
-- `repeats`: number of times to repeat the module
-- `module`: the layer type
-- `args`: arguments for the module
-
 ### How do I troubleshoot channel mismatch errors?
 
 Check that the output channels of one layer match the expected input channels of the next. Use `print(model.model.model)` to inspect your model's architecture.
-
-### Where can I find a list of available modules and their arguments?
-
-Check the source code in the [`ultralytics/nn/modules` directory](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/nn/modules) for all available modules and their arguments.
-
-### How do I add a custom module to my YAML configuration?
-
-Define your module in the source code, import it as shown in [Source Code Modification](#source-code-modification), and reference it by name in your YAML file.
 
 ### Can I use pretrained weights with a custom YAML?
 
 Yes, you can use `model.load("path/to/weights")` to load weights from a pretrained checkpoint. However, only weights for layers that match would load successfully.
 
-### How do I validate my model configuration?
-
-Use `model.info()` to check whether FLOPs count is non-zero. A valid model should show non-zero FLOPs count. If it's zero, follow the suggestions in [Debugging Tips](#debugging-tips) to find the issue.


### PR DESCRIPTION
## summary

- Corrected claims that were wrong against the current package: the distillation training-log sample showed a `dfl_loss` column YOLO26 does not emit (it is DFL-free, the column is `l1_loss`), the `C2f` argument row named `expansion` where `parse_model` passes `groups`, the quoted `parse_model` resolution logic predated a `startswith` rewrite and would `NameError` if pasted, and `unwrap=True` was described as doing what `unwrap=False` does.
- Fixed code that does not run or silently misbehaves. In the K-Fold guide the label glob returns nothing on the standard `labels/<split>/` layout, a hardcoded extension list drops files, positional `zip` pairs images with other images' labels, and chained pandas assignment writes nothing under copy-on-write. In the trainer guide the `best.pt`-by-custom-metric recipe reads `best_fitness` after `super().validate()` has already overwritten it, and the `get_model` override drops `set_model_names_for_load`, which silently disables class-name remapping.
- Switched the K-Fold walkthrough to the Ultralytics-hosted African Wildlife dataset so every number and output block in it is reproducible, and defined folds as image-path lists, which Ultralytics dataset YAMLs accept natively, instead of copying the dataset once per fold.
- Added what the guides assumed the reader already knew: how to load the released `-distill` checkpoints the performance table is about, how to aggregate metrics across folds, what `max_channels` and 8-multiple channel rounding do, that `cls_pw` already performs inverse-frequency class weighting, and that a custom trainer is not carried through `resume`.

## measured

| check | before | after |
| --- | --- | --- |
| K-Fold label glob on the standard layout | 0 of 1504 files | 1504 |
| K-Fold image/label pairing | 1212 of 1501 pairs wrong | 0 |
| `best.pt` for a metric below default fitness | marks the wrong epoch, or is never written | tracks the chosen metric |
| Backbone resumes training after unfreeze | no parameter movement | `2.4e-05` |
| Fold storage at k=5 | ~525 MB / 15,040 files | 500 KB / 15 files |
| YAML examples that build | 3 of 4 | 4 of 4 |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the custom trainer, K-Fold, knowledge distillation, and model YAML guides to match current Ultralytics behavior and replace incorrect or non-working examples.

### 📊 Key Changes

- Corrected trainer examples for custom-metric checkpoint selection, class-name remapping, optimizer setup, backbone unfreezing, and `resume` behavior.
- Rebuilt the K-Fold walkthrough around the African Wildlife dataset, with correct image-label pairing, supported image formats, pandas assignments, reproducible folds, YAML path lists, duplicate handling, and metric aggregation.
- Updated knowledge distillation documentation with the correct YOLO26 `l1_loss` output, released `-distill` checkpoint loading, supported tasks, same-family requirements, checkpoint contents, and `compile` behavior.
- Expanded the model YAML guide with current `parse_model` resolution, channel scaling and rounding, module arguments, `channels` handling, scale naming, custom-module integration, and debugging examples.
- Corrected stale references such as `C2f` arguments, `TorchVision` `unwrap` behavior, and YOLO26's DFL-free configuration.

### 🎯 Purpose & Impact

- Documentation users now receive examples that reflect current package interfaces and avoid documented failure modes such as empty label collections, incorrect image-label pairing, ineffective pandas writes, and wrong `best.pt` selection.
- The K-Fold workflow avoids copying the dataset into every fold by using image-path lists, while adding reproducible fold checks and cross-fold metric summaries.
- Distillation and YAML users get clearer guidance about supported configurations, actual training-log fields, checkpoint loading, model scaling, and task limitations.
- No runtime package behavior changed; the PR updates documentation and its code examples only.