### PR TITLE
Apply YOLOE class updates when only the order changes

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1953,6 +1953,8 @@ def test_yoloe(tmp_path):
     # text-prompts
     model = YOLO(WEIGHTS_DIR / "yoloe-11s-seg.pt")
     model.set_classes(["person", "bus"])
+    model.set_classes(["bus", "person"])
+    assert list(model.names.values()) == ["bus", "person"]
     model(SOURCE, conf=0.01)
 
     from ultralytics import YOLOE

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -343,8 +343,8 @@ class YOLOE(Model):
         # Verify no background class is present
         assert " " not in classes
         assert isinstance(self.model, YOLOEModel)
-        names = self.model.names.values() if isinstance(self.model.names, dict) else self.model.names
-        if embeddings is not None or sorted(names) != sorted(classes):
+        names = list(self.model.names.values()) if isinstance(self.model.names, dict) else list(self.model.names)
+        if embeddings is not None or names != classes:
             if embeddings is None:
                 embeddings = self.get_text_pe(classes)  # generate text embeddings if not provided
             self.model.set_classes(classes, embeddings)


### PR DESCRIPTION
## Description

Fixes #25955.

`YOLOE.set_classes()` compared sorted class names, causing a request that only reordered existing classes to be treated as unchanged. The model therefore retained the previous class IDs and prompt-embedding order.

This change compares class names in their requested order. Identical ordered lists retain the existing no-op optimization, while reordered lists regenerate embeddings and update model names.

## Validation

- `py -3.13 -m ruff check ultralytics/models/yolo/model.py tests/test_python.py`
- `py -3.13 -m ruff format --check ultralytics/models/yolo/model.py tests/test_python.py`
- `git diff --check`
- Lightweight YAML-backed YOLOE runtime check passed with two reordered `set_classes()` calls and two embedding-generation calls.

The focused `py -3.13 -m pytest tests/test_python.py::test_yoloe -q` target was attempted in an isolated CPU environment but was interrupted after the MobileCLIP HTTPS download stalled, before any test executed. This target includes downloads, validation, and training operations, so the full suite remains for CI.

AI assistance disclosure: AI-assisted development tools were used during investigation and implementation. The reported tests were run against the final diff.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
YOLOE now detects class-name reordering in the requested order, regenerating prompt embeddings and updating model names when the order changes.

### 📊 Key Changes
- Converts existing model names to lists before comparing them with the requested `classes` order.
- Preserves the no-op path only when the ordered class lists are identical.
- Adds a YOLOE test that reorders `person` and `bus` and verifies the updated model names.

### 🎯 Purpose & Impact
Reordering classes with `YOLOE.set_classes()` now updates class IDs and prompt-embedding order instead of retaining the previous ordering.