### PR TITLE
Match model scale letters exactly in parse_model and correct the architecture guide

### DIFF
--- a/docs/en/guides/yolo-architecture.md
+++ b/docs/en/guides/yolo-architecture.md
@@ -152,7 +152,7 @@ Where `C3` passes 2 feature maps into its fusion conv, `C2f` passes `n + 2` — 
 - a `C3k` block (`c3k=True`) — a `C3` variant with a configurable kernel size, or
 - a `Bottleneck` + `PSABlock` pair (`attn=True`).
 
-The second YAML arg sets `c3k`; for example `[-1, 2, C3k2, [512, True]]` builds one `C3k2` module at 512 output channels whose internal blocks are `C3k` (since `c3k=True`). For CSP modules, the `repeats` field — here 2, before it is scaled by the variant's depth multiple — becomes the block's internal repeat count rather than stacking separate modules.
+The second YAML arg sets `c3k` unless the scale is `m`, `l` or `x`, which force it to `True` — this is how one `yolo11.yaml` serves all five variants. So `[-1, 2, C3k2, [512, False]]` builds `Bottleneck` internals at `n` and `s` but `C3k` internals at `m`, `l` and `x`; the 512 is the pre-scaling channel count, which the variant's width multiple turns into 128 at `n` and 768 at `x`. For CSP modules, the `repeats` field — here 2, before it is scaled by the variant's depth multiple — becomes the block's internal repeat count rather than stacking separate modules.
 
 ## Spatial Pooling: SPP → SPPF
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -2080,11 +2080,11 @@ def parse_model(d, ch, verbose=True):
                 n = 1
             if m is C3k2:  # for M/L/X sizes
                 legacy = False
-                if scale in "mlx":
-                    args[3] = True
+                if scale in {"m", "l", "x"}:
+                    args[3:4] = [True]  # slice assignment also supplies c3k when the YAML omits it
             if m is A2C2f:
                 legacy = False
-                if scale in "lx":  # for L/X sizes
+                if scale in {"l", "x"}:  # for L/X sizes
                     args.extend((True, 1.2))
             if m is C2fCIB:
                 legacy = False


### PR DESCRIPTION
## summary

- `parse_model` gated the `C3k2` and `A2C2f` scale overrides on `scale in "mlx"` and `scale in "lx"`. Python's `in` on a string is a substring test, so `"" in "mlx"` is `True` and a model YAML with no `scales:` block silently took the largest-model branch; a raw dict passed as `cfg` (a documented `str | dict` contract) left `scale` as `None` and raised `TypeError`. Matching against `{"m", "l", "x"}` and `{"l", "x"}` makes both cases behave as unscaled.
- The `m/l/x` branch also wrote `args[3] = True`, which assumes the YAML spelled out the optional `c3k` positional. `C3k2, [256]` is legal because `c3k` defaults to `False`, and it raised `IndexError` at every one of `m`, `l`, `x` and unscaled. `args[3:4] = [True]` replaces `c3k` when present and supplies it when omitted.
- The predicate was `max_channels == 512` until it was rewritten to `scale in "mlx"`; `max_channels` is `inf` for an unscaled config, so the substring behaviour was never the intent.
- No shipped config is affected: all 55 configs carrying `scales:` resolve to a single scale letter.
- `docs/en/guides/yolo-architecture.md` documented the same override incorrectly, so the guide is corrected in the same PR. It said the second YAML arg sets `c3k`, illustrated with `[512, True]` — a value honoured at every scale, so the sentence could not be seen to be wrong. The rewrite keys on the condition this diff touches (`m`, `l`, `x` force `True`) and drops a second, pre-existing error: `512` is the pre-scaling channel count, not the output width.

## measured

| Case (no `scales:` block, only `scale` varies) | before | after |
| --- | --- | --- |
| `C3k2, [256]` at `''` / `m` / `l` / `x` | `IndexError` | builds |
| `C3k2, [256]` at `n` / `s` | builds | builds, unchanged |
| `C3k2, [256, False, 0.25]` at `''`, `c3k` honoured | no | yes |
| `A2C2f` residual scaling at `''` | on | off, matching `n`/`s`/`m` |
| `DetectionModel(cfg=<dict, no "scale" key>)` | `TypeError` | builds |
| shipped configs x every scale letter, `state_dict` shape map | 246 entries | 0 of 246 differ |

The equivalence run is calibrated: mutating `{"m", "l", "x"}` to `{"l", "x"}` makes the same harness report 23 of 246 differing, all the `m` arm.

The guide sentence was checked against a real `parse_model` on 12 configurations — `n`/`s`/`m`/`l`/`x` with a `scales:` block, an unscaled config, a custom scale key, and five filename-routed configs loaded through `yaml_model_load` — and what the sentence predicts matches what is built in all 12. The channel figures come from `blk.cv2.conv.out_channels` on `yolo11.yaml`'s own scales: 128 / 256 / 512 / 512 / 768 at `n` / `s` / `m` / `l` / `x`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated `parse_model` to match model scale letters exactly and safely handle unscaled configurations, while correcting the architecture guide’s description of scale-dependent `C3k2` behavior.

### 📊 Key Changes

- Replaced substring checks with exact membership checks for `m`, `l`, and `x` in `C3k2` and `A2C2f` scale handling.
- Changed the `C3k2` override to use slice assignment, so `c3k=True` is replaced when present or added when omitted.
- Prevented unscaled configurations and raw dictionary configs with no `scale` key from taking scaled branches or raising a `TypeError`.
- Updated the architecture guide to document that `m`, `l`, and `x` force `c3k=True`, and that YAML channel values are applied before width scaling.

### 🎯 Purpose & Impact

- `C3k2` configurations such as `[256]` now build for unscaled, `m`, `l`, and `x` cases instead of raising `IndexError`; explicitly provided `c3k` values are preserved for unscaled, `n`, and `s` configurations.
- Unscaled `A2C2f` configurations no longer enable the `l`/`x` residual-scaling behavior, and dictionary-based model configs without a `scale` key build correctly.
- No shipped configuration state-dict shapes change; the documentation now matches the implemented architecture behavior.