### PR TITLE
Fix Tune optimizer default

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -903,7 +903,8 @@ class Model(torch.nn.Module):
             >>> results = model.tune(use_ray=True, iterations=20, data="coco8.yaml")
         """
         self._check_is_pytorch_model()
-        kwargs.setdefault("optimizer", "AdamW")
+        if "optimizer" not in (kwargs.get("space") or {}):
+            kwargs.setdefault("optimizer", "AdamW")
         if use_ray:
             from ultralytics.utils.tuner import run_ray_tune
 

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -903,6 +903,7 @@ class Model(torch.nn.Module):
             >>> results = model.tune(use_ray=True, iterations=20, data="coco8.yaml")
         """
         self._check_is_pytorch_model()
+        kwargs.setdefault("optimizer", "AdamW")
         if use_ray:
             from ultralytics.utils.tuner import run_ray_tune
 


### PR DESCRIPTION
## Summary

- default `Model.tune()` to AdamW so the native and Ray search spaces actually tune `lr0` and `momentum`
- preserve any explicitly supplied optimizer

`optimizer=auto` ignores both values in `BaseTrainer.build_optimizer()`, leaving two default tuning dimensions inert. The tuning guide already uses AdamW for these search spaces.

## Validation

- `uvx ruff format --check ultralytics/engine/model.py`
- `uvx ruff check ultralytics/engine/model.py`
- captured native, explicit-override, and Ray dispatch arguments
- completed a real one-epoch CPU native Tune CLI run and verified `optimizer=AdamW` with the mutated `lr0` and `momentum` applied

No version bump.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

`Model.tune()` now defaults to `optimizer="AdamW"` so tuning `lr0` and `momentum` works unless an optimizer is explicitly provided.

### 📊 Key Changes

- Added an `AdamW` default in `ultralytics/engine/model.py` when the tuning search space does not define an optimizer.
- Preserves an explicitly supplied `optimizer` in either the tuning arguments or search space.
- Applies the default before dispatching to native or Ray tuning.

### 🎯 Purpose & Impact

- Native and Ray tuning runs now use AdamW by default, allowing their `lr0` and `momentum` search dimensions to affect training instead of being ignored by `optimizer="auto"`.