### PR TITLE
Add depth dataset license metadata

### DIFF
--- a/docs/en/datasets/classify/mnist.md
+++ b/docs/en/datasets/classify/mnist.md
@@ -6,7 +6,8 @@ creator:
     type: Person
     url: https://engineering.nyu.edu/faculty/yann-lecun
 license:
-    name: None
+    name: CC-BY-SA-3.0
+    url: https://creativecommons.org/licenses/by-sa/3.0/
 description: Train YOLO image classification models on MNIST, a benchmark of 70,000 28x28 grayscale handwritten digit images in 10 classes, split 60k/10k.
 keywords: MNIST, dataset, handwritten digits, image classification, deep learning, machine learning, training set, testing set, NIST
 ---

--- a/docs/en/datasets/depth/arkitscenes.md
+++ b/docs/en/datasets/depth/arkitscenes.md
@@ -1,5 +1,8 @@
 ---
 comments: true
+license:
+    name: Other
+    url: https://github.com/apple/ARKitScenes/blob/main/LICENSE
 description: Explore the ARKitScenes depth dataset for monocular depth estimation. Learn about its structure, usage, pretrained models, and role in YOLO26-Depth training.
 keywords: Ultralytics, YOLO, depth estimation, ARKitScenes, indoor RGB-D, LiDAR, monocular depth, depth dataset
 ---

--- a/docs/en/datasets/depth/depth8.md
+++ b/docs/en/datasets/depth/depth8.md
@@ -1,7 +1,8 @@
 ---
 comments: true
 license:
-    name: None
+    name: CC-BY-4.0
+    url: https://cocodataset.org/#termsofuse
 description: Explore the Ultralytics Depth8 dataset, a compact set of 8 indoor RGB-D images for testing monocular depth estimation models and training pipelines.
 keywords: Depth8, Ultralytics, dataset, depth estimation, monocular depth, YOLO26, training, validation, debugging, SUN RGB-D
 ---

--- a/docs/en/datasets/depth/depth8.md
+++ b/docs/en/datasets/depth/depth8.md
@@ -1,5 +1,7 @@
 ---
 comments: true
+license:
+    name: None
 description: Explore the Ultralytics Depth8 dataset, a compact set of 8 indoor RGB-D images for testing monocular depth estimation models and training pipelines.
 keywords: Depth8, Ultralytics, dataset, depth estimation, monocular depth, YOLO26, training, validation, debugging, SUN RGB-D
 ---

--- a/docs/en/datasets/depth/diode.md
+++ b/docs/en/datasets/depth/diode.md
@@ -1,5 +1,8 @@
 ---
 comments: true
+license:
+    name: MIT
+    url: https://github.com/diode-dataset/diode-devkit/blob/master/LICENSE
 description: Explore the DIODE depth dataset for monocular depth estimation. Learn about its dense indoor/outdoor structure, usage, pretrained models, and role in YOLO26-Depth training.
 keywords: Ultralytics, YOLO, depth estimation, DIODE, dense depth, indoor outdoor, FARO laser scanner, monocular depth, depth dataset
 ---

--- a/docs/en/datasets/depth/eth3d.md
+++ b/docs/en/datasets/depth/eth3d.md
@@ -1,5 +1,8 @@
 ---
 comments: true
+license:
+    name: CC-BY-NC-SA-4.0
+    url: https://creativecommons.org/licenses/by-nc-sa/4.0/
 description: Explore the ETH3D high-resolution benchmark for monocular depth estimation. Learn about its structure, usage, pretrained models, and role as a YOLO26-Depth zero-shot evaluation benchmark.
 keywords: Ultralytics, YOLO, depth estimation, ETH3D, multi-view stereo, laser scanner, monocular depth, indoor outdoor benchmark
 ---

--- a/docs/en/datasets/depth/hypersim.md
+++ b/docs/en/datasets/depth/hypersim.md
@@ -1,5 +1,8 @@
 ---
 comments: true
+license:
+    name: CC-BY-SA-3.0
+    url: https://creativecommons.org/licenses/by-sa/3.0/
 description: Explore the Hypersim depth dataset for monocular depth estimation, a photorealistic synthetic indoor dataset with dense per-pixel ground truth used to train Ultralytics YOLO26-Depth models.
 keywords: Ultralytics, YOLO, depth estimation, Hypersim, synthetic indoor dataset, photorealistic, dense depth, monocular depth
 ---

--- a/docs/en/datasets/depth/ibims-1.md
+++ b/docs/en/datasets/depth/ibims-1.md
@@ -1,5 +1,8 @@
 ---
 comments: true
+license:
+    name: CC-BY-4.0
+    url: https://creativecommons.org/licenses/by/4.0/
 description: Explore the iBims-1 indoor benchmark for monocular depth estimation. Learn about its structure, usage, pretrained models, and role as a YOLO26-Depth zero-shot evaluation benchmark.
 keywords: Ultralytics, YOLO, depth estimation, iBims-1, indoor depth, laser scanner, monocular depth, depth edges, planar surfaces
 ---

--- a/docs/en/datasets/depth/imagenet-pseudo.md
+++ b/docs/en/datasets/depth/imagenet-pseudo.md
@@ -1,5 +1,8 @@
 ---
 comments: true
+license:
+    name: Research-Only
+    url: https://www.image-net.org/download.php
 description: Explore the pseudo-labeled ImageNet depth dataset used for knowledge distillation in YOLO26-Depth. Learn how pseudo depth labels are generated, its role, usage, and pretrained models.
 keywords: ImageNet, pseudo-labeled depth, knowledge distillation, monocular depth estimation, Depth Anything, YOLO26-Depth, depth pretraining, Ultralytics
 ---

--- a/docs/en/datasets/depth/kitti.md
+++ b/docs/en/datasets/depth/kitti.md
@@ -1,5 +1,8 @@
 ---
 comments: true
+license:
+    name: CC-BY-NC-SA-3.0
+    url: https://creativecommons.org/licenses/by-nc-sa/3.0/
 description: Explore the KITTI depth dataset for monocular depth estimation. Learn about its structure, the Eigen evaluation benchmark, usage, and pretrained YOLO26-Depth models.
 keywords: KITTI dataset, depth estimation, monocular depth, autonomous driving, LiDAR depth, Eigen split, YOLO26-Depth, outdoor depth, Ultralytics
 ---

--- a/docs/en/datasets/depth/make3d.md
+++ b/docs/en/datasets/depth/make3d.md
@@ -1,5 +1,8 @@
 ---
 comments: true
+license:
+    name: Other
+    url: http://make3d.cs.cornell.edu/data.html
 description: Explore the Make3D outdoor benchmark for monocular depth estimation. Learn about its structure, usage, pretrained models, and role as a YOLO26-Depth zero-shot generalization benchmark.
 keywords: Ultralytics, YOLO, depth estimation, Make3D, outdoor depth, laser scanner, monocular depth, out-of-distribution benchmark
 ---

--- a/docs/en/datasets/depth/nyu-depth-v2.md
+++ b/docs/en/datasets/depth/nyu-depth-v2.md
@@ -1,5 +1,8 @@
 ---
 comments: true
+license:
+    name: CC-BY-NC-SA-3.0
+    url: https://creativecommons.org/licenses/by-nc-sa/3.0/
 description: Explore the NYU Depth V2 indoor benchmark for monocular depth estimation. Learn about its structure, usage, pretrained models, and role as the primary YOLO26-Depth evaluation benchmark.
 keywords: Ultralytics, YOLO, depth estimation, NYU Depth V2, indoor RGB-D, Kinect, monocular depth, Eigen split, depth benchmark
 ---

--- a/docs/en/datasets/depth/sunrgbd.md
+++ b/docs/en/datasets/depth/sunrgbd.md
@@ -1,5 +1,7 @@
 ---
 comments: true
+license:
+    name: None
 description: Explore the SUN RGB-D depth dataset for monocular depth estimation. Learn about its structure, usage, pretrained models, and role in YOLO26-Depth training.
 keywords: Ultralytics, YOLO, depth estimation, SUN RGB-D, indoor RGB-D, multi-sensor, monocular depth, depth dataset
 ---

--- a/docs/en/datasets/depth/tartanair.md
+++ b/docs/en/datasets/depth/tartanair.md
@@ -1,5 +1,8 @@
 ---
 comments: true
+license:
+    name: CC-BY-4.0
+    url: https://creativecommons.org/licenses/by/4.0/
 description: Explore the TartanAir depth dataset for monocular depth estimation, a large synthetic dataset rendered in AirSim with diverse environments and dense ground truth used to train Ultralytics YOLO26-Depth models.
 keywords: Ultralytics, YOLO, depth estimation, TartanAir, synthetic dataset, AirSim, visual SLAM, dense depth, monocular depth
 ---

--- a/docs/en/datasets/depth/vkitti2.md
+++ b/docs/en/datasets/depth/vkitti2.md
@@ -1,5 +1,8 @@
 ---
 comments: true
+license:
+    name: CC-BY-NC-SA-3.0
+    url: https://creativecommons.org/licenses/by-nc-sa/3.0/
 description: Explore the Virtual KITTI 2 depth dataset for monocular depth estimation, a photorealistic synthetic recreation of KITTI driving scenes with dense per-pixel ground truth used to train Ultralytics YOLO26-Depth models.
 keywords: Ultralytics, YOLO, depth estimation, Virtual KITTI 2, vKITTI2, synthetic driving dataset, dense depth, monocular depth, autonomous driving
 ---

--- a/docs/en/datasets/detect/globalwheat2020.md
+++ b/docs/en/datasets/detect/globalwheat2020.md
@@ -5,7 +5,8 @@ creator:
     name: Global Wheat Dataset Consortium
     url: https://www.global-wheat.com/
 license:
-    name: None
+    name: MIT
+    url: https://api.datacite.org/dois/10.5281/zenodo.4298502
 description: Train YOLO26 on the Global Wheat Head Dataset — 3,422 train, 748 validation, and 1,276 test field images labeled with wheat head boxes for single-class detection.
 keywords: Global Wheat Head Dataset, GWHD, wheat head detection, wheat spike detection, wheat phenotyping, crop management, object detection, YOLO26, agriculture
 ---

--- a/docs/en/datasets/detect/kitti.md
+++ b/docs/en/datasets/detect/kitti.md
@@ -6,6 +6,7 @@ creator:
     url: https://www.cvlibs.net/datasets/kitti/
 license:
     name: CC-BY-NC-SA-3.0
+    url: https://creativecommons.org/licenses/by-nc-sa/3.0/
 description: Ultralytics KITTI is a 2D object detection dataset for autonomous driving with 7,481 annotated images across 8 classes like car, pedestrian, and cyclist.
 keywords: KITTI dataset, autonomous driving, 2D object detection, self-driving cars, YOLO26, computer vision, vehicle detection, pedestrian detection
 ---

--- a/docs/en/datasets/detect/voc.md
+++ b/docs/en/datasets/detect/voc.md
@@ -5,7 +5,8 @@ creator:
     name: PASCAL Visual Object Classes
     url: https://www.robots.ox.ac.uk/~vgg/projects/pascal/VOC/
 license:
-    name: None
+    name: Other
+    url: https://www.robots.ox.ac.uk/~vgg/projects/pascal/VOC/databases.html
 description: Train YOLO26 on the PASCAL VOC detection dataset - 16,551 training and 4,952 validation images across 20 object classes with automatic download.
 keywords: PASCAL VOC, VOC dataset, VOC2007, VOC2012, object detection dataset, YOLO26, download PASCAL VOC, computer vision benchmark
 ---


### PR DESCRIPTION
## Summary

- add license frontmatter to all 13 official depth dataset detail pages that lacked it
- correct existing MNIST, GlobalWheat2020, KITTI, and PASCAL VOC license metadata found by the full audit
- make Depth8 inherit the exact COCO license metadata
- keep docs frontmatter as the existing metadata owner instead of duplicating licenses into dataset YAML files

Verified standardized assignments include DIODE (MIT), ETH3D (CC BY-NC-SA 4.0), Hypersim and MNIST (CC BY-SA 3.0), iBims-1 and TartanAir (CC BY 4.0), GlobalWheat2020 (MIT), ImageNet pseudo-depth (Research-Only), and KITTI, Virtual KITTI 2, and NYU Depth V2 (CC BY-NC-SA 3.0).

ARKitScenes and Make3D retain links to their exact publisher-specific terms. PASCAL VOC is `Other` because its images remain subject to multiple source-specific terms rather than one standard license.

## Audit

- reconciled all 51 dataset YAML files with all 64 dataset detail pages, including docs-only datasets and YAML variants sharing a canonical page
- checked every `None` and `Other` assignment against the original publisher or distributor
- retained `None` only for CIFAR-10/100, SUN RGB-D, African Wildlife, VisDrone, and Package-Seg, where no defensible named license is published
- confirmed COCO, DOTA, ImageNet, Cityscapes, KITTI, and CIFAR parent/derived families have identical license metadata
- confirmed every standardized docs license exists in the companion Platform registry
- verified all 49 dataset license URLs return final HTTP 200

## Validation

- `npx prettier@3.8.5 --tab-width 4 --print-width 120 --check ...`
- `python docs/build_docs.py`: strict docs build passed with no issues
- YAML frontmatter parse across every dataset detail page
- parent/derived license equality audit
- cross-repository Platform enum compatibility audit
- all dataset license URL HTTP-status audit
- `git diff --check`

Companion Platform PR: https://github.com/ultralytics/portal/pull/3797

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated dataset documentation frontmatter to add missing depth-dataset licenses and correct license metadata for MNIST, GlobalWheat2020, KITTI, and PASCAL VOC.

### 📊 Key Changes

- Added license metadata to all 13 official depth dataset pages, including DIODE, ETH3D, Hypersim, iBims-1, TartanAir, and Virtual KITTI 2.
- Assigned `Other` with publisher-specific links for ARKitScenes and Make3D, and `Research-Only` for ImageNet pseudo-depth.
- Corrected existing metadata: MNIST and GlobalWheat2020 now use their documented licenses, KITTI includes its license URL, and PASCAL VOC is marked `Other`.
- Set Depth8 to use the same CC-BY-4.0 metadata and COCO terms URL as its source dataset.
- Kept license information in documentation frontmatter rather than adding duplicate fields to dataset YAML files.

### 🎯 Purpose & Impact

- Dataset detail pages now expose standardized license names and relevant terms links, helping users review usage conditions directly in the documentation.
- No dataset YAML behavior or training workflow changes were introduced.