### PR TITLE
Simplify batched image decoding

### DIFF
--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -8,7 +8,6 @@ import os
 import time
 import urllib
 from dataclasses import dataclass
-from functools import partial
 from io import BytesIO
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
@@ -23,7 +22,7 @@ from PIL import Image, ImageOps
 from ultralytics.data.utils import FORMATS_HELP_MSG, IMG_FORMATS, VID_FORMATS
 from ultralytics.utils import IS_COLAB, IS_KAGGLE, LOGGER, NUM_THREADS, ops
 from ultralytics.utils.checks import check_requirements
-from ultralytics.utils.patches import PIL_FALLBACK_SUFFIXES, imread
+from ultralytics.utils.patches import imread
 
 
 @dataclass
@@ -449,35 +448,29 @@ class LoadImagesAndVideos:
             else:
                 # Handle image files
                 self.mode = "image"
-                if self.bs >= 8 and NUM_THREADS > 1 and (n := min(self.bs - len(imgs), self.ni - self.count)) >= 8:
-                    image_paths = self.files[self.count : self.count + n]
-                    # Keep fallback formats serial: their lazy PIL plugin registration is not thread-safe.
-                    if not any(Path(x).suffix.lower() in PIL_FALLBACK_SUFFIXES for x in image_paths):
-                        with ThreadPool(min(n, NUM_THREADS)) as pool:
-                            decoded = pool.map(partial(imread, flags=self.cv2_flag), image_paths)
-                        for i, (image_path, im0) in enumerate(zip(image_paths, decoded)):
-                            self._append_image(paths, imgs, info, image_path, im0, self.count + i + 1)
-                        self.count += n  # move to the next batch of files
-                        if self.count >= self.ni and imgs:  # flush images before starting videos
-                            break
-                        continue
-
-                im0 = imread(path, flags=self.cv2_flag)  # BGR
-                self._append_image(paths, imgs, info, path, im0, self.count + 1)
-                self.count += 1  # move to the next file
+                n = min(self.bs - len(imgs), self.ni - self.count)
+                image_paths = self.files[self.count : self.count + n]
+                if (
+                    NUM_THREADS > 1
+                    and n >= 8
+                    and not any(x.lower().endswith((".avif", ".heic", ".heif")) for x in image_paths)
+                ):
+                    with ThreadPool(NUM_THREADS) as pool:
+                        decoded = pool.map(lambda x: imread(x, self.cv2_flag), image_paths)
+                else:
+                    image_paths, decoded = (path,), (imread(path, flags=self.cv2_flag),)  # BGR
+                for i, (image_path, im0) in enumerate(zip(image_paths, decoded)):
+                    if im0 is None:
+                        LOGGER.warning(f"Image Read Error {image_path}")
+                    else:
+                        paths.append(image_path)
+                        imgs.append(im0)
+                        info.append(f"image {self.count + i + 1}/{self.nf} {image_path}: ")
+                self.count += len(image_paths)  # move to the next file
                 if self.count >= self.ni and imgs:  # end of image list, flush only a non-empty batch
                     break
 
         return paths, imgs, info
-
-    def _append_image(self, paths: list, imgs: list, info: list, path: str, im0: np.ndarray | None, idx: int):
-        """Append a decoded image to the batch lists, or warn and skip it if decoding failed."""
-        if im0 is None:
-            LOGGER.warning(f"Image Read Error {path}")
-        else:
-            paths.append(path)
-            imgs.append(im0)
-            info.append(f"image {idx}/{self.nf} {path}: ")
 
     def _new_video(self, path: str):
         """Create a new video capture object for the given path and initialize video-related attributes."""

--- a/ultralytics/utils/patches.py
+++ b/ultralytics/utils/patches.py
@@ -16,7 +16,6 @@ from PIL import Image
 
 # OpenCV Multilanguage-friendly functions ------------------------------------------------------------------------------
 _imshow = cv2.imshow  # copy to avoid recursion errors
-PIL_FALLBACK_SUFFIXES = (".avif", ".heic", ".heif")  # formats needing the lazy-PIL decode fallback
 
 
 def imread(filename: str | Path, flags: int = cv2.IMREAD_COLOR) -> np.ndarray | None:
@@ -47,7 +46,7 @@ def imread(filename: str | Path, flags: int = cv2.IMREAD_COLOR) -> np.ndarray | 
     else:
         im = cv2.imdecode(file_bytes, flags)
         # Fallback for formats OpenCV imdecode may not support (AVIF, HEIC, HEIF)
-        if im is None and filename.lower().endswith(PIL_FALLBACK_SUFFIXES):
+        if im is None and filename.lower().endswith((".avif", ".heic", ".heif")):
             im = _imread_pil(filename, flags)
         return im[..., None] if im is not None and im.ndim == 2 else im  # Always ensure 3 dimensions
 


### PR DESCRIPTION
## Summary

- Unifies serial and threaded image bookkeeping in `LoadImagesAndVideos`.
- Removes the new `_append_image` method and cross-module fallback-suffix constant.
- Removes the redundant batch-size guard and separate fast-path control flow.
- Reduces the merged implementation by 8 net lines while keeping the feature in its loader owner.

## Validation

- Pre-feature, merged, and simplified loaders produced identical path/order/image-byte hashes for 256 color images at batches 1, 8, and 16 and grayscale images at batch 16.
- Batch-16 median decode time was 0.4884s before the feature, 0.2966s in the merged implementation, and 0.2957s after simplification.
- Batch-1 median remained effectively unchanged: 0.5151s before and 0.5140s after.
- `python3 -m pytest tests/test_python.py::test_predict_txt -q`
- `ruff format --check`, focused `ruff check`, and `git diff --check`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Simplifies `LoadImagesAndVideos` image batching by using one serial/threaded decoding path while preserving image ordering, batching, and decode-error handling.

### 📊 Key Changes

- Replaced separate serial and threaded image-bookkeeping paths with shared batch construction and result appending.
- Uses threaded decoding for batches of at least eight images when `NUM_THREADS > 1`, excluding `.avif`, `.heic`, and `.heif` files.
- Removed the `_append_image` helper, `partial` import, and `PIL_FALLBACK_SUFFIXES` constant.
- Inlined the AVIF/HEIC/HEIF fallback suffix check in `imread()`.

### 🎯 Purpose & Impact

- Image read failures are still logged and skipped, while successfully decoded images retain their paths, order, and batch metadata.
- The loader implementation is eight net lines shorter; reported validation showed unchanged path/order/image-byte hashes and effectively unchanged batch-1 decoding time.
- No user-facing change.