### PR TITLE
Improve tuning fitness plot

### DIFF
--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -1295,7 +1295,11 @@ def plot_tune_results(results_file: str = "tune_results.ndjson", exclude_zero_fi
     plot_records = records if isinstance(zero_mask, slice) else [r for r, keep in zip(records, zero_mask) if keep]
     datasets = sorted({k for r in plot_records for k in r.get("datasets", {})})
     _, (ax1, ax2) = plt.subplots(
-        1, 2, figsize=(16, max(6, len(datasets) * 0.28)), gridspec_kw={"width_ratios": (1, 1.35)}, layout="constrained"
+        1,
+        2,
+        figsize=(16, max(6, len(datasets) * 0.28)),
+        gridspec_kw={"width_ratios": (1, 1.35)},
+        constrained_layout=True,
     )
     iterations = np.arange(1, len(all_fitness) + 1)
     best_idx = int(all_fitness.argmax())
@@ -1315,9 +1319,10 @@ def plot_tune_results(results_file: str = "tune_results.ndjson", exclude_zero_fi
         y = np.arange(len(datasets))
         ax2.hlines(y, initial[order], best[order], color="0.8")
         ax2.scatter(initial[order], y, s=24, color="#dc2626", label="Initial")
-        ax2.scatter(best[order], y, s=24, color="#16a34a", label="Best")
-        ax2.set_yticks(y, labels=np.array(datasets)[order], fontsize=8)
-        ax2.set(title="Per-Dataset Fitness: Initial vs Best", xlabel="Fitness")
+        ax2.scatter(best[order], y, s=24, color="#16a34a", label=f"Best aggregate iteration {best_idx + 1}")
+        ax2.set_yticks(y)
+        ax2.set_yticklabels(np.array(datasets)[order], fontsize=8)
+        ax2.set(title="Per-Dataset Fitness: Initial vs Best Aggregate Iteration", xlabel="Fitness")
         ax2.grid(axis="x", alpha=0.2)
         ax2.legend()
     else:

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -1291,20 +1291,37 @@ def plot_tune_results(results_file: str = "tune_results.ndjson", exclude_zero_fi
             plt.yticks([])
     _save_one_file(results_file.with_name("tune_scatter_plots.png"))
 
-    # Fitness vs iteration
-    x = range(1, len(all_fitness) + 1)
-    plt.figure(figsize=(10, 6), tight_layout=True)
-    for dataset in sorted({k for r in records for k in r.get("datasets", {})}):
-        y = np.array([r.get("datasets", {}).get(dataset, {}).get("fitness", np.nan) for r in records], dtype=float)
-        if exclude_zero_fitness_points and not isinstance(zero_mask, slice):
-            y = y[zero_mask]
-        plt.plot(x, y, "o", markersize=5, alpha=0.8, label=dataset)
-    plt.plot(x, _gaussian_filter1d(all_fitness, sigma=3), ":", color="0.35", label="smoothed mean", linewidth=2)
-    plt.title("Fitness vs Iteration")
-    plt.xlabel("Iteration")
-    plt.ylabel("Fitness")
-    plt.grid(True)
-    plt.legend()
+    # Fitness progress and per-dataset change from the initial to best result
+    plot_records = records if isinstance(zero_mask, slice) else [r for r, keep in zip(records, zero_mask) if keep]
+    datasets = sorted({k for r in plot_records for k in r.get("datasets", {})})
+    _, (ax1, ax2) = plt.subplots(
+        1, 2, figsize=(16, max(6, len(datasets) * 0.28)), gridspec_kw={"width_ratios": (1, 1.35)}, layout="constrained"
+    )
+    iterations = np.arange(1, len(all_fitness) + 1)
+    best_idx = int(all_fitness.argmax())
+    ax1.scatter(iterations, all_fitness, s=28, color="0.45", alpha=0.75, label="Iteration")
+    ax1.plot(iterations, np.maximum.accumulate(all_fitness), color="#2563eb", linewidth=2.5, label="Best so far")
+    ax1.axhline(all_fitness[0], color="#dc2626", linestyle="--", label=f"Initial {all_fitness[0]:.4f}")
+    ax1.scatter(best_idx + 1, all_fitness[best_idx], s=90, color="#16a34a", zorder=5, label="Best")
+    ax1.set(title="Fitness Progress", xlabel="Iteration", ylabel="Fitness")
+    ax1.grid(alpha=0.2)
+    ax1.legend()
+    if datasets:
+        initial = np.array([plot_records[0].get("datasets", {}).get(k, {}).get("fitness", np.nan) for k in datasets])
+        best = np.array(
+            [plot_records[best_idx].get("datasets", {}).get(k, {}).get("fitness", np.nan) for k in datasets]
+        )
+        order = np.argsort(best - initial)
+        y = np.arange(len(datasets))
+        ax2.hlines(y, initial[order], best[order], color="0.8")
+        ax2.scatter(initial[order], y, s=24, color="#dc2626", label="Initial")
+        ax2.scatter(best[order], y, s=24, color="#16a34a", label="Best")
+        ax2.set_yticks(y, labels=np.array(datasets)[order], fontsize=8)
+        ax2.set(title="Per-Dataset Fitness: Initial vs Best", xlabel="Fitness")
+        ax2.grid(axis="x", alpha=0.2)
+        ax2.legend()
+    else:
+        ax2.set_axis_off()
     _save_one_file(results_file.with_name("tune_fitness.png"))
 
 

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -1301,25 +1301,23 @@ def plot_tune_results(results_file: str = "tune_results.ndjson", exclude_zero_fi
         gridspec_kw={"width_ratios": (1, 1.35)},
         constrained_layout=True,
     )
-    iterations = np.arange(1, len(all_fitness) + 1)
+    iterations = np.array([r.get("iteration", i) for i, r in enumerate(plot_records, 1)])
     best_idx = int(all_fitness.argmax())
     ax1.scatter(iterations, all_fitness, s=28, color="0.45", alpha=0.75, label="Iteration")
     ax1.plot(iterations, np.maximum.accumulate(all_fitness), color="#2563eb", linewidth=2.5, label="Best so far")
     ax1.axhline(all_fitness[0], color="#dc2626", linestyle="--", label=f"Initial {all_fitness[0]:.4f}")
-    ax1.scatter(best_idx + 1, all_fitness[best_idx], s=90, color="#16a34a", zorder=5, label="Best")
+    ax1.scatter(iterations[best_idx], all_fitness[best_idx], s=90, color="#16a34a", zorder=5, label="Best")
     ax1.set(title="Fitness Progress", xlabel="Iteration", ylabel="Fitness")
     ax1.grid(alpha=0.2)
     ax1.legend()
     if datasets:
-        initial = np.array([plot_records[0].get("datasets", {}).get(k, {}).get("fitness", np.nan) for k in datasets])
-        best = np.array(
-            [plot_records[best_idx].get("datasets", {}).get(k, {}).get("fitness", np.nan) for k in datasets]
-        )
+        initial = np.array([plot_records[0].get("datasets", {}).get(k, {}).get("fitness", 0.0) for k in datasets])
+        best = np.array([plot_records[best_idx].get("datasets", {}).get(k, {}).get("fitness", 0.0) for k in datasets])
         order = np.argsort(best - initial)
         y = np.arange(len(datasets))
         ax2.hlines(y, initial[order], best[order], color="0.8")
         ax2.scatter(initial[order], y, s=24, color="#dc2626", label="Initial")
-        ax2.scatter(best[order], y, s=24, color="#16a34a", label=f"Best aggregate iteration {best_idx + 1}")
+        ax2.scatter(best[order], y, s=24, color="#16a34a", label=f"Best aggregate iteration {iterations[best_idx]}")
         ax2.set_yticks(y)
         ax2.set_yticklabels(np.array(datasets)[order], fontsize=8)
         ax2.set(title="Per-Dataset Fitness: Initial vs Best Aggregate Iteration", xlabel="Fitness")


### PR DESCRIPTION
## Summary

- replace the crowded per-dataset iteration legend with fitness and cumulative-best progress
- compare initial and best fitness for every dataset in the same existing `tune_fitness.png`
- preserve single-dataset, missing-metric, and legacy no-dataset result rendering

This changes the existing plotting owner and output file in place; it adds no API, helper, or file.

## Validation

- rendered the real 40-iteration, 33-dataset UL33 NDJSON snapshot
- rendered synthetic single-dataset records including a missing dataset fitness
- rendered legacy records without dataset details
- `uvx ruff format ultralytics/utils/plotting.py`
- `uvx ruff check --select RUF059 ultralytics/utils/plotting.py`
- `git diff --check`

No version bump.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated `tune_fitness.png` to show overall fitness progress and a clearer initial-versus-best comparison for each dataset instead of a crowded per-dataset iteration legend.

### 📊 Key Changes

- Replaced the single fitness plot with a two-panel layout:
  - Overall fitness by iteration, including the best-so-far curve, initial fitness line, and best iteration marker.
  - Per-dataset initial and best fitness values connected and sorted by change.
- Applies the existing zero-fitness filtering when selecting records for plotting.
- Uses recorded iteration values when available and labels the best aggregate iteration in the per-dataset panel.
- Preserves rendering for single-dataset data, missing dataset fitness values, and legacy records without dataset details; the dataset panel is hidden when no dataset information exists.
- Keeps the existing `tune_fitness.png` output path and adds no API or helper changes.

### 🎯 Purpose & Impact

The tuning fitness plot now makes aggregate progress and dataset-level changes easier to compare in one image, while retaining support for existing result formats.