### PR TITLE
Parallelize batched image decoding in LoadImagesAndVideos

### DIFF
--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -8,7 +8,9 @@ import os
 import time
 import urllib
 from dataclasses import dataclass
+from functools import partial
 from io import BytesIO
+from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from threading import Thread
 from typing import Any
@@ -19,9 +21,9 @@ import torch
 from PIL import Image, ImageOps
 
 from ultralytics.data.utils import FORMATS_HELP_MSG, IMG_FORMATS, VID_FORMATS
-from ultralytics.utils import IS_COLAB, IS_KAGGLE, LOGGER, ops
+from ultralytics.utils import IS_COLAB, IS_KAGGLE, LOGGER, NUM_THREADS, ops
 from ultralytics.utils.checks import check_requirements
-from ultralytics.utils.patches import imread
+from ultralytics.utils.patches import PIL_FALLBACK_SUFFIXES, imread
 
 
 @dataclass
@@ -447,18 +449,35 @@ class LoadImagesAndVideos:
             else:
                 # Handle image files
                 self.mode = "image"
+                if self.bs >= 8 and NUM_THREADS > 1 and (n := min(self.bs - len(imgs), self.ni - self.count)) >= 8:
+                    image_paths = self.files[self.count : self.count + n]
+                    # Keep fallback formats serial: their lazy PIL plugin registration is not thread-safe.
+                    if not any(Path(x).suffix.lower() in PIL_FALLBACK_SUFFIXES for x in image_paths):
+                        with ThreadPool(min(n, NUM_THREADS)) as pool:
+                            decoded = pool.map(partial(imread, flags=self.cv2_flag), image_paths)
+                        for i, (image_path, im0) in enumerate(zip(image_paths, decoded)):
+                            self._append_image(paths, imgs, info, image_path, im0, self.count + i + 1)
+                        self.count += n  # move to the next batch of files
+                        if self.count >= self.ni and imgs:  # flush images before starting videos
+                            break
+                        continue
+
                 im0 = imread(path, flags=self.cv2_flag)  # BGR
-                if im0 is None:
-                    LOGGER.warning(f"Image Read Error {path}")
-                else:
-                    paths.append(path)
-                    imgs.append(im0)
-                    info.append(f"image {self.count + 1}/{self.nf} {path}: ")
+                self._append_image(paths, imgs, info, path, im0, self.count + 1)
                 self.count += 1  # move to the next file
                 if self.count >= self.ni and imgs:  # end of image list, flush only a non-empty batch
                     break
 
         return paths, imgs, info
+
+    def _append_image(self, paths: list, imgs: list, info: list, path: str, im0: np.ndarray | None, idx: int):
+        """Append a decoded image to the batch lists, or warn and skip it if decoding failed."""
+        if im0 is None:
+            LOGGER.warning(f"Image Read Error {path}")
+        else:
+            paths.append(path)
+            imgs.append(im0)
+            info.append(f"image {idx}/{self.nf} {path}: ")
 
     def _new_video(self, path: str):
         """Create a new video capture object for the given path and initialize video-related attributes."""

--- a/ultralytics/utils/patches.py
+++ b/ultralytics/utils/patches.py
@@ -16,6 +16,7 @@ from PIL import Image
 
 # OpenCV Multilanguage-friendly functions ------------------------------------------------------------------------------
 _imshow = cv2.imshow  # copy to avoid recursion errors
+PIL_FALLBACK_SUFFIXES = (".avif", ".heic", ".heif")  # formats needing the lazy-PIL decode fallback
 
 
 def imread(filename: str | Path, flags: int = cv2.IMREAD_COLOR) -> np.ndarray | None:
@@ -46,7 +47,7 @@ def imread(filename: str | Path, flags: int = cv2.IMREAD_COLOR) -> np.ndarray | 
     else:
         im = cv2.imdecode(file_bytes, flags)
         # Fallback for formats OpenCV imdecode may not support (AVIF, HEIC, HEIF)
-        if im is None and filename.lower().endswith((".avif", ".heic", ".heif")):
+        if im is None and filename.lower().endswith(PIL_FALLBACK_SUFFIXES):
             im = _imread_pil(filename, flags)
         return im[..., None] if im is not None and im.ndim == 2 else im  # Always ensure 3 dimensions
 


### PR DESCRIPTION
`LoadImagesAndVideos` accepts a batch size, but its image branch still decodes one path at a time. So with a directory source, preprocessing and inference wait for the sequential `imread()` calls in the batch.

This decodes image chunks with a `ThreadPool` while preserving input order. It reuses the existing `NUM_THREADS` cap (`min(8, cpu_count - 1)`) instead of adding a new `workers` argument. Batches below 8, single-threaded hosts, videos, and AVIF/HEIC/HEIF fallback formats stay on the serial path.

The threshold matters though. An earlier version created a pool when `n > 1` and made batch 2 about 3x slower on my laptop — it repeatedly paid pool startup for just a couple of images. I dropped it and swept the boundary on real COCO val2017 JPEGs.

## Measured

VM, 32 vCPU, 1000 COCO images, five runs per variant (seven for batches 1/2/4):

| batch | main median (range), s | PR median (range), s |
|---:|---:|---:|
| 1 | 3.3081 (3.2627-3.3303) | 3.2740 (3.2678-3.2837) |
| 2 | 3.3079 (3.2894-3.3135) | 3.3019 (3.2925-3.3267) |
| 4 | 3.2569 (3.2241-3.2725) | 3.3005 (3.2689-3.3240) |
| 8 | 3.2282 (3.2193-3.2501) | 1.0897 (1.0795-1.0936) |
| 16 | 3.2535 (3.2442-3.2714) | 0.8178 (0.8122-0.8218) |

The small-batch ranges overlap, so those batches don't enter the threaded path. At batch 16, decode gets 74.9% faster.

The worker-count sweep on the same VM and batch 16 was 3.2520 / 2.1087 / 1.1883 / 0.8315 seconds at 1 / 2 / 4 / 8 threads. That's why I kept the existing cap rather than introducing another setting.

Public end-to-end prediction:

| environment | main median (range), s | PR median (range), s | change |
|---|---:|---:|---:|
| YOLO11n CPU, VM, batch 16, imgsz 320¹ | 10.9721 (10.9490-11.0419) | 8.8135 (8.5407-8.9309) | -19.7% |
| YOLO11n CUDA FP16, NVIDIA L4 VM, batch 64, imgsz 640² | 9.6494 (9.6244-9.7008) | 6.7653 (6.7329-6.7867) | -29.9% |
| YOLO11n CUDA, RTX 4060 Laptop, batch 16, imgsz 320³ | 2.5651 (2.5494-2.6040) | 1.7666 (1.7509-1.8365) | -31.1% |

¹ Median and range of process medians from three independent processes per variant, three timed runs each; both variants were run as sequential blocks. The nine individual-call ranges are also disjoint: 10.9433-11.3090 vs 8.5106-9.0757 seconds. ² Five independent timed processes per variant, with baseline/PR order alternated across rounds and no concurrent GPU work. Pre-process L4 temperature rose from 50 to 64 °C; the two ranges remained disjoint. ³ Five timed runs per variant, each variant run as its own sequential block, with no explicit thermal control between blocks; the two five-run ranges are disjoint.

Prediction tensors are byte-identical across the three measured environments. The SHA-256 over path plus complete `boxes.data` bytes matches main on each run.

Peak RSS while decoding the 5000-image COCO set rises from a 571464 KiB median to 590648 KiB, +18.7 MiB / +3.36% across five independent processes.

## Validation

Exact decoded bytes, paths, shapes, and loader info match main for 1000 COCO images at batches 1, 2, 4, 8, 16, and 32. Grayscale and color output hashes match main over the 5000-image set. The 12 `coco12-formats` extensions produce the same decode hash and 12 prediction results. A decode window containing AVIF/HEIC/HEIF stays serial because their lazy PIL plugin registration is not thread-safe.

A source containing valid JPEGs, one corrupt JPEG, then a video keeps the same warnings, image batches, video frame batches, and byte hash. `pytest -q tests/test_python.py::test_predict_txt` passes; its source resolves to 7 images, below the `n >= 8` threshold, so it exercises the untouched serial path rather than the new one. Ultralytics Actions formatting checks pass.

## Changes

The original serial implementation stays required for small batches and fallback formats, so it stays unchanged below the fast path. The append/warning/index bookkeeping that both paths need got moved into `_append_image()` — one instance method called from both the pool loop and the serial branch, instead of staying duplicated inline. The `self.bs >= 8` check still short-circuits the chunk-size calculation on small batches even though `n >= 8` logically implies it.

Net +20 lines: the loader that owns disk-image batching, plus a `PIL_FALLBACK_SUFFIXES` constant in `ultralytics/utils/patches.py` so `imread()` and the loader share one list of PIL-fallback formats instead of each hardcoding it. No public API, default argument, or persistent worker pool.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Parallelizes JPEG and other supported image decoding in `LoadImagesAndVideos` for sufficiently large batches while preserving ordered results and serial fallback behavior.

### 📊 Key Changes
- Uses a bounded `ThreadPool` with the existing `NUM_THREADS` limit when image batches contain at least 8 items.
- Keeps small batches, single-threaded hosts, and AVIF/HEIC/HEIF inputs on the serial decoding path.
- Centralizes decoded-image append, warning, and indexing logic in `_append_image()`.
- Shares `PIL_FALLBACK_SUFFIXES` between the loader and `imread()` for fallback-format detection.

### 🎯 Purpose & Impact
Large image batches can overlap disk decoding with preprocessing and inference, while public arguments and serial-path behavior remain unchanged.