### PR TITLE
Fix concurrent MongoDB tuner default claims

### DIFF
--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -395,13 +395,14 @@ class Tuner:
                     ]
                 )
             else:
-                claim = self.collection.update_one(
-                    {"_id": "defaults"}, {"$setOnInsert": {"timestamp": datetime.now().astimezone()}}, upsert=True
-                )
-                if claim.upserted_id is None:
+                from pymongo.errors import DuplicateKeyError
+
+                try:
+                    self.collection.insert_one({"_id": "defaults", "timestamp": datetime.now().astimezone()})
+                except DuplicateKeyError:  # Another worker already claimed the default generation
                     x = np.array([[0.0] + [getattr(self.args, k) for k in self.space]])
                 self.collection.create_index([("fitness", -1)], background=True)
-                if claim.upserted_id is not None:
+                if x is None:
                     return {k: getattr(self.args, k) for k in self.space}
 
         # Fall back to local NDJSON if MongoDB unavailable or empty

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -189,7 +189,7 @@ class Tuner:
             mongodb_collection (str, optional): Collection name.
 
         Notes:
-            - Creates a fitness index when the first worker claims a new collection
+            - Creates a fitness index when workers start a new collection
             - Falls back to local NDJSON mode if connection fails
             - Uses connection pooling and retry logic for production reliability
         """
@@ -207,7 +207,7 @@ class Tuner:
             (list[dict]): List of result documents with fitness scores and hyperparameters.
         """
         try:
-            return list(self.collection.find().sort("fitness", -1).limit(n))
+            return list(self.collection.find({"fitness": {"$exists": True}}).sort("fitness", -1).limit(n))
         except Exception:
             return []
 
@@ -276,7 +276,7 @@ class Tuner:
         resume, mutation, and plotting on the same local source of truth when using distributed tuning.
         """
         try:
-            all_results = list(self.collection.find().sort("iteration", 1))
+            all_results = list(self.collection.find({"fitness": {"$exists": True}}).sort("iteration", 1))
             if not all_results:
                 return
 
@@ -395,14 +395,13 @@ class Tuner:
                     ]
                 )
             else:
-                from pymongo.errors import CollectionInvalid
-
-                try:
-                    self.collection.database.create_collection(self.collection.name)
-                except CollectionInvalid:  # Another worker already claimed the default generation
+                claim = self.collection.update_one(
+                    {"_id": "defaults"}, {"$setOnInsert": {"timestamp": datetime.now().astimezone()}}, upsert=True
+                )
+                if claim.upserted_id is None:
                     x = np.array([[0.0] + [getattr(self.args, k) for k in self.space]])
                 self.collection.create_index([("fitness", -1)], background=True)
-                if x is None:
+                if claim.upserted_id is not None:
                     return {k: getattr(self.args, k) for k in self.space}
 
         # Fall back to local NDJSON if MongoDB unavailable or empty
@@ -505,7 +504,7 @@ class Tuner:
             if self.mongodb:
                 self._save_to_mongodb(fitness, mutated_hyp, metrics, dataset_metrics, result["save_dirs"], i + 1)
                 self._sync_mongodb_to_file()
-                total_mongo_iterations = self.collection.count_documents({})
+                total_mongo_iterations = self.collection.count_documents({"fitness": {"$exists": True}})
                 if total_mongo_iterations >= iterations:
                     stop_after_iteration = True
             else:


### PR DESCRIPTION
## Summary

- replace concurrent collection creation with an atomic same-collection default claim
- exclude the coordination record from mutation, sync, and iteration counts
- retain the claim to prevent a stale empty read from reclaiming defaults after results arrive

## Validation

- real Atlas contention: 3 fresh simultaneous 8-worker trials each produced exactly 1 default and 7 mutations
- real Atlas stagger: a 2-second stagger produced exactly 1 default and 7 mutations
- forced empty-read/first-save race: the delayed worker mutated and the coordination record stayed excluded from Mongo results and local NDJSON
- `uvx ruff format --check ultralytics/engine/tuner.py`
- `uvx ruff check --ignore BLE001 ultralytics/engine/tuner.py`
- `python3 -m compileall -q ultralytics/engine/tuner.py`
- `git diff --check`

No version bump.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

MongoDB tuning now uses an atomic coordination record to claim the default configuration, preventing concurrent workers from independently creating defaults while keeping that record out of tuning results.

### 📊 Key Changes

- Replaced concurrent MongoDB collection creation with insertion of a shared `_id: "defaults"` coordination document.
- Workers encountering a duplicate coordination record start from the current arguments and mutate instead of claiming another default.
- MongoDB result queries, local synchronization, and iteration counts now include only documents containing `fitness`.
- Updated the tuner documentation to describe index creation when workers start a collection.

### 🎯 Purpose & Impact

- Concurrent MongoDB workers no longer treat collection creation as the default-generation claim, preventing multiple defaults during startup races.
- The coordination document is excluded from result ranking, local NDJSON synchronization, and stopping-condition iteration counts.
- The retained coordination record prevents a later stale empty read from reclaiming the default after tuning results have been written.