### PR TITLE
Correct end-to-end detection guide claims and export fallback coverage

### DIFF
--- a/docs/en/guides/end2end-detection.md
+++ b/docs/en/guides/end2end-detection.md
@@ -138,7 +138,7 @@ The following formats **do not** support end-to-end and automatically fall back 
 
     When you export to one of these formats, Ultralytics automatically switches to the one-to-many head and logs a warning. This means **you'll need NMS in your inference pipeline** for these formats, just like with [YOLOv8](../models/yolov8.md) or [YOLO11](../models/yolo11.md).
 
-For [Hailo](../integrations/hailo.md), the exporter selects the output path automatically and YOLO26 detection models keep their NMS-free one-to-one outputs, so `end2end` cannot be set manually and is rejected if passed.
+For [Hailo](../integrations/hailo.md), the exporter picks the output path from the loaded head rather than from an argument, so `end2end` is rejected if passed: a default YOLO26 detection model keeps its NMS-free one-to-one outputs, while a checkpoint whose head is already `end2end=False` compiles the traditional path with HailoRT NMS.
 
 !!! note "Quantization and runtime version can disable end-to-end"
 
@@ -165,7 +165,8 @@ If you're upgrading an existing project to YOLO26:
 - **Ultralytics API / CLI users:** No changes needed — just update the model name to `yolo26n.pt` (or `yolo26n-seg.pt`, `yolo26n-pose.pt`, `yolo26n-obb.pt`)
 - **Custom post-processing code:** Update to handle the new output shapes — `(N, 300, 6)` for detection, plus task-specific data for [segmentation](../tasks/segment.md), [pose](../tasks/pose.md), and [OBB](../tasks/obb.md). Also note the box format change from `xywh` to `xyxy`
 - **Export pipelines:** Check the [format compatibility](#export-format-compatibility) section for your target format
-- **Quantized exports:** TensorRT older than 8.5.0, TensorRT 10.3.0 with `quantize=8` on JetPack 6, and LiteRT with `quantize=8` or `quantize="w8a16"` all auto-disable end-to-end — upgrade TensorRT, or export at a higher precision, to keep it
+- **TensorRT below 8.5.0:** end-to-end is disabled at every precision — upgrade TensorRT to 8.5.0 or later to keep it
+- **Quantized exports:** TensorRT 10.3.0 with `quantize=8` on JetPack 6, and LiteRT with `quantize=8` or `quantize="w8a16"`, auto-disable end-to-end — export at a higher precision to keep it
 - **FP16 exports:** If you need all outputs in FP16, export with `end2end=False` — see [why output0 stays FP32](../modes/export.md#why-is-output0-fp32-when-exporting-quantized-models-with-end2endtrue)
 - **iOS / CoreML:** End-to-end is fully supported. If you need Xcode Preview support, use `end2end=False` with `nms=True`
 - **Edge devices (NCNN, RKNN):** These formats auto-fallback to one-to-many, so include NMS in your on-device pipeline
@@ -232,7 +233,7 @@ You can check from the Ultralytics Python API or from the exported ONNX model me
         print(metadata.get("end2end"))  # 'True' if end-to-end is enabled
         ```
 
-The two checks answer different questions: the ONNX metadata records the head that was exported, while `predictor.model.end2end` reports whether external NMS is still needed. They disagree for a model exported with `end2end=False, nms=True`, which bakes NMS into the graph and also outputs `(1, 300, 6)` — so the output shape alone does not identify the head. For other task shapes, see the [output shapes FAQ](#my-exported-onnx-model-outputs-1-300-6-is-that-correct).
+The two checks answer different questions: the ONNX metadata records the head that was exported, while `predictor.model.end2end` reports that the backend output is already post-processed and needs no external NMS. They disagree for a model exported with `end2end=False, nms=True`, which uses the one-to-many head but bakes NMS into the graph and also outputs `(1, 300, 6)` — so neither the flag nor the output shape alone identifies the head. For other task shapes, see the [output shapes FAQ](#my-exported-onnx-model-outputs-1-300-6-is-that-correct).
 
 ### Is end-to-end supported for instance segmentation, pose, and OBB tasks?
 

--- a/docs/en/guides/end2end-detection.md
+++ b/docs/en/guides/end2end-detection.md
@@ -7,9 +7,9 @@ keywords: YOLO26, end-to-end detection, NMS-free inference, model export, deploy
 
 # Understanding End-to-End Detection in Ultralytics YOLO26
 
-[YOLO26](../models/yolo26.md) is **NMS-free** by default: it outputs final detections directly from the model, with no [Non-Maximum Suppression](https://www.ultralytics.com/glossary/non-maximum-suppression-nms) (NMS) post-processing step. Earlier models like [YOLOv8](../models/yolov8.md) and [YOLO11](../models/yolo11.md) produce thousands of overlapping predictions that a separate NMS step has to filter down, which adds latency, complicates export graphs, and can behave inconsistently across hardware platforms.
+[YOLO26 detection-style models](../models/yolo26.md) — detection, segmentation, pose, and OBB — are **NMS-free** by default: they output final detections directly from the model, with no [Non-Maximum Suppression](https://www.ultralytics.com/glossary/non-maximum-suppression-nms) (NMS) post-processing step. Earlier models like [YOLOv8](../models/yolov8.md) and [YOLO11](../models/yolo11.md) produce thousands of overlapping predictions that a separate NMS step has to filter down, which adds latency, complicates export graphs, and can behave inconsistently across hardware platforms.
 
-This is known as **end-to-end [object detection](https://www.ultralytics.com/glossary/object-detection)**, and it is enabled by default in every YOLO26 detection-style model (detection, segmentation, pose, and OBB). The result is a simpler deployment pipeline and lower latency — YOLO26n runs up to **43% faster than YOLO11n** on CPU ONNX inference (Intel Xeon CPU @ 2.00 GHz).
+This is known as **end-to-end [object detection](https://www.ultralytics.com/glossary/object-detection)**, and it is enabled by default. The result is a simpler deployment pipeline and lower latency — YOLO26n runs up to **43% faster than YOLO11n** on CPU ONNX inference (Intel Xeon CPU @ 2.00 GHz).
 
 This guide walks you through what changed, whether you need to update your code, which export formats support end-to-end inference, and how to migrate smoothly from older YOLO models.
 

--- a/docs/en/guides/end2end-detection.md
+++ b/docs/en/guides/end2end-detection.md
@@ -9,7 +9,7 @@ keywords: YOLO26, end-to-end detection, NMS-free inference, model export, deploy
 
 [YOLO26](../models/yolo26.md) is **NMS-free** by default: it outputs final detections directly from the model, with no [Non-Maximum Suppression](https://www.ultralytics.com/glossary/non-maximum-suppression-nms) (NMS) post-processing step. Earlier models like [YOLOv8](../models/yolov8.md) and [YOLO11](../models/yolo11.md) produce thousands of overlapping predictions that a separate NMS step has to filter down, which adds latency, complicates export graphs, and can behave inconsistently across hardware platforms.
 
-This is known as **end-to-end [object detection](https://www.ultralytics.com/glossary/object-detection)**, and it is enabled by default in every YOLO26 model. The result is a simpler deployment pipeline and lower latency — YOLO26n runs up to **43% faster than YOLO11n** on CPU ONNX inference (Intel Xeon CPU @ 2.00 GHz).
+This is known as **end-to-end [object detection](https://www.ultralytics.com/glossary/object-detection)**, and it is enabled by default in every YOLO26 detection-style model (detection, segmentation, pose, and OBB). The result is a simpler deployment pipeline and lower latency — YOLO26n runs up to **43% faster than YOLO11n** on CPU ONNX inference (Intel Xeon CPU @ 2.00 GHz).
 
 This guide walks you through what changed, whether you need to update your code, which export formats support end-to-end inference, and how to migrate smoothly from older YOLO models.
 

--- a/docs/en/guides/end2end-detection.md
+++ b/docs/en/guides/end2end-detection.md
@@ -7,9 +7,9 @@ keywords: YOLO26, end-to-end detection, NMS-free inference, model export, deploy
 
 # Understanding End-to-End Detection in Ultralytics YOLO26
 
-If you're upgrading to [YOLO26](../models/yolo26.md) from an earlier model like [YOLOv8](../models/yolov8.md) or [YOLO11](../models/yolo11.md), one of the biggest changes you'll notice is the removal of [Non-Maximum Suppression](https://www.ultralytics.com/glossary/non-maximum-suppression-nms) (NMS). Traditional YOLO models produce thousands of overlapping predictions that need a separate NMS post-processing step to filter down to final detections. This adds latency, complicates export graphs, and can behave inconsistently across different hardware platforms.
+[YOLO26](../models/yolo26.md) is **NMS-free** by default: it outputs final detections directly from the model, with no [Non-Maximum Suppression](https://www.ultralytics.com/glossary/non-maximum-suppression-nms) (NMS) post-processing step. Earlier models like [YOLOv8](../models/yolov8.md) and [YOLO11](../models/yolo11.md) produce thousands of overlapping predictions that a separate NMS step has to filter down, which adds latency, complicates export graphs, and can behave inconsistently across hardware platforms.
 
-YOLO26 takes a different approach. It outputs final detections directly from the model — no external filtering required. This is known as **end-to-end [object detection](https://www.ultralytics.com/glossary/object-detection)**, and it's enabled by default in all YOLO26 models. The result is a simpler deployment pipeline, lower latency, and up to **43% faster inference on CPUs**.
+This is known as **end-to-end [object detection](https://www.ultralytics.com/glossary/object-detection)**, and it is enabled by default in every YOLO26 model. The result is a simpler deployment pipeline and lower latency — YOLO26n runs up to **43% faster than YOLO11n** on CPU ONNX inference (Intel Xeon CPU @ 2.00 GHz).
 
 This guide walks you through what changed, whether you need to update your code, which export formats support end-to-end inference, and how to migrate smoothly from older YOLO models.
 
@@ -19,7 +19,7 @@ For a deeper look at the motivation behind this architectural shift, see the [Ul
 
     - **Using the Ultralytics API or CLI?** No changes needed — just swap your model name to `yolo26n.pt`.
     - **Using custom inference code (ONNX Runtime, TensorRT, etc.)?** Update your post-processing — detection output is now `(N, 300, 6)` in `xyxy` format, no NMS required. Other tasks append extra data (mask coefficients, keypoints, or angle).
-    - **Exporting?** Most formats support end-to-end output natively. However, a few formats (NCNN, RKNN, PaddlePaddle, ExecuTorch, IMX, Edge TPU, and QNN) automatically fall back to traditional output due to unsupported operator constraints (e.g., `torch.topk`). Hailo HEF workflows compile from ONNX with Hailo-specific scripts, so verify the detection head and NMS configuration for your model.
+    - **Exporting?** Most formats keep end-to-end output natively; a few fall back to traditional output, and quantization can disable it — see [Export Format Compatibility](#export-format-compatibility).
 
 ## How End-to-End Detection Works
 
@@ -30,7 +30,7 @@ YOLO26 uses a **dual-head architecture** during [training](../modes/train.md). B
 | **One-to-One** (default) | End-to-end inference    | `(N, 300, 6)`       | Confidence threshold only |
 | **One-to-Many**          | Traditional YOLO output | `(N, nc + 4, 8400)` | Requires NMS              |
 
-The shapes above are for [detection](../tasks/detect.md). Other tasks extend the one-to-one output with additional data per detection:
+The shapes above are for [detection](../tasks/detect.md), where `N` is the [batch size](https://www.ultralytics.com/glossary/batch-size), `nc` is the number of classes (e.g., 80 for [COCO](../datasets/detect/coco.md)), and the 8400 anchor count is the value at `imgsz=640`. Other tasks extend the one-to-one output with additional data per detection:
 
 | Task                                         | End-to-End Output                          | Extra Data                          |
 | -------------------------------------------- | ------------------------------------------ | ----------------------------------- |
@@ -83,8 +83,6 @@ When you call `model.fuse()`, it folds Conv + BatchNorm layers for faster infere
 
 For [segmentation](../tasks/segment.md), [pose](../tasks/pose.md), and [OBB](../tasks/obb.md) tasks, YOLO26 appends task-specific data to each detection — see the [output shapes table](#how-end-to-end-detection-works).
 
-Where `N` is the [batch size](https://www.ultralytics.com/glossary/batch-size) and `nc` is the number of classes (e.g., 80 for [COCO](../datasets/detect/coco.md)).
-
 With end-to-end models, post-processing becomes much simpler — for example, when using [ONNX Runtime](../integrations/onnx.md):
 
 ```python
@@ -96,7 +94,7 @@ output = session.run(None, {session.get_inputs()[0].name: input_tensor})
 
 # End-to-end output: (batch, 300, 6) → [x1, y1, x2, y2, confidence, class_id]
 detections = output[0][0]  # first image in batch
-detections = detections[detections[:, 4] > conf_threshold]  # confidence filter — that's it!
+detections = detections[detections[:, 4] > 0.25]  # confidence filter, no NMS
 ```
 
 ### Switching to the One-to-Many Head
@@ -138,37 +136,36 @@ The following formats **do not** support end-to-end and automatically fall back 
 
 !!! tip "What happens when end-to-end isn't supported"
 
-    When you export to one of these formats, Ultralytics automatically switches to the one-to-many head and logs a warning — no manual intervention needed. This means **you'll need NMS in your inference pipeline** for these formats, just like with [YOLOv8](../models/yolov8.md) or [YOLO11](../models/yolo11.md).
+    When you export to one of these formats, Ultralytics automatically switches to the one-to-many head and logs a warning. This means **you'll need NMS in your inference pipeline** for these formats, just like with [YOLOv8](../models/yolov8.md) or [YOLO11](../models/yolo11.md).
 
-For [Hailo HEF](../integrations/hailo.md), the compile step happens outside `model.export(format=...)` after an ONNX export. Use the Hailo DFC logs, `.alls` model script, and NMS JSON that match your exact detection model; if an end-to-end YOLO26 graph is not supported by your Hailo toolchain, export the ONNX model with `end2end=False` and compile the traditional detection head.
+For [Hailo](../integrations/hailo.md), the exporter selects the output path automatically and YOLO26 detection models keep their NMS-free one-to-one outputs, so `end2end` cannot be set manually and is rejected if passed.
 
-!!! note "TensorRT + INT8"
+!!! note "Quantization and runtime version can disable end-to-end"
 
-    [TensorRT](../integrations/tensorrt.md) supports end-to-end, but it is **auto-disabled** when exporting with `quantize=8` on TensorRT 10.3.0 on JetPack 6.
+    [TensorRT](../integrations/tensorrt.md) and [LiteRT](../integrations/litert.md) support end-to-end, but the branch is **auto-disabled** on TensorRT older than 8.5.0, on TensorRT 10.3.0 with `quantize=8` on JetPack 6, and on LiteRT with `quantize=8` or `quantize="w8a16"`. Each case logs a warning and exports the one-to-many head.
 
-## Accuracy and Speed Tradeoffs
+## Accuracy and Speed Trade-offs
 
 End-to-end detection provides significant deployment benefits with minimal impact on [accuracy](https://www.ultralytics.com/glossary/accuracy):
 
-| Metric                    | End-to-End (default)   | One-to-Many + NMS (`end2end=False`) |
-| ------------------------- | ---------------------- | ----------------------------------- |
-| **CPU Inference Speed**   | Up to **43% faster**   | Baseline                            |
-| **mAP Impact**            | ~0.5 mAP lower         | Matches or exceeds YOLO11           |
-| **Post-Processing**       | Confidence filter only | Full NMS pipeline                   |
-| **Deployment Complexity** | Minimal                | Requires NMS implementation         |
+| Metric                     | End-to-End (default)   | One-to-Many + NMS (`end2end=False`) |
+| -------------------------- | ---------------------- | ----------------------------------- |
+| **COCO mAP<sup>val</sup>** | 0.6-0.8 lower          | Baseline                            |
+| **Post-Processing**        | Confidence filter only | Full NMS pipeline                   |
+| **Deployment Complexity**  | Minimal                | Requires NMS implementation         |
 
-For most real-world applications, the ~0.5 [mAP](https://www.ultralytics.com/glossary/mean-average-precision-map) difference is negligible, especially when considering the speed and simplicity gains. If maximum accuracy is your top priority, you can always fall back to the one-to-many head using `end2end=False`.
+Across the five detection scales the one-to-one head costs 0.6-0.8 [mAP](https://www.ultralytics.com/glossary/mean-average-precision-map) on COCO — 40.9 to 40.1 for YOLO26n and 57.5 to 56.9 for YOLO26x — in exchange for dropping the NMS pass entirely. If maximum accuracy is your priority, fall back to the one-to-many head with `end2end=False`.
 
 See the [YOLO26 performance metrics](../models/yolo26.md#performance-metrics) for detailed benchmarks across all model sizes (n, s, m, l, x).
 
 ## Migrating from YOLOv8 or YOLO11
 
-If you're upgrading an existing project to YOLO26, here's a quick checklist to ensure a smooth transition:
+If you're upgrading an existing project to YOLO26:
 
 - **Ultralytics API / CLI users:** No changes needed — just update the model name to `yolo26n.pt` (or `yolo26n-seg.pt`, `yolo26n-pose.pt`, `yolo26n-obb.pt`)
 - **Custom post-processing code:** Update to handle the new output shapes — `(N, 300, 6)` for detection, plus task-specific data for [segmentation](../tasks/segment.md), [pose](../tasks/pose.md), and [OBB](../tasks/obb.md). Also note the box format change from `xywh` to `xyxy`
 - **Export pipelines:** Check the [format compatibility](#export-format-compatibility) section for your target format
-- **TensorRT + INT8:** On JetPack 6, TensorRT 10.3.0 auto-disables end-to-end with `quantize=8` — use a different TensorRT version to keep end-to-end
+- **Quantized exports:** TensorRT older than 8.5.0, TensorRT 10.3.0 with `quantize=8` on JetPack 6, and LiteRT with `quantize=8` or `quantize="w8a16"` all auto-disable end-to-end — upgrade TensorRT, or export at a higher precision, to keep it
 - **FP16 exports:** If you need all outputs in FP16, export with `end2end=False` — see [why output0 stays FP32](../modes/export.md#why-is-output0-fp32-when-exporting-quantized-models-with-end2endtrue)
 - **iOS / CoreML:** End-to-end is fully supported. If you need Xcode Preview support, use `end2end=False` with `nms=True`
 - **Edge devices (NCNN, RKNN):** These formats auto-fallback to one-to-many, so include NMS in your on-device pipeline
@@ -194,11 +191,11 @@ model.predict("image.jpg", max_det=100)  # fewer detections
 model.export(format="onnx", max_det=500)  # more detections for dense scenes
 ```
 
-Note that the default YOLO26 checkpoints were trained with `max_det=300`. While you can increase this value, the one-to-one head was optimized during training to produce up to 300 clean detections, so detections beyond that limit may be lower quality. If you need more than 300 detections per image, consider retraining with a higher `max_det` value.
+The value is baked into an exported graph as the head's top-k, so `max_det=500` widens the output tensor to up to `(1, 500, 6)`, capped by the anchor count.
 
 ### My exported ONNX model outputs (1, 300, 6) — is that correct?
 
-Yes, that's the expected end-to-end output format for detection: [batch size](https://www.ultralytics.com/glossary/batch-size) of 1, up to 300 detections, each with 6 values `[x1, y1, x2, y2, confidence, class_id]`. Simply filter by confidence threshold and you're done — no NMS needed.
+Yes, that's the expected end-to-end output format for detection: [batch size](https://www.ultralytics.com/glossary/batch-size) of 1, up to 300 detections, each with 6 values `[x1, y1, x2, y2, confidence, class_id]`. Simply filter by confidence threshold — no NMS needed.
 
 For other tasks, the output shape differs:
 
@@ -211,7 +208,7 @@ For other tasks, the output shape differs:
 
 ### How do I check if my exported model is end-to-end?
 
-You can check using either the Ultralytics Python API or by inspecting the exported ONNX model metadata directly:
+You can check from the Ultralytics Python API or from the exported ONNX model metadata:
 
 !!! example "Check if a model is end-to-end"
 
@@ -235,17 +232,10 @@ You can check using either the Ultralytics Python API or by inspecting the expor
         print(metadata.get("end2end"))  # 'True' if end-to-end is enabled
         ```
 
-Alternatively, check the output shape — end-to-end detection models output `(1, 300, 6)`, while traditional models output `(1, nc + 4, 8400)`. For other task shapes, see the [output shapes FAQ](#my-exported-onnx-model-outputs-1-300-6-is-that-correct).
+The two checks answer different questions: the ONNX metadata records the head that was exported, while `predictor.model.end2end` reports whether external NMS is still needed. They disagree for a model exported with `end2end=False, nms=True`, which bakes NMS into the graph and also outputs `(1, 300, 6)` — so the output shape alone does not identify the head. For other task shapes, see the [output shapes FAQ](#my-exported-onnx-model-outputs-1-300-6-is-that-correct).
 
 ### Is end-to-end supported for instance segmentation, pose, and OBB tasks?
 
 Yes. YOLO26 detection-style task variants — [detection](../tasks/detect.md), [instance segmentation](../tasks/segment.md), [pose estimation](../tasks/pose.md), and [oriented object detection (OBB)](../tasks/obb.md) — support end-to-end inference by default. The `end2end=False` fallback is available across these tasks as well.
 
-Each task extends the base detection output with task-specific data:
-
-| Task                  | Model             | End-to-End Output                          |
-| --------------------- | ----------------- | ------------------------------------------ |
-| Detection             | `yolo26n.pt`      | `(N, 300, 6)`                              |
-| Instance Segmentation | `yolo26n-seg.pt`  | `(N, 300, 38)` + proto `(N, 32, 160, 160)` |
-| Pose                  | `yolo26n-pose.pt` | `(N, 300, 57)`                             |
-| OBB                   | `yolo26n-obb.pt`  | `(N, 300, 7)`                              |
+Each task extends the base detection output with task-specific data; `yolo26n.pt`, `yolo26n-seg.pt`, `yolo26n-pose.pt`, and `yolo26n-obb.pt` output shapes are listed under [How End-to-End Detection Works](#how-end-to-end-detection-works).

--- a/docs/en/guides/yolo26-training-recipe.md
+++ b/docs/en/guides/yolo26-training-recipe.md
@@ -23,7 +23,7 @@ All YOLO26 base models were trained in two stages: **[Objects365v1](../datasets/
 Key design choices across all sizes:
 
 - **[Objects365](../datasets/detect/objects365.md) pretraining** for every size before the COCO stage
-- **End-to-end training** (`end2end=True`) with NMS-free one-to-one head
+- **[End-to-end training](end2end-detection.md)** (`end2end=True`) with NMS-free one-to-one head
 - **[MuSGD](../modes/train.md#musgd-optimizer) optimizer** combining SGD with Muon-style orthogonalized updates for weight matrices (2D linear weights and 4D conv filters, which are reshaped to 2D)
 - **Heavy mosaic augmentation** (~0.9-1.0 probability) disabled for the final epochs (`close_mosaic=8` in pretraining, `close_mosaic=10` on COCO)
 - **Aggressive scale augmentation** (0.5-0.95) to handle objects at different sizes

--- a/docs/en/models/yolo26.md
+++ b/docs/en/models/yolo26.md
@@ -237,7 +237,7 @@ Note that the example below is for YOLO26 [Detect](../tasks/detect.md) models fo
         yolo export model=yolo26n.pt format=onnx end2end=False
         ```
 
-    The choice depends on your deployment requirements: use the one-to-one head for maximum speed and simplicity, or the one-to-many head when accuracy is the top priority.
+    The choice depends on your deployment requirements: use the one-to-one head for maximum speed and simplicity, or the one-to-many head when accuracy is the top priority. See the [End-to-End Detection guide](../guides/end2end-detection.md) for output formats, export compatibility, and migration steps.
 
 ## YOLOE-26: Open-Vocabulary Detection and Segmentation
 

--- a/docs/en/modes/export.md
+++ b/docs/en/modes/export.md
@@ -234,7 +234,7 @@ When you export a YOLO model to formats like ONNX or TensorRT, the output tensor
 
 For **YOLO26 detection models** (e.g., `yolo26n.pt`), end-to-end export is enabled by default in formats that support it, so the output is shaped like `(batch_size, max_detections, 6)` with `[x1, y1, x2, y2, confidence, class_id]` values. With the default `max_det=300`, this is commonly `(batch_size, 300, 6)`. Some constrained formats automatically fall back to the traditional output layout when end-to-end operators are unsupported.
 
-For non-end-to-end detection models, or YOLO26 models exported with `end2end=False`, the output is typically a single tensor shaped like `(batch_size, 4 + num_classes, num_predictions)` where the channels represent box coordinates plus per-class scores, and `num_predictions` depends on the export input resolution (and can be dynamic).
+For non-end-to-end detection models, or YOLO26 models exported with `end2end=False`, the output is typically a single tensor shaped like `(batch_size, 4 + num_classes, num_predictions)` where the channels represent box coordinates plus per-class scores, and `num_predictions` depends on the export input resolution (and can be dynamic). The [End-to-End Detection guide](../guides/end2end-detection.md) covers which formats keep the end-to-end output.
 
 For **segmentation models** (e.g., `yolo26n-seg.pt`), you'll typically get two outputs: the first tensor shaped like `(batch_size, 4 + num_classes + mask_dim, num_predictions)` (boxes, class scores, and mask coefficients), and the second tensor shaped like `(batch_size, mask_dim, proto_h, proto_w)` containing mask prototypes used with the coefficients to generate instance masks. Sizes depend on the export input resolution (and can be dynamic).
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1588,8 +1588,6 @@ class Exporter:
         )
         assert IS_PYTHON_MINIMUM_3_9, "IMX export is only supported on Python 3.9 or above."
 
-        if getattr(self.model, "end2end", False):
-            raise ValueError("IMX export is not supported for end2end models.")
         from ultralytics.utils.export.imx import torch2imx
 
         return torch2imx(


### PR DESCRIPTION
## summary

- Re-scopes the 43% CPU figure to its real baseline (YOLO26n vs YOLO11n CPU ONNX on an Intel Xeon @ 2.00 GHz, per the YOLO26 model page) and removes it from the end-to-end vs `end2end=False` comparison table, which measured a different pair of models.
- Replaces the `~0.5 mAP` figure with the 0.6-0.8 range the detection performance macro actually reports across the five scales, and states the two endpoint numbers.
- Updates the Hailo paragraph to the current first-class `format="hailo"` export path, which selects the output path automatically and rejects an explicit `end2end` argument; adds the LiteRT `quantize=8`/`w8a16` and TensorRT `<8.5.0` cases to the fallback note and the migration checklist.
- Corrects the FAQ: `max_det` is applied as the exported head's top-k rather than a training objective, and the Python API check, the ONNX metadata key and the output shape answer different questions and disagree for a model exported with `end2end=False, nms=True`.
- Collapses a third copy of the task output-shape table into a cross-reference, moves the `N`/`nc` legend to first use, and adds inbound links from the YOLO26 model page, the export mode page and the YOLO26 training recipe.
- Removes an unreachable `end2end` guard in `export_imx`: `Exporter` already forces `end2end=False` for `imx` before any format handler runs, including over an explicit `end2end=True`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Corrects YOLO26 end-to-end detection documentation, expands export fallback coverage, and removes an unreachable IMX export guard.

### 📊 Key Changes

- Re-scopes the 43% CPU speed claim to YOLO26n versus YOLO11n CPU ONNX inference on an Intel Xeon, removes it from the end-to-end comparison table, and updates the reported COCO mAP difference to 0.6–0.8 across model scales.
- Documents Hailo’s `format="hailo"` export behavior, including automatic output-path selection and rejection of an explicit `end2end` argument.
- Adds TensorRT versions below 8.5.0, TensorRT JetPack 6 INT8, and LiteRT `quantize=8` or `quantize="w8a16"` to the cases that automatically fall back to the one-to-many head.
- Clarifies that `max_det` becomes the exported head’s top-k and explains why the Python API flag, ONNX metadata, and output shape can report different aspects of an export.
- Consolidates duplicated output-shape documentation, adds cross-links from related YOLO26 pages, and removes the unreachable `end2end` check from `export_imx`.

### 🎯 Purpose & Impact

- Documentation now describes the measured performance baseline, accuracy range, Hailo workflow, quantization fallbacks, and end-to-end detection checks more precisely.
- Users exporting YOLO26 models can identify when NMS is required and how `max_det` affects the exported output shape.
- IMX export behavior is unchanged because `Exporter` already sets `end2end=False` before the IMX handler runs.