### PR TITLE
Correct code-guide claims and verify every example against the package

### DIFF
--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -186,8 +186,11 @@ def unfreeze_backbone(trainer):
         user_freeze = [x for x in trainer.freeze_layer_names if x not in {".dfl", "teacher_model."}]
         LOGGER.info(f"Epoch {trainer.epoch}: Unfreezing requested layers for fine-tuning")
         for name, param in trainer.model.named_parameters():
-            if not param.requires_grad and ".dfl" not in name and "teacher_model." not in name and any(
-                x in name for x in user_freeze
+            if (
+                not param.requires_grad
+                and ".dfl" not in name
+                and "teacher_model." not in name
+                and any(x in name for x in user_freeze)
             ):
                 param.requires_grad = True
                 LOGGER.info(f"  Unfroze: {name}")

--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -83,7 +83,7 @@ model = YOLO("yolo26n.pt")
 model.train(data="coco8.yaml", epochs=5, trainer=MetricsTrainer)
 ```
 
-This logs the mean F1 score across all classes and a per-class breakdown after each validation run.
+This logs the mean F1 score across all classes represented in validation and a per-class breakdown after each validation run.
 
 !!! note "Available Metrics"
 
@@ -181,14 +181,17 @@ FREEZE_EPOCHS = 5
 
 
 def unfreeze_backbone(trainer):
-    """Callback to unfreeze all layers after FREEZE_EPOCHS."""
+    """Callback to unfreeze the user-requested layers after FREEZE_EPOCHS."""
     if trainer.epoch == FREEZE_EPOCHS:
-        LOGGER.info(f"Epoch {trainer.epoch}: Unfreezing all layers for fine-tuning")
+        user_freeze = [x for x in trainer.freeze_layer_names if x not in {".dfl", "teacher_model."}]
+        LOGGER.info(f"Epoch {trainer.epoch}: Unfreezing requested layers for fine-tuning")
         for name, param in trainer.model.named_parameters():
-            if not param.requires_grad:
+            if not param.requires_grad and ".dfl" not in name and "teacher_model." not in name and any(
+                x in name for x in user_freeze
+            ):
                 param.requires_grad = True
                 LOGGER.info(f"  Unfroze: {name}")
-        trainer.freeze_layer_names = [".dfl"]
+        trainer.freeze_layer_names = [x for x in trainer.freeze_layer_names if x not in user_freeze]
 
 
 class FreezingTrainer(DetectionTrainer):
@@ -204,7 +207,7 @@ model = YOLO("yolo26n.pt")
 model.train(data="coco8.yaml", epochs=20, freeze=10, trainer=FreezingTrainer)
 ```
 
-The `freeze=10` parameter freezes the first 10 layers (indices 0-9) at training start, which covers most of the YOLO26 backbone. The backbone spans layers 0-10, so `freeze=10` leaves the final C2PSA block (layer 10) trainable; use `freeze=11` to freeze the entire backbone. The `on_train_epoch_start` callback fires at the beginning of each epoch and unfreezes all parameters once the freeze period is complete.
+The `freeze=10` parameter freezes the first 10 layers (indices 0-9) at training start, which covers most of the YOLO26 backbone. The backbone spans layers 0-10, so `freeze=10` leaves the final C2PSA block (layer 10) trainable; use `freeze=11` to freeze the entire backbone. The `on_train_epoch_start` callback fires at the beginning of each epoch and unfreezes those requested layers once the freeze period is complete, while preserving permanently frozen DFL and distillation-teacher parameters.
 
 !!! tip "Choosing What to Freeze"
 

--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -390,7 +390,7 @@ model.train(data="coco8.yaml", epochs=20, trainer=RTDETRBackboneLRTrainer)
 
 !!! note "Learning Rate Scheduler"
 
-    The built-in learning rate scheduler (`cosine` or `linear`) still applies on top of the per-group base learning rates. Both the backbone and head learning rates will follow the same decay schedule, maintaining the ratio between them throughout training.
+    The built-in learning rate scheduler (`cosine` or `linear`) still applies on top of the per-group base learning rates, so backbone and head follow the same decay schedule and hold `backbone_lr_ratio` between them. Warmup is the exception: `BaseTrainer` ramps bias groups *down* from `warmup_bias_lr` instead of up from zero, so with an explicit optimizer the two bias groups start warmup sharing one learning rate and only reach the ratio by the end of it — weight and BatchNorm groups hold it from the first batch. `optimizer="auto"` sets `warmup_bias_lr=0.0`, and then every group holds the ratio throughout.
 
 !!! tip "Combining Techniques"
 

--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -365,24 +365,7 @@ model.train(data="coco8.yaml", epochs=20, trainer=PerLayerLRTrainer)
 
 ### RT-DETR Variant
 
-Because the backbone length is read from `model.yaml["backbone"]` rather than hardcoded, the same recipe covers RT-DETR-L, RT-DETR-X and the ResNet-50/101 backbones — only the base class changes. This is especially useful for RT-DETR fine-tuning, where the decoder head is typically randomly initialized while the backbone carries pretrained features that benefit from a lower learning rate:
-
-```python
-from ultralytics import RTDETR
-from ultralytics.models.rtdetr.train import RTDETRTrainer
-
-
-class RTDETRBackboneLRTrainer(PerLayerLRTrainer, RTDETRTrainer):
-    """RT-DETR trainer with a lower learning rate for backbone parameters."""
-
-    backbone_lr_ratio = 0.1
-
-
-model = RTDETR("rtdetr-l.pt")
-model.train(data="coco8.yaml", epochs=20, trainer=RTDETRBackboneLRTrainer)
-```
-
-`RTDETRTrainer` follows `PerLayerLRTrainer` in the MRO, so RT-DETR keeps its own `get_model`, `build_dataset` and `get_validator` while `build_optimizer` comes from the mixin.
+Because the backbone length is read from `model.yaml["backbone"]` rather than hardcoded, the same recipe covers RT-DETR-L, RT-DETR-X and the ResNet-50/101 backbones. Switch the parent class to `RTDETRTrainer` (`from ultralytics.models.rtdetr.train import RTDETRTrainer`) and load the checkpoint with `RTDETR("rtdetr-l.pt")`; the `build_optimizer` body is unchanged. This is especially useful for RT-DETR fine-tuning, where the decoder head is typically randomly initialized while the backbone carries pretrained features that benefit from a lower learning rate.
 
 !!! tip "Choosing `backbone_lr_ratio`"
 

--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -343,7 +343,9 @@ class PerLayerLRTrainer(DetectionTrainer):
             name, lr = "AdamW", round(0.002 * 5 / (4 + self.data["nc"]), 6)
         optimizer_cls = getattr(torch.optim, name, None)
         if optimizer_cls is None:
-            raise NotImplementedError(f"optimizer={name!r} is not in torch.optim; pass Adam, AdamW, SGD, RMSprop or auto")
+            raise NotImplementedError(
+                f"optimizer={name!r} is not in torch.optim; pass Adam, AdamW, SGD, RMSprop or auto"
+            )
 
         unwrapped = unwrap_model(model)
         backbone_len = len(unwrapped.yaml["backbone"])  # YOLO26 backbone spans layers 0-10 (C2PSA at layer 10)

--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -1,21 +1,20 @@
 ---
-title: "Customize the YOLO & RT-DETR Trainer"
 comments: true
-description: Subclass DetectionTrainer or RTDETRTrainer to log F1, weight rare classes, save best.pt by a custom metric, freeze backbones, and set per-layer learning rates.
-keywords: Ultralytics, YOLO, custom trainer, DetectionTrainer, RTDETRTrainer, BaseTrainer, custom metrics, class weights, backbone freezing, per-layer learning rate, SyncBatchNorm, gradient clipping, multi-GPU training
+description: Learn how to customize the Ultralytics YOLO trainer with custom metrics, class-weighted loss, custom model saving, backbone freezing, per-layer learning rates, SyncBatchNorm, and gradient clipping.
+keywords: Ultralytics, YOLO, Custom Trainer, DetectionTrainer, BaseTrainer, Custom Metrics, F1 Score, Class Weights, Backbone Freezing, Per-Layer Learning Rate, SyncBatchNorm, Gradient Clipping, Multi-GPU Training, Fine-Tuning, Transfer Learning
 ---
 
-# Customizing the Ultralytics YOLO and RT-DETR Trainer
+# Customizing Trainer
 
-**Ultralytics YOLO26** training is built around `BaseTrainer` and task-specific trainers such as `DetectionTrainer` and `RTDETRTrainer`. These classes handle the training loop, validation, checkpointing, and logging out of the box. When you need more control — tracking custom metrics, adjusting loss weighting, or setting per-layer learning rates — you subclass the trainer and override specific methods.
+The Ultralytics training pipeline is built around `BaseTrainer` and task-specific trainers like `DetectionTrainer`. These classes handle the training loop, validation, checkpointing, and logging out of the box. When you need more control — tracking custom metrics, adjusting loss weighting, or implementing learning rate schedules — you can subclass the trainer and override specific methods.
 
-This guide walks through seven customizations, shown on YOLO26 and, where the recipe differs, on [RT-DETR](../models/rtdetr.md):
+This guide walks through seven common customizations:
 
 1. [Logging custom metrics (F1 score)](#logging-custom-metrics) at the end of each [epoch](https://www.ultralytics.com/glossary/epoch)
-2. [Adding class weights](#adding-class-weights) beyond what the `cls_pw` argument gives you
+2. [Adding class weights](#adding-class-weights) to handle class imbalance
 3. [Saving the best model](#saving-the-best-model-by-custom-metric) based on a different metric
 4. [Freezing the backbone](#freezing-and-unfreezing-the-backbone) for the first N epochs, then unfreezing
-5. [Specifying per-layer learning rates](#per-layer-learning-rates), including an [RT-DETR variant](#rt-detr-variant) with weight, BatchNorm and bias groups
+5. [Specifying per-layer learning rates](#per-layer-learning-rates)
 6. [Synchronizing BatchNorm across GPUs](#synchronized-batchnorm-for-multi-gpu-training) for multi-GPU training
 7. [Configuring gradient clipping](#configurable-gradient-clipping) for stability tuning
 
@@ -42,13 +41,7 @@ model = YOLO("yolo26n.pt")
 model.train(data="coco8.yaml", epochs=10, trainer=CustomTrainer)
 ```
 
-Your custom trainer inherits all functionality from `DetectionTrainer`, so you only need to override the specific methods you want to customize. To change the network itself rather than how it trains, edit the architecture instead — see the [model YAML configuration reference](model-yaml-config.md).
-
-!!! warning "What a custom trainer does and does not reach"
-
-    The `trainer` argument applies to **that one `train()` call**. The class is not recorded in the checkpoint, so `YOLO("last.pt").train(resume=True)` silently reverts to the stock trainer and every customization on this page is lost mid-run — pass `trainer=` again when you resume. Subsequent `model.val()` and `model.export()` calls are unaffected by it either way.
-
-    Under [multi-GPU training](../modes/train.md#multi-gpu-training), Ultralytics re-launches your script through `torchrun` and generates a launcher that imports the trainer by name — `from <your module> import <YourTrainer>`. A class defined in the launch script resolves to `__main__`, which the new process does not carry, so put custom trainer and model classes in their own importable module for any run with more than one device.
+Your custom trainer inherits all functionality from `DetectionTrainer`, so you only need to override the specific methods you want to customize.
 
 ## Logging Custom Metrics
 
@@ -77,7 +70,6 @@ class MetricsTrainer(DetectionTrainer):
             class_indices = box.ap_class_index
             names = self.validator.names
 
-            # average over every evaluated class; dropping the zeros hides the classes that failed
             mean_f1 = float(np.mean(f1_per_class)) if len(f1_per_class) else 0.0
 
             LOGGER.info(f"Mean F1 Score: {mean_f1:.4f}")
@@ -110,125 +102,31 @@ This logs the mean F1 score across all classes and a per-class breakdown after e
 
 ## Adding Class Weights
 
-!!! tip "Try the `cls_pw` argument first"
-
-    Ultralytics already ships inverse-frequency class weighting. Setting `cls_pw` between `0.0` and `1.0` makes the trainer count instances per class in your dataset, raise the inverse frequency to that power, normalize the result to mean 1.0, and multiply the classification loss by it — no custom code at all. See [how to train on an imbalanced dataset](../modes/train.md#how-do-i-train-a-model-on-an-imbalanced-dataset).
-
-    Subclass only when you need something `cls_pw` cannot express, such as hand-chosen per-class weights that do not follow the frequency distribution. That is what the rest of this section shows.
-
-If your dataset has imbalanced classes (e.g., a rare defect in manufacturing inspection), you can upweight specific classes in the [loss function](https://www.ultralytics.com/glossary/loss-function). This makes the model penalize misclassifications on those classes more heavily.
-
-To set weights the frequency-based argument cannot produce, subclass the loss classes, model, and trainer:
+Set `cls_pw` between `0.0` and `1.0` to apply normalized inverse-frequency weights to the classification loss. Override the existing weight computation only when you need hand-picked ratios:
 
 ```python
-import torch
-from torch import nn
+import numpy as np
 
 from ultralytics import YOLO
 from ultralytics.models.yolo.detect import DetectionTrainer
-from ultralytics.nn.tasks import DetectionModel
-from ultralytics.utils import RANK
-from ultralytics.utils.loss import E2ELoss, v8DetectionLoss
-
-
-class WeightedDetectionLoss(v8DetectionLoss):
-    """Detection loss with class weights applied to BCE classification loss."""
-
-    def __init__(self, model, class_weights=None, tal_topk=10, tal_topk2=None):
-        """Initialize loss with optional per-class weights for BCE."""
-        super().__init__(model, tal_topk=tal_topk, tal_topk2=tal_topk2)
-        if class_weights is not None:
-            self.bce = nn.BCEWithLogitsLoss(
-                pos_weight=class_weights.to(self.device),
-                reduction="none",
-            )
-
-
-class WeightedE2ELoss(E2ELoss):
-    """E2E Loss with class weights for YOLO26."""
-
-    def __init__(self, model, class_weights=None):
-        """Initialize E2E loss with weighted detection loss."""
-
-        def weighted_loss_fn(model, tal_topk=10, tal_topk2=None):
-            return WeightedDetectionLoss(model, class_weights=class_weights, tal_topk=tal_topk, tal_topk2=tal_topk2)
-
-        super().__init__(model, loss_fn=weighted_loss_fn)
-
-
-class WeightedDetectionModel(DetectionModel):
-    """Detection model that uses class-weighted loss."""
-
-    def init_criterion(self):
-        """Initialize weighted loss criterion with per-class weights."""
-        class_weights = torch.ones(self.nc)
-        class_weights[0] = 2.0  # upweight class 0
-        class_weights[1] = 3.0  # upweight rare class 1
-        return WeightedE2ELoss(self, class_weights=class_weights)
 
 
 class WeightedTrainer(DetectionTrainer):
-    """Trainer that returns a WeightedDetectionModel."""
+    """Detection trainer with hand-picked class-weight ratios."""
 
-    def get_model(self, cfg=None, weights=None, verbose=True):
-        """Return a WeightedDetectionModel."""
-        model = self.set_model_names_for_load(  # keeps cls_remap working; dropping it transfers head rows positionally
-            WeightedDetectionModel(cfg, nc=self.data["nc"], ch=self.data["channels"], verbose=verbose and RANK == -1)
-        )
-        if weights:
-            model.load(weights)
-        return model
+    def compute_class_weights(self, class_counts):
+        """Return custom per-class weights for the production loss owner."""
+        weights = np.ones_like(class_counts)
+        weights[0] = 2.0
+        weights[1] = 3.0
+        return weights
 
 
 model = YOLO("yolo26n.pt")
-model.train(data="coco8.yaml", epochs=10, trainer=WeightedTrainer)
+model.train(data="custom.yaml", epochs=10, cls_pw=1.0, trainer=WeightedTrainer)
 ```
 
-!!! warning "Pick indices your dataset actually contains"
-
-    Weights only change the loss for classes that appear in the **training** split. The `coco8.yaml` used above contains no instances of class 0 or class 1 in its train images, so the two weights set here leave the loss bit-identical. Check your label distribution and weight indices that are present, or the example runs cleanly and does nothing. The two indices also assume at least two classes — on a single-class dataset `class_weights[1] = 3.0` raises `IndexError` before training starts.
-
-!!! tip "Computing Weights from Dataset"
-
-    You can compute class weights automatically from your dataset's label distribution. A common approach is inverse frequency weighting:
-
-    ```python
-    import numpy as np
-    import torch
-
-    # class_counts: number of instances per class
-    class_counts = np.array([5000, 200, 3000])
-    # Inverse frequency: rarer classes get higher weight
-    class_weights = torch.from_numpy(class_counts.max() / class_counts).float()
-    # tensor([ 1.0000, 25.0000,  1.6667])
-    ```
-
-    The `.float()` tensor is what `init_criterion` above expects — a raw NumPy array has no `.to(self.device)`.
-
-!!! note "Loading a model with custom classes"
-
-    Custom classes such as `WeightedDetectionModel` are stored in the checkpoint by reference. When defined in a training script they belong to the `__main__` module, so loading `best.pt` from a different script raises `AttributeError: Can't get attribute 'WeightedDetectionModel' on <module '__main__'>`.
-
-    Define custom classes in a dedicated module so they remain importable, and ensure that module is on your `PYTHONPATH` at load time.
-
-    ```python
-    # weighted_model.py
-    from ultralytics.nn.tasks import DetectionModel
-
-
-    class WeightedDetectionModel(DetectionModel):
-        """Detection model that uses class-weighted loss."""
-    ```
-
-    ```python
-    # inference script
-    from weighted_model import WeightedDetectionModel  # noqa: F401 - must be importable at checkpoint load time
-
-    from ultralytics import YOLO
-
-    model = YOLO("runs/detect/train/weights/best.pt")
-    metrics = model.val()
-    ```
+`set_class_weights()` normalizes these values to a mean of 1.0 and stores them on the model, where the existing detection loss applies them. The indices above require a dataset with at least two classes.
 
 ## Saving the Best Model by Custom Metric
 
@@ -244,12 +142,12 @@ class CustomSaveTrainer(DetectionTrainer):
 
     def validate(self):
         """Override fitness to use mAP@0.5 for best model selection."""
-        prev_best = self.best_fitness  # BaseTrainer.validate() overwrites this with the default fitness
+        previous_best = self.best_fitness
         metrics, fitness = super().validate()
         if metrics is None:
             return metrics, fitness
         fitness = metrics["metrics/mAP50(B)"]
-        self.best_fitness = fitness if prev_best is None else max(prev_best, fitness)
+        self.best_fitness = fitness if previous_best is None else max(previous_best, fitness)
         return metrics, fitness
 
 
@@ -257,13 +155,11 @@ model = YOLO("yolo26n.pt")
 model.train(data="coco8.yaml", epochs=20, trainer=CustomSaveTrainer)
 ```
 
-!!! warning "Capture `best_fitness` before calling `super().validate()`"
-
-    `BaseTrainer.validate()` sets `self.best_fitness` from the **default** fitness before your override runs, and `save_model()` writes `best.pt` only when `self.best_fitness == self.fitness`. Reading `self.best_fitness` after the `super()` call therefore compares your metric against a number on a different scale. With mAP@0.5 the mistake is hidden, because mAP@0.5 is always at least mAP@0.5:0.95. With a metric that can sit **below** default fitness — recall, for instance — `best.pt` instead tracks whichever epoch first beat the *default* fitness, so it marks the wrong checkpoint, and on a run where the custom metric never crosses that running maximum it is not written at all.
+`BaseTrainer.validate()` updates `best_fitness` using the default metric, so capture its previous value before calling it.
 
 !!! note "Available Metrics"
 
-    Use the `metrics` dict returned by `super().validate()`, as the code above does. The trainer's own `self.metrics` is assigned only *after* `validate()` returns, so inside the override it still holds the previous epoch's values. Its keys are:
+    Common metrics available in `self.metrics` after validation include:
 
     | Key | Description |
     |---|---|
@@ -330,27 +226,27 @@ from ultralytics.utils.torch_utils import unwrap_model
 class PerLayerLRTrainer(DetectionTrainer):
     """Trainer with different learning rates for backbone and head."""
 
-    backbone_lr_ratio = 0.1  # backbone learning rate as a fraction of head learning rate
+    backbone_lr_ratio = 0.1
 
     def build_optimizer(self, model, name="auto", lr=0.001, momentum=0.9, decay=1e-5, iterations=1e5):
-        """Split the trainer's own optimizer groups by section and lower the backbone learning rate."""
+        """Reuse the trainer optimizer and lower its backbone parameter-group rates."""
         optimizer = super().build_optimizer(model, name, lr, momentum, decay, iterations)
         unwrapped = unwrap_model(model)
-        backbone_len = len(unwrapped.yaml["backbone"])  # YOLO26 backbone spans layers 0-10 (C2PSA at layer 10)
+        backbone_len = len(unwrapped.yaml["backbone"])
         backbone = {
             id(p)
-            for k, p in unwrapped.named_parameters()  # no requires_grad filter, so frozen layers can be unfrozen later
-            if any(k.startswith(f"model.{i}.") for i in range(backbone_len))
+            for name, p in unwrapped.named_parameters()
+            if any(name.startswith(f"model.{i}.") for i in range(backbone_len))
         }
 
         groups = []
-        for g in optimizer.param_groups:  # each group already carries BaseTrainer's betas/nesterov/decay
-            head_params = [p for p in g["params"] if id(p) not in backbone]
-            backbone_params = [p for p in g["params"] if id(p) in backbone]
+        for group in optimizer.param_groups:
+            head_params = [p for p in group["params"] if id(p) not in backbone]
+            backbone_params = [p for p in group["params"] if id(p) in backbone]
             if head_params:
-                groups.append({**g, "params": head_params})
+                groups.append({**group, "params": head_params})
             if backbone_params:
-                groups.append({**g, "params": backbone_params, "lr": g["lr"] * self.backbone_lr_ratio})
+                groups.append({**group, "params": backbone_params, "lr": group["lr"] * self.backbone_lr_ratio})
         optimizer.param_groups = groups
 
         LOGGER.info(f"PerLayerLR: {len(backbone)} backbone params at {self.backbone_lr_ratio}x the head rate")
@@ -363,19 +259,7 @@ model.train(data="coco8.yaml", epochs=20, trainer=PerLayerLRTrainer)
 
 ### RT-DETR Variant
 
-Because the backbone length is read from `model.yaml["backbone"]` rather than hardcoded, the same recipe covers RT-DETR-L, RT-DETR-X and the ResNet-50/101 backbones. Switch the parent class to `RTDETRTrainer` (`from ultralytics.models.rtdetr.train import RTDETRTrainer`) and load the checkpoint with `RTDETR("rtdetr-l.pt")`; the `build_optimizer` body is unchanged. This is especially useful for RT-DETR fine-tuning on a new dataset, where the decoder's classification layer is rebuilt for your class count while the backbone carries pretrained features that benefit from a lower learning rate.
-
-!!! tip "Choosing `backbone_lr_ratio`"
-
-    A common starting point is `backbone_lr_ratio = 0.1`, matching the original RT-DETR setup with its HGNetV2 backbone. The literature suggests scaling the ratio inversely with backbone size and pretraining-data scale: large backbones pretrained on very large datasets (for example ViT-L/H trained with DINO, CLIP, or MAE on hundreds of millions of images) typically use smaller ratios such as `0.01` or below to preserve well-learned features, while smaller backbones with lighter pretraining tolerate larger ratios such as `0.5` or higher.
-
-!!! note "Learning Rate Scheduler"
-
-    The built-in learning rate scheduler (`cosine` or `linear`) still applies on top of the per-group base learning rates, so backbone and head follow the same decay schedule and hold `backbone_lr_ratio` between them. Warmup is the exception: `BaseTrainer` ramps bias groups *down* from `warmup_bias_lr` instead of up from zero, so with an explicit optimizer the two bias groups start warmup sharing one learning rate and only reach the ratio by the end of it — weight and BatchNorm groups hold it from the first batch. `optimizer="auto"` sets `warmup_bias_lr=0.0`, and then every group holds the ratio throughout.
-
-!!! tip "Combining Techniques"
-
-    These customizations can be combined into a single trainer class by overriding multiple methods and adding callbacks as needed. One pairing needs care: `BaseTrainer.build_optimizer` deliberately does **not** filter on `requires_grad`, which is exactly why the [freeze and unfreeze](#freezing-and-unfreezing-the-backbone) recipe works — frozen parameters are still in a param group, so they resume training the moment the callback unfreezes them. A custom `build_optimizer` that skips them leaves those parameters with no optimizer state, and the backbone never trains again however many epochs remain. The recipe above only re-splits the groups `BaseTrainer` already built, so it inherits that behavior.
+For RT-DETR, use the same override with `RTDETRTrainer` as the parent and load the checkpoint with `RTDETR("rtdetr-l.pt")`.
 
 ## Synchronized BatchNorm for Multi-GPU Training
 
@@ -434,9 +318,9 @@ class CustomClipTrainer(RTDETRTrainer):
     def optimizer_step(self):
         """Run an optimizer step with a configurable gradient-norm clip."""
         self.scaler.unscale_(self.optimizer)
-        if self.clip_grad_norm > 0:  # BaseTrainer clips at a fixed 10.0, and passes foreach=False on Ascend NPU
-            npu = {"foreach": False} if self.device.type == "npu" and TORCH_2_0 else {}
-            torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=self.clip_grad_norm, **npu)
+        if self.clip_grad_norm > 0:
+            kwargs = {"foreach": False} if self.device.type == "npu" and TORCH_2_0 else {}
+            torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=self.clip_grad_norm, **kwargs)
         self.scaler.step(self.optimizer)
         self.scaler.update()
         self.optimizer.zero_grad()
@@ -470,7 +354,7 @@ from ultralytics.models.yolo.detect import DetectionTrainer
 
 
 class MyCustomTrainer(DetectionTrainer):
-    """A custom trainer that extends DetectionTrainer with additional functionality."""
+    """A custom trainer that extends DetectionTrainer."""
 
 
 model = YOLO("yolo26n.pt")
@@ -511,6 +395,4 @@ model = YOLO("yolo26n.pt")
 model.train(data="coco8.yaml", box=10.0, cls=1.5, dfl=2.0)
 ```
 
-On YOLO26 the `dfl` gain still applies, but not to a distribution focal loss: YOLO26 ships `reg_max: 1`, so there is no DFL term and the gain scales the `l1_loss` column you see in the training log instead. On YOLOv8 and YOLO11, which use `reg_max: 16`, it scales the `dfl_loss` term as the name suggests.
-
-For structural changes to the loss (such as arbitrary class weights), subclass the loss and model as shown in the [class weights section](#adding-class-weights). For inverse-frequency weighting, use the `cls_pw` argument instead of any of this.
+On YOLO26, `dfl` scales the logged `l1_loss` because its detection head uses `reg_max: 1`; on YOLOv8 and YOLO11 it scales `dfl_loss`.

--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -1,20 +1,21 @@
 ---
+title: "Customize the YOLO & RT-DETR Trainer"
 comments: true
-description: Learn how to customize the Ultralytics YOLO trainer with custom metrics, class-weighted loss, custom model saving, backbone freezing, per-layer learning rates, SyncBatchNorm, and gradient clipping.
-keywords: Ultralytics, YOLO, Custom Trainer, DetectionTrainer, BaseTrainer, Custom Metrics, F1 Score, Class Weights, Backbone Freezing, Per-Layer Learning Rate, SyncBatchNorm, Gradient Clipping, Multi-GPU Training, Fine-Tuning, Transfer Learning
+description: Subclass DetectionTrainer or RTDETRTrainer to log F1, weight rare classes, save best.pt by a custom metric, freeze backbones, and set per-layer learning rates.
+keywords: Ultralytics, YOLO, custom trainer, DetectionTrainer, RTDETRTrainer, BaseTrainer, custom metrics, class weights, backbone freezing, per-layer learning rate, SyncBatchNorm, gradient clipping, multi-GPU training
 ---
 
-# Customizing Trainer
+# Customizing the Ultralytics YOLO and RT-DETR Trainer
 
-The Ultralytics training pipeline is built around `BaseTrainer` and task-specific trainers like `DetectionTrainer`. These classes handle the training loop, validation, checkpointing, and logging out of the box. When you need more control — tracking custom metrics, adjusting loss weighting, or implementing learning rate schedules — you can subclass the trainer and override specific methods.
+**Ultralytics YOLO26** training is built around `BaseTrainer` and task-specific trainers such as `DetectionTrainer` and `RTDETRTrainer`. These classes handle the training loop, validation, checkpointing, and logging out of the box. When you need more control — tracking custom metrics, adjusting loss weighting, or setting per-layer learning rates — you subclass the trainer and override specific methods.
 
-This guide walks through seven common customizations:
+This guide walks through seven customizations, shown on YOLO26 and, where the recipe differs, on [RT-DETR](../models/rtdetr.md):
 
 1. [Logging custom metrics (F1 score)](#logging-custom-metrics) at the end of each [epoch](https://www.ultralytics.com/glossary/epoch)
-2. [Adding class weights](#adding-class-weights) to handle class imbalance
+2. [Adding class weights](#adding-class-weights) beyond what the `cls_pw` argument gives you
 3. [Saving the best model](#saving-the-best-model-by-custom-metric) based on a different metric
 4. [Freezing the backbone](#freezing-and-unfreezing-the-backbone) for the first N epochs, then unfreezing
-5. [Specifying per-layer learning rates](#per-layer-learning-rates)
+5. [Specifying per-layer learning rates](#per-layer-learning-rates), including an [RT-DETR variant](#rt-detr-variant) with weight, BatchNorm and bias groups
 6. [Synchronizing BatchNorm across GPUs](#synchronized-batchnorm-for-multi-gpu-training) for multi-GPU training
 7. [Configuring gradient clipping](#configurable-gradient-clipping) for stability tuning
 
@@ -41,7 +42,13 @@ model = YOLO("yolo26n.pt")
 model.train(data="coco8.yaml", epochs=10, trainer=CustomTrainer)
 ```
 
-Your custom trainer inherits all functionality from `DetectionTrainer`, so you only need to override the specific methods you want to customize.
+Your custom trainer inherits all functionality from `DetectionTrainer`, so you only need to override the specific methods you want to customize. To change the network itself rather than how it trains, edit the architecture instead — see the [model YAML configuration reference](model-yaml-config.md).
+
+!!! warning "What a custom trainer does and does not reach"
+
+    The `trainer` argument applies to **that one `train()` call**. The class is not recorded in the checkpoint, so `YOLO("last.pt").train(resume=True)` silently reverts to the stock trainer and every customization on this page is lost mid-run — pass `trainer=` again when you resume. Subsequent `model.val()` and `model.export()` calls are unaffected by it either way.
+
+    Under [multi-GPU training](../modes/train.md#multi-gpu-training), Ultralytics re-launches your script through `torchrun` and generates a launcher that imports the trainer by name — `from <your module> import <YourTrainer>`. A class defined in the launch script resolves to `__main__`, which the new process does not carry, so put custom trainer and model classes in their own importable module for any run with more than one device.
 
 ## Logging Custom Metrics
 
@@ -105,9 +112,15 @@ This logs the mean F1 score across all classes and a per-class breakdown after e
 
 ## Adding Class Weights
 
-If your dataset has imbalanced classes (e.g., a rare defect in manufacturing inspection), you can upweight underrepresented classes in the [loss function](https://www.ultralytics.com/glossary/loss-function). This makes the model penalize misclassifications on rare classes more heavily.
+!!! tip "Try the `cls_pw` argument first"
 
-To customize the loss, subclass the loss classes, model, and trainer:
+    Ultralytics already ships inverse-frequency class weighting. Setting `cls_pw` between `0.0` and `1.0` makes the trainer count instances per class in your dataset, raise the inverse frequency to that power, normalize the result to mean 1.0, and multiply the classification loss by it — no custom code at all. See [how to train on an imbalanced dataset](../modes/train.md#how-do-i-train-a-model-on-an-imbalanced-dataset).
+
+    Subclass only when you need something `cls_pw` cannot express, such as hand-chosen per-class weights that do not follow the frequency distribution. That is what the rest of this section shows.
+
+If your dataset has imbalanced classes (e.g., a rare defect in manufacturing inspection), you can upweight specific classes in the [loss function](https://www.ultralytics.com/glossary/loss-function). This makes the model penalize misclassifications on those classes more heavily.
+
+To set weights the frequency-based argument cannot produce, subclass the loss classes, model, and trainer:
 
 ```python
 import torch
@@ -161,7 +174,9 @@ class WeightedTrainer(DetectionTrainer):
 
     def get_model(self, cfg=None, weights=None, verbose=True):
         """Return a WeightedDetectionModel."""
-        model = WeightedDetectionModel(cfg, nc=self.data["nc"], verbose=verbose and RANK == -1)
+        model = self.set_model_names_for_load(  # keeps cls_remap working; dropping it transfers head rows positionally
+            WeightedDetectionModel(cfg, nc=self.data["nc"], ch=self.data["channels"], verbose=verbose and RANK == -1)
+        )
         if weights:
             model.load(weights)
         return model
@@ -171,19 +186,26 @@ model = YOLO("yolo26n.pt")
 model.train(data="coco8.yaml", epochs=10, trainer=WeightedTrainer)
 ```
 
+!!! warning "Pick indices your dataset actually contains"
+
+    Weights only change the loss for classes that appear in the **training** split. The `coco8.yaml` used above contains no instances of class 0 or class 1 in its train images, so the two weights set here leave the loss bit-identical. Check your label distribution and weight indices that are present, or the example runs cleanly and does nothing. The two indices also assume at least two classes — on a single-class dataset `class_weights[1] = 3.0` raises `IndexError` before training starts.
+
 !!! tip "Computing Weights from Dataset"
 
     You can compute class weights automatically from your dataset's label distribution. A common approach is inverse frequency weighting:
 
     ```python
     import numpy as np
+    import torch
 
     # class_counts: number of instances per class
     class_counts = np.array([5000, 200, 3000])
     # Inverse frequency: rarer classes get higher weight
-    class_weights = max(class_counts) / class_counts
-    # Result: [1.0, 25.0, 1.67]
+    class_weights = torch.from_numpy(class_counts.max() / class_counts).float()
+    # tensor([ 1.0000, 25.0000,  1.6667])
     ```
+
+    The `.float()` tensor is what `init_criterion` above expects — a raw NumPy array has no `.to(self.device)`.
 
 !!! note "Loading a model with custom classes"
 
@@ -224,11 +246,12 @@ class CustomSaveTrainer(DetectionTrainer):
 
     def validate(self):
         """Override fitness to use mAP@0.5 for best model selection."""
+        prev_best = self.best_fitness  # BaseTrainer.validate() overwrites this with the default fitness
         metrics, fitness = super().validate()
-        if metrics:
-            fitness = metrics.get("metrics/mAP50(B)", fitness)
-            if self.best_fitness is None or fitness > self.best_fitness:
-                self.best_fitness = fitness
+        if metrics is None:
+            return metrics, fitness
+        fitness = metrics["metrics/mAP50(B)"]
+        self.best_fitness = fitness if prev_best is None else max(prev_best, fitness)
         return metrics, fitness
 
 
@@ -236,9 +259,13 @@ model = YOLO("yolo26n.pt")
 model.train(data="coco8.yaml", epochs=20, trainer=CustomSaveTrainer)
 ```
 
+!!! warning "Capture `best_fitness` before calling `super().validate()`"
+
+    `BaseTrainer.validate()` sets `self.best_fitness` from the **default** fitness before your override runs, and `save_model()` writes `best.pt` only when `self.best_fitness == self.fitness`. Reading `self.best_fitness` after the `super()` call therefore compares your metric against a number on a different scale. With mAP@0.5 the mistake is hidden, because mAP@0.5 is always at least mAP@0.5:0.95. With a metric that can sit **below** default fitness — recall, for instance — `best.pt` instead tracks whichever epoch first beat the *default* fitness, so it marks the wrong checkpoint, and on a run where the custom metric never crosses that running maximum it is not written at all.
+
 !!! note "Available Metrics"
 
-    Common metrics available in `self.metrics` after validation include:
+    Use the `metrics` dict returned by `super().validate()`, as the code above does. The trainer's own `self.metrics` is assigned only *after* `validate()` returns, so inside the override it still holds the previous epoch's values. Its keys are:
 
     | Key | Description |
     |---|---|
@@ -312,12 +339,16 @@ class PerLayerLRTrainer(DetectionTrainer):
         backbone_params = []
         head_params = []
 
+        if name == "auto":  # BaseTrainer fits an AdamW-scale lr here; without this you inherit lr0, an SGD-scale value
+            name, lr = "AdamW", round(0.002 * 5 / (4 + self.data["nc"]), 6)
+        optimizer_cls = getattr(torch.optim, name, None)
+        if optimizer_cls is None:
+            raise NotImplementedError(f"optimizer={name!r} is not in torch.optim; pass Adam, AdamW, SGD, RMSprop or auto")
+
         unwrapped = unwrap_model(model)
         backbone_len = len(unwrapped.yaml["backbone"])  # YOLO26 backbone spans layers 0-10 (C2PSA at layer 10)
 
-        for k, v in unwrapped.named_parameters():
-            if not v.requires_grad:
-                continue
+        for k, v in unwrapped.named_parameters():  # no requires_grad filter, so frozen layers can be unfrozen later
             is_backbone = any(k.startswith(f"model.{i}.") for i in range(backbone_len))
             if is_backbone:
                 backbone_params.append(v)
@@ -326,15 +357,14 @@ class PerLayerLRTrainer(DetectionTrainer):
 
         backbone_lr = lr * 0.1
 
-        optimizer = torch.optim.AdamW(
-            [
-                {"params": backbone_params, "lr": backbone_lr, "weight_decay": decay},
-                {"params": head_params, "lr": lr, "weight_decay": decay},
-            ],
-        )
+        groups = [
+            {"params": backbone_params, "lr": backbone_lr, "weight_decay": decay},
+            {"params": head_params, "lr": lr, "weight_decay": decay},
+        ]
+        optimizer = optimizer_cls(groups, momentum=momentum) if name in {"SGD", "RMSprop"} else optimizer_cls(groups)
 
         LOGGER.info(
-            f"PerLayerLR optimizer: backbone ({len(backbone_params)} params, lr={backbone_lr}) "
+            f"PerLayerLR {name}: backbone ({len(backbone_params)} params, lr={backbone_lr}) "
             f"| head ({len(head_params)} params, lr={lr})"
         )
         return optimizer
@@ -370,7 +400,7 @@ class RTDETRBackboneLRTrainer(RTDETRTrainer):
         name = {x.lower(): x for x in canonical}.get(name.lower(), name)
         if name == "auto":
             name, lr, momentum = "AdamW", 1e-4, 0.9
-        self.args.warmup_bias_lr = 0.0  # RT-DETR warms biases from 0, unlike YOLO's 0.1
+        self.args.warmup_bias_lr = 0.0  # optimizer="auto" sets this too; keep it for explicit optimizers
         if name not in {"Adam", "Adamax", "AdamW", "NAdam", "RAdam"}:
             raise NotImplementedError(f"This trainer only supports AdamW-family optimizers; got {name}")
 
@@ -382,8 +412,6 @@ class RTDETRBackboneLRTrainer(RTDETRTrainer):
 
         for module_name, module in unwrapped.named_modules():
             for param_name, param in module.named_parameters(recurse=False):
-                if not param.requires_grad:
-                    continue
                 fullname = f"{module_name}.{param_name}" if module_name else param_name
                 parts = fullname.split(".")
                 section = (
@@ -436,7 +464,7 @@ model.train(data="coco8.yaml", epochs=20, trainer=RTDETRBackboneLRTrainer)
 
 !!! tip "Combining Techniques"
 
-    These customizations can be combined into a single trainer class by overriding multiple methods and adding callbacks as needed.
+    These customizations can be combined into a single trainer class by overriding multiple methods and adding callbacks as needed. One pairing needs care: `BaseTrainer.build_optimizer` deliberately does **not** filter on `requires_grad`, which is exactly why the [freeze and unfreeze](#freezing-and-unfreezing-the-backbone) recipe works — frozen parameters are still in a param group, so they resume training the moment the callback unfreezes them. A custom `build_optimizer` that skips them leaves those parameters with no optimizer state, and the backbone never trains again however many epochs remain. Neither `build_optimizer` on this page filters on `requires_grad`, for that reason.
 
 ## Synchronized BatchNorm for Multi-GPU Training
 
@@ -525,6 +553,12 @@ Pass your custom trainer class (not an instance) to the `trainer` parameter in `
 
 ```python
 from ultralytics import YOLO
+from ultralytics.models.yolo.detect import DetectionTrainer
+
+
+class MyCustomTrainer(DetectionTrainer):
+    """A custom trainer that extends DetectionTrainer with additional functionality."""
+
 
 model = YOLO("yolo26n.pt")
 model.train(data="coco8.yaml", trainer=MyCustomTrainer)
@@ -558,7 +592,12 @@ Yes, for simpler customizations, [callbacks](../usage/callbacks.md) are often su
 If your change is simpler (such as adjusting loss gains), you can modify the [hyperparameters](https://www.ultralytics.com/glossary/hyperparameter-tuning) directly:
 
 ```python
+from ultralytics import YOLO
+
+model = YOLO("yolo26n.pt")
 model.train(data="coco8.yaml", box=10.0, cls=1.5, dfl=2.0)
 ```
 
-For structural changes to the loss (such as adding class weights), you need to subclass the loss and model as shown in the [class weights section](#adding-class-weights).
+On YOLO26 the `dfl` gain still applies, but not to a distribution focal loss: YOLO26 ships `reg_max: 1`, so there is no DFL term and the gain scales the `l1_loss` column you see in the training log instead. On YOLOv8 and YOLO11, which use `reg_max: 16`, it scales the `dfl_loss` term as the name suggests.
+
+For structural changes to the loss (such as arbitrary class weights), subclass the loss and model as shown in the [class weights section](#adding-class-weights). For inverse-frequency weighting, use the `cls_pw` argument instead of any of this.

--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -323,8 +323,6 @@ The `freeze=10` parameter freezes the first 10 layers (indices 0-9) at training 
 Different parts of the network can benefit from different [learning rates](https://www.ultralytics.com/glossary/learning-rate). A common strategy is to use a lower learning rate for the pretrained backbone to preserve learned features, while allowing the detection head to adapt more quickly with a higher rate:
 
 ```python
-import torch
-
 from ultralytics import YOLO
 from ultralytics.models.yolo.detect import DetectionTrainer
 from ultralytics.utils import LOGGER
@@ -334,41 +332,30 @@ from ultralytics.utils.torch_utils import unwrap_model
 class PerLayerLRTrainer(DetectionTrainer):
     """Trainer with different learning rates for backbone and head."""
 
+    backbone_lr_ratio = 0.1  # backbone learning rate as a fraction of head learning rate
+
     def build_optimizer(self, model, name="auto", lr=0.001, momentum=0.9, decay=1e-5, iterations=1e5):
-        """Build optimizer with separate learning rates for backbone and head."""
-        backbone_params = []
-        head_params = []
-
-        if name == "auto":  # BaseTrainer fits an AdamW-scale lr here; without this you inherit lr0, an SGD-scale value
-            name, lr = "AdamW", round(0.002 * 5 / (4 + self.data["nc"]), 6)
-        optimizer_cls = getattr(torch.optim, name, None)
-        if optimizer_cls is None:
-            raise NotImplementedError(
-                f"optimizer={name!r} is not in torch.optim; pass Adam, AdamW, SGD, RMSprop or auto"
-            )
-
+        """Split the trainer's own optimizer groups by section and lower the backbone learning rate."""
+        optimizer = super().build_optimizer(model, name, lr, momentum, decay, iterations)
         unwrapped = unwrap_model(model)
         backbone_len = len(unwrapped.yaml["backbone"])  # YOLO26 backbone spans layers 0-10 (C2PSA at layer 10)
+        backbone = {
+            id(p)
+            for k, p in unwrapped.named_parameters()  # no requires_grad filter, so frozen layers can be unfrozen later
+            if any(k.startswith(f"model.{i}.") for i in range(backbone_len))
+        }
 
-        for k, v in unwrapped.named_parameters():  # no requires_grad filter, so frozen layers can be unfrozen later
-            is_backbone = any(k.startswith(f"model.{i}.") for i in range(backbone_len))
-            if is_backbone:
-                backbone_params.append(v)
-            else:
-                head_params.append(v)
+        groups = []
+        for g in optimizer.param_groups:  # each group already carries BaseTrainer's betas/nesterov/decay
+            head_params = [p for p in g["params"] if id(p) not in backbone]
+            backbone_params = [p for p in g["params"] if id(p) in backbone]
+            if head_params:
+                groups.append({**g, "params": head_params})
+            if backbone_params:
+                groups.append({**g, "params": backbone_params, "lr": g["lr"] * self.backbone_lr_ratio})
+        optimizer.param_groups = groups
 
-        backbone_lr = lr * 0.1
-
-        groups = [
-            {"params": backbone_params, "lr": backbone_lr, "weight_decay": decay},
-            {"params": head_params, "lr": lr, "weight_decay": decay},
-        ]
-        optimizer = optimizer_cls(groups, momentum=momentum) if name in {"SGD", "RMSprop"} else optimizer_cls(groups)
-
-        LOGGER.info(
-            f"PerLayerLR {name}: backbone ({len(backbone_params)} params, lr={backbone_lr}) "
-            f"| head ({len(head_params)} params, lr={lr})"
-        )
+        LOGGER.info(f"PerLayerLR: {len(backbone)} backbone params at {self.backbone_lr_ratio}x the head rate")
         return optimizer
 
 
@@ -378,83 +365,24 @@ model.train(data="coco8.yaml", epochs=20, trainer=PerLayerLRTrainer)
 
 ### RT-DETR Variant
 
-For RT-DETR the pattern is the same with two refinements. The backbone length is read from `model.yaml["backbone"]` so the same trainer works across RT-DETR variants (RT-DETR-L, RT-DETR-X, ResNet-50/101 backbones) without hardcoding layer counts. Parameters are also split into weight, BatchNorm, and bias groups within each section so weight decay is excluded from BatchNorm parameters and biases, matching the default trainer's policy. This is especially useful for RT-DETR fine-tuning, where the decoder head is typically randomly initialized while the backbone carries pretrained features that benefit from a lower learning rate:
+Because the backbone length is read from `model.yaml["backbone"]` rather than hardcoded, the same recipe covers RT-DETR-L, RT-DETR-X and the ResNet-50/101 backbones — only the base class changes. This is especially useful for RT-DETR fine-tuning, where the decoder head is typically randomly initialized while the backbone carries pretrained features that benefit from a lower learning rate:
 
 ```python
-import torch
-from torch import nn
-
 from ultralytics import RTDETR
 from ultralytics.models.rtdetr.train import RTDETRTrainer
-from ultralytics.utils import LOGGER, colorstr
-from ultralytics.utils.torch_utils import unwrap_model
 
 
-class RTDETRBackboneLRTrainer(RTDETRTrainer):
+class RTDETRBackboneLRTrainer(PerLayerLRTrainer, RTDETRTrainer):
     """RT-DETR trainer with a lower learning rate for backbone parameters."""
 
-    backbone_lr_ratio = 0.1  # backbone learning rate as a fraction of head learning rate
-
-    def build_optimizer(self, model, name="auto", lr=0.001, momentum=0.9, decay=1e-5, iterations=1e5):
-        """Build an AdamW optimizer with six param groups: head and backbone x {weight, bn, bias}."""
-        # Resolve optimizer name; "auto" maps to AdamW with RT-DETR-style defaults
-        canonical = {"Adam", "Adamax", "AdamW", "NAdam", "RAdam", "auto"}
-        name = {x.lower(): x for x in canonical}.get(name.lower(), name)
-        if name == "auto":
-            name, lr, momentum = "AdamW", 1e-4, 0.9
-        self.args.warmup_bias_lr = 0.0  # optimizer="auto" sets this too; keep it for explicit optimizers
-        if name not in {"Adam", "Adamax", "AdamW", "NAdam", "RAdam"}:
-            raise NotImplementedError(f"This trainer only supports AdamW-family optimizers; got {name}")
-
-        # Identify backbone parameters from model.yaml and route each param into a (section, kind) group
-        unwrapped = unwrap_model(model)
-        backbone_len = len(unwrapped.yaml["backbone"])
-        norm_types = tuple(v for k, v in nn.__dict__.items() if "Norm" in k)
-        groups = {f"{s}_{k}": [] for s in ("head", "backbone") for k in ("weight", "bn", "bias")}
-
-        for module_name, module in unwrapped.named_modules():
-            for param_name, param in module.named_parameters(recurse=False):
-                fullname = f"{module_name}.{param_name}" if module_name else param_name
-                parts = fullname.split(".")
-                section = (
-                    "backbone"
-                    if len(parts) > 1 and parts[0] == "model" and parts[1].isdigit() and int(parts[1]) < backbone_len
-                    else "head"
-                )
-                if "bias" in param_name:
-                    kind = "bias"
-                elif isinstance(module, norm_types) or "logit_scale" in fullname:
-                    kind = "bn"
-                else:
-                    kind = "weight"
-                groups[f"{section}_{kind}"].append(param)
-
-        # Build the optimizer with per-group lr and weight decay; backbone groups use lr * backbone_lr_ratio
-        backbone_lr = lr * self.backbone_lr_ratio
-        param_groups = [
-            {"params": groups["head_weight"], "lr": lr, "weight_decay": decay, "param_group": "weight"},
-            {"params": groups["head_bn"], "lr": lr, "weight_decay": 0.0, "param_group": "bn"},
-            {"params": groups["head_bias"], "lr": lr, "weight_decay": 0.0, "param_group": "bias"},
-            {"params": groups["backbone_weight"], "lr": backbone_lr, "weight_decay": decay, "param_group": "weight"},
-            {"params": groups["backbone_bn"], "lr": backbone_lr, "weight_decay": 0.0, "param_group": "bn"},
-            {"params": groups["backbone_bias"], "lr": backbone_lr, "weight_decay": 0.0, "param_group": "bias"},
-        ]
-        param_groups = [pg for pg in param_groups if pg["params"]]  # drop empty groups
-        optimizer = getattr(torch.optim, name)(param_groups, betas=(momentum, 0.999))
-
-        LOGGER.info(
-            f"{colorstr('optimizer:')} {name}(lr={lr}, backbone_lr={backbone_lr}) with parameter groups\n"
-            f"  Head:     {len(groups['head_bn'])} bn, {len(groups['head_weight'])} weight(decay={decay}), "
-            f"{len(groups['head_bias'])} bias (lr={lr})\n"
-            f"  Backbone: {len(groups['backbone_bn'])} bn, {len(groups['backbone_weight'])} weight(decay={decay}), "
-            f"{len(groups['backbone_bias'])} bias (lr={backbone_lr})"
-        )
-        return optimizer
+    backbone_lr_ratio = 0.1
 
 
 model = RTDETR("rtdetr-l.pt")
 model.train(data="coco8.yaml", epochs=20, trainer=RTDETRBackboneLRTrainer)
 ```
+
+`RTDETRTrainer` follows `PerLayerLRTrainer` in the MRO, so RT-DETR keeps its own `get_model`, `build_dataset` and `get_validator` while `build_optimizer` comes from the mixin.
 
 !!! tip "Choosing `backbone_lr_ratio`"
 
@@ -466,7 +394,7 @@ model.train(data="coco8.yaml", epochs=20, trainer=RTDETRBackboneLRTrainer)
 
 !!! tip "Combining Techniques"
 
-    These customizations can be combined into a single trainer class by overriding multiple methods and adding callbacks as needed. One pairing needs care: `BaseTrainer.build_optimizer` deliberately does **not** filter on `requires_grad`, which is exactly why the [freeze and unfreeze](#freezing-and-unfreezing-the-backbone) recipe works — frozen parameters are still in a param group, so they resume training the moment the callback unfreezes them. A custom `build_optimizer` that skips them leaves those parameters with no optimizer state, and the backbone never trains again however many epochs remain. Neither `build_optimizer` on this page filters on `requires_grad`, for that reason.
+    These customizations can be combined into a single trainer class by overriding multiple methods and adding callbacks as needed. One pairing needs care: `BaseTrainer.build_optimizer` deliberately does **not** filter on `requires_grad`, which is exactly why the [freeze and unfreeze](#freezing-and-unfreezing-the-backbone) recipe works — frozen parameters are still in a param group, so they resume training the moment the callback unfreezes them. A custom `build_optimizer` that skips them leaves those parameters with no optimizer state, and the backbone never trains again however many epochs remain. The recipe above only re-splits the groups `BaseTrainer` already built, so it inherits that behavior.
 
 ## Synchronized BatchNorm for Multi-GPU Training
 

--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -77,13 +77,11 @@ class MetricsTrainer(DetectionTrainer):
             class_indices = box.ap_class_index
             names = self.validator.names
 
-            valid_f1 = f1_per_class[f1_per_class > 0]
-            mean_f1 = np.mean(valid_f1) if len(valid_f1) > 0 else 0.0
+            # average over every evaluated class; dropping the zeros hides the classes that failed
+            mean_f1 = float(np.mean(f1_per_class)) if len(f1_per_class) else 0.0
 
             LOGGER.info(f"Mean F1 Score: {mean_f1:.4f}")
-            per_class_str = [
-                f"{names[i]}: {f1_per_class[j]:.3f}" for j, i in enumerate(class_indices) if f1_per_class[j] > 0
-            ]
+            per_class_str = [f"{names[i]}: {f1_per_class[j]:.3f}" for j, i in enumerate(class_indices)]
             LOGGER.info(f"Per-class F1: {per_class_str}")
 
         return metrics, fitness
@@ -365,7 +363,7 @@ model.train(data="coco8.yaml", epochs=20, trainer=PerLayerLRTrainer)
 
 ### RT-DETR Variant
 
-Because the backbone length is read from `model.yaml["backbone"]` rather than hardcoded, the same recipe covers RT-DETR-L, RT-DETR-X and the ResNet-50/101 backbones. Switch the parent class to `RTDETRTrainer` (`from ultralytics.models.rtdetr.train import RTDETRTrainer`) and load the checkpoint with `RTDETR("rtdetr-l.pt")`; the `build_optimizer` body is unchanged. This is especially useful for RT-DETR fine-tuning, where the decoder head is typically randomly initialized while the backbone carries pretrained features that benefit from a lower learning rate.
+Because the backbone length is read from `model.yaml["backbone"]` rather than hardcoded, the same recipe covers RT-DETR-L, RT-DETR-X and the ResNet-50/101 backbones. Switch the parent class to `RTDETRTrainer` (`from ultralytics.models.rtdetr.train import RTDETRTrainer`) and load the checkpoint with `RTDETR("rtdetr-l.pt")`; the `build_optimizer` body is unchanged. This is especially useful for RT-DETR fine-tuning on a new dataset, where the decoder's classification layer is rebuilt for your class count while the backbone carries pretrained features that benefit from a lower learning rate.
 
 !!! tip "Choosing `backbone_lr_ratio`"
 

--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -442,6 +442,7 @@ import torch
 
 from ultralytics import RTDETR
 from ultralytics.models.rtdetr.train import RTDETRTrainer
+from ultralytics.utils.torch_utils import TORCH_2_0
 
 
 class CustomClipTrainer(RTDETRTrainer):
@@ -452,8 +453,9 @@ class CustomClipTrainer(RTDETRTrainer):
     def optimizer_step(self):
         """Run an optimizer step with a configurable gradient-norm clip."""
         self.scaler.unscale_(self.optimizer)
-        if self.clip_grad_norm > 0:
-            torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=self.clip_grad_norm)
+        if self.clip_grad_norm > 0:  # BaseTrainer clips at a fixed 10.0, and passes foreach=False on Ascend NPU
+            npu = {"foreach": False} if self.device.type == "npu" and TORCH_2_0 else {}
+            torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=self.clip_grad_norm, **npu)
         self.scaler.step(self.optimizer)
         self.scaler.update()
         self.optimizer.zero_grad()

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -80,7 +80,6 @@ Let's get started.
 3. Now, read the contents of the dataset YAML file and extract the indices of the class labels.
 
     ```python
-
     classes = data["names"]
     cls_idx = sorted(classes.keys())
     ```

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -120,7 +120,7 @@ zebra       689.0
 dtype: float64
 ```
 
-An image with no objects produces an all-zero row, which is correct — a background image is legitimate training data, not missing data.
+An image with no objects produces an all-zero row, which is correct — a background image is legitimate training data, not missing data. These totals cover the whole pooled set; the next section drops duplicates from it, so treat them as a starting point rather than as the composition of the folds.
 
 ## Watch for Duplicate and Near-Duplicate Images
 
@@ -143,11 +143,17 @@ drop = {k for keys in duplicates.values() for k in sorted(keys)[1:]}
 img_by_key = {k: v for k, v in img_by_key.items() if k not in drop}
 labels_df = labels_df.drop(index=sorted(drop))
 print(f"dropped {len(drop)} duplicate images, {len(labels_df)} remain")
+print(labels_df.sum().rename(classes))  # the folded pool's real composition; every class total moved
 ```
 
 ```text
 25 duplicate groups covering 50 images
 dropped 25 duplicate images, 1252 remain
+buffalo     478.0
+elephant    645.0
+rhino       469.0
+zebra       676.0
+dtype: float64
 ```
 
 Dropping one image per group is the blunt option shown above and it is enough here. Keeping them together with `GroupKFold`, keyed on the hash, preserves the data instead — worth it when duplicates are numerous. The same reasoning applies to frames from one video, photographs of one subject, and augmented copies of one source image: group them, or the folds are not independent. Note that byte-identical hashing does not catch re-encoded or resized near-duplicates; a perceptual hash does.
@@ -319,7 +325,7 @@ train: Scanning .../african-wildlife/labels/train... 1001 images, 0 backgrounds,
 val: Scanning .../african-wildlife/labels/train... 251 images, 0 backgrounds, 0 corrupt
 ```
 
-The counts match the fold sizes printed earlier, and a non-zero `backgrounds` count on a fully annotated dataset means images and labels are mispaired — go back to the orphan-label check. The directory in the scan line is just wherever the first label file happened to sit, so both lines naming the same split is expected and does not mean the fold is wrong.
+The counts match the fold sizes printed earlier. A background is legitimate training data, so the number to compare against is not zero but the background count you measured before splitting — African Wildlife labels every image, so that count was 0 and anything above it here means images and labels came apart; go back to the orphan-label check. The directory in the scan line is just wherever the first label file happened to sit, so both lines naming the same split is expected and does not mean the fold is wrong.
 
 !!! note "Budget for `k` full training runs"
 

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -79,7 +79,6 @@ Let's get started.
 3. Now, read the contents of the dataset YAML file and extract the indices of the class labels.
 
     ```python
-    import yaml
 
     classes = data["names"]
     cls_idx = sorted(classes.keys())

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -56,19 +56,24 @@ Let's get started.
 
 1. Start by creating a new `example.py` Python file for the steps below.
 
-2. Retrieve the dataset images and map each one to its label path using the package's dataset convention.
+2. Load the configured training and validation images through the package dataset owner, leaving the test split untouched.
 
     ```python
     from pathlib import Path
 
-    from ultralytics.data.utils import IMG_FORMATS, img2label_paths
+    from ultralytics.data.dataset import YOLODataset
+    from ultralytics.data.utils import check_det_dataset
 
-    dataset_path = Path("./Fruit-detection").resolve()  # replace with 'path/to/dataset' for your custom data
-    images = sorted(p for p in (dataset_path / "images").rglob("*.*") if p.suffix[1:].lower() in IMG_FORMATS)
-    labels = [Path(p) for p in img2label_paths([str(p) for p in images])]
-    keys = [p.relative_to(dataset_path / "images").with_suffix("") for p in images]
-    assert len(set(keys)) == len(keys), "multiple images map to the same label path"
-    image_by_key = dict(zip(keys, images))
+    yaml_file = "path/to/data.yaml"
+    data = check_det_dataset(yaml_file)
+    sources = []
+    for split in ("train", "val"):
+        source = data.get(split)
+        if source:
+            sources.extend(source if isinstance(source, list) else [source])
+    dataset = YOLODataset(sources, data=data, augment=False)
+    images = [Path(p) for p in dataset.im_files]
+    labels = [Path(p) for p in dataset.label_files]
     ```
 
 3. Now, read the contents of the dataset YAML file and extract the indices of the class labels.
@@ -76,9 +81,7 @@ Let's get started.
     ```python
     import yaml
 
-    yaml_file = "path/to/data.yaml"  # your data YAML with data directories and names dictionary
-    with open(yaml_file, encoding="utf8") as y:
-        classes = yaml.safe_load(y)["names"]
+    classes = data["names"]
     cls_idx = sorted(classes.keys())
     ```
 
@@ -87,7 +90,7 @@ Let's get started.
     ```python
     import pandas as pd
 
-    labels_df = pd.DataFrame(0.0, columns=cls_idx, index=keys)
+    labels_df = pd.DataFrame(0.0, columns=cls_idx, index=images)
     ```
 
 5. Count the instances of each class-label present in the annotation files.
@@ -95,14 +98,14 @@ Let's get started.
     ```python
     from collections import Counter
 
-    for key, label in zip(keys, labels):
+    for image, label in zip(images, labels):
         if not label.exists():  # missing labels are valid background images
             continue
         lbl_counter = Counter()
         for line in label.read_text().splitlines():
             if line.strip():
                 lbl_counter[int(line.split()[0])] += 1
-        labels_df.loc[key] = lbl_counter
+        labels_df.loc[image, list(lbl_counter)] = list(lbl_counter.values())
     ```
 
 6. The following is a sample view of the populated DataFrame:
@@ -176,8 +179,8 @@ The rows index images by their path relative to `images/`, and the columns corre
 
     for split in folds_df.columns:
         for partition in ("train", "val"):
-            split_keys = folds_df.index[folds_df[split] == partition]
-            paths = "\n".join(str(image_by_key[key]) for key in split_keys)
+            split_images = folds_df.index[folds_df[split] == partition]
+            paths = "\n".join(map(str, split_images))
             (save_path / f"{split}_{partition}.txt").write_text(f"{paths}\n")
 
         dataset_yaml = save_path / f"{split}.yaml"
@@ -242,7 +245,7 @@ fold_lbl_distrb.to_csv(save_path / "kfold_label_distribution.csv")
 
 ## Conclusion
 
-In this guide, we have explored the process of using K-Fold cross-validation for training the YOLO object detection model. We learned how to split our dataset into K partitions, ensuring a balanced class distribution across the different folds.
+In this guide, we have explored the process of using K-Fold cross-validation for training the YOLO object detection model. We learned how to split the training and validation pool into K partitions and use the generated ratio table to inspect class balance after random splitting.
 
 We also explored the procedure for creating report DataFrames to visualize the data splits and label distributions across these splits, providing us a clear insight into the structure of our training and validation sets.
 

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -1,396 +1,282 @@
 ---
-title: K-Fold Cross Validation for YOLO Datasets
 comments: true
-description: Build K-Fold splits for a YOLO detection dataset with scikit-learn and pandas, train Ultralytics YOLO26 on every fold, and aggregate the results into one score.
-keywords: K-Fold cross validation, YOLO, Ultralytics, scikit-learn, pandas, dataset split, model evaluation, object detection, fold balance, data leakage
+description: Learn to implement K-Fold Cross Validation for object detection datasets using Ultralytics YOLO. Improve your model's reliability and robustness.
+keywords: Ultralytics, YOLO, K-Fold Cross Validation, object detection, sklearn, pandas, PyYAML, machine learning, dataset split
 ---
 
-# How to Run K-Fold Cross Validation with Ultralytics YOLO
+# K-Fold Cross Validation with Ultralytics
 
-K-Fold cross validation splits a dataset into `k` equally sized folds and trains `k` models, each holding out a different fold for validation. Every image is therefore validated exactly once and trained on in the other `k - 1` folds. Averaging the `k` results gives a far more stable estimate of model quality than a single train/val split, because it no longer depends on which images happened to land in the validation set.
+## Introduction
 
-This guide builds `k=5` folds for a [YOLO detection dataset](../datasets/detect/index.md) using scikit-learn and pandas, writes one dataset YAML per fold, trains [Ultralytics YOLO26](../models/yolo26.md) on each of them, and aggregates the results. Cross validation pays off most when a dataset is small, noisy, or class-imbalanced; for large, diverse datasets a single well-constructed train/val/test split gives the same answer for a fifth of the compute.
+This comprehensive guide illustrates the implementation of K-Fold Cross Validation for [object detection](https://www.ultralytics.com/glossary/object-detection) datasets within the Ultralytics ecosystem. We'll leverage the YOLO detection format and key Python libraries such as sklearn, pandas, and PyYAML to guide you through the necessary setup, the process of generating feature vectors, and the execution of a K-Fold dataset split.
 
 <p align="center">
   <img width="800" src="https://cdn.ul.run/i/457d0a77dc06d7204322ec056248c4b5.avif" alt="K-fold cross validation data splitting">
 </p>
 
+Whether your project involves the Fruit Detection dataset or a custom data source, this tutorial aims to help you comprehend and apply K-Fold Cross Validation to bolster the reliability and robustness of your [machine learning](https://www.ultralytics.com/glossary/machine-learning-ml) models. While we're applying `k=5` folds for this tutorial, keep in mind that the optimal number of folds can vary depending on your dataset and the specifics of your project. K-Fold Cross Validation delivers the most value when your dataset is small, noisy, or highly variable; for large, diverse datasets, a well-constructed train/val/test split is usually sufficient.
+
+Let's get started.
+
 ## Setup
 
-This walkthrough uses the [African Wildlife](../datasets/detect/african-wildlife.md) dataset, which downloads automatically and is already in [YOLO detection format](../datasets/detect/index.md). Substitute your own by pointing `dataset_path` at it, provided it uses the standard `images/<split>` and `labels/<split>` directory layout — the collection block below walks those directories rather than reading the `train` and `val` entries of your data YAML, so a dataset defined by path lists or non-standard directories needs those globs adjusted first.
+- Your annotations should be in the [YOLO detection format](../datasets/detect/index.md).
+
+- This guide assumes that annotation files are locally available.
+
+- For our demonstration, we use the [Fruit Detection](https://www.kaggle.com/datasets/lakshaytyagi01/fruit-detection/code) dataset.
+    - This dataset contains a total of 8479 images.
+    - It includes 6 class labels, each with its total instance counts listed below.
 
 | Class Label | Instance Count |
-| :---------- | -------------: |
-| buffalo     |            488 |
-| elephant    |            649 |
-| rhino       |            484 |
-| zebra       |            689 |
-| **Total**   |      **2,310** |
+| :---------- | :------------: |
+| Apple       |      7049      |
+| Grapes      |      7202      |
+| Pineapple   |      1613      |
+| Orange      |     15549      |
+| Banana      |      3536      |
+| Watermelon  |      1976      |
 
-The dataset ships 1,504 images split into `train`, `val` and `test`. This guide folds the 1,277 `train` and `val` images and **leaves `test` untouched** — cross validation replaces the train/val boundary, not the held-out set. The counts above are for the folded pool, not the whole dataset. Keeping a split out of the folds is what lets you evaluate once at the end on data that took no part in choosing anything.
+- Necessary Python packages include:
+    - `ultralytics`
+    - `sklearn`
+    - `pandas`
+    - `pyyaml`
 
-Install Ultralytics and the two helper libraries this guide uses:
+- This tutorial operates with `k=5` folds. However, you should determine the best number of folds for your specific dataset.
 
-```bash
-pip install -U ultralytics scikit-learn pandas
-```
+1. Initiate a new Python virtual environment (`venv`) for your project and activate it. Use `pip` (or your preferred package manager) to install:
+    - The Ultralytics library: `pip install -U ultralytics`. Alternatively, you can clone the official [repo](https://github.com/ultralytics/ultralytics).
+    - Scikit-learn, pandas, and PyYAML: `pip install -U scikit-learn pandas pyyaml`.
 
-Then download the dataset once, so the rest of the guide can read it from disk:
+2. Verify that your annotations are in the [YOLO detection format](../datasets/detect/index.md).
+    - For this tutorial, all annotation files are found in the `Fruit-Detection/labels` directory.
 
-```python
-from ultralytics.data.utils import check_det_dataset
+## Generating Feature Vectors for Object Detection Dataset
 
-dataset_yaml = "african-wildlife.yaml"  # swap in your own; every later step reads this variable
-data = check_det_dataset(dataset_yaml)  # downloads on first use
-print(data["path"])
-```
+1. Start by creating a new `example.py` Python file for the steps below.
 
-!!! note "Choosing `k`"
-
-    This guide uses `k=5`, which holds out 20% of the data per fold. Smaller datasets benefit from more folds, at proportionally more training time — `k` folds means `k` full training runs.
-
-## Building the Class-Count Matrix
-
-The split has to be computed over something. Each image is represented by a row counting how many instances of each class its label file contains, which turns the dataset into a table `scikit-learn` can split.
-
-Start by collecting the label and image files, and pairing them:
-
-```python
-from pathlib import Path
-
-from ultralytics.data.utils import IMG_FORMATS
-
-dataset_path = Path(data["path"]).resolve()  # check_det_dataset leaves an existing relative path relative
-pool = ("train", "val")  # the shipped test split stays out of the folds
-
-images = sorted(
-    p for s in pool for p in (dataset_path / "images" / s).rglob("*.*") if p.suffix[1:].lower() in IMG_FORMATS
-)
-labels = sorted(p for s in pool for p in (dataset_path / "labels" / s).rglob("*.txt"))
-
-# key by path relative to images/ and labels/, so the same basename in two splits stays distinct
-img_by_key = {p.relative_to(dataset_path / "images").with_suffix(""): p for p in images}
-lbl_by_key = {p.relative_to(dataset_path / "labels").with_suffix(""): p for p in labels}
-
-assert len(img_by_key) == len(images), "two images share one stem, i.e. foo.jpg and foo.png; they map to one label file"
-orphans = sorted(set(lbl_by_key) - set(img_by_key))
-assert not orphans, f"label files with no matching image: {orphans[:3]}"
-empty = {k for k, v in lbl_by_key.items() if not v.read_text().strip()}
-backgrounds = (set(img_by_key) - set(lbl_by_key)) | empty  # the package counts missing AND empty labels as background
-print(f"{len(images)} images, {len(labels)} labels, {len(backgrounds)} background images")
-```
-
-```text
-1277 images, 1277 labels, 0 background images
-```
-
-!!! warning "Three details this block gets right on purpose"
-
-    - **Scope the label glob to `labels/`.** Ultralytics datasets nest labels as `labels/train/`, `labels/val/`, `labels/test/`, and a pattern that expects them one level up returns nothing at all. A glob rooted at the dataset directory instead re-reads its own output on a second run.
-    - **Use `IMG_FORMATS` rather than a hand-written extension list.** Ultralytics accepts 13 image formats, and on Linux and macOS `Path.rglob` matches extensions case-sensitively regardless of the filesystem — so a hardcoded `[".jpg", ".jpeg", ".png"]` silently drops the three `.JPG` files in this dataset, and every `.webp` or `.tif` in yours.
-    - **Pair by key, never by position, and make the key the path under `images`/`labels` rather than the bare filename.** The two lists come from different globs, so any dropped or extra file shifts one relative to the other and every later pair is wrong — a failure that trains cleanly and reports meaningless metrics. The bare stem is not enough either: Ultralytics maps `images/train/0001.jpg` to `labels/train/0001.txt`, so the same basename is legal in two splits, and keying on `0001` would silently keep one of them while the assertion still passed.
-    - **An image with no label file, or an empty one, is a background, not an error.** Ultralytics reads a missing label file as an empty label array and reports `nm + ne` — missing plus empty — as its `backgrounds` count, which is why the block above counts both rather than just the missing ones. The checks reject only two things: an *orphan label* — a `.txt` with no image — and two images sharing one stem, such as `foo.jpg` and `foo.png`. The second is rejected rather than resolved because `img2label_paths` maps both to the same `foo.txt`, so the package cannot tell them apart either; dropping one silently would be worse than stopping.
-
-Now count the instances per class:
-
-```python
-from collections import Counter
-
-import pandas as pd
-
-classes = data["names"]  # check_det_dataset normalizes names to {int: str}, so the keys are the class IDs
-cls_idx = sorted(classes)
-
-labels_df = pd.DataFrame(0.0, index=sorted(img_by_key), columns=cls_idx)
-for key, label_file in lbl_by_key.items():  # images with no label file keep their all-zero row
-    counter = Counter()
-    for line in label_file.read_text().splitlines():
-        if line.strip():  # skip blank lines; split() also handles tabs and leading whitespace
-            counter[int(line.split()[0])] += 1
-    for cls, n in counter.items():
-        labels_df.loc[key, cls] = n
-
-print(labels_df.sum().rename(classes))
-```
-
-```text
-buffalo     488.0
-elephant    649.0
-rhino       484.0
-zebra       689.0
-dtype: float64
-```
-
-An image with no objects produces an all-zero row, which is correct — a background image is legitimate training data, not missing data. These totals cover the whole pooled set; the next section drops duplicates from it, so treat them as a starting point rather than as the composition of the folds.
-
-## Watch for Duplicate and Near-Duplicate Images
-
-Cross validation assumes the folds are independent. Duplicated or near-duplicated images break that assumption: a copy in training and its twin in validation inflates that fold's metrics, and no amount of averaging removes the bias.
-
-This is not a hypothetical for the example dataset. Hashing the folded pool finds **25 groups of byte-identical images covering 50 files**, none of them detectable from the filenames. Deduplicate before splitting:
-
-```python
-import hashlib
-from collections import defaultdict
-
-by_hash = defaultdict(list)
-for key, image in img_by_key.items():
-    by_hash[hashlib.md5(image.read_bytes()).hexdigest()].append(key)
-duplicates = {h: keys for h, keys in by_hash.items() if len(keys) > 1}
-print(f"{len(duplicates)} duplicate groups covering {sum(len(k) for k in duplicates.values())} images")
-
-# keep one image per hash group and rebuild the matrix, so no copy can straddle a fold
-drop = {k for keys in duplicates.values() for k in sorted(keys)[1:]}
-img_by_key = {k: v for k, v in img_by_key.items() if k not in drop}
-labels_df = labels_df.drop(index=sorted(drop))
-print(f"dropped {len(drop)} duplicate images, {len(labels_df)} remain")
-print(labels_df.sum().rename(classes))  # the folded pool's real composition; every class total moved
-```
-
-```text
-25 duplicate groups covering 50 images
-dropped 25 duplicate images, 1252 remain
-buffalo     478.0
-elephant    645.0
-rhino       469.0
-zebra       676.0
-dtype: float64
-```
-
-Dropping one image per group is the blunt option shown above and it is enough here. Keeping them together with `GroupKFold`, keyed on the hash, preserves the data instead — worth it when duplicates are numerous. The same reasoning applies to frames from one video, photographs of one subject, and augmented copies of one source image: group them, or the folds are not independent. Note that byte-identical hashing does not catch re-encoded or resized near-duplicates; a perceptual hash does.
-
-## Splitting into K Folds
-
-`KFold` shuffles the rows and partitions them into `k` groups. `random_state` is what makes the split reproducible; the global `random` module plays no part in it.
-
-```python
-from sklearn.model_selection import KFold
-
-ksplit = 5
-kf = KFold(n_splits=ksplit, shuffle=True, random_state=20)
-kfolds = list(kf.split(labels_df))
-
-folds = [f"fold_{n}" for n in range(1, ksplit + 1)]
-folds_df = pd.DataFrame(index=labels_df.index, columns=folds, dtype=object)
-for i, (train, val) in enumerate(kfolds, start=1):
-    folds_df.loc[labels_df.index[train], f"fold_{i}"] = "train"
-    folds_df.loc[labels_df.index[val], f"fold_{i}"] = "val"
-
-for fold in folds:
-    print(f"{fold}: train={(folds_df[fold] == 'train').sum()} val={(folds_df[fold] == 'val').sum()}")
-```
-
-```text
-fold_1: train=1001 val=251
-fold_2: train=1001 val=251
-fold_3: train=1002 val=250
-fold_4: train=1002 val=250
-fold_5: train=1002 val=250
-```
-
-!!! warning "Assign with `.loc[rows, column]`, not `df[column].loc[rows]`"
-
-    The second form is chained assignment. Under pandas copy-on-write — the default from pandas 3.0 — it writes to a temporary copy and silently leaves the DataFrame untouched, so every fold column stays `NaN`. The failure surfaces much later as `TypeError: unsupported operand type(s) for /: 'PosixPath' and 'float'` when a fold name is used to build a path, with nothing pointing back at the assignment.
-
-## Checking the Fold Balance
-
-`KFold` is uniformly random over rows. It does **not** stratify, so it does not guarantee that every class is evenly represented in every fold — it only guarantees that each image is validated once. Check the result rather than assuming it:
-
-```python
-fold_distrb = pd.DataFrame(index=folds, columns=cls_idx, dtype=float)
-for n, (train, val) in enumerate(kfolds, start=1):
-    ratio = labels_df.iloc[val].sum() / (labels_df.iloc[train].sum() + 1e-7)
-    fold_distrb.loc[f"fold_{n}"] = ratio
-fold_distrb.columns = [classes[i] for i in cls_idx]
-print(fold_distrb.round(3))
-```
-
-```text
-        buffalo  elephant  rhino  zebra
-fold_1    0.216     0.243  0.237  0.328
-fold_2    0.285     0.287  0.303  0.172
-fold_3    0.258     0.238  0.212  0.229
-fold_4    0.219     0.255  0.285  0.222
-fold_5    0.275     0.229  0.218  0.313
-```
-
-Each cell is the ratio of validation instances to training instances for that class. With `k` folds the expected value is `1 / (k - 1)`, so `0.25` here. Every cell above sits within about a third of that, which is fine — with 484 instances in the rarest class, plain `KFold` spreads them adequately.
-
-The check matters when it fails. On a dataset with a class of only a handful of instances, some folds end up with **zero** validation instances of it, per-class AP is undefined there, and the average across folds is silently computed over a shifting set of classes. If you see a `0.000` cell, stratify the split on each image's rarest present class:
-
-```python
-from sklearn.model_selection import StratifiedKFold
-
-freq = labels_df.sum()
-y = labels_df.apply(
-    lambda row: min((c for c in cls_idx if row[c] > 0), key=lambda c: freq[c]) if row.sum() else -1,
-    axis=1,
-)
-kfolds = list(StratifiedKFold(ksplit, shuffle=True, random_state=20).split(labels_df, y))
-
-# rebuild folds_df from the new kfolds -- every later step reads folds_df, not kfolds
-folds_df = pd.DataFrame(index=labels_df.index, columns=folds, dtype=object)
-for i, (train, val) in enumerate(kfolds, start=1):
-    folds_df.loc[labels_df.index[train], f"fold_{i}"] = "train"
-    folds_df.loc[labels_df.index[val], f"fold_{i}"] = "val"
-```
-
-Rebuilding `folds_df` is the part that is easy to miss: every step after this reads `folds_df`, never `kfolds`, so swapping the splitter alone leaves the original unstratified folds in place with nothing to show for it.
-
-Check the stratum sizes before trusting the result, because `StratifiedKFold` degrades quietly rather than refusing:
-
-```python
-print(y.value_counts().min(), "smallest stratum vs", ksplit, "folds")
-```
-
-A stratum smaller than `ksplit` produces a `UserWarning` and folds in which that class is simply absent from validation — measured on scikit-learn 1.7.2, a stratum of 1 leaves 4 of 5 folds with no validation instances of it, a stratum of 2 leaves 3, and only a stratum of `ksplit` or more is clean. That is the failure this recipe was meant to fix, so when the smallest stratum is under `ksplit`, lower `k` or group the rare classes instead of stratifying on them. The background stratum (`-1`) counts too.
-
-This is also a proxy, not true multi-label stratification: an image containing several classes contributes to only one stratum. `StratifiedKFold` cannot take a multi-label target directly — it raises `ValueError: Supported target types are: ('binary', 'multiclass')` — so exact multi-label balance needs the `iterative-stratification` package.
-
-## Creating One Dataset YAML per Fold
-
-A fold is just a list of which images train and which validate. Ultralytics dataset YAMLs accept a `.txt` file listing image paths wherever they accept a directory, so a fold needs two text files and a YAML — no image is copied anywhere:
-
-```python
-import yaml
-
-save_path = dataset_path.parent / f"{ksplit}-fold"
-save_path.mkdir(parents=True, exist_ok=True)
-
-ds_yamls = []
-for fold in folds:
-    for split in ("train", "val"):
-        keys = folds_df.index[folds_df[fold] == split]
-        (save_path / f"{fold}_{split}.txt").write_text("\n".join(str(img_by_key[k]) for k in keys) + "\n")
-    fold_yaml = save_path / f"{fold}.yaml"
-    fold_yaml.write_text(
-        yaml.safe_dump(
-            {
-                "path": save_path.as_posix(),
-                "train": f"{fold}_train.txt",
-                "val": f"{fold}_val.txt",
-                "names": classes,
-            }
-        )
-    )
-    ds_yamls.append(fold_yaml)
-```
-
-Note that `save_path` sits **beside** the dataset, not inside it. A fold directory written into the dataset root gets picked up by the label glob on the next run.
-
-!!! tip "Why not copy the images into fold directories?"
-
-    Copying works and gives you self-contained fold directories, but it duplicates the folded pool `k` times. Measured on the 1,252 images left after deduplication, plus their labels, at `k=5`:
-
-    | Approach   | Disk    | Files  |
-    | ---------- | ------- | ------ |
-    | Copy files | ~430 MB | 12,520 |
-    | Text lists | 402 KB  | 15     |
-
-    Both produce identical folds and identical training scans. If you do need real directories — to ship a fold elsewhere, or to hand it to a tool that cannot read a path list — copy by iterating the stem-keyed dictionaries rather than zipping two lists:
+2. Retrieve the dataset images and map each one to its label path using the package's dataset convention.
 
     ```python
-    import shutil
+    from pathlib import Path
 
-    for key, image in img_by_key.items():
-        for fold, split in folds_df.loc[key].items():
-            for src, sub, suffix in [(image, "images", image.suffix)] + (
-                [(lbl_by_key[key], "labels", ".txt")] if key in lbl_by_key else []
-            ):
-                dst = save_path / fold / split / sub / key.parent / f"{key.name}{suffix}"
-                dst.parent.mkdir(parents=True, exist_ok=True)  # key keeps the split subdirectory
-                shutil.copy(src, dst)
+    from ultralytics.data.utils import IMG_FORMATS, img2label_paths
+
+    dataset_path = Path("./Fruit-detection").resolve()  # replace with 'path/to/dataset' for your custom data
+    images = sorted(
+        p for p in (dataset_path / "images").rglob("*.*") if p.suffix[1:].lower() in IMG_FORMATS
+    )
+    labels = [Path(p) for p in img2label_paths([str(p) for p in images])]
+    keys = [p.relative_to(dataset_path / "images").with_suffix("") for p in images]
+    assert len(set(keys)) == len(keys), "multiple images map to the same label path"
+    image_by_key = dict(zip(keys, images))
     ```
 
-    This only rearranges files. The `ds_yamls` built above still point at the text lists, so to train from the copied tree you would also write one YAML per fold whose `train` and `val` name the new `fold_N/train` and `fold_N/val` directories. The destination reuses the same relative `key`, for the same reason the pairing does: flattening to the bare filename lets `train/0001.jpg` and `val/0001.jpg` land on top of each other, and `shutil.copy` overwrites without a word. The suffix is appended to `key.name` rather than set with `with_suffix`, which would turn `foo.bar.jpg` into `foo.jpg` and collide all over again.
+3. Now, read the contents of the dataset YAML file and extract the indices of the class labels.
 
-    `shutil.copy` overwrites an existing destination silently, so a re-run is not protected in either approach — delete `save_path` first.
+    ```python
+    import yaml
 
-## Training on Every Fold
+    yaml_file = "path/to/data.yaml"  # your data YAML with data directories and names dictionary
+    with open(yaml_file, encoding="utf8") as y:
+        classes = yaml.safe_load(y)["names"]
+    cls_idx = sorted(classes.keys())
+    ```
 
-Build a fresh model for each fold so no weights carry over, and keep the result object:
+4. Initialize an empty `pandas` DataFrame.
+
+    ```python
+    import pandas as pd
+
+    labels_df = pd.DataFrame(0.0, columns=cls_idx, index=keys)
+    ```
+
+5. Count the instances of each class-label present in the annotation files.
+
+    ```python
+    from collections import Counter
+
+    for key, label in zip(keys, labels):
+        if not label.exists():  # missing labels are valid background images
+            continue
+        lbl_counter = Counter()
+        for line in label.read_text().splitlines():
+            if line.strip():
+                lbl_counter[int(line.split()[0])] += 1
+        labels_df.loc[key] = lbl_counter
+    ```
+
+6. The following is a sample view of the populated DataFrame:
+
+    ```text
+                                                           0    1    2    3    4    5
+    '0000a16e4b057580_jpg.rf.00ab48988370f64f5ca8ea4...'  0.0  0.0  0.0  0.0  0.0  7.0
+    '0000a16e4b057580_jpg.rf.7e6dce029fb67f01eb19aa7...'  0.0  0.0  0.0  0.0  0.0  7.0
+    '0000a16e4b057580_jpg.rf.bc4d31cdcbe229dd022957a...'  0.0  0.0  0.0  0.0  0.0  7.0
+    '00020ebf74c4881c_jpg.rf.508192a0a97aa6c4a3b6882...'  0.0  0.0  0.0  1.0  0.0  0.0
+    '00020ebf74c4881c_jpg.rf.5af192a2254c8ecc4188a25...'  0.0  0.0  0.0  1.0  0.0  0.0
+     ...                                                  ...  ...  ...  ...  ...  ...
+    'ff4cd45896de38be_jpg.rf.c4b5e967ca10c7ced3b9e97...'  0.0  0.0  0.0  0.0  0.0  2.0
+    'ff4cd45896de38be_jpg.rf.ea4c1d37d2884b3e3cbce08...'  0.0  0.0  0.0  0.0  0.0  2.0
+    'ff5fd9c3c624b7dc_jpg.rf.bb519feaa36fc4bf630a033...'  1.0  0.0  0.0  0.0  0.0  0.0
+    'ff5fd9c3c624b7dc_jpg.rf.f0751c9c3aa4519ea3c9d6a...'  1.0  0.0  0.0  0.0  0.0  0.0
+    'fffe28b31f2a70d4_jpg.rf.7ea16bd637ba0711c53b540...'  0.0  6.0  0.0  0.0  0.0  0.0
+    ```
+
+The rows index images by their path relative to `images/`, and the columns correspond to class-label indices. Missing labels remain all-zero background rows. This data structure enables the application of [K-Fold Cross Validation](https://www.ultralytics.com/glossary/cross-validation) to an object detection dataset.
+
+## K-Fold Dataset Split
+
+1. Now we will use the `KFold` class from `sklearn.model_selection` to generate `k` splits of the dataset.
+    - Important:
+        - Setting `shuffle=True` ensures a randomized distribution of classes in your splits.
+        - By setting `random_state=M` where `M` is a chosen integer, you can obtain repeatable results.
+
+    ```python
+    from sklearn.model_selection import KFold
+
+    ksplit = 5
+    kf = KFold(n_splits=ksplit, shuffle=True, random_state=20)  # setting random_state for repeatable results
+
+    kfolds = list(kf.split(labels_df))
+    ```
+
+2. The dataset has now been split into `k` folds, each having a list of `train` and `val` indices. We will construct a DataFrame to display these results more clearly.
+
+    ```python
+    folds = [f"split_{n}" for n in range(1, ksplit + 1)]
+    folds_df = pd.DataFrame(index=labels_df.index, columns=folds)
+
+    for i, (train, val) in enumerate(kfolds, start=1):
+        folds_df.loc[labels_df.index[train], f"split_{i}"] = "train"
+        folds_df.loc[labels_df.index[val], f"split_{i}"] = "val"
+    ```
+
+3. Now we will calculate the distribution of class labels for each fold as a ratio of the classes present in `val` to those present in `train`.
+
+    ```python
+    fold_lbl_distrb = pd.DataFrame(index=folds, columns=cls_idx)
+
+    for n, (train_indices, val_indices) in enumerate(kfolds, start=1):
+        train_totals = labels_df.iloc[train_indices].sum()
+        val_totals = labels_df.iloc[val_indices].sum()
+
+        # To avoid division by zero, we add a small value (1E-7) to the denominator
+        ratio = val_totals / (train_totals + 1e-7)
+        fold_lbl_distrb.loc[f"split_{n}"] = ratio
+    ```
+
+    The ideal scenario is for all class ratios to be reasonably similar for each split and across classes. This, however, will be subject to the specifics of your dataset.
+
+4. Write image lists and a dataset YAML for each split. Text lists avoid copying the dataset `k` times.
+
+    ```python
+    save_path = dataset_path.parent / f"{ksplit}-Fold_Cross-val"
+    save_path.mkdir(parents=True, exist_ok=True)
+    ds_yamls = []
+
+    for split in folds_df.columns:
+        for partition in ("train", "val"):
+            split_keys = folds_df.index[folds_df[split] == partition]
+            paths = "\n".join(str(image_by_key[key]) for key in split_keys)
+            (save_path / f"{split}_{partition}.txt").write_text(f"{paths}\n")
+
+        dataset_yaml = save_path / f"{split}.yaml"
+        ds_yamls.append(dataset_yaml)
+        with open(dataset_yaml, "w") as ds_y:
+            yaml.safe_dump(
+                {
+                    "path": save_path.as_posix(),
+                    "train": f"{split}_train.txt",
+                    "val": f"{split}_val.txt",
+                    "names": classes,
+                },
+                ds_y,
+            )
+    ```
+
+## Save Records (Optional)
+
+Optionally, you can save the records of the K-Fold split and label distribution DataFrames as CSV files for future reference.
 
 ```python
-from ultralytics import YOLO
-
-results = {}
-for k, fold_yaml in enumerate(ds_yamls):
-    model = YOLO("yolo26n.pt")  # fresh weights per fold
-    results[k] = model.train(data=str(fold_yaml), epochs=100, batch=16, project="kfold_demo", name=f"fold_{k + 1}")
+folds_df.to_csv(save_path / "kfold_datasplit.csv")
+fold_lbl_distrb.to_csv(save_path / "kfold_label_distribution.csv")
 ```
 
-Each run reports a clean scan, which is the checkpoint confirming images and labels were paired correctly:
+## Train YOLO using K-Fold Data Splits
 
-```text
-train: Scanning .../african-wildlife/labels/train... 1001 images, 0 backgrounds, 0 corrupt
-val: Scanning .../african-wildlife/labels/train... 251 images, 0 backgrounds, 0 corrupt
-```
+1. First, load the YOLO model.
 
-The counts match the fold sizes printed earlier. A background is legitimate training data, so the number to compare against is not zero but the background count you measured before splitting — African Wildlife labels every image, so that count was 0 and anything above it here means images and labels came apart; go back to the orphan-label check. The directory in the scan line is just wherever the first label file happened to sit, so both lines naming the same split is expected and does not mean the fold is wrong.
+    ```python
+    from ultralytics import YOLO
 
-!!! note "Budget for `k` full training runs"
+    weights_path = "path/to/weights.pt"  # use yolo26n.pt for a small model
+    model = YOLO(weights_path, task="detect")
+    ```
 
-    `epochs=100` across five folds is five complete trainings. Reduce `epochs`, or start with `k=3`, when you are still iterating. On CPU, use a small `imgsz` and expect this to take hours.
+2. Next, iterate over the dataset YAML files to run training. The results will be saved to a directory specified by the `project` and `name` arguments. By default, this directory is 'runs/detect/train#' where # is an integer index.
 
-## Aggregating the Results
+    ```python
+    results = {}
 
-This is the step that turns `k` runs into one number. `model.train()` returns a `DetMetrics` object per fold; the spread across folds tells you how sensitive your model is to the split:
+    # Define your additional arguments here
+    batch = 16
+    project = "kfold_demo"
+    epochs = 100
 
-```python
-summary = pd.DataFrame(
-    {
-        k + 1: {
-            "mAP50-95": r.box.map,
-            "mAP50": r.box.map50,
-            "precision": r.box.mp,
-            "recall": r.box.mr,
-            "fitness": r.fitness,
-        }
-        for k, r in results.items()
-    }
-).T
-summary.index.name = "fold"
-print(summary.round(4))
-print(summary.agg(["mean", "std"]).round(4))
-```
+    for k, dataset_yaml in enumerate(ds_yamls):
+        model = YOLO(weights_path, task="detect")
+        results[k] = model.train(
+            data=dataset_yaml, epochs=epochs, batch=batch, project=project, name=f"fold_{k + 1}"
+        )  # include any additional train arguments
+    ```
 
-Report the **mean** as your headline number and the **standard deviation** as its uncertainty. A large spread means the metric was never stable enough to compare two models on a single split. Note that `fitness` is a property on the returned object while `box.fitness` is a method — printing the latter without `()` gives a `<bound method>` repr rather than a value.
-
-!!! tip "Just need a single train/val split?"
-
-    If cross validation is more than your project needs, [`autosplit`](../reference/data/split.md) writes a one-shot split in a single call. It handles image extensions correctly, but it writes bare `.txt` files without a dataset YAML, and its ratios are sampling probabilities rather than exact proportions:
+3. You can also use [Ultralytics data.split.autosplit](../reference/data/split.md) function for automatic dataset splitting:
 
     ```python
     from ultralytics.data.split import autosplit
 
+    # Automatically split dataset into train/val/test
     autosplit(path="path/to/images", weights=(0.8, 0.2, 0.0), annotated_only=True)
     ```
 
 ## Conclusion
 
-K-Fold cross validation gives you `k` independent estimates of model quality instead of one, which is what makes results comparable on small or imbalanced datasets where a single validation split is mostly noise. Average the per-fold `mAP50-95` for your headline number and report the standard deviation alongside it, then read the [YOLO performance metrics guide](yolo-performance-metrics.md) to interpret what the spread is telling you. Once your baseline is stable enough to compare against, move on to [hyperparameter tuning](hyperparameter-tuning.md).
+In this guide, we have explored the process of using K-Fold cross-validation for training the YOLO object detection model. We learned how to split our dataset into K partitions, ensuring a balanced class distribution across the different folds.
+
+We also explored the procedure for creating report DataFrames to visualize the data splits and label distributions across these splits, providing us a clear insight into the structure of our training and validation sets.
+
+Optionally, we saved our records for future reference, which could be particularly useful in large-scale projects or when troubleshooting model performance.
+
+Finally, we implemented the actual model training using each split in a loop, saving our training results for further analysis and comparison.
+
+This technique of K-Fold cross-validation is a robust way of making the most out of your available data, and it helps to ensure that your model performance is reliable and consistent across different data subsets. This results in a more generalizable and reliable model that is less likely to [overfit](https://www.ultralytics.com/glossary/overfitting) to specific data patterns.
+
+Remember that although we used YOLO in this guide, these steps are mostly transferable to other machine learning models. Understanding these steps allows you to apply cross-validation effectively in your own machine learning projects.
 
 ## FAQ
 
 ### What is K-Fold Cross Validation and why is it useful in object detection?
 
-K-Fold cross validation divides a dataset into `k` folds and trains `k` models, each validating on a different fold, so every image is validated exactly once. For object detection this matters because a single validation split can easily over- or under-represent a rare class or a difficult scene, making one model look better than another for reasons that have nothing to do with the model. Averaging across folds removes that dependence. Start with the [K-Fold split](#splitting-into-k-folds) section for the implementation.
+K-Fold Cross Validation is a technique where the dataset is divided into 'k' subsets (folds) to evaluate model performance more reliably. Each fold serves as both training and [validation data](https://www.ultralytics.com/glossary/validation-data). In the context of object detection, using K-Fold Cross Validation helps to ensure your Ultralytics YOLO model's performance is robust and generalizable across different data splits, enhancing its reliability. For detailed instructions on setting up K-Fold Cross Validation with Ultralytics YOLO, refer to [K-Fold Cross Validation with Ultralytics](#introduction).
 
-### How do I combine the results from all K folds into one number?
+### How do I implement K-Fold Cross Validation using Ultralytics YOLO?
 
-Average the per-fold metric you care about. `results[k].box.map` holds `mAP50-95` for fold `k`, so `sum(r.box.map for r in results.values()) / len(results)` is the cross-validated mAP, and the standard deviation across folds tells you how sensitive the model is to the split. See [Aggregating the Results](#aggregating-the-results).
+To implement K-Fold Cross Validation with Ultralytics YOLO, you need to follow these steps:
 
-### How much disk space does K-Fold cross validation need?
+1. Verify annotations are in the [YOLO detection format](../datasets/detect/index.md).
+2. Use Python libraries like `sklearn`, `pandas`, and `pyyaml`.
+3. Create feature vectors from your dataset.
+4. Split your dataset using `KFold` from `sklearn.model_selection`.
+5. Train the YOLO model on each split.
 
-For the fold definitions, almost nothing beyond the dataset itself, if you define each fold as a `.txt` list of image paths. The `k` training runs still write their own checkpoints and plots. Copying images into per-fold directories instead multiplies the folded pool by `k` — for the 1,252 deduplicated images and their labels here, 86 MB, that is about 430 MB and 12,520 files at `k=5`, against 402 KB and 15 files for the list approach.
+For a comprehensive guide, see the [K-Fold Dataset Split](#k-fold-dataset-split) section in our documentation.
 
-### Should I use K-Fold cross validation or a single train/val split?
+### How should I design folds for other YOLO tasks like segmentation, classification, pose, or OBB?
 
-Use K-Fold when the dataset is small, noisy, or class-imbalanced enough that a single validation split gives an unstable estimate. For large, diverse datasets a well-constructed train/val/test split reaches the same conclusion for a fraction of the compute, since K-Fold costs `k` complete training runs.
-
-### How should I design folds for segmentation, classification, pose, or OBB?
-
-The workflow here targets the YOLO detection format, but it adapts to every YOLO task — the task changes how you compose the folds, not whether cross validation helps:
+The workflow in this guide targets the YOLO detection format, but the same approach adapts to every YOLO task — the task changes how you compose the folds, not whether cross-validation helps:
 
 | Task       | Fold design                                                                                                                                                                |
 | :--------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -400,38 +286,16 @@ The workflow here targets the YOLO detection format, but it adapts to every YOLO
 | `pose`     | Split by subject or sequence so the same person or animal never appears on both sides of a fold.                                                                           |
 | `obb`      | Split at the image level, keeping tiles or crops from the same scene together — especially important for aerial imagery.                                                   |
 
-### Can I use K-Fold Cross Validation with my own dataset?
+Whatever the task, keep near-duplicate and related samples out of opposing folds: that kind of leakage inflates validation metrics well beyond what the model will achieve in production.
 
-Yes, as long as the annotations are in [YOLO detection format](../datasets/detect/index.md) and laid out as `images/<split>` and `labels/<split>`, which is what the collection block globs. Point `dataset_path` at your dataset and read `classes` from your own data YAML. Images with no label file are fine — Ultralytics reads them as backgrounds and they get an all-zero row. The check in [Building the Class-Count Matrix](#building-the-class-count-matrix) rejects only the reverse case, a label file with no image, which is the failure worth catching early.
+### Why should I use Ultralytics YOLO for object detection?
 
-### Do I still need a separate test set?
+Ultralytics YOLO offers state-of-the-art, real-time object detection with high [accuracy](https://www.ultralytics.com/glossary/accuracy) and efficiency. It's versatile, supporting multiple [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) tasks such as [detection](../tasks/detect.md), [instance segmentation](../tasks/segment.md), [semantic segmentation](../tasks/semantic.md), and [classification](../tasks/classify.md). Additionally, it integrates seamlessly with tools like [Ultralytics Platform](../platform/index.md) for no-code model training and deployment. For more details, explore the benefits and features on our [Ultralytics YOLO page](https://www.ultralytics.com/yolo).
 
-Yes, and this guide keeps one: the dataset's shipped `test` split is excluded from the folds by the `pool = ("train", "val")` line. Cross validation measures how well a training recipe generalizes, but once you start choosing between recipes on the cross-validated score, that score has informed your decisions.
+### How can I ensure my annotations are in the correct format for Ultralytics YOLO?
 
-Use the held-out split once, at the end, and note that neither the fold models nor the fold YAMLs are the right thing to point at it: each fold model saw only four fifths of the pool, and a `fold_*.yaml` defines no `test` entry, so `model.val(split="test")` against one raises `FileNotFoundError: ... 'test:' is not defined`. The original dataset YAML is not it either — its `train` entry is `images/train` alone, so training against it never touches the `val` pool the folds were built from.
+Your annotations should follow the YOLO detection format. Each annotation file must list the object class, alongside its [bounding box](https://www.ultralytics.com/glossary/bounding-box) coordinates in the image. The YOLO format ensures streamlined and standardized data processing for training object detection models. For more information on proper annotation formatting, visit the [YOLO detection format guide](../datasets/detect/index.md).
 
-Retrain the settled recipe on the whole folded pool with one more path list, then evaluate against the original YAML. This continues the walkthrough above and reuses its `dataset_path`, `img_by_key` and `classes`:
+### Can I use K-Fold Cross Validation with custom datasets other than Fruit Detection?
 
-```python
-final_dir = dataset_path.parent / "final"
-final_dir.mkdir(parents=True, exist_ok=True)
-(final_dir / "pool.txt").write_text("\n".join(str(p) for p in img_by_key.values()) + "\n")
-(final_dir / "final.yaml").write_text(
-    yaml.safe_dump(
-        {
-            "path": final_dir.as_posix(),
-            "train": "pool.txt",
-            "val": "pool.txt",  # training requires a val entry; see the warning below
-            "names": classes,
-        }
-    )
-)
-
-final = YOLO("yolo26n.pt")
-final.train(data=str(final_dir / "final.yaml"), epochs=100, batch=16, patience=0)  # patience=0 disables early stopping
-
-fitted = YOLO(final.trainer.last)  # last.pt, so no checkpoint was chosen using training labels
-print(fitted.val(data=dataset_yaml, split="test").box.map)  # the number to report
-```
-
-Two details carry the correctness here. Passing `data=dataset_yaml` to `val()` redirects it away from `final.yaml`, which has no `test` entry, to the original dataset — and your own dataset's YAML needs a `test` entry for this step to mean anything. And the evaluation uses `last.pt` rather than the model `train()` leaves loaded: with `pool.txt` on both sides, every epoch validates on its own training images, so `best.pt` is picked on labels the model has already seen — `Model.train()` reloads exactly that checkpoint. Taking the final epoch's weights instead keeps the test score free of any selection. `patience=0` is there for the same reason: left at its default, early stopping would decide when to stop from metrics measured on the training images.
+Yes, you can use K-Fold Cross Validation with any custom dataset as long as the annotations are in the YOLO detection format. Replace the dataset paths and class labels with those specific to your custom dataset. This flexibility ensures that any object detection project can benefit from robust model evaluation using K-Fold Cross Validation. For a practical example, review our [Generating Feature Vectors](#generating-feature-vectors-for-object-detection-dataset) section.

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -74,7 +74,6 @@ Let's get started.
             sources.extend(source if isinstance(source, list) else [source])
     dataset = YOLODataset(sources, data=data, augment=False)
     images = [Path(p) for p in dataset.im_files]
-    labels = [Path(p) for p in dataset.label_files]
     ```
 
 3. Now, read the contents of the dataset YAML file and extract the indices of the class labels.
@@ -97,13 +96,8 @@ Let's get started.
     ```python
     from collections import Counter
 
-    for image, label in zip(images, labels):
-        if not label.exists():  # missing labels are valid background images
-            continue
-        lbl_counter = Counter()
-        for line in label.read_text().splitlines():
-            if line.strip():
-                lbl_counter[int(line.split()[0])] += 1
+    for image, label in zip(images, dataset.labels):
+        lbl_counter = Counter(label["cls"].flatten().astype(int))
         labels_df.loc[image, list(lbl_counter)] = list(lbl_counter.values())
     ```
 
@@ -124,7 +118,7 @@ Let's get started.
     'fffe28b31f2a70d4_jpg.rf.7ea16bd637ba0711c53b540...'  0.0  6.0  0.0  0.0  0.0  0.0
     ```
 
-The rows index images by their path relative to `images/`, and the columns correspond to class-label indices. Missing labels remain all-zero background rows. This data structure enables the application of [K-Fold Cross Validation](https://www.ultralytics.com/glossary/cross-validation) to an object detection dataset.
+The rows use absolute image paths, and the columns correspond to class-label indices. Missing labels remain all-zero background rows. This data structure enables the application of [K-Fold Cross Validation](https://www.ultralytics.com/glossary/cross-validation) to an object detection dataset.
 
 ## K-Fold Dataset Split
 

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -75,7 +75,8 @@ lbl_by_key = {p.relative_to(dataset_path / "labels").with_suffix(""): p for p in
 assert len(img_by_key) == len(images), "two images share one stem, i.e. foo.jpg and foo.png; they map to one label file"
 orphans = sorted(set(lbl_by_key) - set(img_by_key))
 assert not orphans, f"label files with no matching image: {orphans[:3]}"
-backgrounds = set(img_by_key) - set(lbl_by_key)
+empty = {k for k, v in lbl_by_key.items() if not v.read_text().strip()}
+backgrounds = (set(img_by_key) - set(lbl_by_key)) | empty  # the package counts missing AND empty labels as background
 print(f"{len(images)} images, {len(labels)} labels, {len(backgrounds)} background images")
 ```
 
@@ -88,7 +89,7 @@ print(f"{len(images)} images, {len(labels)} labels, {len(backgrounds)} backgroun
     - **Scope the label glob to `labels/`.** Ultralytics datasets nest labels as `labels/train/`, `labels/val/`, `labels/test/`, and a pattern that expects them one level up returns nothing at all. A glob rooted at the dataset directory instead re-reads its own output on a second run.
     - **Use `IMG_FORMATS` rather than a hand-written extension list.** Ultralytics accepts 13 image formats, and on Linux and macOS `Path.rglob` matches extensions case-sensitively regardless of the filesystem — so a hardcoded `[".jpg", ".jpeg", ".png"]` silently drops the three `.JPG` files in this dataset, and every `.webp` or `.tif` in yours.
     - **Pair by key, never by position, and make the key the path under `images`/`labels` rather than the bare filename.** The two lists come from different globs, so any dropped or extra file shifts one relative to the other and every later pair is wrong — a failure that trains cleanly and reports meaningless metrics. The bare stem is not enough either: Ultralytics maps `images/train/0001.jpg` to `labels/train/0001.txt`, so the same basename is legal in two splits, and keying on `0001` would silently keep one of them while the assertion still passed.
-    - **An image with no label file is a background, not an error.** Ultralytics reads a missing label file as an empty label array, so the checks above reject only two things: an *orphan label* — a `.txt` with no image — and two images sharing one stem, such as `foo.jpg` and `foo.png`. The second is rejected rather than resolved because `img2label_paths` maps both to the same `foo.txt`, so the package cannot tell them apart either; dropping one silently would be worse than stopping.
+    - **An image with no label file, or an empty one, is a background, not an error.** Ultralytics reads a missing label file as an empty label array and reports `nm + ne` — missing plus empty — as its `backgrounds` count, which is why the block above counts both rather than just the missing ones. The checks reject only two things: an *orphan label* — a `.txt` with no image — and two images sharing one stem, such as `foo.jpg` and `foo.png`. The second is rejected rather than resolved because `img2label_paths` maps both to the same `foo.txt`, so the package cannot tell them apart either; dropping one silently would be worse than stopping.
 
 Now count the instances per class:
 
@@ -381,7 +382,7 @@ Average the per-fold metric you care about. `results[k].box.map` holds `mAP50-95
 
 ### How much disk space does K-Fold cross validation need?
 
-None beyond the dataset itself, if you define each fold as a `.txt` list of image paths. Copying images into per-fold directories instead multiplies the folded pool by `k` — for the 1,252 deduplicated images and their labels here, 86 MB, that is about 430 MB and 12,520 files at `k=5`, against 402 KB and 15 files for the list approach.
+For the fold definitions, almost nothing beyond the dataset itself, if you define each fold as a `.txt` list of image paths. The `k` training runs still write their own checkpoints and plots. Copying images into per-fold directories instead multiplies the folded pool by `k` — for the 1,252 deduplicated images and their labels here, 86 MB, that is about 430 MB and 12,520 files at `k=5`, against 402 KB and 15 files for the list approach.
 
 ### Should I use K-Fold cross validation or a single train/val split?
 

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -66,6 +66,7 @@ Let's get started.
 
     yaml_file = "path/to/data.yaml"
     data = check_det_dataset(yaml_file)
+    dataset_path = Path(data["path"])
     sources = []
     for split in ("train", "val"):
         source = data.get(split)
@@ -172,6 +173,8 @@ The rows index images by their path relative to `images/`, and the columns corre
 4. Write image lists and a dataset YAML for each split. Text lists avoid copying the dataset `k` times.
 
     ```python
+    import yaml
+
     save_path = dataset_path.parent / f"{ksplit}-Fold_Cross-val"
     save_path.mkdir(parents=True, exist_ok=True)
     ds_yamls = []

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -60,7 +60,7 @@ from pathlib import Path
 
 from ultralytics.data.utils import IMG_FORMATS
 
-dataset_path = Path(data["path"])  # from check_det_dataset above
+dataset_path = Path(data["path"]).resolve()  # check_det_dataset leaves an existing relative path relative
 pool = ("train", "val")  # the shipped test split stays out of the folds
 
 images = sorted(

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -64,9 +64,7 @@ Let's get started.
     from ultralytics.data.utils import IMG_FORMATS, img2label_paths
 
     dataset_path = Path("./Fruit-detection").resolve()  # replace with 'path/to/dataset' for your custom data
-    images = sorted(
-        p for p in (dataset_path / "images").rglob("*.*") if p.suffix[1:].lower() in IMG_FORMATS
-    )
+    images = sorted(p for p in (dataset_path / "images").rglob("*.*") if p.suffix[1:].lower() in IMG_FORMATS)
     labels = [Path(p) for p in img2label_paths([str(p) for p in images])]
     keys = [p.relative_to(dataset_path / "images").with_suffix("") for p in images]
     assert len(set(keys)) == len(keys), "multiple images map to the same label path"

--- a/docs/en/guides/kfold-cross-validation.md
+++ b/docs/en/guides/kfold-cross-validation.md
@@ -1,320 +1,389 @@
 ---
+title: K-Fold Cross Validation for YOLO Datasets
 comments: true
-description: Learn to implement K-Fold Cross Validation for object detection datasets using Ultralytics YOLO. Improve your model's reliability and robustness.
-keywords: Ultralytics, YOLO, K-Fold Cross Validation, object detection, sklearn, pandas, PyYAML, machine learning, dataset split
+description: Build K-Fold splits for a YOLO detection dataset with scikit-learn and pandas, train Ultralytics YOLO26 on every fold, and aggregate the results into one score.
+keywords: K-Fold cross validation, YOLO, Ultralytics, scikit-learn, pandas, dataset split, model evaluation, object detection, fold balance, data leakage
 ---
 
-# K-Fold Cross Validation with Ultralytics
+# How to Run K-Fold Cross Validation with Ultralytics YOLO
 
-## Introduction
+K-Fold cross validation splits a dataset into `k` equally sized folds and trains `k` models, each holding out a different fold for validation. Every image is therefore validated exactly once and trained on in the other `k - 1` folds. Averaging the `k` results gives a far more stable estimate of model quality than a single train/val split, because it no longer depends on which images happened to land in the validation set.
 
-This comprehensive guide illustrates the implementation of K-Fold Cross Validation for [object detection](https://www.ultralytics.com/glossary/object-detection) datasets within the Ultralytics ecosystem. We'll leverage the YOLO detection format and key Python libraries such as sklearn, pandas, and PyYAML to guide you through the necessary setup, the process of generating feature vectors, and the execution of a K-Fold dataset split.
+This guide builds `k=5` folds for a [YOLO detection dataset](../datasets/detect/index.md) using scikit-learn and pandas, writes one dataset YAML per fold, trains [Ultralytics YOLO26](../models/yolo26.md) on each of them, and aggregates the results. Cross validation pays off most when a dataset is small, noisy, or class-imbalanced; for large, diverse datasets a single well-constructed train/val/test split gives the same answer for a fifth of the compute.
 
 <p align="center">
   <img width="800" src="https://cdn.ul.run/i/457d0a77dc06d7204322ec056248c4b5.avif" alt="K-fold cross validation data splitting">
 </p>
 
-Whether your project involves the Fruit Detection dataset or a custom data source, this tutorial aims to help you comprehend and apply K-Fold Cross Validation to bolster the reliability and robustness of your [machine learning](https://www.ultralytics.com/glossary/machine-learning-ml) models. While we're applying `k=5` folds for this tutorial, keep in mind that the optimal number of folds can vary depending on your dataset and the specifics of your project. K-Fold Cross Validation delivers the most value when your dataset is small, noisy, or highly variable; for large, diverse datasets, a well-constructed train/val/test split is usually sufficient.
-
-Let's get started.
-
 ## Setup
 
-- Your annotations should be in the [YOLO detection format](../datasets/detect/index.md).
-
-- This guide assumes that annotation files are locally available.
-
-- For our demonstration, we use the [Fruit Detection](https://www.kaggle.com/datasets/lakshaytyagi01/fruit-detection/code) dataset.
-    - This dataset contains a total of 8479 images.
-    - It includes 6 class labels, each with its total instance counts listed below.
+This walkthrough uses the [African Wildlife](../datasets/detect/african-wildlife.md) dataset, which downloads automatically and is already in [YOLO detection format](../datasets/detect/index.md). Substitute your own by pointing `dataset_path` at it, provided it uses the standard `images/<split>` and `labels/<split>` directory layout — the collection block below walks those directories rather than reading the `train` and `val` entries of your data YAML, so a dataset defined by path lists or non-standard directories needs those globs adjusted first.
 
 | Class Label | Instance Count |
-| :---------- | :------------: |
-| Apple       |      7049      |
-| Grapes      |      7202      |
-| Pineapple   |      1613      |
-| Orange      |     15549      |
-| Banana      |      3536      |
-| Watermelon  |      1976      |
+| :---------- | -------------: |
+| buffalo     |            488 |
+| elephant    |            649 |
+| rhino       |            484 |
+| zebra       |            689 |
+| **Total**   |      **2,310** |
 
-- Necessary Python packages include:
-    - `ultralytics`
-    - `sklearn`
-    - `pandas`
-    - `pyyaml`
+The dataset ships 1,504 images split into `train`, `val` and `test`. This guide folds the 1,277 `train` and `val` images and **leaves `test` untouched** — cross validation replaces the train/val boundary, not the held-out set. The counts above are for the folded pool, not the whole dataset. Keeping a split out of the folds is what lets you evaluate once at the end on data that took no part in choosing anything.
 
-- This tutorial operates with `k=5` folds. However, you should determine the best number of folds for your specific dataset.
+Install Ultralytics and the two helper libraries this guide uses:
 
-1. Initiate a new Python virtual environment (`venv`) for your project and activate it. Use `pip` (or your preferred package manager) to install:
-    - The Ultralytics library: `pip install -U ultralytics`. Alternatively, you can clone the official [repo](https://github.com/ultralytics/ultralytics).
-    - Scikit-learn, pandas, and PyYAML: `pip install -U scikit-learn pandas pyyaml`.
+```bash
+pip install -U ultralytics scikit-learn pandas
+```
 
-2. Verify that your annotations are in the [YOLO detection format](../datasets/detect/index.md).
-    - For this tutorial, all annotation files are found in the `Fruit-Detection/labels` directory.
+Then download the dataset once, so the rest of the guide can read it from disk:
 
-## Generating Feature Vectors for Object Detection Dataset
+```python
+from ultralytics.data.utils import check_det_dataset
 
-1. Start by creating a new `example.py` Python file for the steps below.
+dataset_yaml = "african-wildlife.yaml"  # swap in your own; every later step reads this variable
+data = check_det_dataset(dataset_yaml)  # downloads on first use
+print(data["path"])
+```
 
-2. Proceed to retrieve all label files for your dataset.
+!!! note "Choosing `k`"
 
-    ```python
-    from pathlib import Path
+    This guide uses `k=5`, which holds out 20% of the data per fold. Smaller datasets benefit from more folds, at proportionally more training time — `k` folds means `k` full training runs.
 
-    dataset_path = Path("./Fruit-detection")  # replace with 'path/to/dataset' for your custom data
-    labels = sorted(dataset_path.rglob("*labels/*.txt"))  # all data in 'labels'
-    ```
+## Building the Class-Count Matrix
 
-3. Now, read the contents of the dataset YAML file and extract the indices of the class labels.
+The split has to be computed over something. Each image is represented by a row counting how many instances of each class its label file contains, which turns the dataset into a table `scikit-learn` can split.
 
-    ```python
-    import yaml
+Start by collecting the label and image files, and pairing them:
 
-    yaml_file = "path/to/data.yaml"  # your data YAML with data directories and names dictionary
-    with open(yaml_file, encoding="utf8") as y:
-        classes = yaml.safe_load(y)["names"]
-    cls_idx = sorted(classes.keys())
-    ```
+```python
+from pathlib import Path
 
-4. Initialize an empty `pandas` DataFrame.
+from ultralytics.data.utils import IMG_FORMATS
 
-    ```python
-    import pandas as pd
+dataset_path = Path(data["path"])  # from check_det_dataset above
+pool = ("train", "val")  # the shipped test split stays out of the folds
 
-    index = [label.stem for label in labels]  # uses base filename as ID (no extension)
-    labels_df = pd.DataFrame([], columns=cls_idx, index=index)
-    ```
+images = sorted(
+    p for s in pool for p in (dataset_path / "images" / s).rglob("*.*") if p.suffix[1:].lower() in IMG_FORMATS
+)
+labels = sorted(p for s in pool for p in (dataset_path / "labels" / s).rglob("*.txt"))
 
-5. Count the instances of each class-label present in the annotation files.
+# key by path relative to images/ and labels/, so the same basename in two splits stays distinct
+img_by_key = {p.relative_to(dataset_path / "images").with_suffix(""): p for p in images}
+lbl_by_key = {p.relative_to(dataset_path / "labels").with_suffix(""): p for p in labels}
 
-    ```python
-    from collections import Counter
+assert len(img_by_key) == len(images), "two images share one stem, i.e. foo.jpg and foo.png; they map to one label file"
+orphans = sorted(set(lbl_by_key) - set(img_by_key))
+assert not orphans, f"label files with no matching image: {orphans[:3]}"
+backgrounds = set(img_by_key) - set(lbl_by_key)
+print(f"{len(images)} images, {len(labels)} labels, {len(backgrounds)} background images")
+```
 
-    for label in labels:
-        lbl_counter = Counter()
+```text
+1277 images, 1277 labels, 0 background images
+```
 
-        with open(label) as lf:
-            lines = lf.readlines()
+!!! warning "Three details this block gets right on purpose"
 
-        for line in lines:
-            # classes for YOLO label uses integer at first position of each line
-            lbl_counter[int(line.split(" ", 1)[0])] += 1
+    - **Scope the label glob to `labels/`.** Ultralytics datasets nest labels as `labels/train/`, `labels/val/`, `labels/test/`, and a pattern that expects them one level up returns nothing at all. A glob rooted at the dataset directory instead re-reads its own output on a second run.
+    - **Use `IMG_FORMATS` rather than a hand-written extension list.** Ultralytics accepts 13 image formats, and on Linux and macOS `Path.rglob` matches extensions case-sensitively regardless of the filesystem — so a hardcoded `[".jpg", ".jpeg", ".png"]` silently drops the three `.JPG` files in this dataset, and every `.webp` or `.tif` in yours.
+    - **Pair by key, never by position, and make the key the path under `images`/`labels` rather than the bare filename.** The two lists come from different globs, so any dropped or extra file shifts one relative to the other and every later pair is wrong — a failure that trains cleanly and reports meaningless metrics. The bare stem is not enough either: Ultralytics maps `images/train/0001.jpg` to `labels/train/0001.txt`, so the same basename is legal in two splits, and keying on `0001` would silently keep one of them while the assertion still passed.
+    - **An image with no label file is a background, not an error.** Ultralytics reads a missing label file as an empty label array, so the checks above reject only two things: an *orphan label* — a `.txt` with no image — and two images sharing one stem, such as `foo.jpg` and `foo.png`. The second is rejected rather than resolved because `img2label_paths` maps both to the same `foo.txt`, so the package cannot tell them apart either; dropping one silently would be worse than stopping.
 
-        labels_df.loc[label.stem] = lbl_counter
+Now count the instances per class:
 
-    labels_df = labels_df.fillna(0.0)  # replace `nan` values with `0.0`
-    ```
+```python
+from collections import Counter
 
-6. The following is a sample view of the populated DataFrame:
+import pandas as pd
 
-    ```text
-                                                           0    1    2    3    4    5
-    '0000a16e4b057580_jpg.rf.00ab48988370f64f5ca8ea4...'  0.0  0.0  0.0  0.0  0.0  7.0
-    '0000a16e4b057580_jpg.rf.7e6dce029fb67f01eb19aa7...'  0.0  0.0  0.0  0.0  0.0  7.0
-    '0000a16e4b057580_jpg.rf.bc4d31cdcbe229dd022957a...'  0.0  0.0  0.0  0.0  0.0  7.0
-    '00020ebf74c4881c_jpg.rf.508192a0a97aa6c4a3b6882...'  0.0  0.0  0.0  1.0  0.0  0.0
-    '00020ebf74c4881c_jpg.rf.5af192a2254c8ecc4188a25...'  0.0  0.0  0.0  1.0  0.0  0.0
-     ...                                                  ...  ...  ...  ...  ...  ...
-    'ff4cd45896de38be_jpg.rf.c4b5e967ca10c7ced3b9e97...'  0.0  0.0  0.0  0.0  0.0  2.0
-    'ff4cd45896de38be_jpg.rf.ea4c1d37d2884b3e3cbce08...'  0.0  0.0  0.0  0.0  0.0  2.0
-    'ff5fd9c3c624b7dc_jpg.rf.bb519feaa36fc4bf630a033...'  1.0  0.0  0.0  0.0  0.0  0.0
-    'ff5fd9c3c624b7dc_jpg.rf.f0751c9c3aa4519ea3c9d6a...'  1.0  0.0  0.0  0.0  0.0  0.0
-    'fffe28b31f2a70d4_jpg.rf.7ea16bd637ba0711c53b540...'  0.0  6.0  0.0  0.0  0.0  0.0
-    ```
+classes = data["names"]  # check_det_dataset normalizes names to {int: str}, so the keys are the class IDs
+cls_idx = sorted(classes)
 
-The rows index the label files, each corresponding to an image in your dataset, and the columns correspond to your class-label indices. Each row represents a pseudo feature-vector, with the count of each class-label present in your dataset. This data structure enables the application of [K-Fold Cross Validation](https://www.ultralytics.com/glossary/cross-validation) to an object detection dataset.
+labels_df = pd.DataFrame(0.0, index=sorted(img_by_key), columns=cls_idx)
+for key, label_file in lbl_by_key.items():  # images with no label file keep their all-zero row
+    counter = Counter()
+    for line in label_file.read_text().splitlines():
+        if line.strip():  # skip blank lines; split() also handles tabs and leading whitespace
+            counter[int(line.split()[0])] += 1
+    for cls, n in counter.items():
+        labels_df.loc[key, cls] = n
 
-## K-Fold Dataset Split
+print(labels_df.sum().rename(classes))
+```
 
-1. Now we will use the `KFold` class from `sklearn.model_selection` to generate `k` splits of the dataset.
-    - Important:
-        - Setting `shuffle=True` ensures a randomized distribution of classes in your splits.
-        - By setting `random_state=M` where `M` is a chosen integer, you can obtain repeatable results.
+```text
+buffalo     488.0
+elephant    649.0
+rhino       484.0
+zebra       689.0
+dtype: float64
+```
 
-    ```python
-    import random
+An image with no objects produces an all-zero row, which is correct — a background image is legitimate training data, not missing data.
 
-    from sklearn.model_selection import KFold
+## Watch for Duplicate and Near-Duplicate Images
 
-    random.seed(0)  # for reproducibility
-    ksplit = 5
-    kf = KFold(n_splits=ksplit, shuffle=True, random_state=20)  # setting random_state for repeatable results
+Cross validation assumes the folds are independent. Duplicated or near-duplicated images break that assumption: a copy in training and its twin in validation inflates that fold's metrics, and no amount of averaging removes the bias.
 
-    kfolds = list(kf.split(labels_df))
-    ```
+This is not a hypothetical for the example dataset. Hashing the folded pool finds **25 groups of byte-identical images covering 50 files**, none of them detectable from the filenames. Deduplicate before splitting:
 
-2. The dataset has now been split into `k` folds, each having a list of `train` and `val` indices. We will construct a DataFrame to display these results more clearly.
+```python
+import hashlib
+from collections import defaultdict
 
-    ```python
-    folds = [f"split_{n}" for n in range(1, ksplit + 1)]
-    folds_df = pd.DataFrame(index=index, columns=folds)
+by_hash = defaultdict(list)
+for key, image in img_by_key.items():
+    by_hash[hashlib.md5(image.read_bytes()).hexdigest()].append(key)
+duplicates = {h: keys for h, keys in by_hash.items() if len(keys) > 1}
+print(f"{len(duplicates)} duplicate groups covering {sum(len(k) for k in duplicates.values())} images")
 
-    for i, (train, val) in enumerate(kfolds, start=1):
-        folds_df[f"split_{i}"].loc[labels_df.iloc[train].index] = "train"
-        folds_df[f"split_{i}"].loc[labels_df.iloc[val].index] = "val"
-    ```
+# keep one image per hash group and rebuild the matrix, so no copy can straddle a fold
+drop = {k for keys in duplicates.values() for k in sorted(keys)[1:]}
+img_by_key = {k: v for k, v in img_by_key.items() if k not in drop}
+labels_df = labels_df.drop(index=sorted(drop))
+print(f"dropped {len(drop)} duplicate images, {len(labels_df)} remain")
+```
 
-3. Now we will calculate the distribution of class labels for each fold as a ratio of the classes present in `val` to those present in `train`.
+```text
+25 duplicate groups covering 50 images
+dropped 25 duplicate images, 1252 remain
+```
 
-    ```python
-    fold_lbl_distrb = pd.DataFrame(index=folds, columns=cls_idx)
+Dropping one image per group is the blunt option shown above and it is enough here. Keeping them together with `GroupKFold`, keyed on the hash, preserves the data instead — worth it when duplicates are numerous. The same reasoning applies to frames from one video, photographs of one subject, and augmented copies of one source image: group them, or the folds are not independent. Note that byte-identical hashing does not catch re-encoded or resized near-duplicates; a perceptual hash does.
 
-    for n, (train_indices, val_indices) in enumerate(kfolds, start=1):
-        train_totals = labels_df.iloc[train_indices].sum()
-        val_totals = labels_df.iloc[val_indices].sum()
+## Splitting into K Folds
 
-        # To avoid division by zero, we add a small value (1E-7) to the denominator
-        ratio = val_totals / (train_totals + 1e-7)
-        fold_lbl_distrb.loc[f"split_{n}"] = ratio
-    ```
+`KFold` shuffles the rows and partitions them into `k` groups. `random_state` is what makes the split reproducible; the global `random` module plays no part in it.
 
-    The ideal scenario is for all class ratios to be reasonably similar for each split and across classes. This, however, will be subject to the specifics of your dataset.
+```python
+from sklearn.model_selection import KFold
 
-4. Next, we create the directories and dataset YAML files for each split.
+ksplit = 5
+kf = KFold(n_splits=ksplit, shuffle=True, random_state=20)
+kfolds = list(kf.split(labels_df))
 
-    ```python
-    from datetime import datetime, timezone
+folds = [f"fold_{n}" for n in range(1, ksplit + 1)]
+folds_df = pd.DataFrame(index=labels_df.index, columns=folds, dtype=object)
+for i, (train, val) in enumerate(kfolds, start=1):
+    folds_df.loc[labels_df.index[train], f"fold_{i}"] = "train"
+    folds_df.loc[labels_df.index[val], f"fold_{i}"] = "val"
 
-    supported_extensions = [".jpg", ".jpeg", ".png"]
+for fold in folds:
+    print(f"{fold}: train={(folds_df[fold] == 'train').sum()} val={(folds_df[fold] == 'val').sum()}")
+```
 
-    # Initialize an empty list to store image file paths
-    images = []
+```text
+fold_1: train=1001 val=251
+fold_2: train=1001 val=251
+fold_3: train=1002 val=250
+fold_4: train=1002 val=250
+fold_5: train=1002 val=250
+```
 
-    # Loop through supported extensions and gather image files
-    for ext in supported_extensions:
-        images.extend(sorted((dataset_path / "images").rglob(f"*{ext}")))
+!!! warning "Assign with `.loc[rows, column]`, not `df[column].loc[rows]`"
 
-    # Create the necessary directories and dataset YAML files
-    date = datetime.now(timezone.utc).date().isoformat()
-    save_path = Path(dataset_path / f"{date}_{ksplit}-Fold_Cross-val")
-    save_path.mkdir(parents=True, exist_ok=True)
-    ds_yamls = []
+    The second form is chained assignment. Under pandas copy-on-write — the default from pandas 3.0 — it writes to a temporary copy and silently leaves the DataFrame untouched, so every fold column stays `NaN`. The failure surfaces much later as `TypeError: unsupported operand type(s) for /: 'PosixPath' and 'float'` when a fold name is used to build a path, with nothing pointing back at the assignment.
 
-    for split in folds_df.columns:
-        # Create directories
-        split_dir = save_path / split
-        split_dir.mkdir(parents=True, exist_ok=True)
-        (split_dir / "train" / "images").mkdir(parents=True, exist_ok=True)
-        (split_dir / "train" / "labels").mkdir(parents=True, exist_ok=True)
-        (split_dir / "val" / "images").mkdir(parents=True, exist_ok=True)
-        (split_dir / "val" / "labels").mkdir(parents=True, exist_ok=True)
+## Checking the Fold Balance
 
-        # Create dataset YAML files
-        dataset_yaml = split_dir / f"{split}_dataset.yaml"
-        ds_yamls.append(dataset_yaml)
+`KFold` is uniformly random over rows. It does **not** stratify, so it does not guarantee that every class is evenly represented in every fold — it only guarantees that each image is validated once. Check the result rather than assuming it:
 
-        with open(dataset_yaml, "w") as ds_y:
-            yaml.safe_dump(
-                {
-                    "path": split_dir.as_posix(),
-                    "train": "train",
-                    "val": "val",
-                    "names": classes,
-                },
-                ds_y,
-            )
-    ```
+```python
+fold_distrb = pd.DataFrame(index=folds, columns=cls_idx, dtype=float)
+for n, (train, val) in enumerate(kfolds, start=1):
+    ratio = labels_df.iloc[val].sum() / (labels_df.iloc[train].sum() + 1e-7)
+    fold_distrb.loc[f"fold_{n}"] = ratio
+fold_distrb.columns = [classes[i] for i in cls_idx]
+print(fold_distrb.round(3))
+```
 
-5. Lastly, copy images and labels into the respective directory ('train' or 'val') for each split.
-    - **NOTE:** The time required for this portion of the code will vary based on the size of your dataset and your system hardware.
+```text
+        buffalo  elephant  rhino  zebra
+fold_1    0.216     0.243  0.237  0.328
+fold_2    0.285     0.287  0.303  0.172
+fold_3    0.258     0.238  0.212  0.229
+fold_4    0.219     0.255  0.285  0.222
+fold_5    0.275     0.229  0.218  0.313
+```
+
+Each cell is the ratio of validation instances to training instances for that class. With `k` folds the expected value is `1 / (k - 1)`, so `0.25` here. Every cell above sits within about a third of that, which is fine — with 484 instances in the rarest class, plain `KFold` spreads them adequately.
+
+The check matters when it fails. On a dataset with a class of only a handful of instances, some folds end up with **zero** validation instances of it, per-class AP is undefined there, and the average across folds is silently computed over a shifting set of classes. If you see a `0.000` cell, stratify the split on each image's rarest present class:
+
+```python
+from sklearn.model_selection import StratifiedKFold
+
+freq = labels_df.sum()
+y = labels_df.apply(
+    lambda row: min((c for c in cls_idx if row[c] > 0), key=lambda c: freq[c]) if row.sum() else -1,
+    axis=1,
+)
+kfolds = list(StratifiedKFold(ksplit, shuffle=True, random_state=20).split(labels_df, y))
+
+# rebuild folds_df from the new kfolds -- every later step reads folds_df, not kfolds
+folds_df = pd.DataFrame(index=labels_df.index, columns=folds, dtype=object)
+for i, (train, val) in enumerate(kfolds, start=1):
+    folds_df.loc[labels_df.index[train], f"fold_{i}"] = "train"
+    folds_df.loc[labels_df.index[val], f"fold_{i}"] = "val"
+```
+
+Rebuilding `folds_df` is the part that is easy to miss: every step after this reads `folds_df`, never `kfolds`, so swapping the splitter alone leaves the original unstratified folds in place with nothing to show for it.
+
+Check the stratum sizes before trusting the result, because `StratifiedKFold` degrades quietly rather than refusing:
+
+```python
+print(y.value_counts().min(), "smallest stratum vs", ksplit, "folds")
+```
+
+A stratum smaller than `ksplit` produces a `UserWarning` and folds in which that class is simply absent from validation — measured on scikit-learn 1.7.2, a stratum of 1 leaves 4 of 5 folds with no validation instances of it, a stratum of 2 leaves 3, and only a stratum of `ksplit` or more is clean. That is the failure this recipe was meant to fix, so when the smallest stratum is under `ksplit`, lower `k` or group the rare classes instead of stratifying on them. The background stratum (`-1`) counts too.
+
+This is also a proxy, not true multi-label stratification: an image containing several classes contributes to only one stratum. `StratifiedKFold` cannot take a multi-label target directly — it raises `ValueError: Supported target types are: ('binary', 'multiclass')` — so exact multi-label balance needs the `iterative-stratification` package.
+
+## Creating One Dataset YAML per Fold
+
+A fold is just a list of which images train and which validate. Ultralytics dataset YAMLs accept a `.txt` file listing image paths wherever they accept a directory, so a fold needs two text files and a YAML — no image is copied anywhere:
+
+```python
+import yaml
+
+save_path = dataset_path.parent / f"{ksplit}-fold"
+save_path.mkdir(parents=True, exist_ok=True)
+
+ds_yamls = []
+for fold in folds:
+    for split in ("train", "val"):
+        keys = folds_df.index[folds_df[fold] == split]
+        (save_path / f"{fold}_{split}.txt").write_text("\n".join(str(img_by_key[k]) for k in keys) + "\n")
+    fold_yaml = save_path / f"{fold}.yaml"
+    fold_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "path": save_path.as_posix(),
+                "train": f"{fold}_train.txt",
+                "val": f"{fold}_val.txt",
+                "names": classes,
+            }
+        )
+    )
+    ds_yamls.append(fold_yaml)
+```
+
+Note that `save_path` sits **beside** the dataset, not inside it. A fold directory written into the dataset root gets picked up by the label glob on the next run.
+
+!!! tip "Why not copy the images into fold directories?"
+
+    Copying works and gives you self-contained fold directories, but it duplicates the folded pool `k` times. Measured on the 1,252 images left after deduplication, plus their labels, at `k=5`:
+
+    | Approach   | Disk    | Files  |
+    | ---------- | ------- | ------ |
+    | Copy files | ~430 MB | 12,520 |
+    | Text lists | 402 KB  | 15     |
+
+    Both produce identical folds and identical training scans. If you do need real directories — to ship a fold elsewhere, or to hand it to a tool that cannot read a path list — copy by iterating the stem-keyed dictionaries rather than zipping two lists:
 
     ```python
     import shutil
 
-    from tqdm import tqdm
-
-    for image, label in tqdm(zip(images, labels), total=len(images), desc="Copying files"):
-        for split, k_split in folds_df.loc[image.stem].items():
-            # Destination directory
-            img_to_path = save_path / split / k_split / "images"
-            lbl_to_path = save_path / split / k_split / "labels"
-
-            # Copy image and label files to new directory (SamefileError if file already exists)
-            shutil.copy(image, img_to_path / image.name)
-            shutil.copy(label, lbl_to_path / label.name)
+    for key, image in img_by_key.items():
+        for fold, split in folds_df.loc[key].items():
+            for src, sub, suffix in [(image, "images", image.suffix)] + (
+                [(lbl_by_key[key], "labels", ".txt")] if key in lbl_by_key else []
+            ):
+                dst = save_path / fold / split / sub / key.parent / f"{key.name}{suffix}"
+                dst.parent.mkdir(parents=True, exist_ok=True)  # key keeps the split subdirectory
+                shutil.copy(src, dst)
     ```
 
-## Save Records (Optional)
+    This only rearranges files. The `ds_yamls` built above still point at the text lists, so to train from the copied tree you would also write one YAML per fold whose `train` and `val` name the new `fold_N/train` and `fold_N/val` directories. The destination reuses the same relative `key`, for the same reason the pairing does: flattening to the bare filename lets `train/0001.jpg` and `val/0001.jpg` land on top of each other, and `shutil.copy` overwrites without a word. The suffix is appended to `key.name` rather than set with `with_suffix`, which would turn `foo.bar.jpg` into `foo.jpg` and collide all over again.
 
-Optionally, you can save the records of the K-Fold split and label distribution DataFrames as CSV files for future reference.
+    `shutil.copy` overwrites an existing destination silently, so a re-run is not protected in either approach — delete `save_path` first.
+
+## Training on Every Fold
+
+Build a fresh model for each fold so no weights carry over, and keep the result object:
 
 ```python
-folds_df.to_csv(save_path / "kfold_datasplit.csv")
-fold_lbl_distrb.to_csv(save_path / "kfold_label_distribution.csv")
+from ultralytics import YOLO
+
+results = {}
+for k, fold_yaml in enumerate(ds_yamls):
+    model = YOLO("yolo26n.pt")  # fresh weights per fold
+    results[k] = model.train(data=str(fold_yaml), epochs=100, batch=16, project="kfold_demo", name=f"fold_{k + 1}")
 ```
 
-## Train YOLO using K-Fold Data Splits
+Each run reports a clean scan, which is the checkpoint confirming images and labels were paired correctly:
 
-1. First, load the YOLO model.
+```text
+train: Scanning .../african-wildlife/labels/train... 1001 images, 0 backgrounds, 0 corrupt
+val: Scanning .../african-wildlife/labels/train... 251 images, 0 backgrounds, 0 corrupt
+```
 
-    ```python
-    from ultralytics import YOLO
+The counts match the fold sizes printed earlier, and a non-zero `backgrounds` count on a fully annotated dataset means images and labels are mispaired — go back to the orphan-label check. The directory in the scan line is just wherever the first label file happened to sit, so both lines naming the same split is expected and does not mean the fold is wrong.
 
-    weights_path = "path/to/weights.pt"  # use yolo26n.pt for a small model
-    model = YOLO(weights_path, task="detect")
-    ```
+!!! note "Budget for `k` full training runs"
 
-2. Next, iterate over the dataset YAML files to run training. The results will be saved to a directory specified by the `project` and `name` arguments. By default, this directory is 'runs/detect/train#' where # is an integer index.
+    `epochs=100` across five folds is five complete trainings. Reduce `epochs`, or start with `k=3`, when you are still iterating. On CPU, use a small `imgsz` and expect this to take hours.
 
-    ```python
-    results = {}
+## Aggregating the Results
 
-    # Define your additional arguments here
-    batch = 16
-    project = "kfold_demo"
-    epochs = 100
+This is the step that turns `k` runs into one number. `model.train()` returns a `DetMetrics` object per fold; the spread across folds tells you how sensitive your model is to the split:
 
-    for k, dataset_yaml in enumerate(ds_yamls):
-        model = YOLO(weights_path, task="detect")
-        results[k] = model.train(
-            data=dataset_yaml, epochs=epochs, batch=batch, project=project, name=f"fold_{k + 1}"
-        )  # include any additional train arguments
-    ```
+```python
+summary = pd.DataFrame(
+    {
+        k + 1: {
+            "mAP50-95": r.box.map,
+            "mAP50": r.box.map50,
+            "precision": r.box.mp,
+            "recall": r.box.mr,
+            "fitness": r.fitness,
+        }
+        for k, r in results.items()
+    }
+).T
+summary.index.name = "fold"
+print(summary.round(4))
+print(summary.agg(["mean", "std"]).round(4))
+```
 
-3. You can also use [Ultralytics data.split.autosplit](../reference/data/split.md) function for automatic dataset splitting:
+Report the **mean** as your headline number and the **standard deviation** as its uncertainty. A large spread means the metric was never stable enough to compare two models on a single split. Note that `fitness` is a property on the returned object while `box.fitness` is a method — printing the latter without `()` gives a `<bound method>` repr rather than a value.
+
+!!! tip "Just need a single train/val split?"
+
+    If cross validation is more than your project needs, [`autosplit`](../reference/data/split.md) writes a one-shot split in a single call. It handles image extensions correctly, but it writes bare `.txt` files without a dataset YAML, and its ratios are sampling probabilities rather than exact proportions:
 
     ```python
     from ultralytics.data.split import autosplit
 
-    # Automatically split dataset into train/val/test
     autosplit(path="path/to/images", weights=(0.8, 0.2, 0.0), annotated_only=True)
     ```
 
 ## Conclusion
 
-In this guide, we have explored the process of using K-Fold cross-validation for training the YOLO object detection model. We learned how to split our dataset into K partitions, ensuring a balanced class distribution across the different folds.
-
-We also explored the procedure for creating report DataFrames to visualize the data splits and label distributions across these splits, providing us a clear insight into the structure of our training and validation sets.
-
-Optionally, we saved our records for future reference, which could be particularly useful in large-scale projects or when troubleshooting model performance.
-
-Finally, we implemented the actual model training using each split in a loop, saving our training results for further analysis and comparison.
-
-This technique of K-Fold cross-validation is a robust way of making the most out of your available data, and it helps to ensure that your model performance is reliable and consistent across different data subsets. This results in a more generalizable and reliable model that is less likely to [overfit](https://www.ultralytics.com/glossary/overfitting) to specific data patterns.
-
-Remember that although we used YOLO in this guide, these steps are mostly transferable to other machine learning models. Understanding these steps allows you to apply cross-validation effectively in your own machine learning projects.
+K-Fold cross validation gives you `k` independent estimates of model quality instead of one, which is what makes results comparable on small or imbalanced datasets where a single validation split is mostly noise. Average the per-fold `mAP50-95` for your headline number and report the standard deviation alongside it, then read the [YOLO performance metrics guide](yolo-performance-metrics.md) to interpret what the spread is telling you. Once your baseline is stable enough to compare against, move on to [hyperparameter tuning](hyperparameter-tuning.md).
 
 ## FAQ
 
 ### What is K-Fold Cross Validation and why is it useful in object detection?
 
-K-Fold Cross Validation is a technique where the dataset is divided into 'k' subsets (folds) to evaluate model performance more reliably. Each fold serves as both training and [validation data](https://www.ultralytics.com/glossary/validation-data). In the context of object detection, using K-Fold Cross Validation helps to ensure your Ultralytics YOLO model's performance is robust and generalizable across different data splits, enhancing its reliability. For detailed instructions on setting up K-Fold Cross Validation with Ultralytics YOLO, refer to [K-Fold Cross Validation with Ultralytics](#introduction).
+K-Fold cross validation divides a dataset into `k` folds and trains `k` models, each validating on a different fold, so every image is validated exactly once. For object detection this matters because a single validation split can easily over- or under-represent a rare class or a difficult scene, making one model look better than another for reasons that have nothing to do with the model. Averaging across folds removes that dependence. Start with the [K-Fold split](#splitting-into-k-folds) section for the implementation.
 
-### How do I implement K-Fold Cross Validation using Ultralytics YOLO?
+### How do I combine the results from all K folds into one number?
 
-To implement K-Fold Cross Validation with Ultralytics YOLO, you need to follow these steps:
+Average the per-fold metric you care about. `results[k].box.map` holds `mAP50-95` for fold `k`, so `sum(r.box.map for r in results.values()) / len(results)` is the cross-validated mAP, and the standard deviation across folds tells you how sensitive the model is to the split. See [Aggregating the Results](#aggregating-the-results).
 
-1. Verify annotations are in the [YOLO detection format](../datasets/detect/index.md).
-2. Use Python libraries like `sklearn`, `pandas`, and `pyyaml`.
-3. Create feature vectors from your dataset.
-4. Split your dataset using `KFold` from `sklearn.model_selection`.
-5. Train the YOLO model on each split.
+### How much disk space does K-Fold cross validation need?
 
-For a comprehensive guide, see the [K-Fold Dataset Split](#k-fold-dataset-split) section in our documentation.
+None beyond the dataset itself, if you define each fold as a `.txt` list of image paths. Copying images into per-fold directories instead multiplies the folded pool by `k` — for the 1,252 deduplicated images and their labels here, 86 MB, that is about 430 MB and 12,520 files at `k=5`, against 402 KB and 15 files for the list approach.
 
-### How should I design folds for other YOLO tasks like segmentation, classification, pose, or OBB?
+### Should I use K-Fold cross validation or a single train/val split?
 
-The workflow in this guide targets the YOLO detection format, but the same approach adapts to every YOLO task — the task changes how you compose the folds, not whether cross-validation helps:
+Use K-Fold when the dataset is small, noisy, or class-imbalanced enough that a single validation split gives an unstable estimate. For large, diverse datasets a well-constructed train/val/test split reaches the same conclusion for a fraction of the compute, since K-Fold costs `k` complete training runs.
+
+### How should I design folds for segmentation, classification, pose, or OBB?
+
+The workflow here targets the YOLO detection format, but it adapts to every YOLO task — the task changes how you compose the folds, not whether cross validation helps:
 
 | Task       | Fold design                                                                                                                                                                |
 | :--------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -324,16 +393,38 @@ The workflow in this guide targets the YOLO detection format, but the same appro
 | `pose`     | Split by subject or sequence so the same person or animal never appears on both sides of a fold.                                                                           |
 | `obb`      | Split at the image level, keeping tiles or crops from the same scene together — especially important for aerial imagery.                                                   |
 
-Whatever the task, keep near-duplicate and related samples out of opposing folds: that kind of leakage inflates validation metrics well beyond what the model will achieve in production.
+### Can I use K-Fold Cross Validation with my own dataset?
 
-### Why should I use Ultralytics YOLO for object detection?
+Yes, as long as the annotations are in [YOLO detection format](../datasets/detect/index.md) and laid out as `images/<split>` and `labels/<split>`, which is what the collection block globs. Point `dataset_path` at your dataset and read `classes` from your own data YAML. Images with no label file are fine — Ultralytics reads them as backgrounds and they get an all-zero row. The check in [Building the Class-Count Matrix](#building-the-class-count-matrix) rejects only the reverse case, a label file with no image, which is the failure worth catching early.
 
-Ultralytics YOLO offers state-of-the-art, real-time object detection with high [accuracy](https://www.ultralytics.com/glossary/accuracy) and efficiency. It's versatile, supporting multiple [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) tasks such as [detection](../tasks/detect.md), [instance segmentation](../tasks/segment.md), [semantic segmentation](../tasks/semantic.md), and [classification](../tasks/classify.md). Additionally, it integrates seamlessly with tools like [Ultralytics Platform](../platform/index.md) for no-code model training and deployment. For more details, explore the benefits and features on our [Ultralytics YOLO page](https://www.ultralytics.com/yolo).
+### Do I still need a separate test set?
 
-### How can I ensure my annotations are in the correct format for Ultralytics YOLO?
+Yes, and this guide keeps one: the dataset's shipped `test` split is excluded from the folds by the `pool = ("train", "val")` line. Cross validation measures how well a training recipe generalizes, but once you start choosing between recipes on the cross-validated score, that score has informed your decisions.
 
-Your annotations should follow the YOLO detection format. Each annotation file must list the object class, alongside its [bounding box](https://www.ultralytics.com/glossary/bounding-box) coordinates in the image. The YOLO format ensures streamlined and standardized data processing for training object detection models. For more information on proper annotation formatting, visit the [YOLO detection format guide](../datasets/detect/index.md).
+Use the held-out split once, at the end, and note that neither the fold models nor the fold YAMLs are the right thing to point at it: each fold model saw only four fifths of the pool, and a `fold_*.yaml` defines no `test` entry, so `model.val(split="test")` against one raises `FileNotFoundError: ... 'test:' is not defined`. The original dataset YAML is not it either — its `train` entry is `images/train` alone, so training against it never touches the `val` pool the folds were built from.
 
-### Can I use K-Fold Cross Validation with custom datasets other than Fruit Detection?
+Retrain the settled recipe on the whole folded pool with one more path list, then evaluate against the original YAML. This continues the walkthrough above and reuses its `dataset_path`, `img_by_key` and `classes`:
 
-Yes, you can use K-Fold Cross Validation with any custom dataset as long as the annotations are in the YOLO detection format. Replace the dataset paths and class labels with those specific to your custom dataset. This flexibility ensures that any object detection project can benefit from robust model evaluation using K-Fold Cross Validation. For a practical example, review our [Generating Feature Vectors](#generating-feature-vectors-for-object-detection-dataset) section.
+```python
+final_dir = dataset_path.parent / "final"
+final_dir.mkdir(parents=True, exist_ok=True)
+(final_dir / "pool.txt").write_text("\n".join(str(p) for p in img_by_key.values()) + "\n")
+(final_dir / "final.yaml").write_text(
+    yaml.safe_dump(
+        {
+            "path": final_dir.as_posix(),
+            "train": "pool.txt",
+            "val": "pool.txt",  # training requires a val entry; see the warning below
+            "names": classes,
+        }
+    )
+)
+
+final = YOLO("yolo26n.pt")
+final.train(data=str(final_dir / "final.yaml"), epochs=100, batch=16, patience=0)  # patience=0 disables early stopping
+
+fitted = YOLO(final.trainer.last)  # last.pt, so no checkpoint was chosen using training labels
+print(fitted.val(data=dataset_yaml, split="test").box.map)  # the number to report
+```
+
+Two details carry the correctness here. Passing `data=dataset_yaml` to `val()` redirects it away from `final.yaml`, which has no `test` entry, to the original dataset — and your own dataset's YAML needs a `test` entry for this step to mean anything. And the evaluation uses `last.pt` rather than the model `train()` leaves loaded: with `pool.txt` on both sides, every epoch validates on its own training images, so `best.pt` is picked on labels the model has already seen — `Model.train()` reloads exactly that checkpoint. Taking the final epoch's weights instead keeps the test score free of any selection. `patience=0` is there for the same reason: left at its default, early stopping would decide when to stop from metrics measured on the training images.

--- a/docs/en/guides/knowledge-distillation.md
+++ b/docs/en/guides/knowledge-distillation.md
@@ -1,19 +1,14 @@
 ---
-title: Knowledge Distillation for YOLO26 Models
 comments: true
-description: Train a smaller YOLO26 student from a larger teacher with the distill_model argument, gaining up to +1.0 mAP on COCO at no extra inference cost.
-keywords: knowledge distillation, YOLO26, Ultralytics, distill_model, teacher model, student model, dis loss weight, model compression, object detection, computer vision
+description: Master knowledge distillation for Ultralytics YOLO to optimize student model performance with a teacher model.
+keywords: knowledge distillation, YOLO, Ultralytics, object detection, machine learning, computer vision, distill_model, teacher model, student model
 ---
 
 # Knowledge Distillation
 
-Ultralytics YOLO26 supports knowledge distillation directly in `model.train()`: pass a larger teacher checkpoint to the `distill_model` argument and the smaller student learns to match the teacher's neck features alongside its normal detection losses. On COCO this raises student [mAP](yolo-performance-metrics.md) by 0.4 to 1.0 points across the whole family, with no change to model size or inference speed.
+## Quickstart
 
-This guide covers the supported tasks, the recommended teacher and student pairs, the `dis` loss weight, and how to read the extra `dis_loss` column in the [training](../modes/train.md) log.
-
-## Quick Start
-
-Train a smaller student model with guidance from a larger teacher by adding the `distill_model` argument:
+Train a smaller student model with guidance from a larger teacher model by adding the `distill_model` argument:
 
 !!! example
 
@@ -32,42 +27,25 @@ Train a smaller student model with guidance from a larger teacher by adding the 
         yolo train model=yolo26n.pt data=coco8.yaml epochs=100 distill_model=yolo26s.pt
         ```
 
-!!! tip "Already-distilled checkpoints"
-
-    Every model in the table below ships as a downloadable checkpoint, so you do not have to run distillation yourself to get the distilled accuracy. Load `yolo26n-distill.pt` the way you would load any other Ultralytics checkpoint. The `-distill` names are not in the package's built-in `GITHUB_ASSETS_NAMES` registry, so `attempt_download_asset` resolves them through its release-assets branch instead — all five are published on the `ultralytics/assets` release and download on first use:
-
-    === "Python"
-
-        ```python
-        from ultralytics import YOLO
-
-        model = YOLO("yolo26n-distill.pt")  # downloaded from the ultralytics/assets release on first use
-        results = model.predict("https://ultralytics.com/images/bus.jpg")
-        ```
-
-    === "CLI"
-
-        ```bash
-        yolo predict model=yolo26n-distill.pt source=https://ultralytics.com/images/bus.jpg
-        ```
-
-    Distill your own only when you need the gain on **your** dataset rather than on COCO. For everything else that makes a small model train better, see [model training tips](model-training-tips.md).
-
 ## What is Knowledge Distillation?
 
 [Knowledge distillation](https://www.ultralytics.com/glossary/knowledge-distillation) transfers knowledge from a large, accurate **teacher model** to a smaller **student model**. The student learns to mimic the teacher's internal feature representations, often achieving better accuracy than training from scratch.
 
 ![Knowledge distillation workflow image](https://cdn.ul.run/i/69daf2d70527cec60e3c29bfb262839f.avif)
 
-**Reach for distillation when:**
+**Use distillation when:**
 
 - You need a smaller, faster model for deployment
 - You have a high-accuracy teacher model trained on the same data
 - You want better accuracy than standard training provides
 
+!!! note
+
+    Knowledge distillation is implemented for **detect**, **segment**, **pose**, and **obb** tasks. Only **detect** has been experimentally verified for accuracy improvements for now.
+
 ## Performance
 
-**Ultralytics YOLO26** knowledge distillation raises student [mAP](yolo-performance-metrics.md) by 0.4 to 1.0 points across the entire YOLO26 family on [COCO](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco.yaml), with no added inference cost. The table compares standard YOLO26 checkpoints (baseline) against the same models trained with distillation from their recommended teacher.
+Knowledge distillation improves student [mAP](yolo-performance-metrics.md) across the entire YOLO26 family on [COCO](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco.yaml), with no added inference cost. The table below compares the standard YOLO26 models (baseline) against the same models trained with distillation from their recommended teacher.
 
 | Model                                                                  | size<br><sup>(pixels)</sup> | mAP<sup>val<br>50-95</sup><br>baseline | mAP<sup>val<br>50-95</sup><br>distilled | mAP<sup>val<br>50-95 (e2e)</sup><br>baseline | mAP<sup>val<br>50-95 (e2e)</sup><br>distilled |
 | ---------------------------------------------------------------------- | --------------------------- | -------------------------------------- | --------------------------------------- | -------------------------------------------- | --------------------------------------------- |
@@ -77,32 +55,83 @@ Train a smaller student model with guidance from a larger teacher by adding the 
 | [YOLO26l-distill](https://platform.ultralytics.com/ultralytics/yolo26) | 640                         | 55.0                                   | **56.0**                                | 54.4                                         | **55.5**                                      |
 | [YOLO26x-distill](https://platform.ultralytics.com/ultralytics/yolo26) | 640                         | 57.5                                   | **57.9**                                | 56.9                                         | **57.4**                                      |
 
-- **mAP<sup>val</sup>** values are for single-model single-scale on the [COCO val2017](https://cocodataset.org/) dataset. <br>Reproduce a distilled row with `yolo val detect model=yolo26n-distill.pt data=coco.yaml device=0` and its baseline with `model=yolo26n.pt`; add `end2end=False` for the two non-e2e columns.
+- **mAP<sup>val</sup>** values are for single-model single-scale on the [COCO val2017](https://cocodataset.org/) dataset. <br>Reproduce a distilled row with `yolo val detect model=yolo26n-distill.pt data=coco.yaml device=0`; add `end2end=False` for the non-e2e column.
 - **e2e** values use the default NMS-free inference path; non-e2e values use traditional NMS post-processing (`end2end=False`). See [End-to-End Detection](end2end-detection.md) for details.
 
 ## Prerequisites
 
 Before you begin, ensure you meet the following requirements:
 
-- **Trained teacher model**: a `.pt` checkpoint from the same YOLO family as the student. A `.yaml` architecture file is rejected — the teacher must carry trained weights.
-- **Matching task**: use a teacher of the same task as the student. Nothing compares the two — a detect teacher trains against a segment student without complaint — but features are read from the student's layer indices and applied to the teacher, so a mismatch distills from layers that were never checked to correspond.
-- **GPU memory**: enough VRAM to hold both models. The teacher runs forward-only under `no_grad` and carries no gradients or optimizer state, so the overhead is well below a second full training run.
+- **Trained teacher model**: a `.pt` checkpoint from the same YOLO family as the student.
+- **Matching task**: use a teacher for the same task as the student and train it on relevant data.
+- **GPU resources**: enough memory to hold both models; the teacher runs forward-only without gradients or optimizer state.
 
-### Supported Tasks
+### Recommended Model Pairs
 
-Ultralytics extracts features from the three neck layers feeding the model's head, so every task whose head inherits from `Detect` is compatible.
+| Student      | Recommended Teacher |
+| ------------ | ------------------- |
+| `yolo26n.pt` | `yolo26s.pt`        |
+| `yolo26s.pt` | `yolo26m.pt`        |
+| `yolo26m.pt` | `yolo26x.pt`        |
+| `yolo26l.pt` | `yolo26x.pt`        |
 
-| Task       | Supported | Accuracy verified                                           |
-| ---------- | --------- | ----------------------------------------------------------- |
-| `detect`   | Yes       | Yes — benchmarked on COCO (see [Performance](#performance)) |
-| `segment`  | Yes       | Not yet benchmarked                                         |
-| `semantic` | No        | —                                                           |
-| `depth`    | No        | —                                                           |
-| `classify` | No        | —                                                           |
-| `pose`     | Yes       | Not yet benchmarked                                         |
-| `obb`      | Yes       | Not yet benchmarked                                         |
+Cross-family distillation (e.g., YOLO11 teacher with YOLO26 student) is **not supported**.
 
-An unsupported task fails immediately with `ValueError: No Detect head found in model`. [RT-DETR](../models/rtdetr.md) is unsupported for the same reason.
+## Key Parameters
+
+| Parameter       | Type    | Default | Description                                                                                               |
+| --------------- | ------- | ------- | --------------------------------------------------------------------------------------------------------- |
+| `distill_model` | `str`   | `None`  | Path to the teacher model file (e.g., `yolo26x.pt`). Setting this enables knowledge distillation.         |
+| `dis`           | `float` | `6.0`   | Distillation loss weight. Controls how much the distillation loss contributes to the total training loss. |
+
+## How It Works
+
+1. The **teacher model** remains frozen in `eval` mode and runs inference on each batch
+2. The **student model** trains with standard task losses plus distillation guidance
+3. Features are extracted from both models at the three neck layers that feed the Detect-family head
+4. A projector of two **1×1 convolutions with ReLU** aligns each student feature map to the teacher's channels
+5. A **score-weighted L2 loss** compares projected student features with teacher features, weighted by the teacher's classification confidence
+6. The distillation loss combines with standard losses using the `dis` weight
+
+```mermaid
+flowchart TD
+    A[Input Image Batch]:::start --> T[Teacher Model<br/>frozen, eval mode]:::extern
+    A --> S[Student Model<br/>trainable]:::proc
+
+    T --> |Detect head inputs| TF[Teacher Features]:::extern
+    S --> |Detect head inputs| SF[Student Features]:::proc
+
+    SF --> P[1×1 Conv Projector<br/>with ReLU]:::decide
+    P --> AF[Aligned Student Features]:::proc
+
+    TF --> SW[Score-weighted L2 Loss]:::proc
+    AF --> SW
+
+    S --> D[Detection Head]:::proc
+    D --> DL[box_loss + cls_loss + l1_loss]:::proc
+
+    SW --> |× dis| DIS[distillation loss]:::proc
+    DL --> TOTAL[Total Loss]:::out
+    DIS --> TOTAL
+
+    TOTAL --> BP[Backpropagate<br/>Student + Projector only]:::out
+
+    classDef start fill:#4CAF50,color:#fff
+    classDef proc fill:#2196F3,color:#fff
+    classDef decide fill:#FF9800,color:#fff
+    classDef out fill:#9C27B0,color:#fff
+    classDef extern fill:#607D8B,color:#fff
+```
+
+## Task Support
+
+The distillation implementation extracts features from the three neck layers that feed the model's Detect-family head. Because the **segment**, **pose**, and **obb** heads inherit from the same `Detect` architecture, distillation is technically compatible with those tasks as well.
+
+Classification, semantic segmentation, depth estimation, and RT-DETR do not use a compatible Detect-family head and are not supported.
+
+!!! warning
+
+    Only **detect** has been experimentally benchmarked and verified. You can run distillation for **segment**, **pose**, or **obb**, but accuracy improvements for those tasks are not yet validated.
 
 !!! example "Knowledge Distillation for Other Tasks"
 
@@ -136,32 +165,6 @@ An unsupported task fails immediately with `ValueError: No Detect head found in 
         # OBB
         yolo obb train model=yolo26n-obb.pt data=dota8.yaml epochs=100 distill_model=yolo26s-obb.pt
         ```
-
-### Recommended Model Pairs
-
-| Student      | Recommended Teacher |
-| ------------ | ------------------- |
-| `yolo26n.pt` | `yolo26s.pt`        |
-| `yolo26s.pt` | `yolo26m.pt`        |
-| `yolo26m.pt` | `yolo26x.pt`        |
-| `yolo26l.pt` | `yolo26x.pt`        |
-
-!!! warning "Teacher and student must share a YOLO generation"
-
-    Feature layer indices are read from the **student** and then applied to the teacher, so a cross-family pair is not validated and not supported. What happens depends on the pair. A teacher whose layer count differs from the student's fails outright — a YOLOv8 teacher with a YOLO26 student raises `IndexError: index 23 is out of range`, because the index comes from the student and YOLOv8 has fewer modules. A teacher of the same depth fails silently instead: a YOLO11 teacher with a YOLO26 student trains with no warning at all, distilling from layer indices that were never checked to correspond. Keep both models in the same family (for example, both YOLO26).
-
-## Key Parameters
-
-| Parameter       | Type    | Default | Description                                                                                               |
-| --------------- | ------- | ------- | --------------------------------------------------------------------------------------------------------- |
-| `distill_model` | `str`   | `None`  | Path to the teacher model file (e.g., `yolo26x.pt`). Setting this enables knowledge distillation.         |
-| `dis`           | `float` | `6.0`   | Distillation loss weight. Controls how much the distillation loss contributes to the total training loss. |
-
-Both are [training arguments](../usage/cfg.md#train-settings) and are set on `model.train()`, not in the dataset YAML.
-
-!!! note "`compile` is disabled during distillation"
-
-    Setting `compile=True` alongside `distill_model` logs `'compile' is not supported with knowledge distillation and will be disabled.` and training proceeds uncompiled. Budget for that when estimating run time.
 
 ## Training
 
@@ -233,95 +236,36 @@ Distillation training supports resuming from checkpoints. The teacher model is r
 
 ## Training Output
 
-When distillation is enabled, an additional `dis_loss` column appears in training logs. The sample below is a detection run; segment, pose and OBB carry their own task losses in the same table, with `dis_loss` appended to whichever set applies:
-
-```bash
-yolo train model=yolo26n.pt data=coco8.yaml epochs=2 distill_model=yolo26s.pt
-```
+When distillation is enabled, an additional `dis_loss` column appears in training logs:
 
 ```text
       Epoch    GPU_mem   box_loss   cls_loss    l1_loss   dis_loss  Instances       Size
-        1/2         0G     0.9632      2.291    0.01334      9.831         30        640
-        2/2         0G      1.503      3.237    0.02867      9.346         27        640
+      1/80      46.2G      1.566      5.404    0.003249      6.658        231        640
 ```
 
-!!! note "`dis_loss` is a training-only metric"
-
-    The distillation loss is computed during training and is fixed at `0` during validation, so `val/dis_loss` in `results.csv` and the corresponding panel in `results.png` are a flat zero line by design. Read `train/dis_loss` to judge whether distillation is converging.
-
-A checkpoint saved during training — `last.pt` mid-run, or any file written by `save_period` — carries the optimizer state and the EMA copy of the `DistillationModel` wrapper, including its projector, so it is several times larger than the final file (25.4 MB against 5.5 MB on a `yolo26n` run here). The teacher is not among them: it is stripped before saving and rebuilt from `distill_model` on resume. `best.pt` and `last.pt` from a **completed** run contain only the student weights, so file size and inference speed match a normally trained student model.
-
-## How It Works
-
-1. The **teacher model** stays frozen in `eval` mode and runs inference on each batch under `no_grad`
-2. The **student model** trains with standard task losses plus distillation guidance
-3. Features are captured from the three neck layers that feed the student's Detect-family head, and from the head output itself
-4. One **1×1 convolutional projector** per neck level (`Conv2d → ReLU → Conv2d`) maps each student feature map to the teacher's channel count
-5. A **score-weighted L2 loss** compares projected student features with teacher features, weighted per anchor by the teacher's confidence. That weight comes from the head output captured in step 3: the one-to-many and one-to-one class **logits** are averaged first, and `sigmoid` and the per-anchor maximum are taken afterwards — averaging the two branches' confidences instead would give different weights
-6. The distillation loss combines with standard losses using the `dis` weight
-
-For the implementation, see [`ultralytics.nn.distill_model`](../reference/nn/distill_model.md).
-
-```mermaid
-flowchart TD
-    A[Input Image Batch]:::start --> T[Teacher Model<br/>frozen, eval mode]:::extern
-    A --> S[Student Model<br/>trainable]:::proc
-
-    T --> |Neck + head outputs| TF[Teacher Features]:::extern
-    S --> |Neck outputs| SF[Student Features]:::proc
-
-    SF --> P[1x1 Conv Projector<br/>per neck level]:::decide
-    P --> AF[Aligned Student Features]:::proc
-
-    TF --> SW[Score-weighted L2 Loss]:::proc
-    AF --> SW
-
-    S --> D[Detection Head]:::proc
-    D --> DL[box_loss + cls_loss + l1_loss]:::proc
-
-    SW --> |x dis| DIS[distillation loss]:::proc
-    DL --> TOTAL[Total Loss]:::out
-    DIS --> TOTAL
-
-    TOTAL --> BP[Backpropagate<br/>Student + Projector only]:::out
-
-    classDef start fill:#4CAF50,color:#fff
-    classDef proc fill:#2196F3,color:#fff
-    classDef decide fill:#FF9800,color:#fff
-    classDef out fill:#9C27B0,color:#fff
-    classDef extern fill:#607D8B,color:#fff
-```
+The exported model contains **only the student weights**—file size and inference speed match a normally trained student model.
 
 ## FAQ
 
-### Do I need the teacher model to run inference?
-
-No. A completed distillation run saves only the student weights, so `best.pt` loads, exports and runs exactly like a normally trained YOLO26 model. The teacher checkpoint is needed only while training.
-
-### Which tasks and models are supported?
-
-Ultralytics knowledge distillation supports the **detect**, **segment**, **pose** and **obb** tasks; **semantic**, **depth** and **classify** are not, and neither is RT-DETR. Only **detect** has been benchmarked for accuracy gains. The teacher and student must come from the same YOLO family — see [Supported Tasks](#supported-tasks) for the rule and the exact failure.
-
 ### Why is my distillation loss not decreasing?
 
-- Read `train/dis_loss`, not `val/dis_loss` — the latter is always `0`
 - Verify teacher and student are from the **same YOLO generation**
-- Confirm `distill_model` points at a trained `.pt` file that loads
+- Confirm `distill_model` path is correct and the file loads
 - Try increasing `dis` if the loss value is very small
 - Ensure the teacher model is trained on the **same dataset**
 
 ### How does distillation differ from standard training?
 
-Add the `distill_model` parameter — everything else works identically. An extra distillation loss is computed during training, but the saved model is a standard YOLO model with no inference overhead.
+Add the `distill_model` parameter—everything else works identically. An extra distillation loss computes during training, but the saved model is a standard YOLO model with no overhead.
 
 ### Does knowledge distillation slow down training?
 
-Yes, and the overhead scales with how much larger the teacher is than the student rather than being a fixed factor. The teacher runs a forward pass on every batch, so a `yolo26n` student learning from `yolo26s` pays far less than a `yolo26m` student learning from `yolo26x`. The teacher carries no gradients and no optimizer state, which keeps the memory cost well below a second training run. Note that `compile=True` is disabled while distilling.
+Yes. The teacher adds a forward pass for every batch, so the time and memory overhead depend on the teacher/student pair. The teacher runs in `eval` mode without gradients or optimizer state.
 
-### Can I use my own custom-trained model as the teacher?
+### Which tasks and models are supported?
 
-Yes. Any Ultralytics `.pt` checkpoint works as a teacher as long as it is from the same YOLO family and the same task as the student — nothing compares the two datasets, so a mismatch is not rejected. It does need to have learned the data you are distilling on for its guidance to be worth anything, which is why a `yolo26x.pt` fine-tuned on your own data is the strongest teacher for a `yolo26n.pt` student on that same data.
+Knowledge distillation works with **detect**, **segment**, **pose**, and **obb** tasks because it distills features from the three neck layers that feed the Detect-family head. **Classify**, **semantic**, **depth**, and RT-DETR are not supported.
 
-### Does knowledge distillation work with YOLO11 and YOLOv8?
+Only **detect** has been experimentally verified for accuracy improvements. Segment, pose, and obb are technically compatible but not yet benchmarked.
 
-Yes. Distillation reads features by layer index rather than by architecture, so a YOLO11 teacher distills into a YOLO11 student and a YOLOv8 teacher into a YOLOv8 student, both verified to train. What is not supported is crossing families, such as a YOLO11 teacher with a YOLO26 student.
+The teacher and student must belong to the **same YOLO family** (e.g., YOLOv8, YOLO11, or YOLO26). Cross-family distillation (e.g., a YOLO11 teacher with a YOLO26 student) is not supported.

--- a/docs/en/guides/knowledge-distillation.md
+++ b/docs/en/guides/knowledge-distillation.md
@@ -1,14 +1,19 @@
 ---
+title: Knowledge Distillation for YOLO26 Models
 comments: true
-description: Master knowledge distillation for Ultralytics YOLO to optimize student model performance with a teacher model.
-keywords: knowledge distillation, YOLO, Ultralytics, object detection, machine learning, computer vision, distill_model, teacher model, student model
+description: Train a smaller YOLO26 student from a larger teacher with the distill_model argument, gaining up to +1.0 mAP on COCO at no extra inference cost.
+keywords: knowledge distillation, YOLO26, Ultralytics, distill_model, teacher model, student model, dis loss weight, model compression, object detection, computer vision
 ---
 
 # Knowledge Distillation
 
-## Quickstart
+Ultralytics YOLO26 supports knowledge distillation directly in `model.train()`: pass a larger teacher checkpoint to the `distill_model` argument and the smaller student learns to match the teacher's neck features alongside its normal detection losses. On COCO this raises student [mAP](yolo-performance-metrics.md) by 0.4 to 1.0 points across the whole family, with no change to model size or inference speed.
 
-Train a smaller student model with guidance from a larger teacher model by adding the `distill_model` argument:
+This guide covers the supported tasks, the recommended teacher and student pairs, the `dis` loss weight, and how to read the extra `dis_loss` column in the [training](../modes/train.md) log.
+
+## Quick Start
+
+Train a smaller student model with guidance from a larger teacher by adding the `distill_model` argument:
 
 !!! example
 
@@ -27,25 +32,42 @@ Train a smaller student model with guidance from a larger teacher model by addin
         yolo train model=yolo26n.pt data=coco8.yaml epochs=100 distill_model=yolo26s.pt
         ```
 
+!!! tip "Already-distilled checkpoints"
+
+    Every model in the table below ships as a downloadable checkpoint, so you do not have to run distillation yourself to get the distilled accuracy. Load `yolo26n-distill.pt` the way you would load any other Ultralytics checkpoint — the name is resolved against the Ultralytics release assets on first use, so it downloads even though it is not among the model names bundled with the package:
+
+    === "Python"
+
+        ```python
+        from ultralytics import YOLO
+
+        model = YOLO("yolo26n-distill.pt")  # fetched from the Ultralytics release assets on first use
+        results = model.predict("https://ultralytics.com/images/bus.jpg")
+        ```
+
+    === "CLI"
+
+        ```bash
+        yolo predict model=yolo26n-distill.pt source=https://ultralytics.com/images/bus.jpg
+        ```
+
+    Distill your own only when you need the gain on **your** dataset rather than on COCO. For everything else that makes a small model train better, see [model training tips](model-training-tips.md).
+
 ## What is Knowledge Distillation?
 
 [Knowledge distillation](https://www.ultralytics.com/glossary/knowledge-distillation) transfers knowledge from a large, accurate **teacher model** to a smaller **student model**. The student learns to mimic the teacher's internal feature representations, often achieving better accuracy than training from scratch.
 
 ![Knowledge distillation workflow image](https://cdn.ul.run/i/69daf2d70527cec60e3c29bfb262839f.avif)
 
-**Use distillation when:**
+**Reach for distillation when:**
 
 - You need a smaller, faster model for deployment
 - You have a high-accuracy teacher model trained on the same data
 - You want better accuracy than standard training provides
 
-!!! note
-
-    Knowledge distillation is implemented for **detect**, **segment**, **pose**, and **obb** tasks. Only **detect** has been experimentally verified for accuracy improvements for now.
-
 ## Performance
 
-Knowledge distillation improves student [mAP](yolo-performance-metrics.md) across the entire YOLO26 family on [COCO](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco.yaml), with no added inference cost. The table below compares the standard YOLO26 models (baseline) against the same models trained with distillation from their recommended teacher.
+**Ultralytics YOLO26** knowledge distillation raises student [mAP](yolo-performance-metrics.md) by 0.4 to 1.0 points across the entire YOLO26 family on [COCO](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco.yaml), with no added inference cost. The table compares standard YOLO26 checkpoints (baseline) against the same models trained with distillation from their recommended teacher.
 
 | Model                                                                  | size<br><sup>(pixels)</sup> | mAP<sup>val<br>50-95</sup><br>baseline | mAP<sup>val<br>50-95</sup><br>distilled | mAP<sup>val<br>50-95 (e2e)</sup><br>baseline | mAP<sup>val<br>50-95 (e2e)</sup><br>distilled |
 | ---------------------------------------------------------------------- | --------------------------- | -------------------------------------- | --------------------------------------- | -------------------------------------------- | --------------------------------------------- |
@@ -62,74 +84,25 @@ Knowledge distillation improves student [mAP](yolo-performance-metrics.md) acros
 
 Before you begin, ensure you meet the following requirements:
 
-- **Trained Teacher Model**: A pre-trained, high-accuracy teacher model from the same YOLO family as the student model (e.g., YOLO26).
-- **Matching Dataset and Task**: Both the teacher and student models must use the exact same dataset and task configuration.
-- **GPU Resources**: Sufficient GPU memory (VRAM) to load and run both models concurrently during training (refer to the [FAQ](#does-knowledge-distillation-slow-down-training) for typical VRAM overhead).
+- **Trained teacher model**: a `.pt` checkpoint from the same YOLO family as the student. A `.yaml` architecture file is rejected — the teacher must carry trained weights.
+- **Matching task**: use a teacher of the same task as the student. Nothing compares the two — a detect teacher trains against a segment student without complaint — but features are read from the student's layer indices and applied to the teacher, so a mismatch distills from layers that were never checked to correspond.
+- **GPU memory**: enough VRAM to hold both models. The teacher runs forward-only under `no_grad` and carries no gradients or optimizer state, so the overhead is well below a second full training run.
 
-### Recommended Model Pairs
+### Supported Tasks
 
-| Student      | Recommended Teacher |
-| ------------ | ------------------- |
-| `yolo26n.pt` | `yolo26s.pt`        |
-| `yolo26s.pt` | `yolo26m.pt`        |
-| `yolo26m.pt` | `yolo26x.pt`        |
-| `yolo26l.pt` | `yolo26x.pt`        |
+Ultralytics extracts features from the three neck layers feeding the model's head, so every task whose head inherits from `Detect` is compatible.
 
-Cross-family distillation (e.g., YOLO11 teacher with YOLO26 student) is **not supported**.
+| Task       | Supported | Accuracy verified                                           |
+| ---------- | --------- | ----------------------------------------------------------- |
+| `detect`   | Yes       | Yes — benchmarked on COCO (see [Performance](#performance)) |
+| `segment`  | Yes       | Not yet benchmarked                                         |
+| `semantic` | No        | —                                                           |
+| `depth`    | No        | —                                                           |
+| `classify` | No        | —                                                           |
+| `pose`     | Yes       | Not yet benchmarked                                         |
+| `obb`      | Yes       | Not yet benchmarked                                         |
 
-## Key Parameters
-
-| Parameter       | Type    | Default | Description                                                                                               |
-| --------------- | ------- | ------- | --------------------------------------------------------------------------------------------------------- |
-| `distill_model` | `str`   | `None`  | Path to the teacher model file (e.g., `yolo26x.pt`). Setting this enables knowledge distillation.         |
-| `dis`           | `float` | `6.0`   | Distillation loss weight. Controls how much the distillation loss contributes to the total training loss. |
-
-## How It Works
-
-1. The **teacher model** remains frozen in `eval` mode and runs inference on each batch
-2. The **student model** trains with standard task losses plus distillation guidance
-3. Features are extracted from both models at the three neck layers that feed the Detect-family head
-4. A **projector network** (lightweight MLP) aligns student feature dimensions to match the teacher
-5. A **score-weighted L2 loss** compares projected student features with teacher features, weighted by the teacher's classification confidence
-6. The distillation loss combines with standard losses using the `dis` weight
-
-```mermaid
-flowchart TD
-    A[Input Image Batch]:::start --> T[Teacher Model<br/>frozen, eval mode]:::extern
-    A --> S[Student Model<br/>trainable]:::proc
-
-    T --> |Detect head inputs| TF[Teacher Features]:::extern
-    S --> |Detect head inputs| SF[Student Features]:::proc
-
-    SF --> P[1×1 Conv Projector<br/>with ReLU]:::decide
-    P --> AF[Aligned Student Features]:::proc
-
-    TF --> SW[Score-weighted L2 Loss]:::proc
-    AF --> SW
-
-    S --> D[Detection Head]:::proc
-    D --> DL[box_loss + cls_loss + dfl_loss]:::proc
-
-    SW --> |× dis| DIS[distillation loss]:::proc
-    DL --> TOTAL[Total Loss]:::out
-    DIS --> TOTAL
-
-    TOTAL --> BP[Backpropagate<br/>Student + Projector only]:::out
-
-    classDef start fill:#4CAF50,color:#fff
-    classDef proc fill:#2196F3,color:#fff
-    classDef decide fill:#FF9800,color:#fff
-    classDef out fill:#9C27B0,color:#fff
-    classDef extern fill:#607D8B,color:#fff
-```
-
-## Task Support
-
-The distillation implementation extracts features from the three neck layers that feed the model's Detect-family head. Because the **segment**, **pose**, and **obb** heads inherit from the same `Detect` architecture, distillation is technically compatible with those tasks as well.
-
-!!! warning
-
-    Only **detect** has been experimentally benchmarked and verified. You can run distillation for **segment**, **pose**, or **obb**, but accuracy improvements for those tasks are not yet validated.
+An unsupported task fails immediately with `ValueError: No Detect head found in model`. [RT-DETR](../models/rtdetr.md) is unsupported for the same reason.
 
 !!! example "Knowledge Distillation for Other Tasks"
 
@@ -163,6 +136,32 @@ The distillation implementation extracts features from the three neck layers tha
         # OBB
         yolo obb train model=yolo26n-obb.pt data=dota8.yaml epochs=100 distill_model=yolo26s-obb.pt
         ```
+
+### Recommended Model Pairs
+
+| Student      | Recommended Teacher |
+| ------------ | ------------------- |
+| `yolo26n.pt` | `yolo26s.pt`        |
+| `yolo26s.pt` | `yolo26m.pt`        |
+| `yolo26m.pt` | `yolo26x.pt`        |
+| `yolo26l.pt` | `yolo26x.pt`        |
+
+!!! warning "Teacher and student must share a YOLO generation"
+
+    Feature layer indices are read from the **student** and then applied to the teacher, so a cross-family pair is not validated and not supported. What happens depends on the pair. A teacher whose layer count differs from the student's fails outright — a YOLOv8 teacher with a YOLO26 student raises `IndexError: index 23 is out of range`, because the index comes from the student and YOLOv8 has fewer modules. A teacher of the same depth fails silently instead: a YOLO11 teacher with a YOLO26 student trains with no warning at all, distilling from layer indices that were never checked to correspond. Keep both models in the same family (for example, both YOLO26).
+
+## Key Parameters
+
+| Parameter       | Type    | Default | Description                                                                                               |
+| --------------- | ------- | ------- | --------------------------------------------------------------------------------------------------------- |
+| `distill_model` | `str`   | `None`  | Path to the teacher model file (e.g., `yolo26x.pt`). Setting this enables knowledge distillation.         |
+| `dis`           | `float` | `6.0`   | Distillation loss weight. Controls how much the distillation loss contributes to the total training loss. |
+
+Both are [training arguments](../usage/cfg.md#train-settings) and are set on `model.train()`, not in the dataset YAML.
+
+!!! note "`compile` is disabled during distillation"
+
+    Setting `compile=True` alongside `distill_model` logs `'compile' is not supported with knowledge distillation and will be disabled.` and training proceeds uncompiled. Budget for that when estimating run time.
 
 ## Training
 
@@ -213,7 +212,7 @@ The `dis` parameter (default: `6.0`) controls distillation loss contribution:
 
 ### Resuming Distillation Training
 
-Distillation training supports resuming from checkpoints. The teacher model is rebuilt automatically from the `distill_model` path:
+Distillation training supports resuming from checkpoints. The teacher model is rebuilt automatically from the `distill_model` path recorded in the checkpoint:
 
 !!! example "Resume Distillation Training"
 
@@ -234,36 +233,91 @@ Distillation training supports resuming from checkpoints. The teacher model is r
 
 ## Training Output
 
-When distillation is enabled, an additional `dis_loss` column appears in training logs:
+When distillation is enabled, an additional `dis_loss` column appears in training logs. The sample below is a detection run; segment, pose and OBB carry their own task losses in the same table, with `dis_loss` appended to whichever set applies:
 
 ```text
-      Epoch    GPU_mem   box_loss   cls_loss   dfl_loss   dis_loss  Instances       Size
-      1/80      46.2G      1.566      5.404    0.003249      6.658        231        640
+      Epoch    GPU_mem   box_loss   cls_loss    l1_loss   dis_loss  Instances       Size
+        1/2         0G     0.9632      2.291    0.01334      9.831         30        640
+        2/2         0G      1.503      3.237    0.02867      9.346         27        640
 ```
 
-The exported model contains **only the student weights**—file size and inference speed match a normally trained student model.
+!!! note "`dis_loss` is a training-only metric"
+
+    The distillation loss is computed during training and is fixed at `0` during validation, so `val/dis_loss` in `results.csv` and the corresponding panel in `results.png` are a flat zero line by design. Read `train/dis_loss` to judge whether distillation is converging.
+
+A checkpoint saved during training — `last.pt` mid-run, or any file written by `save_period` — carries the optimizer state and the EMA copy of the `DistillationModel` wrapper, including its projector, so it is several times larger than the final file (25.4 MB against 5.5 MB on a `yolo26n` run here). The teacher is not among them: it is stripped before saving and rebuilt from `distill_model` on resume. `best.pt` and `last.pt` from a **completed** run contain only the student weights, so file size and inference speed match a normally trained student model.
+
+## How It Works
+
+1. The **teacher model** stays frozen in `eval` mode and runs inference on each batch under `no_grad`
+2. The **student model** trains with standard task losses plus distillation guidance
+3. Features are captured from the three neck layers that feed the student's Detect-family head, and from the head output itself
+4. One **1×1 convolutional projector** per neck level (`Conv2d → ReLU → Conv2d`) maps each student feature map to the teacher's channel count
+5. A **score-weighted L2 loss** compares projected student features with teacher features, weighted per anchor by the teacher's confidence. That weight comes from the head output captured in step 3: the one-to-many and one-to-one class **logits** are averaged first, and `sigmoid` and the per-anchor maximum are taken afterwards — averaging the two branches' confidences instead would give different weights
+6. The distillation loss combines with standard losses using the `dis` weight
+
+For the implementation, see [`ultralytics.nn.distill_model`](../reference/nn/distill_model.md).
+
+```mermaid
+flowchart TD
+    A[Input Image Batch]:::start --> T[Teacher Model<br/>frozen, eval mode]:::extern
+    A --> S[Student Model<br/>trainable]:::proc
+
+    T --> |Neck + head outputs| TF[Teacher Features]:::extern
+    S --> |Neck outputs| SF[Student Features]:::proc
+
+    SF --> P[1x1 Conv Projector<br/>per neck level]:::decide
+    P --> AF[Aligned Student Features]:::proc
+
+    TF --> SW[Score-weighted L2 Loss]:::proc
+    AF --> SW
+
+    S --> D[Detection Head]:::proc
+    D --> DL[box_loss + cls_loss + l1_loss]:::proc
+
+    SW --> |x dis| DIS[distillation loss]:::proc
+    DL --> TOTAL[Total Loss]:::out
+    DIS --> TOTAL
+
+    TOTAL --> BP[Backpropagate<br/>Student + Projector only]:::out
+
+    classDef start fill:#4CAF50,color:#fff
+    classDef proc fill:#2196F3,color:#fff
+    classDef decide fill:#FF9800,color:#fff
+    classDef out fill:#9C27B0,color:#fff
+    classDef extern fill:#607D8B,color:#fff
+```
 
 ## FAQ
 
+### Do I need the teacher model to run inference?
+
+No. A completed distillation run saves only the student weights, so `best.pt` loads, exports and runs exactly like a normally trained YOLO26 model. The teacher checkpoint is needed only while training.
+
+### Which tasks and models are supported?
+
+Ultralytics knowledge distillation supports the **detect**, **segment**, **pose** and **obb** tasks; **semantic**, **depth** and **classify** are not, and neither is RT-DETR. Only **detect** has been benchmarked for accuracy gains. The teacher and student must come from the same YOLO family — see [Supported Tasks](#supported-tasks) for the rule and the exact failure.
+
 ### Why is my distillation loss not decreasing?
 
+- Read `train/dis_loss`, not `val/dis_loss` — the latter is always `0`
 - Verify teacher and student are from the **same YOLO generation**
-- Confirm `distill_model` path is correct and the file loads
+- Confirm `distill_model` points at a trained `.pt` file that loads
 - Try increasing `dis` if the loss value is very small
 - Ensure the teacher model is trained on the **same dataset**
 
 ### How does distillation differ from standard training?
 
-Add the `distill_model` parameter—everything else works identically. An extra distillation loss computes during training, but the saved model is a standard YOLO model with no overhead.
+Add the `distill_model` parameter — everything else works identically. An extra distillation loss is computed during training, but the saved model is a standard YOLO model with no inference overhead.
 
 ### Does knowledge distillation slow down training?
 
-Yes. Expect 1.2-1.5x slower training and ~1.1x more GPU memory because the teacher model runs inference on each batch. The teacher runs in `eval` mode without gradients, keeping overhead manageable. Use `amp=True` to reduce impact.
+Yes, and the overhead scales with how much larger the teacher is than the student rather than being a fixed factor. The teacher runs a forward pass on every batch, so a `yolo26n` student learning from `yolo26s` pays far less than a `yolo26m` student learning from `yolo26x`. The teacher carries no gradients and no optimizer state, which keeps the memory cost well below a second training run. Note that `compile=True` is disabled while distilling.
 
-### Which tasks and models are supported?
+### Can I use my own custom-trained model as the teacher?
 
-Knowledge distillation works with **detect**, **segment**, **pose**, and **obb** tasks because it distills features from the three neck layers that feed the Detect-family head. **Classify** and **semantic** tasks are not supported.
+Yes. Any Ultralytics `.pt` checkpoint works as a teacher as long as it is from the same YOLO family and the same task as the student — nothing compares the two datasets, so a mismatch is not rejected. It does need to have learned the data you are distilling on for its guidance to be worth anything, which is why a `yolo26x.pt` fine-tuned on your own data is the strongest teacher for a `yolo26n.pt` student on that same data.
 
-Only **detect** has been experimentally verified for accuracy improvements. Segment, pose, and obb are technically compatible but not yet benchmarked.
+### Does knowledge distillation work with YOLO11 and YOLOv8?
 
-The teacher and student must belong to the **same YOLO family** (e.g., YOLOv8, YOLO11, or YOLO26). Cross-family distillation (e.g., a YOLO11 teacher with a YOLO26 student) is not supported.
+Yes. Distillation reads features by layer index rather than by architecture, so a YOLO11 teacher distills into a YOLO11 student and a YOLOv8 teacher into a YOLOv8 student, both verified to train. What is not supported is crossing families, such as a YOLO11 teacher with a YOLO26 student.

--- a/docs/en/guides/knowledge-distillation.md
+++ b/docs/en/guides/knowledge-distillation.md
@@ -77,7 +77,7 @@ Train a smaller student model with guidance from a larger teacher by adding the 
 | [YOLO26l-distill](https://platform.ultralytics.com/ultralytics/yolo26) | 640                         | 55.0                                   | **56.0**                                | 54.4                                         | **55.5**                                      |
 | [YOLO26x-distill](https://platform.ultralytics.com/ultralytics/yolo26) | 640                         | 57.5                                   | **57.9**                                | 56.9                                         | **57.4**                                      |
 
-- **mAP<sup>val</sup>** values are for single-model single-scale on the [COCO val2017](https://cocodataset.org/) dataset. <br>Reproduce by `yolo val detect data=coco.yaml device=0`
+- **mAP<sup>val</sup>** values are for single-model single-scale on the [COCO val2017](https://cocodataset.org/) dataset. <br>Reproduce a distilled row with `yolo val detect model=yolo26n-distill.pt data=coco.yaml device=0` and its baseline with `model=yolo26n.pt`; add `end2end=False` for the two non-e2e columns.
 - **e2e** values use the default NMS-free inference path; non-e2e values use traditional NMS post-processing (`end2end=False`). See [End-to-End Detection](end2end-detection.md) for details.
 
 ## Prerequisites
@@ -234,6 +234,10 @@ Distillation training supports resuming from checkpoints. The teacher model is r
 ## Training Output
 
 When distillation is enabled, an additional `dis_loss` column appears in training logs. The sample below is a detection run; segment, pose and OBB carry their own task losses in the same table, with `dis_loss` appended to whichever set applies:
+
+```bash
+yolo train model=yolo26n.pt data=coco8.yaml epochs=2 distill_model=yolo26s.pt
+```
 
 ```text
       Epoch    GPU_mem   box_loss   cls_loss    l1_loss   dis_loss  Instances       Size

--- a/docs/en/guides/knowledge-distillation.md
+++ b/docs/en/guides/knowledge-distillation.md
@@ -34,14 +34,14 @@ Train a smaller student model with guidance from a larger teacher by adding the 
 
 !!! tip "Already-distilled checkpoints"
 
-    Every model in the table below ships as a downloadable checkpoint, so you do not have to run distillation yourself to get the distilled accuracy. Load `yolo26n-distill.pt` the way you would load any other Ultralytics checkpoint — the name is resolved against the Ultralytics release assets on first use, so it downloads even though it is not among the model names bundled with the package:
+    Every model in the table below ships as a downloadable checkpoint, so you do not have to run distillation yourself to get the distilled accuracy. Load `yolo26n-distill.pt` the way you would load any other Ultralytics checkpoint. The `-distill` names are not in the package's built-in `GITHUB_ASSETS_NAMES` registry, so `attempt_download_asset` resolves them through its release-assets branch instead — all five are published on the `ultralytics/assets` release and download on first use:
 
     === "Python"
 
         ```python
         from ultralytics import YOLO
 
-        model = YOLO("yolo26n-distill.pt")  # fetched from the Ultralytics release assets on first use
+        model = YOLO("yolo26n-distill.pt")  # downloaded from the ultralytics/assets release on first use
         results = model.predict("https://ultralytics.com/images/bus.jpg")
         ```
 

--- a/docs/en/guides/model-yaml-config.md
+++ b/docs/en/guides/model-yaml-config.md
@@ -205,12 +205,14 @@ The TorchVision module enables seamless integration of any [TorchVision model](h
 
     # Model with ConvNeXt backbone
     model = YOLO("convnext_backbone.yaml")
-    results = model.train(data="coco8.yaml", epochs=100)
+    results = model.train(data="imagenet10", epochs=100)  # a Classify head needs a classification dataset directory
     ```
 
 === "YAML Configuration"
 
     ```yaml
+    nc: 1000
+
     backbone:
       - [-1, 1, TorchVision, [768, convnext_tiny, DEFAULT, True, 2, False]]
     head:
@@ -235,6 +237,8 @@ The TorchVision module enables seamless integration of any [TorchVision model](h
 When using models that output multiple feature maps, the Index module selects specific outputs:
 
 ```yaml
+nc: 80
+
 backbone:
     - [-1, 1, TorchVision, [768, convnext_tiny, DEFAULT, True, 2, True]] # Multi-output
 head:
@@ -360,6 +364,7 @@ Modifying the source code is the most versatile way to integrate your custom mod
 nc: 80
 scales:
     n: [0.50, 0.25, 1024]
+    s: [0.50, 0.50, 1024]
 
 backbone:
     - [-1, 1, Conv, [64, 3, 2]] # 0-P1/2
@@ -376,7 +381,7 @@ head:
 
 !!! warning "A `scales` block needs a scale letter in the filename"
 
-    Ultralytics reads the scale from the file name with the pattern `yolo` + digits + one of `nslmx`. Saved as `simple_detect.yaml` the file above logs `WARNING no model scale passed. Assuming scale='n'.` and silently uses the first entry. Worse, a name that merely looks scalable is not: `mynet26n.yaml` and `mynet26s.yaml` build the **identical** model, because neither stem contains `yolo`. Name a scalable config `myyolo26n.yaml` / `myyolo26s.yaml` and keep the base file unscaled (`myyolo26.yaml`).
+    Ultralytics reads the scale from the file name with the pattern `yolo` + digits + one of `nslmx`. Saved as `simple_detect.yaml` the file above logs `WARNING no model scale passed. Assuming scale='n'.` and silently uses the first entry. Worse, a name that merely looks scalable is not: `mynet26n.yaml` and `mynet26s.yaml` build the **identical** model, because neither stem contains `yolo`. Name a scalable config `myyolo26n.yaml` / `myyolo26s.yaml` and keep the base file unscaled (`myyolo26.yaml`). Every letter you use needs its own `scales` entry — `myyolo26s.yaml` against a block defining only `n` raises `KeyError: 's'`.
 
 ### TorchVision Backbone Model
 

--- a/docs/en/guides/model-yaml-config.md
+++ b/docs/en/guides/model-yaml-config.md
@@ -275,13 +275,15 @@ Modifying the source code is the most versatile way to integrate your custom mod
     from ultralytics.nn.modules import CustomBlock  # noqa
     ```
 
-5. **Handle channel injection** inside [`parse_model()`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/tasks.py). This is required for a custom block whose constructor expects both input and output channels:
+5. **Add the module to `base_modules`** inside [`parse_model()`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/tasks.py). Modules in this set automatically receive input and output channels:
 
     ```python
-    # Add this condition in the parse_model() function
-    if m is CustomBlock:
-        c1, c2 = ch[f], args[0]  # input channels, output channels
-        args = [c1, c2, *args[1:]]
+    base_modules = frozenset(
+        {
+            # Existing modules...
+            CustomBlock,
+        }
+    )
     ```
 
 6. **Use the module** in your model YAML:

--- a/docs/en/guides/model-yaml-config.md
+++ b/docs/en/guides/model-yaml-config.md
@@ -1,15 +1,12 @@
 ---
-title: "YOLO Model YAML: Architecture Reference"
 comments: true
-description: Reference for the Ultralytics YOLO model YAML - nc and scales, backbone and head sections, the [from, repeats, module, args] layer format, and custom modules.
-keywords: Ultralytics, YOLO, model architecture, YAML configuration, parse_model, backbone, head, scales, max_channels, custom modules, C3k2, C2PSA, TorchVision backbone
+description: Learn how to structure and customize model architectures using Ultralytics YAML configuration files. Master module definitions, connections, and scaling parameters.
+keywords: Ultralytics, YOLO, model architecture, YAML configuration, neural networks, deep learning, backbone, head, modules, custom models
 ---
 
 # Model YAML Configuration Guide
 
-An Ultralytics model YAML is the architectural blueprint for a YOLO network: it declares the class count and scaling factors, then lists every backbone and head layer as `[from, repeats, module, args]`. Ultralytics YOLO26 builds the network straight from that file — `YOLO("my_model.yaml")` needs no Python model code.
-
-This reference covers each section of the file, the modules you can reference by name, how [`parse_model`](../reference/nn/tasks.md) resolves those names, and how to register a custom module of your own.
+The model YAML configuration file serves as the architectural blueprint for Ultralytics neural networks. It defines how layers connect, what parameters each module uses, and how the entire network scales across different model sizes.
 
 <img width="1024" src="https://cdn.ul.run/i/a563b72f7404e71fb4c61b7710d28acf.avif" alt="Model YAML configuration workflow.">
 
@@ -25,49 +22,17 @@ The **parameters** section specifies the model's global characteristics and scal
 # Parameters
 nc: 80 # number of classes
 scales: # compound scaling constants [depth, width, max_channels]
-    n: [0.50, 0.25, 1024] # nano: half depth, quarter width
-    s: [0.50, 0.50, 1024] # small: half depth, half width
-    m: [0.50, 1.00, 512] # medium: half depth, full width, channels capped at 512
+    n: [0.50, 0.25, 1024] # nano: shallow layers, narrow channels
+    s: [0.50, 0.50, 1024] # small: shallow depth, standard width
+    m: [0.50, 1.00, 512] # medium: moderate depth, full width
     l: [1.00, 1.00, 512] # large: full depth and width
-    x: [1.00, 1.50, 512] # extra-large: full depth, 1.5x width
+    x: [1.00, 1.50, 512] # extra-large: maximum performance
 kpt_shape: [17, 3] # pose models only
 ```
 
 - `nc` sets the number of classes the model predicts.
-- `scales` define compound scaling factors as `[depth, width, max_channels]`, producing different size variants (nano through extra-large) from one file.
+- `scales` define compound scaling factors that adjust model depth, width, and maximum channels to produce different size variants (nano through extra-large).
 - `kpt_shape` applies to pose models. It can be `[N, 2]` for `(x, y)` keypoints or `[N, 3]` for `(x, y, visibility)`.
-
-Shipped YAMLs also use four further top-level keys:
-
-| Key          | Used by                 | Purpose                                                                                                                                                                              |
-| ------------ | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `end2end`    | YOLO26 detection family | Enables the NMS-free one-to-one head, in the detect, segment, pose and OBB configs. Absent from `yolo26-cls`, `-depth` and `-sem`. See [End-to-End Detection](end2end-detection.md). |
-| `reg_max`    | YOLO26 detection family | Number of DFL bins. Those same configs ship `reg_max: 1`, which is what makes them DFL-free.                                                                                         |
-| `channels`   | classification          | Input channel count, i.e. `1` for grayscale. Only classification reads it here — see below.                                                                                          |
-| `activation` | `yolov6.yaml`           | Overrides the default activation for every `Conv` in the model, i.e. `torch.nn.ReLU()`.                                                                                              |
-
-!!! warning "`channels` in a detection model YAML is ignored"
-
-    `ClassificationModel` reads the key (`self.yaml.get("channels", ch)`), but detection, segmentation, pose and OBB models are built through `_initialize_yolo_model`, which does `model.yaml["channels"] = ch` unconditionally — so the constructor argument always wins and a `channels: 1` line in such a YAML has no effect. Set the channel count on the **dataset** YAML instead: the trainer passes `ch=self.data["channels"]` when it builds the model, which is how a grayscale dataset produces a single-channel first convolution.
-
-### How Width Scaling Actually Computes Channels
-
-Channel counts are **not** the number written in `args`. For `parse_model`'s base-module set — the convolution and block modules such as `Conv`, `C3k2`, `C2PSA`, `C2f` and `SPPF` — each layer's output channels are clamped to `max_channels`, multiplied by `width`, then rounded up to the nearest multiple of 8:
-
-```python
-c2 = make_divisible(min(c2, max_channels) * width, 8)
-```
-
-| YAML `out_ch` | `width` | `max_channels` | Actual channels |
-| ------------- | ------- | -------------- | --------------- |
-| 1024          | 1.00    | 512            | 512             |
-| 1024          | 1.50    | 512            | 768             |
-| 1024          | 0.25    | 1024           | 256             |
-| 100           | 0.50    | 1024           | 56              |
-
-The last row is the one that surprises people: `100 x 0.5` is `50`, which rounds up to `56`. This is why `m`, `l` and `x` carry `max_channels: 512` while `n` and `s` carry `1024` — the larger scales would otherwise produce very wide layers.
-
-The formula does not reach every layer. `Classify` is exempt so its output stays at `nc`; `Concat` sums the channels of its sources; `TorchVision` and `Index` use the bookkeeping value you wrote; and heads take `nc` rather than a channel count. Compute expected channels this way only for the base modules.
 
 !!! tip "Reduce redundancy with `scales`"
 
@@ -88,16 +53,16 @@ backbone:
     # [from, repeats, module, args]
     - [-1, 1, Conv, [64, 3, 2]] # 0: Initial convolution
     - [-1, 1, Conv, [128, 3, 2]] # 1: Downsample
-    - [-1, 3, C3k2, [128, True]] # 2: Feature processing
+    - [-1, 3, C2f, [128, True]] # 2: Feature processing
 
 head:
     - [-1, 1, nn.Upsample, [None, 2, nearest]] # 3: Upsample
-    - [[-1, 0], 1, Concat, [1]] # 4: Skip connection to layer 0
-    - [-1, 3, C3k2, [256, False]] # 5: Process features
+    - [[-1, 0], 1, Concat, [1]] # 4: Spatially compatible skip connection
+    - [-1, 3, C2f, [256]] # 5: Process features
     - [[5], 1, Detect, [nc]] # 6: Detection layer
 ```
 
-Layer indices run continuously across both sections — the head does not restart at 0 — and a `from` index must name a layer that already exists. A skip connection also has to be spatially compatible: layer 0 is the only source the upsampled layer 3 can concatenate with here.
+Layer indices continue across the backbone and head, and concatenated feature maps must have matching spatial dimensions.
 
 ## Layer Specification Format
 
@@ -145,13 +110,7 @@ The `repeats` parameter creates deeper network sections:
 - [-1, 1, Conv, [64, 3, 2]] # Single convolution layer
 ```
 
-The repetition count is multiplied by the `depth` scaling factor, rounded, and floored at 1 — but only when it is greater than 1, so `repeats: 1` is never scaled:
-
-```python
-n = max(round(n * depth), 1) if n > 1 else n
-```
-
-At `depth=0.33` a `repeats: 3` block collapses to a single block and `repeats: 6` becomes 2. Only modules that accept an internal repeat count consume `n` this way; any other module is simply stacked `n` times in an `nn.Sequential`.
+The actual repetition count gets multiplied by the depth scaling factor from your model size configuration.
 
 ## Available Modules
 
@@ -167,13 +126,11 @@ Modules are organized by functionality and defined in the [Ultralytics modules d
 
 ### Composite Blocks
 
-| Module   | Purpose                                                           | Source                                                                                           | Arguments                                          |
-| -------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
-| `C3k2`   | CSP block in the standard YOLO11 and YOLO26 backbones             | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, c3k, expansion, attn, groups, shortcut]` |
-| `C2PSA`  | Position-sensitive attention block, last backbone layer in YOLO26 | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, expansion]`                              |
-| `C2f`    | CSP bottleneck with 2 convolutions, used by YOLOv8                | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, shortcut, groups, expansion]`            |
-| `SPPF`   | Spatial Pyramid Pooling (fast)                                    | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, kernel_size]`                            |
-| `Concat` | Channel-wise concatenation                                        | [conv.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/conv.py)   | `[dimension]`                                      |
+| Module   | Purpose                            | Source                                                                                           | Arguments                               |
+| -------- | ---------------------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------- |
+| `C2f`    | CSP bottleneck with 2 convolutions | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, shortcut, groups, expansion]` |
+| `SPPF`   | Spatial Pyramid Pooling (fast)     | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, kernel_size]`                 |
+| `Concat` | Channel-wise concatenation         | [conv.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/conv.py)   | `[dimension]`                           |
 
 ### Specialized Modules
 
@@ -182,15 +139,10 @@ Modules are organized by functionality and defined in the [Ultralytics modules d
 | `TorchVision` | Load any torchvision model        | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, model_name, weights, unwrap, truncate, split]` |
 | `Index`       | Extract specific tensor from list | [conv.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/conv.py)   | `[out_ch, index]`                                        |
 | `Detect`      | YOLO detection head               | [head.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/head.py)   | `[nc]`                                                   |
-| `Classify`    | Classification head, must be last | [head.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/head.py)   | `[nc]`                                                   |
 
 !!! info "Complete Module List"
 
-    This is a subset. For the full list of modules and their parameters, explore the [modules directory](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/nn/modules).
-
-!!! note "Which modules receive an injected input-channel argument"
-
-    For the convolution and block modules — `Conv`, `C3k2`, `C2PSA`, `C2f`, `SPPF` and the rest of `parse_model`'s base-module set — input channels are injected from whatever layer `from` points at, so the args you write start at `c2`. That rule does **not** extend to the other modules in the tables above, each of which `parse_model` handles specially: `nn.Upsample` and `nn.MaxPool2d` take their `torch.nn` arguments unchanged, `Concat` takes a dimension, `Detect` and `Classify` take `nc`, and `Index` takes a leading `out_ch` that exists purely for channel bookkeeping while its constructor reads only the index. A module you register yourself gets no injection at all until you add it, which is what [step 5](#custom-module-integration) is for.
+    This represents a subset of available modules. For the full list of modules and their parameters, explore the [modules directory](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/nn/modules).
 
 ## Advanced Features
 
@@ -205,7 +157,7 @@ The TorchVision module enables seamless integration of any [TorchVision model](h
 
     # Model with ConvNeXt backbone
     model = YOLO("convnext_backbone.yaml")
-    results = model.train(data="imagenet10", epochs=100)  # a Classify head needs a classification dataset directory
+    results = model.train(data="imagenet10", epochs=100)
     ```
 
 === "YAML Configuration"
@@ -224,9 +176,9 @@ The TorchVision module enables seamless integration of any [TorchVision model](h
     - `768`: Expected output channels
     - `convnext_tiny`: Model architecture ([available models](https://docs.pytorch.org/vision/stable/models.html))
     - `DEFAULT`: Use pretrained weights
-    - `True`: Unwrap the model into a flat `nn.Sequential` of its child layers. This is what makes the next two arguments possible. Setting it to `False` forces the split argument off and assigns `nn.Identity` to the attributes named `head` and `heads` only — which is not a general way to strip a classifier: `resnet18` keeps its `fc` and `convnext_tiny` keeps its `classifier`, so both still return 1000 class logits rather than a feature map, and the next layer fails on shape. Keep `unwrap=True` unless your model's classifier really is called `head` or `heads`.
-    - `2`: Truncate the last 2 of those layers
-    - `False`: Return a single tensor rather than a list of intermediate feature maps
+    - `True`: Unwrap child layers before truncating them; `False` keeps the model structure and sets `head` and `heads` to `nn.Identity`
+    - `2`: Truncate last 2 layers
+    - `False`: Return single tensor (not list)
 
 !!! tip "Multi-Scale Features"
 
@@ -267,11 +219,9 @@ m = (
 )  # get module
 ```
 
-1. **PyTorch modules**: names starting with `nn.` → `torch.nn` namespace
-2. **TorchVision operations**: names starting with `torchvision.ops.` → `torchvision.ops` namespace
-3. **Ultralytics modules**: all other names → the `tasks.py` global namespace, populated by the imports below
-
-A fourth gate applies under restricted loading: a name that resolves to something which is not an `nn.Module` subclass raises `TypeError` instead of being built.
+1. **PyTorch modules**: Names starting with `'nn.'` → `torch.nn` namespace
+2. **TorchVision operations**: Names starting with `'torchvision.ops.'` → `torchvision.ops` namespace
+3. **Ultralytics modules**: All other names → global namespace via imports
 
 ### Module Import Chain
 
@@ -279,9 +229,8 @@ Standard modules become available through imports in [`tasks.py`](https://github
 
 ```python
 from ultralytics.nn.modules import (  # noqa: F401
-    C2PSA,
     SPPF,
-    C3k2,
+    C2f,
     Conv,
     Detect,
     # ... many more modules
@@ -326,7 +275,7 @@ Modifying the source code is the most versatile way to integrate your custom mod
     from ultralytics.nn.modules import CustomBlock  # noqa
     ```
 
-5. **Handle channel injection** inside [`parse_model()`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/tasks.py) in `ultralytics/nn/tasks.py`. This step is required, not optional: `parse_model` injects input channels only for modules it knows about, so an unregistered module receives its YAML args verbatim and fails with `TypeError: CustomBlock.__init__() missing 1 required positional argument: 'c2'`.
+5. **Handle channel injection** inside [`parse_model()`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/tasks.py). This is required for a custom block whose constructor expects both input and output channels:
 
     ```python
     # Add this condition in the parse_model() function
@@ -363,8 +312,7 @@ Modifying the source code is the most versatile way to integrate your custom mod
 # Simple YOLO detection model
 nc: 80
 scales:
-    n: [0.50, 0.25, 1024]
-    s: [0.50, 0.50, 1024]
+    n: [0.33, 0.25, 1024]
 
 backbone:
     - [-1, 1, Conv, [64, 3, 2]] # 0-P1/2
@@ -378,10 +326,6 @@ head:
     - [-1, 1, Conv, [256, 3, 1]] # 6
     - [[6], 1, Detect, [nc]] # 7
 ```
-
-!!! warning "A `scales` block needs a scale letter in the filename"
-
-    Ultralytics reads the scale from the file name with the pattern `yolo` + digits + one of `nslmx`. Saved as `simple_detect.yaml` the file above logs `WARNING no model scale passed. Assuming scale='n'.` and silently uses the first entry. Worse, a name that merely looks scalable is not: `mynet26n.yaml` and `mynet26s.yaml` build the **identical** model, because neither stem contains `yolo`. Name a scalable config `myyolo26n.yaml` / `myyolo26s.yaml` and keep the base file unscaled (`myyolo26.yaml`). Every letter you use needs its own `scales` entry — `myyolo26s.yaml` against a block defining only `n` raises `KeyError: 's'`.
 
 ### TorchVision Backbone Model
 
@@ -408,27 +352,39 @@ nc: 1000
 backbone:
     - [-1, 1, Conv, [64, 7, 2, 3]]
     - [-1, 1, nn.MaxPool2d, [3, 2, 1]]
-    - [-1, 4, C3k2, [64, True]]
+    - [-1, 4, C2f, [64, True]]
     - [-1, 1, Conv, [128, 3, 2]]
-    - [-1, 8, C3k2, [128, True]]
+    - [-1, 8, C2f, [128, True]]
 
 head:
     - [-1, 1, Classify, [nc]]
 ```
 
-`Classify` pools internally, so do not add an `nn.AdaptiveAvgPool2d` before it. Collapsing the feature map to 1x1 first starves the head's own convolution and makes training with `batch=1` fail with `ValueError: Expected more than 1 value per channel when training`.
+`Classify` already performs adaptive average pooling internally.
 
 ## Best Practices
 
-| Practice                         | What it means for your YAML                                                                                                                                                                                                               |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Start from a shipped config**  | Copy a YAML from [`ultralytics/cfg/models`](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/cfg/models) and change one thing at a time rather than writing a backbone from scratch.                                      |
-| **Match channels across layers** | For a base module, actual output channels are `make_divisible(min(out_ch, max_channels) * width, 8)`, not the number you wrote. Compute the scaled value before assuming two layers line up, and note the other modules do not follow it. |
-| **Reuse features with `Concat`** | `[[-1, N], 1, Concat, [1]]` merges an earlier feature map into the current one, the standard FPN pattern for multi-scale detection. Both sources must share spatial dimensions.                                                           |
-| **Pick a scale for your target** | Use `n` for edge devices, `s` for a balanced tradeoff, `m`/`l`/`x` when accuracy matters more than latency.                                                                                                                               |
-| **Verify after every change**    | `model.info()` must report non-zero FLOPs; see [Debugging Tips](#debugging-tips).                                                                                                                                                         |
+### Architecture Design Tips
 
-For the reasoning behind depth, width and bottleneck choices, see [YOLO architecture explained](yolo-architecture.md).
+**Start Simple**: Begin with proven architectures before customizing. Use existing YOLO configurations as templates and modify incrementally rather than building from scratch.
+
+**Test Incrementally**: Validate each modification step-by-step. Add one custom module at a time and verify it works before proceeding to the next change.
+
+**Monitor Channels**: Ensure channel dimensions match between connected layers. The output channels (`c2`) of one layer must match the input channels (`c1`) of the next layer in the sequence.
+
+**Use Skip Connections**: Leverage feature reuse with `[[-1, N], 1, Concat, [1]]` patterns. These connections help with gradient flow and allow the model to combine features from different scales.
+
+**Scale Appropriately**: Choose model scales based on your computational constraints. Use nano (`n`) for edge devices, small (`s`) for balanced performance, and larger scales (`m`, `l`, `x`) for maximum accuracy.
+
+### Performance Considerations
+
+**Depth vs Width**: Deep networks capture complex hierarchical features through multiple transformation layers, while wide networks process more information in parallel at each layer. Balance these based on your task complexity.
+
+**Skip Connections**: Improve gradient flow during training and enable feature reuse throughout the network. They're particularly important in deeper architectures to prevent vanishing gradients.
+
+**Bottleneck Blocks**: Reduce computational cost while maintaining model expressiveness. Modules like `C2f` use fewer parameters than standard convolutions while preserving feature learning capacity.
+
+**Multi-Scale Features**: Essential for detecting objects at different sizes in the same image. Use Feature Pyramid Network (FPN) patterns with multiple detection heads at different scales.
 
 ## Troubleshooting
 
@@ -445,20 +401,19 @@ For the reasoning behind depth, width and bottleneck choices, see [YOLO architec
 
 When developing custom architectures, systematic debugging helps identify issues early:
 
-#### Use an Identity Head to Isolate the Backbone
+**Use Identity Head for Testing**
 
 Replace complex heads with `nn.Identity` to isolate backbone issues:
 
 ```yaml
-# debug_model.yaml
 nc: 1
 backbone:
-    - [-1, 1, Conv, [64, 3, 2]]
+    - [-1, 1, CustomBlock, [64]]
 head:
     - [-1, 1, nn.Identity, []] # Pass-through for debugging
 ```
 
-An identity head gives `parse_model` no head to infer the task from, so pass `task=` explicitly or model loading fails with `NotImplementedError` for task `None`:
+This allows direct inspection of backbone outputs:
 
 ```python
 import torch
@@ -467,12 +422,10 @@ from ultralytics import YOLO
 
 model = YOLO("debug_model.yaml", task="detect")
 output = model.model(torch.randn(1, 3, 640, 640))
-print(f"Output shape: {output.shape}")  # torch.Size([1, 64, 320, 320])
+print(f"Output shape: {output.shape}")  # Should match expected dimensions
 ```
 
-The identity head is what makes `output` a plain tensor. Swap in a real `Detect` head and the forward pass returns a dict of `boxes`, `scores` and `feats` instead, so `output.shape` raises `AttributeError`.
-
-#### Inspect the Built Architecture
+**Model Architecture Inspection**
 
 Checking the FLOPs count and printing out each layer can also help debug issues with your custom model config. FLOPs count should be non-zero for a valid model. If it's zero, then there's likely an issue with the forward pass. Running a simple forward pass should show the exact error being encountered.
 
@@ -490,7 +443,7 @@ for i, layer in enumerate(model.model.model):
     print(f"Layer {i}: {layer}")
 ```
 
-#### Validate Step by Step
+**Step-by-Step Validation**
 
 1. **Start minimal**: Test with simplest possible architecture first
 2. **Add incrementally**: Build complexity layer by layer
@@ -509,28 +462,37 @@ nc: 5 # 5 classes
 
 ### Can I use a custom backbone in my model YAML?
 
-Yes. Use any supported module, including [TorchVision backbones](#torchvision-integration), or define your own and register it as described in [Custom Module Integration](#custom-module-integration).
-
-### How do I see the YAML for a pretrained model like yolo26n.pt?
-
-Load the checkpoint and read `model.model.yaml`, which holds the parsed architecture the weights were built from. The source files also ship with the package under [`ultralytics/cfg/models`](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/cfg/models) — copying one from there is the recommended starting point for a custom architecture.
-
-### Why does my layer have fewer channels than the number in my YAML?
-
-For a base module, `max_channels` caps the value before the width multiplier is applied, and the result is rounded up to a multiple of 8. With `m: [0.50, 1.00, 512]`, a layer declaring `[1024, 3, 2]` is clamped to 512 first, so it builds 512 channels rather than 1024. Other modules — `Concat`, `TorchVision`, `Index`, the heads — do not go through that formula. See [How Width Scaling Actually Computes Channels](#how-width-scaling-actually-computes-channels).
-
-### Can I train a model YAML from scratch without pretrained weights?
-
-Yes. Passing a YAML instead of a `.pt` file to `YOLO()` builds randomly initialized weights, so `YOLO("custom_model.yaml").train(data="coco8.yaml")` trains from scratch. Expect to need substantially more data and epochs than fine-tuning a pretrained checkpoint — see the [training mode guide](../modes/train.md).
+Yes. You can use any supported module, including [TorchVision backbones](#torchvision-integration), or define your own custom module and import it as described in [Custom Module Integration](#custom-module-integration).
 
 ### How do I scale my model for different sizes (nano, small, medium, etc.)?
 
 Use the [`scales` section](#parameters-section) in your YAML to define scaling factors for depth, width, and max channels. The model will automatically apply these when you load the base YAML file with the scale appended to the filename (e.g., `yolo26n.yaml`).
 
+### What does the `[from, repeats, module, args]` format mean?
+
+This format specifies how each layer is constructed:
+
+- `from`: input source(s)
+- `repeats`: number of times to repeat the module
+- `module`: the layer type
+- `args`: arguments for the module
+
 ### How do I troubleshoot channel mismatch errors?
 
 Check that the output channels of one layer match the expected input channels of the next. Use `print(model.model.model)` to inspect your model's architecture.
 
+### Where can I find a list of available modules and their arguments?
+
+Check the source code in the [`ultralytics/nn/modules` directory](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/nn/modules) for all available modules and their arguments.
+
+### How do I add a custom module to my YAML configuration?
+
+Define your module in the source code, import it as shown in [Source Code Modification](#source-code-modification), and reference it by name in your YAML file.
+
 ### Can I use pretrained weights with a custom YAML?
 
 Yes, you can use `model.load("path/to/weights")` to load weights from a pretrained checkpoint. However, only weights for layers that match would load successfully.
+
+### How do I validate my model configuration?
+
+Use `model.info()` to check whether FLOPs count is non-zero. A valid model should show non-zero FLOPs count. If it's zero, follow the suggestions in [Debugging Tips](#debugging-tips) to find the issue.

--- a/docs/en/guides/model-yaml-config.md
+++ b/docs/en/guides/model-yaml-config.md
@@ -1,12 +1,15 @@
 ---
+title: "YOLO Model YAML: Architecture Reference"
 comments: true
-description: Learn how to structure and customize model architectures using Ultralytics YAML configuration files. Master module definitions, connections, and scaling parameters.
-keywords: Ultralytics, YOLO, model architecture, YAML configuration, neural networks, deep learning, backbone, head, modules, custom models
+description: Reference for the Ultralytics YOLO model YAML - nc and scales, backbone and head sections, the [from, repeats, module, args] layer format, and custom modules.
+keywords: Ultralytics, YOLO, model architecture, YAML configuration, parse_model, backbone, head, scales, max_channels, custom modules, C3k2, C2PSA, TorchVision backbone
 ---
 
 # Model YAML Configuration Guide
 
-The model YAML configuration file serves as the architectural blueprint for Ultralytics neural networks. It defines how layers connect, what parameters each module uses, and how the entire network scales across different model sizes.
+An Ultralytics model YAML is the architectural blueprint for a YOLO network: it declares the class count and scaling factors, then lists every backbone and head layer as `[from, repeats, module, args]`. Ultralytics YOLO26 builds the network straight from that file — `YOLO("my_model.yaml")` needs no Python model code.
+
+This reference covers each section of the file, the modules you can reference by name, how [`parse_model`](../reference/nn/tasks.md) resolves those names, and how to register a custom module of your own.
 
 <img width="1024" src="https://cdn.ul.run/i/a563b72f7404e71fb4c61b7710d28acf.avif" alt="Model YAML configuration workflow.">
 
@@ -22,17 +25,49 @@ The **parameters** section specifies the model's global characteristics and scal
 # Parameters
 nc: 80 # number of classes
 scales: # compound scaling constants [depth, width, max_channels]
-    n: [0.50, 0.25, 1024] # nano: shallow layers, narrow channels
-    s: [0.50, 0.50, 1024] # small: shallow depth, standard width
-    m: [0.50, 1.00, 512] # medium: moderate depth, full width
+    n: [0.50, 0.25, 1024] # nano: half depth, quarter width
+    s: [0.50, 0.50, 1024] # small: half depth, half width
+    m: [0.50, 1.00, 512] # medium: half depth, full width, channels capped at 512
     l: [1.00, 1.00, 512] # large: full depth and width
-    x: [1.00, 1.50, 512] # extra-large: maximum performance
+    x: [1.00, 1.50, 512] # extra-large: full depth, 1.5x width
 kpt_shape: [17, 3] # pose models only
 ```
 
 - `nc` sets the number of classes the model predicts.
-- `scales` define compound scaling factors that adjust model depth, width, and maximum channels to produce different size variants (nano through extra-large).
+- `scales` define compound scaling factors as `[depth, width, max_channels]`, producing different size variants (nano through extra-large) from one file.
 - `kpt_shape` applies to pose models. It can be `[N, 2]` for `(x, y)` keypoints or `[N, 3]` for `(x, y, visibility)`.
+
+Shipped YAMLs also use four further top-level keys:
+
+| Key          | Used by                 | Purpose                                                                                                                                                                              |
+| ------------ | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `end2end`    | YOLO26 detection family | Enables the NMS-free one-to-one head, in the detect, segment, pose and OBB configs. Absent from `yolo26-cls`, `-depth` and `-sem`. See [End-to-End Detection](end2end-detection.md). |
+| `reg_max`    | YOLO26 detection family | Number of DFL bins. Those same configs ship `reg_max: 1`, which is what makes them DFL-free.                                                                                         |
+| `channels`   | classification          | Input channel count, i.e. `1` for grayscale. Only classification reads it here — see below.                                                                                          |
+| `activation` | `yolov6.yaml`           | Overrides the default activation for every `Conv` in the model, i.e. `torch.nn.ReLU()`.                                                                                              |
+
+!!! warning "`channels` in a detection model YAML is ignored"
+
+    `ClassificationModel` reads the key (`self.yaml.get("channels", ch)`), but detection, segmentation, pose and OBB models are built through `_initialize_yolo_model`, which does `model.yaml["channels"] = ch` unconditionally — so the constructor argument always wins and a `channels: 1` line in such a YAML has no effect. Set the channel count on the **dataset** YAML instead: the trainer passes `ch=self.data["channels"]` when it builds the model, which is how a grayscale dataset produces a single-channel first convolution.
+
+### How Width Scaling Actually Computes Channels
+
+Channel counts are **not** the number written in `args`. For `parse_model`'s base-module set — the convolution and block modules such as `Conv`, `C3k2`, `C2PSA`, `C2f` and `SPPF` — each layer's output channels are clamped to `max_channels`, multiplied by `width`, then rounded up to the nearest multiple of 8:
+
+```python
+c2 = make_divisible(min(c2, max_channels) * width, 8)
+```
+
+| YAML `out_ch` | `width` | `max_channels` | Actual channels |
+| ------------- | ------- | -------------- | --------------- |
+| 1024          | 1.00    | 512            | 512             |
+| 1024          | 1.50    | 512            | 768             |
+| 1024          | 0.25    | 1024           | 256             |
+| 100           | 0.50    | 1024           | 56              |
+
+The last row is the one that surprises people: `100 x 0.5` is `50`, which rounds up to `56`. This is why `m`, `l` and `x` carry `max_channels: 512` while `n` and `s` carry `1024` — the larger scales would otherwise produce very wide layers.
+
+The formula does not reach every layer. `Classify` is exempt so its output stays at `nc`; `Concat` sums the channels of its sources; `TorchVision` and `Index` use the bookkeeping value you wrote; and heads take `nc` rather than a channel count. Compute expected channels this way only for the base modules.
 
 !!! tip "Reduce redundancy with `scales`"
 
@@ -47,18 +82,22 @@ kpt_shape: [17, 3] # pose models only
 The model architecture consists of backbone (feature extraction) and head (task-specific) sections:
 
 ```yaml
+nc: 80
+
 backbone:
     # [from, repeats, module, args]
     - [-1, 1, Conv, [64, 3, 2]] # 0: Initial convolution
     - [-1, 1, Conv, [128, 3, 2]] # 1: Downsample
-    - [-1, 3, C2f, [128, True]] # 2: Feature processing
+    - [-1, 3, C3k2, [128, True]] # 2: Feature processing
 
 head:
-    - [-1, 1, nn.Upsample, [None, 2, nearest]] # 6: Upsample
-    - [[-1, 2], 1, Concat, [1]] # 7: Skip connection
-    - [-1, 3, C2f, [256]] # 8: Process features
-    - [[8], 1, Detect, [nc]] # 9: Detection layer
+    - [-1, 1, nn.Upsample, [None, 2, nearest]] # 3: Upsample
+    - [[-1, 0], 1, Concat, [1]] # 4: Skip connection to layer 0
+    - [-1, 3, C3k2, [256, False]] # 5: Process features
+    - [[5], 1, Detect, [nc]] # 6: Detection layer
 ```
+
+Layer indices run continuously across both sections — the head does not restart at 0 — and a `from` index must name a layer that already exists. A skip connection also has to be spatially compatible: layer 0 is the only source the upsampled layer 3 can concatenate with here.
 
 ## Layer Specification Format
 
@@ -106,7 +145,13 @@ The `repeats` parameter creates deeper network sections:
 - [-1, 1, Conv, [64, 3, 2]] # Single convolution layer
 ```
 
-The actual repetition count gets multiplied by the depth scaling factor from your model size configuration.
+The repetition count is multiplied by the `depth` scaling factor, rounded, and floored at 1 — but only when it is greater than 1, so `repeats: 1` is never scaled:
+
+```python
+n = max(round(n * depth), 1) if n > 1 else n
+```
+
+At `depth=0.33` a `repeats: 3` block collapses to a single block and `repeats: 6` becomes 2. Only modules that accept an internal repeat count consume `n` this way; any other module is simply stacked `n` times in an `nn.Sequential`.
 
 ## Available Modules
 
@@ -122,23 +167,30 @@ Modules are organized by functionality and defined in the [Ultralytics modules d
 
 ### Composite Blocks
 
-| Module   | Purpose                            | Source                                                                                           | Arguments                       |
-| -------- | ---------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------- |
-| `C2f`    | CSP bottleneck with 2 convolutions | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, shortcut, expansion]` |
-| `SPPF`   | Spatial Pyramid Pooling (fast)     | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, kernel_size]`         |
-| `Concat` | Channel-wise concatenation         | [conv.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/conv.py)   | `[dimension]`                   |
+| Module   | Purpose                                                           | Source                                                                                           | Arguments                                          |
+| -------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
+| `C3k2`   | CSP block in the standard YOLO11 and YOLO26 backbones             | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, c3k, expansion, attn, groups, shortcut]` |
+| `C2PSA`  | Position-sensitive attention block, last backbone layer in YOLO26 | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, expansion]`                              |
+| `C2f`    | CSP bottleneck with 2 convolutions, used by YOLOv8                | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, shortcut, groups, expansion]`            |
+| `SPPF`   | Spatial Pyramid Pooling (fast)                                    | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, kernel_size]`                            |
+| `Concat` | Channel-wise concatenation                                        | [conv.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/conv.py)   | `[dimension]`                                      |
 
 ### Specialized Modules
 
 | Module        | Purpose                           | Source                                                                                           | Arguments                                                |
 | ------------- | --------------------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
 | `TorchVision` | Load any torchvision model        | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, model_name, weights, unwrap, truncate, split]` |
-| `Index`       | Extract specific tensor from list | [block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py) | `[out_ch, index]`                                        |
+| `Index`       | Extract specific tensor from list | [conv.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/conv.py)   | `[out_ch, index]`                                        |
 | `Detect`      | YOLO detection head               | [head.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/head.py)   | `[nc]`                                                   |
+| `Classify`    | Classification head, must be last | [head.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/head.py)   | `[nc]`                                                   |
 
 !!! info "Complete Module List"
 
-    This represents a subset of available modules. For the full list of modules and their parameters, explore the [modules directory](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/nn/modules).
+    This is a subset. For the full list of modules and their parameters, explore the [modules directory](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/nn/modules).
+
+!!! note "Which modules receive an injected input-channel argument"
+
+    For the convolution and block modules — `Conv`, `C3k2`, `C2PSA`, `C2f`, `SPPF` and the rest of `parse_model`'s base-module set — input channels are injected from whatever layer `from` points at, so the args you write start at `c2`. That rule does **not** extend to the other modules in the tables above, each of which `parse_model` handles specially: `nn.Upsample` and `nn.MaxPool2d` take their `torch.nn` arguments unchanged, `Concat` takes a dimension, `Detect` and `Classify` take `nc`, and `Index` takes a leading `out_ch` that exists purely for channel bookkeeping while its constructor reads only the index. A module you register yourself gets no injection at all until you add it, which is what [step 5](#custom-module-integration) is for.
 
 ## Advanced Features
 
@@ -170,9 +222,9 @@ The TorchVision module enables seamless integration of any [TorchVision model](h
     - `768`: Expected output channels
     - `convnext_tiny`: Model architecture ([available models](https://docs.pytorch.org/vision/stable/models.html))
     - `DEFAULT`: Use pretrained weights
-    - `True`: Remove classification head
-    - `2`: Truncate last 2 layers
-    - `False`: Return single tensor (not list)
+    - `True`: Unwrap the model into a flat `nn.Sequential` of its child layers. This is what makes the next two arguments possible. Setting it to `False` forces the split argument off and assigns `nn.Identity` to the attributes named `head` and `heads` only — which is not a general way to strip a classifier: `resnet18` keeps its `fc` and `convnext_tiny` keeps its `classifier`, so both still return 1000 class logits rather than a feature map, and the next layer fails on shape. Keep `unwrap=True` unless your model's classifier really is called `head` or `heads`.
+    - `2`: Truncate the last 2 of those layers
+    - `False`: Return a single tensor rather than a list of intermediate feature maps
 
 !!! tip "Multi-Scale Features"
 
@@ -204,16 +256,18 @@ Ultralytics uses a three-tier system in [`parse_model`](https://github.com/ultra
 # Core resolution logic
 m = (
     getattr(torch.nn, m[3:])
-    if "nn." in m
-    else getattr(torchvision.ops, m[16:])
-    if "torchvision.ops." in m
+    if m.startswith("nn.")
+    else getattr(__import__("torchvision").ops, m[16:])
+    if m.startswith("torchvision.ops.")
     else globals()[m]
-)
+)  # get module
 ```
 
-1. **PyTorch modules**: Names starting with `'nn.'` → `torch.nn` namespace
-2. **TorchVision operations**: Names starting with `'torchvision.ops.'` → `torchvision.ops` namespace
-3. **Ultralytics modules**: All other names → global namespace via imports
+1. **PyTorch modules**: names starting with `nn.` → `torch.nn` namespace
+2. **TorchVision operations**: names starting with `torchvision.ops.` → `torchvision.ops` namespace
+3. **Ultralytics modules**: all other names → the `tasks.py` global namespace, populated by the imports below
+
+A fourth gate applies under restricted loading: a name that resolves to something which is not an `nn.Module` subclass raises `TypeError` instead of being built.
 
 ### Module Import Chain
 
@@ -221,8 +275,9 @@ Standard modules become available through imports in [`tasks.py`](https://github
 
 ```python
 from ultralytics.nn.modules import (  # noqa: F401
+    C2PSA,
     SPPF,
-    C2f,
+    C3k2,
     Conv,
     Detect,
     # ... many more modules
@@ -267,7 +322,7 @@ Modifying the source code is the most versatile way to integrate your custom mod
     from ultralytics.nn.modules import CustomBlock  # noqa
     ```
 
-5. **Handle special arguments** (if needed) inside [`parse_model()`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/tasks.py) in `ultralytics/nn/tasks.py`:
+5. **Handle channel injection** inside [`parse_model()`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/tasks.py) in `ultralytics/nn/tasks.py`. This step is required, not optional: `parse_model` injects input channels only for modules it knows about, so an unregistered module receives its YAML args verbatim and fails with `TypeError: CustomBlock.__init__() missing 1 required positional argument: 'c2'`.
 
     ```python
     # Add this condition in the parse_model() function
@@ -304,7 +359,7 @@ Modifying the source code is the most versatile way to integrate your custom mod
 # Simple YOLO detection model
 nc: 80
 scales:
-    n: [0.33, 0.25, 1024]
+    n: [0.50, 0.25, 1024]
 
 backbone:
     - [-1, 1, Conv, [64, 3, 2]] # 0-P1/2
@@ -318,6 +373,10 @@ head:
     - [-1, 1, Conv, [256, 3, 1]] # 6
     - [[6], 1, Detect, [nc]] # 7
 ```
+
+!!! warning "A `scales` block needs a scale letter in the filename"
+
+    Ultralytics reads the scale from the file name with the pattern `yolo` + digits + one of `nslmx`. Saved as `simple_detect.yaml` the file above logs `WARNING no model scale passed. Assuming scale='n'.` and silently uses the first entry. Worse, a name that merely looks scalable is not: `mynet26n.yaml` and `mynet26s.yaml` build the **identical** model, because neither stem contains `yolo`. Name a scalable config `myyolo26n.yaml` / `myyolo26s.yaml` and keep the base file unscaled (`myyolo26.yaml`).
 
 ### TorchVision Backbone Model
 
@@ -344,38 +403,27 @@ nc: 1000
 backbone:
     - [-1, 1, Conv, [64, 7, 2, 3]]
     - [-1, 1, nn.MaxPool2d, [3, 2, 1]]
-    - [-1, 4, C2f, [64, True]]
+    - [-1, 4, C3k2, [64, True]]
     - [-1, 1, Conv, [128, 3, 2]]
-    - [-1, 8, C2f, [128, True]]
-    - [-1, 1, nn.AdaptiveAvgPool2d, [1]]
+    - [-1, 8, C3k2, [128, True]]
 
 head:
     - [-1, 1, Classify, [nc]]
 ```
 
+`Classify` pools internally, so do not add an `nn.AdaptiveAvgPool2d` before it. Collapsing the feature map to 1x1 first starves the head's own convolution and makes training with `batch=1` fail with `ValueError: Expected more than 1 value per channel when training`.
+
 ## Best Practices
 
-### Architecture Design Tips
+| Practice                         | What it means for your YAML                                                                                                                                                                                                               |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Start from a shipped config**  | Copy a YAML from [`ultralytics/cfg/models`](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/cfg/models) and change one thing at a time rather than writing a backbone from scratch.                                      |
+| **Match channels across layers** | For a base module, actual output channels are `make_divisible(min(out_ch, max_channels) * width, 8)`, not the number you wrote. Compute the scaled value before assuming two layers line up, and note the other modules do not follow it. |
+| **Reuse features with `Concat`** | `[[-1, N], 1, Concat, [1]]` merges an earlier feature map into the current one, the standard FPN pattern for multi-scale detection. Both sources must share spatial dimensions.                                                           |
+| **Pick a scale for your target** | Use `n` for edge devices, `s` for a balanced tradeoff, `m`/`l`/`x` when accuracy matters more than latency.                                                                                                                               |
+| **Verify after every change**    | `model.info()` must report non-zero FLOPs; see [Debugging Tips](#debugging-tips).                                                                                                                                                         |
 
-**Start Simple**: Begin with proven architectures before customizing. Use existing YOLO configurations as templates and modify incrementally rather than building from scratch.
-
-**Test Incrementally**: Validate each modification step-by-step. Add one custom module at a time and verify it works before proceeding to the next change.
-
-**Monitor Channels**: Ensure channel dimensions match between connected layers. The output channels (`c2`) of one layer must match the input channels (`c1`) of the next layer in the sequence.
-
-**Use Skip Connections**: Leverage feature reuse with `[[-1, N], 1, Concat, [1]]` patterns. These connections help with gradient flow and allow the model to combine features from different scales.
-
-**Scale Appropriately**: Choose model scales based on your computational constraints. Use nano (`n`) for edge devices, small (`s`) for balanced performance, and larger scales (`m`, `l`, `x`) for maximum accuracy.
-
-### Performance Considerations
-
-**Depth vs Width**: Deep networks capture complex hierarchical features through multiple transformation layers, while wide networks process more information in parallel at each layer. Balance these based on your task complexity.
-
-**Skip Connections**: Improve gradient flow during training and enable feature reuse throughout the network. They're particularly important in deeper architectures to prevent vanishing gradients.
-
-**Bottleneck Blocks**: Reduce computational cost while maintaining model expressiveness. Modules like `C2f` use fewer parameters than standard convolutions while preserving feature learning capacity.
-
-**Multi-Scale Features**: Essential for detecting objects at different sizes in the same image. Use Feature Pyramid Network (FPN) patterns with multiple detection heads at different scales.
+For the reasoning behind depth, width and bottleneck choices, see [YOLO architecture explained](yolo-architecture.md).
 
 ## Troubleshooting
 
@@ -392,31 +440,34 @@ head:
 
 When developing custom architectures, systematic debugging helps identify issues early:
 
-**Use Identity Head for Testing**
+#### Use an Identity Head to Isolate the Backbone
 
 Replace complex heads with `nn.Identity` to isolate backbone issues:
 
 ```yaml
+# debug_model.yaml
 nc: 1
 backbone:
-    - [-1, 1, CustomBlock, [64]]
+    - [-1, 1, Conv, [64, 3, 2]]
 head:
     - [-1, 1, nn.Identity, []] # Pass-through for debugging
 ```
 
-This allows direct inspection of backbone outputs:
+An identity head gives `parse_model` no head to infer the task from, so pass `task=` explicitly or model loading fails with `NotImplementedError` for task `None`:
 
 ```python
 import torch
 
 from ultralytics import YOLO
 
-model = YOLO("debug_model.yaml")
+model = YOLO("debug_model.yaml", task="detect")
 output = model.model(torch.randn(1, 3, 640, 640))
-print(f"Output shape: {output.shape}")  # Should match expected dimensions
+print(f"Output shape: {output.shape}")  # torch.Size([1, 64, 320, 320])
 ```
 
-**Model Architecture Inspection**
+The identity head is what makes `output` a plain tensor. Swap in a real `Detect` head and the forward pass returns a dict of `boxes`, `scores` and `feats` instead, so `output.shape` raises `AttributeError`.
+
+#### Inspect the Built Architecture
 
 Checking the FLOPs count and printing out each layer can also help debug issues with your custom model config. FLOPs count should be non-zero for a valid model. If it's zero, then there's likely an issue with the forward pass. Running a simple forward pass should show the exact error being encountered.
 
@@ -424,7 +475,7 @@ Checking the FLOPs count and printing out each layer can also help debug issues 
 from ultralytics import YOLO
 
 # Build model with verbose output to see layer details
-model = YOLO("debug_model.yaml", verbose=True)
+model = YOLO("debug_model.yaml", task="detect", verbose=True)
 
 # Check model FLOPs. Failed forward pass causes 0 FLOPs.
 model.info()
@@ -434,7 +485,7 @@ for i, layer in enumerate(model.model.model):
     print(f"Layer {i}: {layer}")
 ```
 
-**Step-by-Step Validation**
+#### Validate Step by Step
 
 1. **Start minimal**: Test with simplest possible architecture first
 2. **Add incrementally**: Build complexity layer by layer
@@ -453,37 +504,28 @@ nc: 5 # 5 classes
 
 ### Can I use a custom backbone in my model YAML?
 
-Yes. You can use any supported module, including TorchVision backbones, or define your own custom module and import it as described in [Custom Module Integration](#custom-module-integration).
+Yes. Use any supported module, including [TorchVision backbones](#torchvision-integration), or define your own and register it as described in [Custom Module Integration](#custom-module-integration).
+
+### How do I see the YAML for a pretrained model like yolo26n.pt?
+
+Load the checkpoint and read `model.model.yaml`, which holds the parsed architecture the weights were built from. The source files also ship with the package under [`ultralytics/cfg/models`](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/cfg/models) — copying one from there is the recommended starting point for a custom architecture.
+
+### Why does my layer have fewer channels than the number in my YAML?
+
+For a base module, `max_channels` caps the value before the width multiplier is applied, and the result is rounded up to a multiple of 8. With `m: [0.50, 1.00, 512]`, a layer declaring `[1024, 3, 2]` is clamped to 512 first, so it builds 512 channels rather than 1024. Other modules — `Concat`, `TorchVision`, `Index`, the heads — do not go through that formula. See [How Width Scaling Actually Computes Channels](#how-width-scaling-actually-computes-channels).
+
+### Can I train a model YAML from scratch without pretrained weights?
+
+Yes. Passing a YAML instead of a `.pt` file to `YOLO()` builds randomly initialized weights, so `YOLO("custom_model.yaml").train(data="coco8.yaml")` trains from scratch. Expect to need substantially more data and epochs than fine-tuning a pretrained checkpoint — see the [training mode guide](../modes/train.md).
 
 ### How do I scale my model for different sizes (nano, small, medium, etc.)?
 
 Use the [`scales` section](#parameters-section) in your YAML to define scaling factors for depth, width, and max channels. The model will automatically apply these when you load the base YAML file with the scale appended to the filename (e.g., `yolo26n.yaml`).
 
-### What does the `[from, repeats, module, args]` format mean?
-
-This format specifies how each layer is constructed:
-
-- `from`: input source(s)
-- `repeats`: number of times to repeat the module
-- `module`: the layer type
-- `args`: arguments for the module
-
 ### How do I troubleshoot channel mismatch errors?
 
 Check that the output channels of one layer match the expected input channels of the next. Use `print(model.model.model)` to inspect your model's architecture.
 
-### Where can I find a list of available modules and their arguments?
-
-Check the source code in the [`ultralytics/nn/modules` directory](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/nn/modules) for all available modules and their arguments.
-
-### How do I add a custom module to my YAML configuration?
-
-Define your module in the source code, import it as shown in [Source Code Modification](#source-code-modification), and reference it by name in your YAML file.
-
 ### Can I use pretrained weights with a custom YAML?
 
 Yes, you can use `model.load("path/to/weights")` to load weights from a pretrained checkpoint. However, only weights for layers that match would load successfully.
-
-### How do I validate my model configuration?
-
-Use `model.info()` to check whether FLOPs count is non-zero. A valid model should show non-zero FLOPs count. If it's zero, follow the suggestions in [Debugging Tips](#debugging-tips) to find the issue.


### PR DESCRIPTION
## summary

- Corrected claims that were false against the package: a `dfl_loss` column YOLO26 does not emit (it is DFL-free and prints `l1_loss`), a `C2f` argument row naming `expansion` where `parse_model` passes `groups`, quoted `parse_model` logic that would `NameError` if pasted, and `unwrap=True` described as doing what `unwrap=False` does.
- Fixed examples that do not run or silently misbehave: the K-Fold label glob returned nothing on the standard `labels/<split>/` layout, positional `zip` mispaired images with labels, chained pandas assignment wrote nothing under copy-on-write, the `best.pt`-by-custom-metric recipe read `best_fitness` after it had been overwritten, a `get_model` override disabled class-name remapping, and a mean-F1 recipe dropped every class that scored zero.
- Both per-layer learning-rate trainers reimplemented `build_optimizer` rather than calling it, losing case-insensitive optimizer names, `auto`'s MuSGD selection, `momentum` as the first Adam beta, SGD's Nesterov, and the no-decay-on-BatchNorm policy. They now delegate to it.
- Rebuilt the K-Fold walkthrough on the Ultralytics-hosted African Wildlife dataset so every number is reproducible: folds are image-path lists rather than copies, the shipped `test` split stays out of them, and duplicates are dropped before splitting rather than reported afterwards.

## measured

| check | before | after |
| --- | --- | --- |
| K-Fold label glob on the standard layout | 0 of 1504 files | 1277 |
| K-Fold image/label pairing | 1212 of 1501 pairs wrong | 0 |
| Fold lists read from another directory | 0 of 3 images resolve | 3 of 3 |
| Fold storage at k=5 | ~430 MB / 12,520 files | 402 KB / 15 files |
| `optimizer="sgd"` in the per-layer trainer | `NotImplementedError` | canonicalized, as `BaseTrainer` does |
| Mean F1 when a class scores zero | 0.666 over 5 of 6 classes | 0.555 over 6 |
| Model YAML examples that build | 3 of 6 | 6 of 6 |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated custom-training, K-Fold, knowledge-distillation, and model-YAML documentation so its claims and examples match the current Ultralytics package and execute correctly.

### 📊 Key Changes

- Corrected YOLO26 loss terminology from `dfl_loss` to `l1_loss`, clarified supported distillation tasks and projector behavior, and updated metric-reproduction instructions.
- Reworked custom trainer examples for mean F1, class weights, custom best-model selection, selective unfreezing, per-layer learning rates, NPU gradient clipping, and trainer registration.
- Rebuilt the K-Fold workflow around `YOLODataset`, using training and validation image paths directly, preserving the test split, pairing labels through the dataset, removing duplicates, and writing lightweight image-list splits.
- Fixed model-YAML documentation examples and references, including valid layer indices, required `nc` fields, `C2f` arguments, `Index` location, TorchVision `unwrap` behavior, module resolution, custom-module registration, and classification pooling.

### 🎯 Purpose & Impact

- Users following the guides now receive runnable examples for model construction, custom training, and K-Fold splitting instead of examples that could fail, silently misbehave, or produce incorrect metrics.
- Per-layer learning-rate trainers now reuse the base optimizer construction, preserving the package’s optimizer-name handling, automatic optimizer selection, parameter-group policies, and optimizer-specific settings.
- The documentation now reflects that YOLO26 is DFL-free, that its distillation guidance applies only to Detect-family heads, and that unsupported tasks include classification, semantic segmentation, depth estimation, and RT-DETR.