### PR TITLE
Fit the TQDM bar on zero-width and notebook terminals

### DIFF
--- a/ultralytics/utils/tqdm.py
+++ b/ultralytics/utils/tqdm.py
@@ -209,7 +209,7 @@ class TQDM:
     @staticmethod
     def _fit(text: str, width: int) -> str:
         """Truncate text to width display cells, skipping zero-width ANSI codes and counting CJK chars as 2."""
-        cells = i = 0
+        cells = i = cut = 0
         while i < len(text):
             if text[i] == "\033":  # ANSI escape sequence: zero width, runs through its letter terminator
                 while i < len(text) and not text[i].isalpha():
@@ -217,7 +217,9 @@ class TQDM:
             else:
                 cells += 2 if unicodedata.east_asian_width(text[i]) in "WF" else 1
                 if cells > width:
-                    return f"{text[:i]}\033[0m"  # reset so a truncated color does not bleed
+                    return f"{text[:cut]}…\033[0m"  # reset so a truncated color does not bleed
+                if cells < width:
+                    cut = i + 1  # last cut that still leaves a cell for the ellipsis
             i += 1
         return text
 
@@ -297,9 +299,10 @@ class TQDM:
             progress_str = f"{self.desc}: {fields}"
             if self.file.isatty():  # description yields its cells first so the progress fields survive
                 try:  # measure self.file's own terminal, not sys.__stdout__
-                    width = os.get_terminal_size(self.file.fileno()).columns - 1
+                    width = os.get_terminal_size(self.file.fileno()).columns
                 except Exception:  # streams without a usable fileno (io.StringIO, wrapped stdout)
-                    width = shutil.get_terminal_size().columns - 1  # COLUMNS env, else sys.__stdout__
+                    width = shutil.get_terminal_size().columns  # COLUMNS env, else sys.__stdout__
+                width = (width or 80) - 1  # a pty opened without a winsize reports 0 columns
                 progress_str = self._fit(f"{self._fit(self.desc, width - len(fields) - 2)}: {fields}", width)
             # Non-interactive environments avoid the carriage return which creates empty lines
             frame = progress_str if self.noninteractive else f"\r\033[K{progress_str}"

--- a/ultralytics/utils/tqdm.py
+++ b/ultralytics/utils/tqdm.py
@@ -302,8 +302,9 @@ class TQDM:
                     width = os.get_terminal_size(self.file.fileno()).columns
                 except Exception:  # streams without a usable fileno (io.StringIO, wrapped stdout)
                     width = shutil.get_terminal_size().columns  # COLUMNS env, else sys.__stdout__
-                width = (width or 80) - 1  # a pty opened without a winsize reports 0 columns
-                progress_str = self._fit(f"{self._fit(self.desc, width - len(fields) - 2)}: {fields}", width)
+                if width:  # a pty opened without a winsize reports 0 columns, so there is no width to fit to
+                    width -= 1
+                    progress_str = self._fit(f"{self._fit(self.desc, width - len(fields) - 2)}: {fields}", width)
             # Non-interactive environments avoid the carriage return which creates empty lines
             frame = progress_str if self.noninteractive else f"\r\033[K{progress_str}"
             if progress := getattr(self.file, "progress", None):

--- a/ultralytics/utils/tqdm.py
+++ b/ultralytics/utils/tqdm.py
@@ -297,7 +297,7 @@ class TQDM:
         # Write to output, fitting real terminals only so redirected logs keep full lines
         try:
             progress_str = f"{self.desc}: {fields}"
-            if self.file.isatty():  # description yields its cells first so the progress fields survive
+            if self.file.isatty() and "JPY_PARENT_PID" not in os.environ:  # a notebook pane scrolls, never fit it
                 try:  # measure self.file's own terminal, not sys.__stdout__
                     width = os.get_terminal_size(self.file.fileno()).columns - 1
                 except Exception:  # streams without a usable fileno (io.StringIO, wrapped stdout)

--- a/ultralytics/utils/tqdm.py
+++ b/ultralytics/utils/tqdm.py
@@ -299,11 +299,10 @@ class TQDM:
             progress_str = f"{self.desc}: {fields}"
             if self.file.isatty():  # description yields its cells first so the progress fields survive
                 try:  # measure self.file's own terminal, not sys.__stdout__
-                    width = os.get_terminal_size(self.file.fileno()).columns
+                    width = os.get_terminal_size(self.file.fileno()).columns - 1
                 except Exception:  # streams without a usable fileno (io.StringIO, wrapped stdout)
-                    width = shutil.get_terminal_size().columns  # COLUMNS env, else sys.__stdout__
-                if width:  # a pty opened without a winsize reports 0 columns, so there is no width to fit to
-                    width -= 1
+                    width = shutil.get_terminal_size().columns - 1  # COLUMNS env, else sys.__stdout__
+                if width > 0:  # a pty opened without a winsize reports 0 columns, so there is no width to fit to
                     progress_str = self._fit(f"{self._fit(self.desc, width - len(fields) - 2)}: {fields}", width)
             # Non-interactive environments avoid the carriage return which creates empty lines
             frame = progress_str if self.noninteractive else f"\r\033[K{progress_str}"


### PR DESCRIPTION
Fixes https://github.com/ultralytics/ultralytics/issues/25952.

Notebooks run `!yolo ...` through a pseudo terminal, and the reported width of that pty does not describe the surface the output lands on. Colab never sets a window size, so `os.get_terminal_size()` returns **0 columns**, `TQDM._display` passed `-1` to `_fit`, and every frame was truncated to nothing. Training printed the epoch header and then blank lines. IPython reports a placeholder **80 columns** instead, which cut long training lines even though the notebook pane scrolls horizontally.

Three changes:

1. Skip fitting when `JPY_PARENT_PID` is set. The kernel launcher sets it and shell magics inherit it, so it marks output that lands in a scrolling notebook pane. JupyterLab terminals do not go through the launcher and keep their fitting.
2. Fit only when the terminal reports a width above 0. A width of 0 means unknown, not zero.
3. Mark truncated text with `…`. `_fit` now cuts one cell earlier so the ellipsis fits inside the requested width.

Progress frame by environment, before and after:

| Environment | Reported columns | Before | After |
| --- | --- | --- | --- |
| Colab `!yolo` | 0 | `\x1b[0m\x1b[0m` | `1/100 3.21G 1.234 ... 640: 33% ━━━━──────── 1/3 22.7Kit/s 0.0s<0.0s` |
| Jupyter `!yolo` | 80 | `1/100 3.21G 1.234 0.567 0.891 1.045 0\x1b[0m: 33% ━━━━──────── 1/3 15.3Kit/s 0.0s<0.0s` | `1/100 3.21G 1.234 0.567 0.891 1.045 0.332 128 640 extra padding to exceed eighty cells: 33% ━━━━──────── 1/3 22.7Kit/s 0.0s<0.0s` |
| Terminal, 60 columns | 60 | `Very long epoch d\x1b[0m: 33% ━━━━──────── 1/3 5.6Kit/s 0.0s<0.0s` | `Very long epoch d…\x1b[0m: 33% ━━━━──────── 1/3 5.6Kit/s 0.0s<0.0s` |
| Terminal, 120 columns | 120 | `Very long epoch description here: 33% ━━━━──────── 1/3 6.3Kit/s 0.0s<0.0s` | `Very long epoch description here: 33% ━━━━──────── 1/3 6.3Kit/s 0.0s<0.0s` |

The Jupyter rows come from a live `ipykernel` 7.3.0 kernel driven by `jupyter_client`. The others come from a local pty with the window size set or left unset.

Width checks for `_fit`, counting display cells and ignoring ANSI codes:

| Text | Width | Result | Cells |
| --- | --- | --- | --- |
| `abcdef` | 5 | `abcd…` | 5 |
| `abcde` | 5 | `abcde` | 5 |
| `abcd` | 5 | `abcd` | 4 |
| `日本語テスト` | 5 | `日本…` | 5 |
| `\x1b[31mredtext\x1b[0m` | 4 | `\x1b[31mred…` | 4 |
| `a日b` | 2 | `a…` | 2 |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated `TQDM` output fitting to handle zero-width terminals and notebook panes correctly, while marking terminal truncation with an ellipsis.

### 📊 Key Changes
- Skips terminal-width fitting when `JPY_PARENT_PID` is set, preserving full progress lines in notebook output panes.
- Applies fitting only when the detected terminal width is greater than zero, avoiding empty progress frames from zero-width pseudo-terminals.
- Updates `_fit` to reserve space for `…` when truncating text, while continuing to account for ANSI escape sequences and wide characters.

### 🎯 Purpose & Impact
- Colab-style `!yolo` output no longer gets reduced to blank progress lines when the pseudo-terminal reports zero columns.
- Notebook output using an 80-column placeholder is no longer truncated, allowing the pane to scroll horizontally.
- Regular terminals still fit progress output to their available width, with truncated descriptions visibly ending in `…`.