### PR TITLE
Fix Depth8 licensing and tracker docs

### DIFF
--- a/docs/en/datasets/depth/depth8.md
+++ b/docs/en/datasets/depth/depth8.md
@@ -1,7 +1,7 @@
 ---
 comments: true
 license:
-  name: None
+    name: None
 description: Explore the Ultralytics Depth8 dataset, a compact set of 8 indoor RGB-D images for testing monocular depth estimation models and training pipelines.
 keywords: Depth8, Ultralytics, dataset, depth estimation, monocular depth, YOLO26, training, validation, debugging, SUN RGB-D
 ---

--- a/docs/en/datasets/depth/depth8.md
+++ b/docs/en/datasets/depth/depth8.md
@@ -1,8 +1,7 @@
 ---
 comments: true
 license:
-    name: CC-BY-4.0
-    url: https://cocodataset.org/#termsofuse
+  name: None
 description: Explore the Ultralytics Depth8 dataset, a compact set of 8 indoor RGB-D images for testing monocular depth estimation models and training pipelines.
 keywords: Depth8, Ultralytics, dataset, depth estimation, monocular depth, YOLO26, training, validation, debugging, SUN RGB-D
 ---
@@ -72,7 +71,7 @@ To train a YOLO26n-depth model on the Depth8 dataset with an image size of 640, 
 
 ## Citations and Acknowledgments
 
-Depth8 is sampled from SUN RGB-D — see the full [SUN RGB-D dataset page](sunrgbd.md#citations-and-acknowledgments) for source attribution and citation details. For licensing, see the [COCO Terms of Use](https://cocodataset.org/#termsofuse).
+Depth8 is sampled from SUN RGB-D — see the full [SUN RGB-D dataset page](sunrgbd.md#citations-and-acknowledgments) for source attribution and citation details. The source dataset does not specify a license.
 
 If you use the SUN RGB-D dataset in your research or development work, please cite the following paper:
 

--- a/docs/en/datasets/depth/depth8.md
+++ b/docs/en/datasets/depth/depth8.md
@@ -72,7 +72,7 @@ To train a YOLO26n-depth model on the Depth8 dataset with an image size of 640, 
 
 ## Citations and Acknowledgments
 
-Depth8 is sampled from SUN RGB-D — see the full [SUN RGB-D dataset page](sunrgbd.md#citations-and-acknowledgments) for license details.
+Depth8 is sampled from SUN RGB-D — see the full [SUN RGB-D dataset page](sunrgbd.md#citations-and-acknowledgments) for source attribution and citation details. For licensing, see the [COCO Terms of Use](https://cocodataset.org/#termsofuse).
 
 If you use the SUN RGB-D dataset in your research or development work, please cite the following paper:
 

--- a/docs/en/datasets/track/index.md
+++ b/docs/en/datasets/track/index.md
@@ -9,9 +9,9 @@ title: Multi-Object Tracking Datasets
 
 Multi-object tracking is a critical component in video analytics that identifies objects and maintains unique IDs for each detected object across video frames. Ultralytics YOLO provides powerful tracking capabilities that can be applied to various domains including surveillance, sports analytics, and traffic monitoring.
 
-## Dataset Format (Coming Soon)
+## Dataset Format
 
-Ultralytics tracking currently reuses detection, segmentation, pose, or OBB models without requiring tracker-specific training. Native tracker-training support is under active development.
+Track mode does not train a tracker or require a tracker-specific dataset. Train a detection, segmentation, pose, or OBB model with that task's standard dataset format, then use the resulting weights with `model.track()` or `yolo track`. The selected tracker associates the model's predictions across frames at inference time.
 
 ## Available Trackers
 
@@ -106,10 +106,6 @@ To use Multi-Object Tracking with Ultralytics YOLO, you can start by using the P
 
 These commands load the YOLO26 model and use it for tracking objects in the given video source with specific confidence (`conf`) and [Intersection over Union](https://www.ultralytics.com/glossary/intersection-over-union-iou) (`iou`) thresholds. For more details, refer to the [track mode documentation](../../modes/track.md).
 
-### What are the upcoming features for training trackers in Ultralytics?
-
-Ultralytics is continuously enhancing its AI models. An upcoming feature will enable the training of standalone trackers. Until then, Multi-Object Detector leverages pretrained detection, segmentation, pose, or OBB models for tracking without requiring standalone training. Stay updated by following our [blog](https://www.ultralytics.com/blog).
-
 ### Why should I use Ultralytics YOLO for multi-object tracking?
 
 Ultralytics YOLO is a state-of-the-art [object detection](https://www.ultralytics.com/glossary/object-detection) model known for its real-time performance and high [accuracy](https://www.ultralytics.com/glossary/accuracy). Using YOLO for multi-object tracking provides several advantages:
@@ -123,7 +119,7 @@ For more details on setting up and using YOLO for tracking, visit our [track usa
 
 ### Can I use custom datasets for multi-object tracking with Ultralytics YOLO?
 
-Yes, you can use custom datasets for multi-object tracking with Ultralytics YOLO. While support for standalone tracker training is an upcoming feature, you can already use pretrained models on your custom datasets. Prepare your datasets in the appropriate format compatible with YOLO and follow the documentation to integrate them.
+Yes. Train a detection, segmentation, pose, or OBB model on your custom dataset, then pass its weights to `model.track()`. The tracker itself runs during inference and does not require separate training data.
 
 ### How do I interpret the results from the Ultralytics YOLO tracking model?
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -96,7 +96,7 @@ See the [Quickstart](quickstart.md) guide for the full installation and usage re
 
     ***
 
-    Track objects across video frames with a persistent ID using BoT-SORT or ByteTrack, built into YOLO26's predict pipeline
+    Track objects across video frames with persistent IDs using six built-in trackers, with TrackTrack as the default
 
     ***
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -96,7 +96,7 @@ See the [Quickstart](quickstart.md) guide for the full installation and usage re
 
     ***
 
-    Track objects across video frames with persistent IDs using six built-in trackers, with TrackTrack as the default
+    Track objects with persistent IDs using TrackTrack (default), BoT-SORT, ByteTrack, OC-SORT, Deep OC-SORT, or FastTracker
 
     ***
 

--- a/docs/en/modes/index.md
+++ b/docs/en/modes/index.md
@@ -62,7 +62,7 @@ Export mode is used for converting a YOLO26 model to formats suitable for deploy
 
 ## [Track](track.md)
 
-Track mode extends YOLO26's object detection capabilities to track objects across video frames or live streams. This mode is particularly valuable for applications requiring persistent object identification, such as [surveillance systems](https://www.ultralytics.com/blog/shattering-the-surveillance-status-quo-with-vision-ai) or [self-driving cars](https://www.ultralytics.com/solutions/computer-vision-in-automotive). Track mode implements sophisticated trackers such as TrackTrack (default), BoT-SORT and ByteTrack to maintain object identity across frames, even when objects temporarily disappear from view.
+Track mode extends YOLO26's object detection capabilities to track objects across video frames or live streams. This mode is particularly valuable for applications requiring persistent object identification, such as [surveillance systems](https://www.ultralytics.com/blog/shattering-the-surveillance-status-quo-with-vision-ai) or [self-driving cars](https://www.ultralytics.com/solutions/computer-vision-in-automotive). It includes six trackers: TrackTrack (default), BoT-SORT, ByteTrack, OC-SORT, Deep OC-SORT, and FastTracker.
 
 [Track Examples](track.md){ .md-button }
 

--- a/docs/en/modes/track.md
+++ b/docs/en/modes/track.md
@@ -13,7 +13,7 @@ Object tracking in the realm of video analytics is a critical task that not only
 
 !!! tip "🚀 New Trackers: OC-SORT, Deep OC-SORT, FastTracker, TrackTrack"
 
-    Starting with Ultralytics YOLO v8.4.63, new tracking algorithms are available: [OC-SORT](#oc-sort), [Deep OC-SORT](#deep-oc-sort), [FastTracker](#fasttracker), and [TrackTrack](#tracktrack). These trackers improve multi-object tracking performance and ID consistency.
+    Starting with Ultralytics YOLO v8.4.63, [OC-SORT](#oc-sort), [Deep OC-SORT](#deep-oc-sort), [FastTracker](#fasttracker), and [TrackTrack](#tracktrack) are available alongside BoT-SORT and ByteTrack.
 
 ## Why Choose Ultralytics YOLO for Object Tracking?
 
@@ -109,14 +109,14 @@ To run the tracker on video streams, use a trained Detect, Segment, Pose, or OBB
 
 Ultralytics YOLO ships with six built-in trackers. Enable one by passing its YAML config file to the `tracker` argument.
 
-| Tracker                           | Config file       | Motion model               | Appearance / ReID         | Camera motion compensation | Occlusion handling                              |
-| --------------------------------- | ----------------- | -------------------------- | ------------------------- | -------------------------- | ----------------------------------------------- |
-| **[BoT-SORT](#bot-sort)**         | `botsort.yaml`    | Linear Kalman              | Optional (`with_reid`)    | Yes (sparseOptFlow / ECC)  | Track buffer + ReID rebinding                   |
-| **[ByteTrack](#bytetrack)**       | `bytetrack.yaml`  | Linear Kalman              | None                      | No                         | Two-stage low-conf rescue                       |
-| **[OC-SORT](#oc-sort)**           | `ocsort.yaml`     | Observation-centric Kalman | None                      | No                         | ORU, OCM, OCR re-update from last observation   |
-| **[Deep OC-SORT](#deep-oc-sort)** | `deepocsort.yaml` | Observation-centric Kalman | Optional (`with_reid`)    | Optional (`gmc_method`)    | OC-SORT + adaptive appearance EMA               |
-| **[FastTracker](#fasttracker)**   | `fasttrack.yaml`  | Linear Kalman + rollback   | None                      | No                         | Kalman rollback + bbox enlargement on occlusion |
-| **[TrackTrack](#tracktrack)**     | `tracktrack.yaml` | Linear Kalman (NSA)        | Optional (HMIoU fallback) | Yes (sparseOptFlow / ECC)  | Iterative multi-cue association + TAI           |
+| Tracker                           | Config file       | Motion model               | Appearance / ReID      | Camera motion compensation  | Occlusion handling                              |
+| --------------------------------- | ----------------- | -------------------------- | ---------------------- | --------------------------- | ----------------------------------------------- |
+| **[BoT-SORT](#bot-sort)**         | `botsort.yaml`    | Linear Kalman              | Optional (`with_reid`) | Configurable (`gmc_method`) | Track buffer + ReID rebinding                   |
+| **[ByteTrack](#bytetrack)**       | `bytetrack.yaml`  | Linear Kalman              | None                   | No                          | Two-stage low-conf rescue                       |
+| **[OC-SORT](#oc-sort)**           | `ocsort.yaml`     | Observation-centric Kalman | None                   | No                          | ORU, OCM, OCR re-update from last observation   |
+| **[Deep OC-SORT](#deep-oc-sort)** | `deepocsort.yaml` | Observation-centric Kalman | Optional (`with_reid`) | Configurable (`gmc_method`) | OC-SORT + optional adaptive appearance EMA      |
+| **[FastTracker](#fasttracker)**   | `fasttrack.yaml`  | Linear Kalman + rollback   | None                   | No                          | Kalman rollback + bbox enlargement on occlusion |
+| **[TrackTrack](#tracktrack)**     | `tracktrack.yaml` | Linear Kalman (NSA)        | Optional (`with_reid`) | Configurable (`gmc_method`) | Iterative multi-cue association + TAI           |
 
 ### Which Tracker Should I Use?
 
@@ -125,7 +125,7 @@ Use this flow to pick a starting point; `tracktrack.yaml` is used when you pass 
 1. **Need the fastest, simplest baseline?** → **ByteTrack** (no ReID, no camera-motion compensation, minimum overhead).
 2. **Handheld, drone, or moving-camera footage?** → **BoT-SORT** (adds camera-motion compensation and optional ReID).
 3. **Non-linear motion (sports, dancing, abrupt turns) and no ReID?** → **OC-SORT** (observation-centric corrections without appearance cost).
-4. **Crowded moving-camera scenes where ID swaps are the main problem?** → **Deep OC-SORT** or **TrackTrack** (both add adaptive appearance fusion; TrackTrack also adds multi-cue association and duplicate-ID suppression).
+4. **Crowded moving-camera scenes where ID swaps are the main problem?** → **Deep OC-SORT** or **TrackTrack** (both support optional appearance matching; TrackTrack also adds multi-cue association and duplicate-ID suppression).
 5. **Frequent partial overlap in real-time, no ReID budget?** → **FastTracker** (occlusion-aware ByteTrack variant with Kalman rollback).
 
 ## Switching Trackers
@@ -206,22 +206,22 @@ The following parameters are common to most tracker YAML files; not every parame
 
 !!! warning "Tracker Threshold Information"
 
-    If a detection's confidence score falls below `track_high_thresh`, the tracker will not update that object, resulting in no active tracks.
+    Detections at or above `track_high_thresh` enter the first association stage. Detections between `track_low_thresh` and `track_high_thresh` can recover existing tracks when the selected tracker enables low-confidence association, but they do not start new tracks. Detections at or below `track_low_thresh` are ignored.
 
-| Parameter           | Valid Values or Ranges                                                    | Description                                                                                                                                                                                          |
-| ------------------- | ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `tracker_type`      | `botsort`, `bytetrack`, `ocsort`, `deepocsort`, `fasttrack`, `tracktrack` | Specifies the tracker type.                                                                                                                                                                          |
-| `track_high_thresh` | `0.0-1.0`                                                                 | Threshold for the first association. Affects how confidently a detection is matched to an existing track.                                                                                            |
-| `track_low_thresh`  | `0.0-1.0`                                                                 | Threshold for the second association over low-confidence detections. For OC-SORT and Deep OC-SORT this applies only when `use_byte: True`.                                                           |
-| `new_track_thresh`  | `0.0-1.0`                                                                 | Threshold to initialize a new track if the detection does not match any existing tracks.                                                                                                             |
-| `track_buffer`      | `>=0`                                                                     | Frames lost tracks are kept alive before removal. Higher value means more tolerance for occlusion.                                                                                                   |
-| `match_thresh`      | `0.0-1.0`                                                                 | Threshold for matching tracks. Higher values make matching more lenient.                                                                                                                             |
-| `fuse_score`        | `True`, `False`                                                           | Whether to fuse confidence scores with IoU distances before matching.                                                                                                                                |
-| `gmc_method`        | `sparseOptFlow`, `orb`, `sift`, `ecc`, `none`                             | Global motion compensation method. Helps account for camera movement.                                                                                                                                |
-| `proximity_thresh`  | `0.0-1.0`                                                                 | Minimum IoU required for a valid ReID match. Ensures spatial closeness before using appearance cues.                                                                                                 |
-| `appearance_thresh` | `0.0-1.0`                                                                 | Minimum appearance similarity required for ReID.                                                                                                                                                     |
-| `with_reid`         | `True`, `False`                                                           | Enable appearance-based matching for better tracking across occlusions. Supported by BoT-SORT, Deep OC-SORT, and TrackTrack.                                                                         |
-| `model`             | `auto` or path to an exported file                                        | ReID model. `auto` uses native YOLO backbone features when available; otherwise falls back to `yolo26n-cls.pt`. Pass a `.torchscript`, `.onnx`, `.engine`, `.openvino`, … file for a custom encoder. |
+| Parameter           | Valid Values or Ranges                                                    | Description                                                                                                                                                                                                                                                 |
+| ------------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tracker_type`      | `botsort`, `bytetrack`, `ocsort`, `deepocsort`, `fasttrack`, `tracktrack` | Specifies the tracker type.                                                                                                                                                                                                                                 |
+| `track_high_thresh` | `0.0-1.0`                                                                 | Threshold for the first association. Affects how confidently a detection is matched to an existing track.                                                                                                                                                   |
+| `track_low_thresh`  | `0.0-1.0`                                                                 | Lower bound for low-confidence recovery detections. OC-SORT and Deep OC-SORT use these only when `use_byte: True`; TrackTrack includes them in its penalized association pool.                                                                              |
+| `new_track_thresh`  | `0.0-1.0`                                                                 | Threshold to initialize a new track if the detection does not match any existing tracks.                                                                                                                                                                    |
+| `track_buffer`      | `>=0`                                                                     | Frames lost tracks are kept alive before removal. Higher value means more tolerance for occlusion.                                                                                                                                                          |
+| `match_thresh`      | `0.0-1.0`                                                                 | Threshold for matching tracks. Higher values make matching more lenient.                                                                                                                                                                                    |
+| `fuse_score`        | `True`, `False`                                                           | Whether to fuse confidence scores with IoU distances before matching.                                                                                                                                                                                       |
+| `gmc_method`        | `sparseOptFlow`, `orb`, `sift`, `ecc`, `none`                             | Global motion compensation method. Helps account for camera movement.                                                                                                                                                                                       |
+| `proximity_thresh`  | `0.0-1.0`                                                                 | Minimum IoU required for a valid ReID match. Ensures spatial closeness before using appearance cues.                                                                                                                                                        |
+| `appearance_thresh` | `0.0-1.0`                                                                 | Minimum normalized appearance similarity required for ReID.                                                                                                                                                                                                 |
+| `with_reid`         | `True`, `False`                                                           | Enable appearance-based matching for better tracking across occlusions. Supported by BoT-SORT, Deep OC-SORT, and TrackTrack.                                                                                                                                |
+| `model`             | `auto` or compatible ReID model path                                      | ReID model. `auto` uses native YOLO backbone features when available; otherwise falls back to `yolo26n-cls.pt`. A custom encoder can be a `.pt` checkpoint or an exported model such as `.torchscript`, `.onnx`, `.engine`, or an OpenVINO model directory. |
 
 #### Tracker-specific Arguments
 
@@ -241,7 +241,7 @@ ReID is disabled by default to minimize overhead. Enable it by setting `with_rei
 **ReID model options:**
 
 - **`model: auto`** — Uses native YOLO detector features, adding minimal overhead. Ideal when you need some ReID without a large performance hit. Falls back to `yolo26n-cls.pt` if the detector does not expose compatible features.
-- **Exported ReID model** — Point `model:` at an exported file (`.torchscript`, `.onnx`, `.engine`, `.openvino`, etc.) for more discriminative embeddings at the cost of an extra forward pass per crop. The encoder is loaded via `AutoBackend`, so any export format Ultralytics supports works without code changes.
+- **Custom ReID model** — Point `model:` at a `.pt` checkpoint or a compatible exported embedding model, such as `.torchscript`, `.onnx`, `.engine`, or an OpenVINO model directory. Exported models are loaded through `AutoBackend` and must output an embedding tensor directly.
 
 Ready-to-use ONNX encoders are published for every model size. Set `model:` to one of these names and the file is downloaded automatically the first time the tracker runs (the same way YOLO weights are fetched) — no manual export or download step required:
 
@@ -302,13 +302,13 @@ Expand the sections below for each tracker's design, specific parameters, and tu
 
 **BoT-SORT-specific arguments:**
 
-| Parameter           | Valid Values or Ranges                        | Description                                                                                                              |
-| ------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `gmc_method`        | `sparseOptFlow`, `orb`, `sift`, `ecc`, `none` | Camera-motion-compensation backend. `sparseOptFlow` is the default. `none` disables CMC.                                 |
-| `with_reid`         | `True`, `False`                               | Enable appearance-based matching. Off by default.                                                                        |
-| `model`             | `auto` or path to a ReID model                | ReID model. `auto` uses native YOLO features when available; otherwise pass a `.torchscript` / `.onnx` / `.engine` path. |
-| `proximity_thresh`  | `0.0-1.0`                                     | Minimum IoU before appearance features are considered.                                                                   |
-| `appearance_thresh` | `0.0-1.0`                                     | Minimum cosine similarity required for a ReID match. Raise to reduce identity swaps.                                     |
+| Parameter           | Valid Values or Ranges                        | Description                                                                                                    |
+| ------------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `gmc_method`        | `sparseOptFlow`, `orb`, `sift`, `ecc`, `none` | Camera-motion-compensation backend. `sparseOptFlow` is the default. `none` disables CMC.                       |
+| `with_reid`         | `True`, `False`                               | Enable appearance-based matching. Off by default.                                                              |
+| `model`             | `auto` or compatible ReID model path          | `auto` uses native YOLO features when available; custom models can be `.pt` checkpoints or compatible exports. |
+| `proximity_thresh`  | `0.0-1.0`                                     | Minimum IoU before appearance features are considered.                                                         |
+| `appearance_thresh` | `0.0-1.0`                                     | Minimum normalized appearance similarity required for a ReID match. Raise to make matching stricter.           |
 
 **Tuning tips:**
 
@@ -359,11 +359,13 @@ There is no appearance model and no camera-motion compensation.
 - **Sparse detections:** enable `use_byte: True`.
 - **Long occlusions:** raise `track_buffer` so OCR has more lost tracks to rebind.
 
+With OBB models, OCR uses the Kalman-predicted oriented box because an oriented last-observation history is not retained.
+
 #### Deep OC-SORT
 
 [Deep OC-SORT](https://arxiv.org/abs/2302.11813) augments OC-SORT with appearance information and camera-motion compensation:
 
-- **Adaptive appearance fusion:** detection embeddings are fused into the cost matrix with weight modulated by detection confidence and overlap.
+- **Appearance matching:** cosine embedding distance is gated by overlap and fused with motion cost.
 - **Dynamic appearance EMA:** track embeddings update with an EMA whose smoothing factor adapts to detection confidence.
 - **Camera Motion Compensation:** Kalman states are warped frame-to-frame via sparse optical flow, ORB, or ECC.
 
@@ -371,21 +373,21 @@ There is no appearance model and no camera-motion compensation.
 
 **Deep OC-SORT-specific arguments:**
 
-| Parameter           | Valid Values or Ranges                        | Description                                                                                                              |
-| ------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `with_reid`         | `True`, `False`                               | Enable appearance-based matching. Off by default.                                                                        |
-| `model`             | `auto`, exported ReID model file              | ReID model. `auto` reuses native YOLO features; otherwise pass an exported file (`.torchscript`, `.onnx`, `.engine`, …). |
-| `proximity_thresh`  | `0.0-1.0`                                     | Minimum IoU before appearance features are considered.                                                                   |
-| `appearance_thresh` | `0.0-1.0`                                     | Minimum cosine similarity required for a ReID match.                                                                     |
-| `alpha_fixed_emb`   | `0.0-1.0`                                     | Base EMA factor for track-embedding updates. Higher values preserve the older embedding longer.                          |
-| `gmc_method`        | `sparseOptFlow`, `orb`, `sift`, `ecc`, `none` | Global motion compensation method.                                                                                       |
-| `delta_t`           | `>=1`                                         | Temporal window (frames) for velocity-direction computation in OCM (inherited from OC-SORT).                             |
-| `inertia`           | `0.0-1.0`                                     | Weight of the velocity-consistency cost (inherited from OC-SORT).                                                        |
-| `use_byte`          | `True`, `False`                               | Enable a ByteTrack-style second association over low-confidence detections (inherited from OC-SORT).                     |
+| Parameter           | Valid Values or Ranges                        | Description                                                                                                    |
+| ------------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `with_reid`         | `True`, `False`                               | Enable appearance-based matching. Off by default.                                                              |
+| `model`             | `auto` or compatible ReID model path          | `auto` uses native YOLO features when available; custom models can be `.pt` checkpoints or compatible exports. |
+| `proximity_thresh`  | `0.0-1.0`                                     | Minimum IoU before appearance features are considered.                                                         |
+| `appearance_thresh` | `0.0-1.0`                                     | Minimum normalized appearance similarity required for a ReID match.                                            |
+| `alpha_fixed_emb`   | `0.0-1.0`                                     | Base EMA factor for track-embedding updates. Higher values preserve the older embedding longer.                |
+| `gmc_method`        | `sparseOptFlow`, `orb`, `sift`, `ecc`, `none` | Global motion compensation method.                                                                             |
+| `delta_t`           | `>=1`                                         | Temporal window (frames) for velocity-direction computation in OCM (inherited from OC-SORT).                   |
+| `inertia`           | `0.0-1.0`                                     | Weight of the velocity-consistency cost (inherited from OC-SORT).                                              |
+| `use_byte`          | `True`, `False`                               | Enable a ByteTrack-style second association over low-confidence detections (inherited from OC-SORT).           |
 
 **Tuning tips:**
 
-- **Identity swaps in crowds:** raise `appearance_thresh` (e.g. `0.92-0.95`) and lower `alpha_fixed_emb` so embeddings adapt more slowly.
+- **Identity swaps in crowds:** raise `appearance_thresh` (e.g. `0.92-0.95`) and raise `alpha_fixed_emb` so embeddings adapt more slowly.
 - **Moving camera:** set `gmc_method: sparseOptFlow` (Deep OC-SORT defaults to `none`).
 - **Lower latency:** keep `with_reid: False` (default) for motion + CMC only; enable ReID only when ID swaps dominate errors.
 
@@ -418,34 +420,34 @@ There is no appearance model and no camera-motion compensation.
 - **Frequent partial occlusions:** lower `occ_cover_thresh` (e.g. `0.5-0.6`).
 - **Duplicate IDs around overlap:** lower `init_iou_suppress` (e.g. `0.5`).
 - **Long occlusions:** raise `occ_reappear_window` and `track_buffer` together.
-- **Fast-moving targets:** raise `dampen_motion_occ` (closer to `1.0`) and lower `enlarge_bbox_occ`.
+- **Fast-moving targets:** raise `dampen_motion_occ` (closer to `1.0`); raise `enlarge_bbox_occ` only when a wider search region improves recovery.
 
 #### TrackTrack
 
 [TrackTrack](https://openaccess.thecvf.com/content/CVPR2025/papers/Shim_Focusing_on_Tracks_for_Online_Multi-Object_Tracking_CVPR_2025_paper.pdf) (Shim et al., CVPR 2025) is the default tracker. It reasons from each track's perspective with multi-cue iterative association:
 
-- **Track-Perspective-Based Association (TPA):** combines HMIoU, cosine ReID distance, confidence-projection distance, and corner-angle distance. Assignment is solved iteratively with a relaxing threshold.
+- **Track-Perspective-Based Association (TPA):** combines HMIoU, optional cosine ReID distance, confidence-projection distance, and corner-angle distance. Assignment is solved iteratively with a relaxing threshold.
 - **Track-Aware Initialization (TAI):** suppresses duplicate spawns before a new ID is created.
 
 **Best for:** crowded scenes with frequent occlusion where duplicate IDs are a problem.
 
 **TrackTrack-specific arguments:**
 
-| Parameter        | Valid Values or Ranges                        | Description                                                                         |
-| ---------------- | --------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `iou_weight`     | `0.0-1.0`                                     | Weight of HMIoU distance in the multi-cue cost matrix.                              |
-| `reid_weight`    | `0.0-1.0`                                     | Weight of cosine ReID distance. Falls back to HMIoU if ReID is disabled.            |
-| `conf_weight`    | `0.0-1.0`                                     | Weight of confidence-projection distance.                                           |
-| `angle_weight`   | `0.0-1.0`                                     | Weight of corner-angle distance.                                                    |
-| `penalty_p`      | `0.0-1.0`                                     | Cost penalty for low-confidence detections.                                         |
-| `penalty_q`      | `0.0-1.0`                                     | Cost penalty for detections recovered by secondary NMS.                             |
-| `reduce_step`    | `0.0-1.0`                                     | Match-threshold relaxation per iteration.                                           |
-| `tai_thr`        | `0.0-1.0`                                     | IoU threshold for Track-Aware Initialization NMS.                                   |
-| `min_track_len`  | `>=0`                                         | Minimum history length before a new track is confirmed.                             |
-| `lost_match_thr` | `0.0-1.0`                                     | Looser cost gate for relaxed lost-rebind pass; `0` disables it.                     |
-| `with_reid`      | `True`, `False`                               | Enable cosine-ReID appearance matching (uses native YOLO features). Off by default. |
-| `model`          | `auto`, ReID file                             | ReID model; `auto` uses native YOLO features, otherwise an exported ReID file.      |
-| `gmc_method`     | `sparseOptFlow`, `orb`, `sift`, `ecc`, `none` | Global motion compensation method.                                                  |
+| Parameter        | Valid Values or Ranges                        | Description                                                                                                    |
+| ---------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `iou_weight`     | `0.0-1.0`                                     | Weight of HMIoU distance when ReID is enabled; otherwise HMIoU is used directly.                               |
+| `reid_weight`    | `0.0-1.0`                                     | Weight of cosine ReID distance when ReID is enabled; otherwise it is ignored.                                  |
+| `conf_weight`    | `0.0-1.0`                                     | Weight of confidence-projection distance.                                                                      |
+| `angle_weight`   | `0.0-1.0`                                     | Weight of corner-angle distance.                                                                               |
+| `penalty_p`      | `0.0-1.0`                                     | Cost penalty for low-confidence detections.                                                                    |
+| `penalty_q`      | `0.0-1.0`                                     | Cost penalty for detections recovered by secondary NMS.                                                        |
+| `reduce_step`    | `0.0-1.0`                                     | Match-threshold relaxation per iteration.                                                                      |
+| `tai_thr`        | `0.0-1.0`                                     | IoU threshold for Track-Aware Initialization NMS.                                                              |
+| `min_track_len`  | `>=0`                                         | Minimum history length before a new track is confirmed.                                                        |
+| `lost_match_thr` | `0.0-1.0`                                     | Looser cost gate for relaxed lost-rebind pass; `0` disables it.                                                |
+| `with_reid`      | `True`, `False`                               | Enable cosine-ReID appearance matching (uses native YOLO features). Off by default.                            |
+| `model`          | `auto` or compatible ReID model path          | `auto` uses native YOLO features when available; custom models can be `.pt` checkpoints or compatible exports. |
+| `gmc_method`     | `sparseOptFlow`, `orb`, `sift`, `ecc`, `none` | Global motion compensation method.                                                                             |
 
 **Tuning tips:**
 
@@ -453,6 +455,8 @@ There is no appearance model and no camera-motion compensation.
 - **Fast camera motion:** keep `gmc_method: sparseOptFlow` enabled.
 - **Small/fast objects:** raise `angle_weight` slightly and lower `min_track_len`.
 - **Enable ReID only when needed:** it adds inference cost; for short occlusions, the default multi-cue cost is usually sufficient.
+
+With Segment and Pose models, TrackTrack skips loose-NMS detection recovery so masks and keypoints remain aligned with their detections.
 
 ## Python Examples
 
@@ -623,7 +627,7 @@ Finally, after all threads have completed their task, the windows displaying the
         """Run YOLO tracker in its own thread for concurrent processing.
 
         Args:
-            model_name (str): The YOLO26 model object.
+            model_name (str): Model checkpoint name or path loaded inside the thread.
             filename (str): The path to the video file or the identifier for the webcam/external camera source.
         """
         model = YOLO(model_name)
@@ -714,7 +718,7 @@ To run object tracking on multiple video streams simultaneously, you can use Pyt
         """Run YOLO tracker in its own thread for concurrent processing.
 
         Args:
-            model_name (str): The YOLO26 model object.
+            model_name (str): Model checkpoint name or path loaded inside the thread.
             filename (str): The path to the video file or the identifier for the webcam/external camera source.
         """
         model = YOLO(model_name)

--- a/docs/en/reference/index.md
+++ b/docs/en/reference/index.md
@@ -20,7 +20,7 @@ If you're new to Ultralytics, the [Quickstart](../quickstart.md), [Modes](../mod
 - [`nn`](nn/tasks.md): Neural network building blocks — backbones, necks, heads, layers, and the multi-backend `AutoBackend` runtime (PyTorch, ONNX, TensorRT, CoreML, OpenVINO, LiteRT, and more).
 - [`optim`](optim/muon.md): Custom optimizers, including the Muon optimizer used for advanced training experiments.
 - [`solutions`](solutions/solutions.md): Ready-made [Ultralytics Solutions](../solutions/index.md) — object counting, heatmaps, AI Gym, parking management, region counting, similarity search, and more.
-- [`trackers`](trackers/track.md): Multi-object trackers (`BYTETracker`, `BoTSORT`) and the unified [tracking API](../modes/track.md) that plugs them into any YOLO model.
+- [`trackers`](trackers/track.md): Six multi-object trackers (`BOTSORT`, `BYTETracker`, `OCSORT`, `DeepOCSORT`, `FASTTracker`, and `TRACKTRACK`) and the unified [tracking API](../modes/track.md) that plugs them into compatible YOLO models.
 - [`utils`](utils/__init__.md): Cross-cutting utilities — logging, metrics, plotting, ops, downloads, checks, callbacks, and integrations with [Weights & Biases](../integrations/weights-biases.md), [MLflow](../integrations/mlflow.md), [Comet](../integrations/comet.md), and other tools.
 
 ## How this reference is generated

--- a/ultralytics/cfg/trackers/deepocsort.yaml
+++ b/ultralytics/cfg/trackers/deepocsort.yaml
@@ -20,7 +20,7 @@ use_byte: False # (bool) Enable ByteTrack-style low-confidence second associatio
 # Deep OC-SORT specifics
 gmc_method: none # (str) Global motion compensation: sparseOptFlow|orb|sift|ecc|none; enable for moving-camera scenes
 with_reid: False # (bool) Enable ReID model use; needs extra model and compute
-model: auto # (str) ReID model name/path; "auto" uses detector features when available. Otherwise an exported file (.torchscript / .onnx / .engine / …) or a `.pt` checkpoint.
+model: auto # (str) ReID model path; "auto" uses detector features, or use a .pt checkpoint or exported embedding model
 proximity_thresh: 0.5 # (float) Min IoU to consider tracks proximate for ReID; higher is stricter
 appearance_thresh: 0.9 # (float) Min appearance similarity for ReID; raise to avoid identity swaps
 alpha_fixed_emb: 0.95 # (float) Base EMA factor for track embedding updates; higher = slower update

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -565,14 +565,14 @@ class Model(torch.nn.Module):
             ...     print(r.boxes.id)  # print tracking IDs
 
         Notes:
-            - This method sets a default confidence threshold of 0.1 for ByteTrack-based tracking.
+            - This method sets a default confidence threshold of 0.1 so trackers receive low-confidence detections.
             - The tracking mode is explicitly set in the keyword arguments.
             - Batch size is set to 1 for tracking in videos.
         """
         from ultralytics.trackers import register_tracker
 
         register_tracker(self, persist)
-        kwargs["conf"] = kwargs.get("conf") or 0.1  # ByteTrack-based method needs low confidence predictions as input
+        kwargs["conf"] = kwargs.get("conf") or 0.1  # trackers need low-confidence predictions as input
         kwargs["batch"] = kwargs.get("batch") or 1  # batch-size 1 for tracking in videos
         kwargs["mode"] = "track"
         return self.predict(source=source, stream=stream, **kwargs)

--- a/ultralytics/trackers/README.md
+++ b/ultralytics/trackers/README.md
@@ -17,7 +17,7 @@ Ultralytics YOLO trackers provide output consistent with standard [object detect
 
 **Watch:** Object Detection and Tracking with Ultralytics YOLO26.
 
-[![Watch the video](https://user-images.githubusercontent.com/26833433/244171528-66a4a68d-cb85-466a-984a-34301616b7a3.png)](https://www.youtube.com/watch?v=hHyHmOtmEgs)
+[![Watch the video](https://img.youtube.com/vi/hHyHmOtmEgs/maxresdefault.jpg)](https://www.youtube.com/watch?v=hHyHmOtmEgs)
 
 ## ✨ Features at a Glance
 
@@ -38,7 +38,7 @@ Ultralytics YOLO supports the following tracking algorithms. Enable them by pass
 - **FastTracker:** Use [`fasttrack.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/trackers/fasttrack.yaml) to enable this tracker. Based on the [FastTracker paper](https://arxiv.org/abs/2508.14370): occlusion-aware ByteTrack variant with Kalman rollback and init-IoU suppression.
 - **TrackTrack:** Use [`tracktrack.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/trackers/tracktrack.yaml) to enable this tracker. Based on the [TrackTrack paper](https://openaccess.thecvf.com/content/CVPR2025/papers/Shim_Focusing_on_Tracks_for_Online_Multi-Object_Tracking_CVPR_2025_paper.pdf) (CVPR 2025) — multi-cue iterative association with Track-Aware Initialization.
 
-The default tracker is **BoT-SORT**.
+The default tracker is **TrackTrack**.
 
 ## ⚙️ Usage
 
@@ -119,7 +119,7 @@ For a comprehensive list of tracking arguments, consult the [Tracking Configurat
 
 ### Persisting Tracks Loop
 
-This Python script uses [OpenCV (`cv2`)](https://opencv.org/) and Ultralytics YOLO26 to perform object tracking on video frames. Ensure you have installed the necessary packages (`opencv-python` and `ultralytics`). The [`persist=True`](https://docs.ultralytics.com/modes/predict#tracking) argument indicates that the current frame is the next in a sequence, allowing the tracker to maintain track continuity from the previous frame.
+This Python script uses [OpenCV (`cv2`)](https://github.com/opencv/opencv) and Ultralytics YOLO26 to perform object tracking on video frames. Ensure you have installed the necessary packages (`opencv-python` and `ultralytics`). The [`persist=True`](https://docs.ultralytics.com/modes/track#persisting-tracks-loop) argument indicates that the current frame is the next in a sequence, allowing the tracker to maintain track continuity from the previous frame.
 
 ```python
 # Python

--- a/ultralytics/trackers/utils/reid.py
+++ b/ultralytics/trackers/utils/reid.py
@@ -4,8 +4,8 @@
 * `.pt` YOLO checkpoints — loaded via `YOLO()`; embeddings are pulled from the second-to-last
 layer through the predictor's `embed=[...]` argument (works with classification and ReID
 backbones).
-* Any other extension (`.torchscript`, `.onnx`, `.engine`, `.openvino`, …) — loaded via
-`AutoBackend`; the model is expected to output the embedding tensor directly.
+* Compatible exported models (`.torchscript`, `.onnx`, `.engine`, OpenVINO model directories, …) —
+loaded via `AutoBackend`; the model is expected to output the embedding tensor directly.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

- align Depth8 license metadata with its SUN RGB-D source, which does not specify a license
- align the tracking guide, docs home and indexes, package README, and generated-reference wording with all six registered trackers and the TrackTrack default
- correct threshold, ReID, tuning, and task-specific behavior, and remove speculative standalone-tracker training copy
- replace stale tracker documentation links

## Validation

- `python3 docs/build_docs.py` (strict Zensical build)
- `pytest tests/test_python.py -k 'track' -v` (16 passed)
- `ruff check ultralytics/engine/model.py ultralytics/trackers/utils/reid.py`
- verified all 6 tracker registry entries match their YAML files and all 79 configuration entries appear in the tracking guide
- verified all 76 external URLs referenced by the audited tracker documentation return HTTP 200

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated Depth8 licensing metadata and aligned tracking documentation, defaults, configuration descriptions, ReID guidance, and tracker references with the six registered trackers and TrackTrack as the default.

### 📊 Key Changes
- Marked Depth8's license as unspecified and changed its acknowledgment text to reference source attribution and citation details.
- Documented all six built-in trackers—TrackTrack, BoT-SORT, ByteTrack, OC-SORT, Deep OC-SORT, and FastTracker—with TrackTrack identified as the default across the documentation and package README.
- Corrected tracking guidance for low-confidence thresholds, ReID model formats and similarity behavior, tracker-specific tuning, OBB handling in OC-SORT, and Segment/Pose handling in TrackTrack.
- Replaced the tracking dataset section with the implemented workflow: train the task model using its standard dataset format, then run the tracker during inference; removed speculative standalone-tracker training text.
- Updated generated-reference wording and stale tracker documentation links, including the README video thumbnail, OpenCV link, and tracking persistence link.

### 🎯 Purpose & Impact
- Users now see the actual TrackTrack default, the complete tracker registry, and more precise instructions for configuring thresholds, ReID, tuning, and task-specific tracking workflows.