### PR TITLE
Recommend deterministic=False for RT-DETR training

### DIFF
--- a/docs/en/models/rtdetr.md
+++ b/docs/en/models/rtdetr.md
@@ -79,7 +79,7 @@ This example provides simple RT-DETR training and inference examples. For full d
 
 !!! tip "Deterministic Training"
 
-    Set `deterministic=False` when training RT-DETR on CUDA. Its deformable attention uses `F.grid_sample`, which has no deterministic CUDA backward, so `deterministic=True` cannot make the run reproducible yet still costs around 25% of training throughput. `seed` still controls weight initialization, data order, and augmentation sampling.
+    Set `deterministic=False` when training RT-DETR on CUDA with PyTorch 2.0 or later. Its deformable attention uses `F.grid_sample`, which has no deterministic CUDA backward, so `deterministic=True` cannot make the run reproducible and can reduce training throughput. `seed` still controls weight initialization, data order, and augmentation sampling.
 
 !!! tip "Faster Inference Trade-Offs"
 

--- a/docs/en/models/rtdetr.md
+++ b/docs/en/models/rtdetr.md
@@ -77,6 +77,10 @@ This example provides simple RT-DETR training and inference examples. For full d
         yolo predict model=rtdetr-l.pt source=path/to/bus.jpg
         ```
 
+!!! tip "Deterministic Training"
+
+    Set `deterministic=False` when training RT-DETR. The `F.grid_sample` call in its deformable attention has no deterministic CUDA backward, so `deterministic=True` cannot make a run reproducible yet still costs around 25% of training throughput.
+
 !!! tip "Faster Inference Trade-Offs"
 
     RT-DETR pretrained weights support two inference-time settings to reduce latency without retraining:

--- a/docs/en/models/rtdetr.md
+++ b/docs/en/models/rtdetr.md
@@ -79,7 +79,7 @@ This example provides simple RT-DETR training and inference examples. For full d
 
 !!! tip "Deterministic Training"
 
-    Set `deterministic=False` when training RT-DETR. The `F.grid_sample` call in its deformable attention has no deterministic CUDA backward, so `deterministic=True` cannot make a run reproducible yet still costs around 25% of training throughput.
+    Set `deterministic=False` when training RT-DETR on CUDA. Its deformable attention uses `F.grid_sample`, which has no deterministic CUDA backward, so `deterministic=True` cannot make the run reproducible yet still costs around 25% of training throughput. `seed` still controls weight initialization, data order, and augmentation sampling.
 
 !!! tip "Faster Inference Trade-Offs"
 


### PR DESCRIPTION
F.grid_sample has no deterministic CUDA backward, so deterministic=True costs speed without making runs reproducible.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

RT-DETR cannot train deterministically on CUDA, but `default.yaml` ships `deterministic: True`, so every RT-DETR training pays the cost of deterministic algorithms while still producing non-reproducible results. This adds a tip next to the training example on the RT-DETR page recommending `deterministic=False`.

```python
from ultralytics import RTDETR

RTDETR("rtdetr-l.pt").train(data="coco8.yaml", epochs=100, imgsz=640, deterministic=False)
```

### Why RT-DETR cannot be deterministic

`RTDETRDecoder` uses `MSDeformAttn`, which calls `F.grid_sample`. Under `torch.use_deterministic_algorithms(True, warn_only=True)` (what `init_seeds` sets) PyTorch reports:

```
UserWarning: grid_sampler_2d_backward_cuda does not have a deterministic implementation,
but you set 'torch.use_deterministic_algorithms(True, warn_only=True)'.
```

Because `warn_only=True`, the run does not fail — it silently continues with a non-deterministic gradient. Two consequences make this unrecoverable rather than a minor rounding concern:

- `grid_sample` sits in the **decoder**, so its gradient flows back through the encoder and the entire backbone. Every parameter is downstream of the non-deterministic kernel.
- `RTDETRDetectionLoss` uses Hungarian bipartite matching, a **discrete** argmin. A 1-ULP gradient difference flips a query-to-target assignment, so divergence is amplified discontinuously rather than staying at rounding scale.

Only the CUDA backward is affected; the CPU backward is deterministic, and forward-only paths (`val`, `predict`, `export`) are unaffected.

### Measured: determinism is not achieved

`rtdetr-l`, fp32 (no AMP), identical seed, identical batch, 5 SGD steps, `deterministic=True`, same GPU. SHA-256 over the full `state_dict`:

| run | weights sha256 | loss @ 5 steps |
| --- | --- | --- |
| rtdetr-l #1 | `35bb7c6fd0e28d24…` | 62.3840179443 |
| rtdetr-l #2 | `4ae8a13ac67428ec…` | 63.0046463013 |
| rtdetr-l #3 | `dd7317231a4d2576…` | 62.4183883667 |
| rtdetr-l #4 | `bd37c9367734d4db…` | 62.1620864868 |
| rtdetr-l #5 | `bca2a03a030c64e2…` | 61.8274497986 |
| yolo11n #1-3 (control) | `f52df496687d852b…` x3 | 46.3437728882 x3 |

5/5 unique for RT-DETR; the YOLO11n control is bitwise identical across 3 separate processes, confirming the harness itself is sound.

### Measured: partial determinism does not reduce divergence

`deterministic=True` still makes every other op deterministic, so does it at least shrink the divergence? No. 12 runs per setting, 66 pairwise weight comparisons each:

| metric | `deterministic=True` | `deterministic=False` |
| --- | --- | --- |
| final-loss sd | 0.364 | 0.456 |
| final-loss range | 1.413 | **1.382** |
| mean pairwise max abs weight delta | 2.998e-01 | 3.075e-01 |
| mean pairwise relative L2 | 3.693e-02 | 3.780e-02 |
| parameters differing between runs | **99.79%** | **99.79%** |

The weight-space metrics are indistinguishable and the loss range is marginally *worse* with `deterministic=True`. F-test on the loss variances: `F = 1.564`, df = (11, 11), two-sided **p = 0.47**.

At n=5 this looked like a real effect (loss range 0.474 vs 1.030, a 2.2x gap) and it inverted once n reached 12 — the signature of a small-sample draw, not an effect.

### Measured: the cost

`rtdetr-l`, bs=8, imgsz=640, AMP, RTX PRO 6000 Blackwell, torch 2.11.0+cu128. Median ms/iter over 25 timed iterations after 8 warmup, 3 alternating A/B rounds:

| round | `deterministic=True` | `deterministic=False` |
| --- | --- | --- |
| 1 | 146.9 ms | 120.7 ms |
| 2 | 160.3 ms | 117.7 ms |
| 3 | 161.1 ms | 120.2 ms |

Roughly **1.3x slower**, about 25% of training throughput. Decomposing which of the three settings `init_seeds` applies is responsible (min ms/iter, least-contended sample):

| setting | min ms/iter | cost |
| --- | --- | --- |
| none | 94-95 | baseline |
| `cudnn.deterministic = True` | 94-97 | free |
| `CUBLAS_WORKSPACE_CONFIG=:4096:8` | 98-103 | ~6% |
| `use_deterministic_algorithms(True, warn_only=True)` | 111 | ~17% |
| all three | 116-122 | ~25% |

The dominant cost is `use_deterministic_algorithms`, which forces deterministic gather/scatter/`index_put` kernels — heavily used by RT-DETR's decoder, denoising groups, and matcher. It is also the setting whose entire purpose `grid_sample` defeats.

### Scope

Documentation only, no behavior change. `RTDETRTrainer` still honors `deterministic` as passed; users opt into the speed themselves.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the RT-DETR documentation to recommend `deterministic=False` for CUDA training because `F.grid_sample` prevents deterministic backward execution while deterministic settings reduce throughput.

### 📊 Key Changes
- Added a **Deterministic Training** tip to `docs/en/models/rtdetr.md`.
- Documents using `deterministic=False` with RT-DETR training on CUDA and PyTorch 2.0 or later.
- Explains that deformable attention uses `F.grid_sample`, which lacks a deterministic CUDA backward implementation.
- Notes that `deterministic=True` may reduce training throughput without making CUDA training reproducible.
- Clarifies that `seed` still controls weight initialization, data order, and augmentation sampling.

### 🎯 Purpose & Impact
- RT-DETR users are guided to opt out of deterministic algorithms during CUDA training to avoid unnecessary performance costs.
- No user-facing code behavior change; `RTDETRTrainer` continues to honor the `deterministic` argument provided by the user.