### PR TITLE
Fix classification fraction sampling

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1802,6 +1802,22 @@ def test_nn_depth_head_no_dead_parameters():
     assert not unused, f"parameters with no gradient: {unused}"
 
 
+def test_classification_fraction_samples_across_classes(tmp_path):
+    """Sample classification fractions across the class-major ImageFolder ordering."""
+    from ultralytics.data.dataset import ClassificationDataset
+
+    for class_index in range(3):
+        class_dir = tmp_path / str(class_index)
+        class_dir.mkdir()
+        for image_index in range(4):
+            cv2.imwrite(str(class_dir / f"{image_index}.jpg"), np.full((16, 16, 3), class_index, dtype=np.uint8))
+    args = copy(DEFAULT_CFG)
+    args.fraction = 0.5
+    samples = ClassificationDataset(tmp_path, args, augment=True).samples
+
+    assert np.bincount([sample[1] for sample in samples]).tolist() == [2, 2, 2]
+
+
 @pytest.fixture
 def image():
     """Load and return an image from a predefined source (OpenCV BGR)."""

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -1177,7 +1177,11 @@ class ClassificationDataset:
         # Initialize attributes
         fraction = 1.0 if is_ndjson else get_split_fraction(args.fraction, prefix or ("train" if augment else "val"))
         count = fraction if isinstance(fraction, int) else round(len(self.samples) * fraction)
-        self.samples = self.samples[:count] if count < len(self.samples) else self.samples
+        self.samples = (
+            [self.samples[i] for i in np.linspace(0, len(self.samples) - 1, count, dtype=int)]
+            if count < len(self.samples)
+            else self.samples
+        )
         self.prefix = colorstr(f"{prefix}: ") if prefix else ""
         self.cache_ram = args.cache is True or str(args.cache).lower() == "ram"  # cache images into RAM
         self.cache_disk = str(args.cache).lower() == "disk"  # cache images on hard drive as uncompressed *.npy files


### PR DESCRIPTION
NDJSON dataset fractions already select evenly spaced records, but local classification datasets take a prefix from `torchvision.datasets.ImageFolder.samples`. Since that list is ordered by class, `fraction=0.1` on ImageNette keeps 947 images from class 0 and none from the other nine classes.

This changes the local classification path to use the same deterministic `np.linspace` selection already used by the NDJSON converter, so it keeps the requested sample count and gives an approximately proportional subset. There is no balancing sampler, no new argument, no second code path. A very small class can still disappear when its expected proportional count is below one.

## Measured

On ImageNette160, the selected train distribution changes from:

```text
main:  [947, 0, 0, 0, 0, 0, 0, 0, 0, 0]
patch: [97, 95, 99, 86, 94, 96, 96, 93, 95, 96]
```

The supported list form also applies this to validation. With `fraction=[0.1, 0.1]`, main selects `[387, 5, 0, 0, 0, 0, 0, 0, 0, 0]`, while the patch selects `[39, 39, 36, 38, 41, 39, 39, 42, 40, 39]`. A scalar fraction still leaves validation at its full size.

I also ran YOLO11n-cls pretrained for two epochs at `imgsz=160`, `batch=128`, using seeds 0, 1, and 2. Validation used the complete 3,925-image split:

| selection | top-1 median | range |
|---|---:|---:|
| main prefix | 9.89% | 9.89–10.14% |
| spaced subset | 87.64% | 87.36–88.82% |

## Validation

- The focused regression test fails on main with `[4, 2]` instead of `[2, 2, 2]`, then passes with this change.
- `test_classification_fraction_samples_across_classes` and the existing NDJSON classification case pass together: 2 passed.
- Full train and validation selections keep their current counts and distributions.
- The official Ultralytics formatting check and `git diff --check` pass.

So the change stays limited to local classification sampling. Detection keeps its existing filename-prefix behaviour, and NDJSON remains pre-sampled by its converter.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Classification dataset fraction sampling now selects evenly spaced records instead of taking a class-ordered prefix, preserving representative samples across classes.

### 📊 Key Changes
- Replaced prefix slicing in `ClassificationDataset` with deterministic `np.linspace` index selection when a fraction selects fewer than all samples.
- Added a regression test confirming a 50% fraction across three classes produces two samples per class.
- Kept full-dataset behavior unchanged when the requested count is not smaller than the available samples.

### 🎯 Purpose & Impact
Local classification subsets now retain samples from across the class-ordered `ImageFolder` dataset, while detection sampling and NDJSON conversion behavior remain unchanged.