### PR TITLE
Remove RT-DETR filename routing

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -925,11 +925,11 @@ def test_train_pretrained(scls):
 def test_all_model_yamls():
     """Test YOLO model creation for all available YAML configurations in the `cfg/models` directory."""
     for m in (ROOT / "cfg" / "models").rglob("*.yaml"):
-        if "rtdetr" in m.name:
-            if TORCH_1_11:
-                _ = RTDETR(m.name)(SOURCE, imgsz=160)
-        else:
-            YOLO(m.name)
+        if not TORCH_1_11 and YAML.load(m)["head"][-1][-2] == "RTDETRDecoder":
+            continue
+        model = YOLO(m.name)
+        if isinstance(model, RTDETR):
+            model(SOURCE, imgsz=160)
 
 
 @pytest.mark.skipif(WINDOWS, reason="Windows slow CI export bug https://github.com/ultralytics/ultralytics/pull/16003")

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -1090,11 +1090,7 @@ def entrypoint(debug: str = "") -> None:
         LOGGER.warning(f"'model' argument is missing. Using default 'model={model}'.")
     overrides["model"] = model
     stem = Path(model).stem.lower()
-    if "rtdetr" in stem:  # guess architecture
-        from ultralytics import RTDETR
-
-        model = RTDETR(model)  # no task argument
-    elif "fastsam" in stem:
+    if "fastsam" in stem:
         from ultralytics import FastSAM
 
         model = FastSAM(model)

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -20,6 +20,7 @@ from ultralytics.nn.tasks import (
     DetectionModel,
     OBBModel,
     PoseModel,
+    RTDETRDetectionModel,
     SegmentationModel,
     SemanticSegmentationModel,
     WorldModel,
@@ -79,12 +80,6 @@ class YOLO(Model):
             new_instance = YOLOE(path, task=task, verbose=verbose)
             self.__class__ = type(new_instance)
             self.__dict__ = new_instance.__dict__
-        elif path.suffix in {".yaml", ".yml"} and yaml_model_load(model)["head"][-1][-2] == "RTDETRDecoder":
-            from ultralytics import RTDETR
-
-            new_instance = RTDETR(model)
-            self.__class__ = type(new_instance)
-            self.__dict__ = new_instance.__dict__
         else:
             # Continue with default YOLO initialization
             super().__init__(model=model, task=task, verbose=verbose)
@@ -97,6 +92,12 @@ class YOLO(Model):
                 new_instance = RTDETR(self)
                 self.__class__ = type(new_instance)
                 self.__dict__ = new_instance.__dict__
+
+    def _new(self, cfg: str, task=None, model=None, verbose=False) -> None:
+        """Initialize a model from YAML, selecting RT-DETR from its declared head."""
+        if model is None and yaml_model_load(cfg)["head"][-1][-2] == "RTDETRDecoder":
+            model, task = RTDETRDetectionModel, "detect"
+        super()._new(cfg, task=task, model=model, verbose=verbose)
 
     @property
     def task_map(self) -> dict[str, dict[str, Any]]:

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -25,6 +25,7 @@ from ultralytics.nn.tasks import (
     WorldModel,
     YOLOEModel,
     YOLOESegModel,
+    yaml_model_load,
 )
 from ultralytics.utils import ROOT, YAML
 
@@ -78,13 +79,19 @@ class YOLO(Model):
             new_instance = YOLOE(path, task=task, verbose=verbose)
             self.__class__ = type(new_instance)
             self.__dict__ = new_instance.__dict__
+        elif path.suffix in {".yaml", ".yml"} and yaml_model_load(model)["head"][-1][-2] == "RTDETRDecoder":
+            from ultralytics import RTDETR
+
+            new_instance = RTDETR(model)
+            self.__class__ = type(new_instance)
+            self.__dict__ = new_instance.__dict__
         else:
             # Continue with default YOLO initialization
             super().__init__(model=model, task=task, verbose=verbose)
             head = self.model.model[-1]._get_name() if hasattr(self.model, "model") else ""
             if not head and isinstance(self.model, (str, Path)):  # an exported model keeps its head name in metadata
                 head = BaseBackend.read_metadata(self.model).get("head", "")
-            if "RTDETR" in head:  # if RTDETR head
+            if head == "RTDETRDecoder":  # if RTDETR head
                 from ultralytics import RTDETR
 
                 new_instance = RTDETR(self)


### PR DESCRIPTION
## Summary
- remove the CLI RT-DETR filename heuristic
- route RT-DETR YAMLs from their declared decoder head in the YOLO loader
- match loaded and exported RT-DETR head metadata exactly
- exercise all model YAMLs through the unified YOLO loader

## Validation
- pytest tests/test_python.py::test_all_model_yamls -q
- ruff check --ignore BLE001 ultralytics/models/yolo/model.py ultralytics/cfg/__init__.py tests/test_python.py
- ruff format --check ultralytics/models/yolo/model.py ultralytics/cfg/__init__.py tests/test_python.py
- CLI prediction smoke tests with RT-DETR checkpoint and YAML paths renamed to anonymous-model

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Removed RT-DETR filename-based routing and made the YOLO loader select RT-DETR models from their declared `RTDETRDecoder` head in YAML or model metadata.

### 📊 Key Changes

- Removed the CLI heuristic that instantiated `RTDETR` when a model filename contained `rtdetr`.
- Added YAML-based routing in `YOLO._new()` to use `RTDETRDetectionModel` when the final declared head is `RTDETRDecoder`.
- Restricted loaded and exported model head detection to the exact `RTDETRDecoder` metadata value.
- Updated `test_all_model_yamls()` to load every model YAML through `YOLO` and run RT-DETR inference models with the existing test source and image size.

### 🎯 Purpose & Impact

- RT-DETR model selection now depends on model configuration or exact head metadata rather than filenames, allowing RT-DETR checkpoints and YAMLs to use arbitrary filenames.
- The unified YOLO loader exercises all model YAMLs, with RT-DETR-specific inference handling preserved in the test workflow.