### PR TITLE
fix: use standard DataLoader for validation to release workers and memory

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -60,6 +60,25 @@ def test_dataloader_caps_workers_to_batches():
         two_batches.close()
 
 
+def test_dataloader_val_mode_releases_workers():
+    """Validation dataloader should be a plain DataLoader, not InfiniteDataLoader."""
+    from torch.utils.data import DataLoader
+
+    from ultralytics.data.build import InfiniteDataLoader
+
+    train_loader = build_dataloader(range(16), batch=4, workers=2, mode="train")
+    val_loader = build_dataloader(range(16), batch=4, workers=2, mode="val")
+    try:
+        assert isinstance(train_loader, InfiniteDataLoader), "train mode must use InfiniteDataLoader"
+        assert isinstance(val_loader, DataLoader) and not isinstance(val_loader, InfiniteDataLoader), (
+            "val mode must use plain DataLoader"
+        )
+        assert val_loader.persistent_workers is False, "val workers must not persist"
+    finally:
+        train_loader.close()
+        del val_loader
+
+
 def test_dataloader_cap_preserves_distributed_drop_last(monkeypatch):
     """Test worker cap follows distributed sampler size without changing global drop_last behavior."""
     sampler_cls = data_build.distributed.DistributedSampler

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -68,15 +68,24 @@ def test_dataloader_val_mode_releases_workers():
 
     train_loader = build_dataloader(range(16), batch=4, workers=2, mode="train")
     val_loader = build_dataloader(range(16), batch=4, workers=2, mode="val")
+    # Also cover the workers=0 path (CPU/MPS validation), where prefetch_factor must
+    # be omitted entirely to avoid ValueError on older PyTorch versions.
+    val_loader_no_workers = build_dataloader(range(16), batch=4, workers=0, mode="val")
     try:
         assert isinstance(train_loader, InfiniteDataLoader), "train mode must use InfiniteDataLoader"
         assert isinstance(val_loader, DataLoader) and not isinstance(val_loader, InfiniteDataLoader), (
             "val mode must use plain DataLoader"
         )
         assert val_loader.persistent_workers is False, "val workers must not persist"
+        # Verify workers=0 val loader is also a plain DataLoader
+        assert isinstance(val_loader_no_workers, DataLoader) and not isinstance(
+            val_loader_no_workers, InfiniteDataLoader
+        ), "val mode with 0 workers must use plain DataLoader"
+        assert val_loader_no_workers.persistent_workers is False, "val workers=0 must not persist"
     finally:
         train_loader.close()
         del val_loader
+        del val_loader_no_workers
 
 
 def test_dataloader_cap_preserves_distributed_drop_last(monkeypatch):

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -324,8 +324,13 @@ def build_dataloader(
     drop_last: bool = False,
     pin_memory: bool = True,
     device: torch.device | str = "cuda",
-) -> InfiniteDataLoader:
-    """Create and return an InfiniteDataLoader for training or validation.
+    mode: str = "train",
+) -> dataloader.DataLoader:
+    """Create a DataLoader for training or validation.
+
+    Training uses InfiniteDataLoader with persistent workers for efficiency.
+    Validation uses a standard DataLoader so workers and prefetched batches
+    are released after each validation pass.
 
     Args:
         dataset (Dataset): Dataset to load data from.
@@ -336,9 +341,11 @@ def build_dataloader(
         drop_last (bool, optional): Whether to drop the last incomplete batch.
         pin_memory (bool, optional): Whether to use pinned memory for dataloader.
         device (torch.device | str, optional): Device used by the dataloader consumer.
+        mode (str): ``"train"`` for InfiniteDataLoader with persistent workers,
+            ``"val"`` for a standard DataLoader that releases workers after iteration.
 
     Returns:
-        (InfiniteDataLoader): A dataloader that can be used for training or validation.
+        (dataloader.DataLoader): A dataloader suitable for the given mode.
 
     Examples:
         Create a dataloader for training
@@ -369,19 +376,29 @@ def build_dataloader(
     pin_memory_device = (
         device_type if pin_memory and device_type in {"npu", "xpu"} and TORCH_1_13 and not TORCH_2_7 else None
     )
+    loader_kwargs = {
+        "dataset": dataset,
+        "batch_size": batch,
+        "shuffle": shuffle and sampler is None,
+        "num_workers": nw,
+        "sampler": sampler,
+        "pin_memory": pin_memory,
+        "collate_fn": getattr(dataset, "collate_fn", None),
+        "worker_init_fn": seed_worker,
+        "generator": generator,
+        "drop_last": drop_last,
+    }
+    if pin_memory_device:
+        loader_kwargs["pin_memory_device"] = pin_memory_device
+    if mode == "val":
+        return dataloader.DataLoader(
+            **loader_kwargs,
+            prefetch_factor=2 if nw > 0 else None,
+            persistent_workers=False,
+        )
     return InfiniteDataLoader(
-        dataset=dataset,
-        batch_size=batch,
-        shuffle=shuffle and sampler is None,
-        num_workers=nw,
-        sampler=sampler,
+        **loader_kwargs,
         prefetch_factor=4 if nw > 0 else None,  # increase over default 2
-        pin_memory=pin_memory,
-        collate_fn=getattr(dataset, "collate_fn", None),
-        worker_init_fn=seed_worker,
-        generator=generator,
-        drop_last=drop_last,
-        **({"pin_memory_device": pin_memory_device} if pin_memory_device else {}),
     )
 
 

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -392,12 +392,12 @@ def build_dataloader(
     if mode == "val":
         return dataloader.DataLoader(
             **loader_kwargs,
-            prefetch_factor=2 if nw > 0 else None,
+            **({"prefetch_factor": 2} if nw > 0 else {}),
             persistent_workers=False,
         )
     return InfiniteDataLoader(
         **loader_kwargs,
-        prefetch_factor=4 if nw > 0 else None,  # increase over default 2
+        **({"prefetch_factor": 4} if nw > 0 else {}),  # increase over default 2
     )
 
 

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -328,9 +328,8 @@ def build_dataloader(
 ) -> dataloader.DataLoader:
     """Create a DataLoader for training or validation.
 
-    Training uses InfiniteDataLoader with persistent workers for efficiency.
-    Validation uses a standard DataLoader so workers and prefetched batches
-    are released after each validation pass.
+    Training uses InfiniteDataLoader with persistent workers for efficiency. Validation uses a standard DataLoader so
+    workers and prefetched batches are released after each validation pass.
 
     Args:
         dataset (Dataset): Dataset to load data from.
@@ -341,8 +340,8 @@ def build_dataloader(
         drop_last (bool, optional): Whether to drop the last incomplete batch.
         pin_memory (bool, optional): Whether to use pinned memory for dataloader.
         device (torch.device | str, optional): Device used by the dataloader consumer.
-        mode (str): ``"train"`` for InfiniteDataLoader with persistent workers,
-            ``"val"`` for a standard DataLoader that releases workers after iteration.
+        mode (str): ``"train"`` for InfiniteDataLoader with persistent workers, ``"val"`` for a standard DataLoader that
+            releases workers after iteration.
 
     Returns:
         (dataloader.DataLoader): A dataloader suitable for the given mode.

--- a/ultralytics/models/yolo/classify/train.py
+++ b/ultralytics/models/yolo/classify/train.py
@@ -162,7 +162,7 @@ class ClassificationTrainer(BaseTrainer):
                 )
         drop_last = self.args.compile and mode == "train"
         loader = build_dataloader(
-            dataset, batch_size, self.args.workers, rank=rank, drop_last=drop_last, device=self.device
+            dataset, batch_size, self.args.workers, rank=rank, drop_last=drop_last, device=self.device, mode=mode
         )
         # Attach inference transforms
         if mode != "train":

--- a/ultralytics/models/yolo/classify/val.py
+++ b/ultralytics/models/yolo/classify/val.py
@@ -161,7 +161,7 @@ class ClassificationValidator(BaseValidator):
             (torch.utils.data.DataLoader): DataLoader object for the classification validation dataset.
         """
         dataset = self.build_dataset(dataset_path)
-        return build_dataloader(dataset, batch_size, self.args.workers, rank=-1, device=self.device)
+        return build_dataloader(dataset, batch_size, self.args.workers, rank=-1, device=self.device, mode="val")
 
     def print_results(self) -> None:
         """Print evaluation metrics for the classification model."""

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -102,6 +102,7 @@ class DetectionTrainer(BaseTrainer):
             rank=rank,
             drop_last=self.args.compile and mode == "train",
             device=self.device,
+            mode=mode,
         )
 
     def preprocess_batch(self, batch: dict) -> dict:

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -350,6 +350,7 @@ class DetectionValidator(BaseValidator):
             drop_last=self.args.compile,
             pin_memory=self.training,
             device=self.device,
+            mode="val",
         )
 
     def plot_val_samples(self, batch: dict[str, Any], ni: int) -> None:

--- a/ultralytics/models/yolo/yoloe/val.py
+++ b/ultralytics/models/yolo/yoloe/val.py
@@ -128,6 +128,7 @@ class YOLOEDetectValidator(DetectionValidator):
             shuffle=False,
             rank=-1,
             device=self.device,
+            mode="val",
         )
 
     @smart_inference_mode()


### PR DESCRIPTION
## Summary

Fixes #25827

Validation was using `InfiniteDataLoader`, which keeps worker processes and prefetched batches alive between epochs. With large images and high worker counts this retained tens of gigabytes of memory and saturated the CPU after validation completed.

## Changes

- Add `mode` parameter to `build_dataloader`: `'train'` returns `InfiniteDataLoader` (unchanged behavior), `'val'` returns a standard `DataLoader` with `persistent_workers=False` and `prefetch_factor=2`.
- Pass `mode` through from all validation callers (detect, classify, yoloe).
- Add regression test verifying val mode returns plain `DataLoader`.

## Testing

```bash
python -m pytest tests/test_python.py::test_dataloader_val_mode_releases_workers -xvs
python -m pytest tests/test_python.py::test_dataloader_caps_workers_to_batches -xvs
```

Both pass. The new test asserts that:
1. Train mode still returns `InfiniteDataLoader`
2. Val mode returns plain `DataLoader` (not `InfiniteDataLoader`)
3. Val workers have `persistent_workers=False`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated validation dataloaders to use standard PyTorch `DataLoader` instances with non-persistent workers, preventing worker and prefetched-batch retention after validation while preserving `InfiniteDataLoader` for training.

### 📊 Key Changes
- Added a `mode` parameter to `build_dataloader`, supporting training and validation loader behavior.
- Configured validation loaders with `persistent_workers=False` and a prefetch factor of 2.
- Passed validation mode through detection, classification, and YOLOE dataloader callers.
- Added a regression test confirming training uses `InfiniteDataLoader` and validation uses a plain `DataLoader` with non-persistent workers.

### 🎯 Purpose & Impact
Validation workers and prefetched batches can be released after iteration, reducing retained memory and CPU activity between validation passes. Training dataloader behavior remains unchanged.