### PR TITLE
Cap the 'optimizer=auto' rate by dataset size

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1109,7 +1109,10 @@ class BaseTrainer:
                 f"determining best 'optimizer', 'lr0' and 'momentum' automatically... "
             )
             nc = self.data.get("nc", 10)  # number of classes
-            lr_fit = round(0.002 * 5 / (4 + nc), 6)  # lr0 fit equation to 6 decimal places
+            n = len(self.train_loader.dataset)  # training images
+            # the class-count term alone gives a one-class dataset the highest rate the equation can produce, however
+            # few images it holds, so cap it by dataset size, which leaves anything above 500 images unchanged
+            lr_fit = round(min(0.002 * 5 / (4 + nc), 0.002 * math.sqrt(max(n, 1) / 500)), 6)
             name, lr, momentum = ("MuSGD", 0.01, 0.9) if iterations > 10000 else ("AdamW", lr_fit, 0.9)
             self.args.warmup_bias_lr = 0.0  # no higher than 0.01 for Adam
 


### PR DESCRIPTION
`lr_fit` scales only with class count:

```python
lr_fit = round(0.002 * 5 / (4 + nc), 6)
```

A one-class dataset therefore gets `0.002`, the highest rate the equation can produce, however few images it holds. Measured on a 25-image one-class dataset, that rate sits on the edge of a cliff.

| AdamW lr0 | mAP50-95 |
| --------- | -------- |
| 0.0005    | 18.2     |
| 0.001     | 21.0     |
| **0.002** | **11.0** |
| 0.005     | 1.4      |
| 0.01      | 0.9      |

This PR caps the rate by dataset size. The cap can only lower a rate, and `0.002 * sqrt(n / 500)` is at least `0.002` once `n >= 500`, which is the largest value the class-count term can take. Every dataset above 500 training images keeps exactly the rate it has today.

Verified unchanged on three full datasets, stock against patched:

| images | classes | before | after |
| ------ | ------- | ------ | ----- |
| 2687   | 6       | 76.24  | 76.24 |
| 1050   | 6       | 75.88  | 75.88 |
| 445    | 7       | 50.40  | 50.40 |

Below the threshold, on nine public detection datasets subsampled to 12 to 59 images, yolo26n, 100 epochs, batch 16, seeds 0 to 2:

| images | classes | capped | before | after     |
| ------ | ------- | ------ | ------ | --------- |
| 13     | 1       | yes    | 3.48   | **12.55** |
| 35     | 1       | yes    | 4.76   | **9.63**  |
| 36     | 5       | yes    | 10.80  | 13.12     |
| 33     | 2       | yes    | 4.07   | 4.50      |
| 31     | 1       | yes    | 1.88   | 1.86      |
| 39     | 11      | yes    | 19.27  | 18.94     |
| 59     | 2       | yes    | 20.12  | 18.38     |
| 41     | 34      | no     | 3.79   | 3.79      |
| 57     | 11      | no     | 7.83   | 7.83      |

The two datasets the cap does not bind on return identical scores, as expected.

Scope and limits. The mean over the nine is +1.6 but the median is 0.0, so this is not an average accuracy gain and is not offered as one. The case for it is that the gains are large where the equation is furthest wrong, the losses are small, and the change is inert above 500 images. It does not touch the `iterations > 10000` branch or any explicit `lr0`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated `optimizer=auto` to cap its automatically selected AdamW learning rate based on training dataset size, preventing high rates on very small datasets while leaving larger datasets unchanged.

### 📊 Key Changes

- `Trainer.build_optimizer()` now reads the number of images from `self.train_loader.dataset`.
- The automatic learning rate is limited by both the existing class-count calculation and a dataset-size-based cap.
- The cap increases with dataset size and reaches the existing maximum at 500 training images, so datasets above that size retain their previous rate.
- Explicit `lr0` settings and the `iterations > 10000` MuSGD optimizer branch are unchanged.

### 🎯 Purpose & Impact

- Small datasets using `optimizer=auto` may receive a lower AdamW learning rate; datasets with at least 500 training images use the same automatically selected rate as before.
- No user-facing change occurs for explicit learning rates or the MuSGD automatic-optimizer path.