### PR TITLE
Parallelize FastSAM CLIP preprocessing

### DIFF
--- a/ultralytics/models/fastsam/predict.py
+++ b/ultralytics/models/fastsam/predict.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from multiprocessing.pool import ThreadPool
+
 import torch
 from PIL import Image
 
 from ultralytics.models.yolo.segment import SegmentationPredictor
-from ultralytics.utils import DEFAULT_CFG
+from ultralytics.utils import DEFAULT_CFG, NUM_THREADS
 from ultralytics.utils.metrics import box_iou
 from ultralytics.utils.ops import clip_boxes, clip_coords, scale_masks
 from ultralytics.utils.torch_utils import TORCH_1_10
@@ -164,7 +166,12 @@ class FastSAMPredictor(SegmentationPredictor):
 
         if not hasattr(self, "clip"):
             self.clip = CLIP("ViT-B/32", device=self.device)
-        images = torch.stack([self.clip.image_preprocess(image).to(self.device) for image in images])
+        if self.device.type == "cuda" and NUM_THREADS > 1 and len(images) >= 2 * NUM_THREADS:
+            with ThreadPool(NUM_THREADS) as pool:
+                images = pool.map(self.clip.image_preprocess, images)
+            images = torch.stack([image.to(self.device) for image in images])
+        else:
+            images = torch.stack([self.clip.image_preprocess(image).to(self.device) for image in images])
         image_features = self.clip.encode_image(images)
         text_features = self.clip.encode_text(self.clip.tokenize(texts))
         return text_features @ image_features.T  # (M, N)


### PR DESCRIPTION
FastSAM text prompts preprocess candidate crops one by one on the CPU before CLIP image encoding. With scenes that produce tens of masks, this leaves the GPU waiting while the independent resize/normalise transforms run serially.

So this uses a `ThreadPool` for that crop preprocessing when the prompt is on CUDA and has at least `2 * NUM_THREADS` candidates. `pool.map()` preserves crop order, and the tensors still move to the GPU and stack in that order. CPU, MPS, single-threaded hosts, and smaller CUDA prompts keep the current serial path.

The threshold matters though. An earlier version also threaded CPU prompts, but it regressed the public call and was dropped. On the laptop, 8 real crops went from 6.28 to 10.79 ms while 16 went from 13.05 to 8.21 ms, so the final path starts at 16 with the normal 8-thread cap.

## Measured

Five fresh processes per variant, warmup excluded, A/B order alternated, and no concurrent GPU work:

| real source and environment | main public median (range), ms | PR public median (range), ms | paired change |
|---|---:|---:|---:|
| `bus.jpg`, 74 masks, RTX 4060 Laptop | 156.05 (150.16-158.55) | 128.69 (127.73-130.61) | -17.6% |
| COCO8, 8 images / 166 masks, RTX 4060 Laptop | 383.90 (371.65-406.20) | 357.46 (350.67-368.73) | -6.3% |
| `bus.jpg`, 74 masks, NVIDIA L4 | 283.83 (282.58-286.21) | 186.98 (186.27-187.46) | -34.3% |
| COCO8, 8 images / 166 masks, NVIDIA L4 | 751.40 (743.62-758.96) | 607.04 (605.91-618.71) | -18.6% |

Each row improves in its five process pairs. Looking only at `predictor.prompt()`, the changes are -20.1%, -9.0%, -38.4%, and -24.3% in the same order.

The full result bytes match main across the four GPU suites. A separate two-prompt check over the 74 real crops also gives byte-identical float32 similarity tensors and the same top indices in both GPUs. Peak CUDA allocation is unchanged, and process RSS ranges overlap on both machines.

CPU and 13-crop CUDA controls stay on the serial path. Their timing ranges overlap, so no performance change is claimed for those cases.

## Validation

- `pytest -q tests/test_cli.py::test_fastsam`: 1 passed on the L4 VM; this existing test exercises FastSAM text, box, and point prompts.
- Exact boxes, masks, similarity matrices, shapes, and dtypes were compared by raw-byte SHA-256, not rounded values.
- The official Ultralytics formatting check and `git diff --check` pass.

No new public argument, persistent pool, or model behaviour change. No new test is added because the existing focused test covers the functional prompt path, while the CUDA threshold and timing are validated with repeated real-image A/B runs.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
FastSAM now parallelizes CLIP image preprocessing for sufficiently large CUDA candidate sets to reduce serial CPU preprocessing time while preserving the existing path for other devices and smaller inputs.

### 📊 Key Changes
- Imports `ThreadPool` and `NUM_THREADS` for bounded preprocessing concurrency.
- Uses a `ThreadPool` with `NUM_THREADS` workers when the device is CUDA, multiple threads are available, and the candidate count reaches twice `NUM_THREADS`.
- Preserves crop order through `pool.map()` before moving tensors to the GPU and stacking them.
- Retains the existing serial preprocessing path for CPU, MPS, single-threaded, and smaller CUDA inputs.

### 🎯 Purpose & Impact
- Reduces CPU preprocessing wait time before FastSAM CLIP image encoding for larger CUDA prompt workloads without changing the public API or prompt behavior.