### PR TITLE
Document running non-YOLO exports through Ultralytics and correct parity claims

### DIFF
--- a/docs/en/guides/export-non-yolo-models.md
+++ b/docs/en/guides/export-non-yolo-models.md
@@ -7,7 +7,7 @@ keywords: export PyTorch model, convert PyTorch to ONNX, PyTorch to CoreML, PyTo
 
 # How to Export Non-YOLO PyTorch Models with Ultralytics
 
-Ultralytics ships standalone export utilities under [`ultralytics.utils.export`](../reference/utils/export/onnx.md) that wrap multiple backends behind one consistent interface. You can export any `torch.nn.Module`, including [timm](https://github.com/huggingface/pytorch-image-models) image models, [torchvision](https://docs.pytorch.org/vision/) classifiers and detectors, or your own custom architectures, to [ONNX](../integrations/onnx.md), [TorchScript](../integrations/torchscript.md), [OpenVINO](../integrations/openvino.md), [CoreML](../integrations/coreml.md), [NCNN](../integrations/ncnn.md), [PaddlePaddle](../integrations/paddlepaddle.md), [MNN](../integrations/mnn.md), [ExecuTorch](../integrations/executorch.md), and [TensorFlow SavedModel](../integrations/tf-savedmodel.md) without learning each backend separately.
+Ultralytics ships standalone export utilities under [`ultralytics.utils.export`](../reference/utils/export/engine.md) that wrap multiple backends behind one consistent interface. You can export any `torch.nn.Module`, including [timm](https://github.com/huggingface/pytorch-image-models) image models, [torchvision](https://docs.pytorch.org/vision/) classifiers and detectors, or your own custom architectures, to [ONNX](../integrations/onnx.md), [TorchScript](../integrations/torchscript.md), [OpenVINO](../integrations/openvino.md), [CoreML](../integrations/coreml.md), [NCNN](../integrations/ncnn.md), [PaddlePaddle](../integrations/paddlepaddle.md), [MNN](../integrations/mnn.md), [ExecuTorch](../integrations/executorch.md), and [TensorFlow SavedModel](../integrations/tf-savedmodel.md) without learning each backend separately.
 
 Deploying PyTorch models to production usually means juggling a different exporter for every target: `torch.onnx.export` for ONNX, `coremltools` for Apple devices, `onnx2tf` for TensorFlow, `pnnx` for NCNN, and so on. Each tool has its own API, dependency quirks, and output conventions. These utilities collapse that into a single calling pattern.
 
@@ -39,7 +39,7 @@ The `torch2*` functions take a standard `torch.nn.Module` and an example input t
 
 | Format          | Function                                                          | Install                                                             | Output                         |
 | --------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------- | ------------------------------ |
-| ONNX            | [`torch2onnx()`](../reference/utils/export/onnx.md)               | `pip install onnx`                                                  | `.onnx` file                   |
+| ONNX            | [`torch2onnx()`](../reference/utils/export/engine.md)             | `pip install onnx`                                                  | `.onnx` file                   |
 | TorchScript     | [`torch2torchscript()`](../reference/utils/export/torchscript.md) | included with PyTorch                                               | `.torchscript` file            |
 | OpenVINO        | [`torch2openvino()`](../reference/utils/export/openvino.md)       | `pip install openvino`                                              | `_openvino_model/` directory   |
 | CoreML          | [`torch2coreml()`](../reference/utils/export/coreml.md)           | `pip install coremltools`                                           | `.mlpackage`                   |
@@ -150,16 +150,19 @@ torch2onnx(model, im, output_file="resnet18.onnx")
 keras_model = onnx2saved_model("resnet18.onnx", output_dir="resnet18_saved_model")
 ```
 
-The function returns a Keras model and also generates TFLite files (`.tflite`) inside the output directory:
+The function returns a Keras model and also generates FP32 and FP16 [LiteRT](../integrations/litert.md) files (`.tflite`) inside the output directory:
 
 ```text
 resnet18_saved_model/
 ├── saved_model.pb
 ├── variables/
+├── assets/
+├── fingerprint.pb
 ├── resnet18_float32.tflite
-├── resnet18_float16.tflite
-└── resnet18_int8.tflite
+└── resnet18_float16.tflite
 ```
+
+Pass `quantize=8` to add an INT8 `.tflite` alongside them.
 
 Requirements:
 
@@ -278,20 +281,56 @@ onnx_model = ONNXBackend("resnet18.onnx", device=torch.device("cpu"))
 onnx_output = onnx_model(im)[0]
 
 diff = np.abs(pytorch_output - onnx_output).max()
-print(f"Max difference: {diff:.6f}")  # typically ~1e-5, well under 1e-4 for FP32
+print(f"Max difference: {diff:.6f}")  # ~1e-6 for an FP32 ONNX export
 ```
 
 !!! tip "Expected difference"
 
-    For FP32 exports, the max absolute difference is typically around `1e-5` and should stay well under `1e-4`. Larger differences point to unsupported ops, incorrect input shape, or a model not in eval mode. FP16 and INT8 exports have looser tolerances. Validate on real data instead of random tensors.
+    The tolerance is per format, not global. On a ResNet-18 the FP32 exports land near `1e-6` for ONNX, TF SavedModel and LiteRT, and at exactly `0` for TorchScript. NCNN is the outlier at roughly `1e-2`: its CPU runtime enables FP16 packing and arithmetic by default, so an FP32 export still runs in half precision. A difference far above the format's own baseline points to unsupported ops, a wrong input shape, or a model not in eval mode. FP16 and INT8 exports have looser tolerances. Validate on real data instead of random tensors.
 
 For other runtimes, the input tensor name may differ. OpenVINO, for example, uses the model's forward-argument name (typically `x` for generic models), while `torch2onnx` defaults to `"images"`.
+
+## Run Your Exported Model
+
+Exported non-YOLO models load back through the normal `YOLO()` API. The exports above carry no Ultralytics task or input-size metadata, so pass `task` explicitly and `imgsz` matching the example tensor you exported with:
+
+```python
+from ultralytics import YOLO
+
+results = YOLO("resnet18.onnx", task="classify")("path/to/image.jpg", imgsz=224)
+print(results[0].probs.top1)
+```
+
+`imgsz` matters when the export has a fixed input shape: the ONNX and TF SavedModel exports above reject the default of 640, while the TorchScript and NCNN ones accept any size. Which applies depends on the model and the export arguments, so check your own export.
+
+### Calling a Backend Directly
+
+For raw tensors without Ultralytics [preprocessing](https://www.ultralytics.com/glossary/data-preprocessing) and post-processing, use the per-format classes in [`ultralytics.nn.backends`](../reference/nn/backends/base.md), as the [verification example](#verify-your-exported-model) above does. Each takes the exported artifact and a device, and is callable:
+
+| Format                      | Backend                                                       | Input layout |
+| --------------------------- | ------------------------------------------------------------- | ------------ |
+| ONNX                        | [`ONNXBackend`](../reference/nn/backends/onnx.md)             | BCHW         |
+| TorchScript                 | [`TorchScriptBackend`](../reference/nn/backends/pytorch.md)   | BCHW         |
+| OpenVINO                    | [`OpenVINOBackend`](../reference/nn/backends/openvino.md)     | BCHW         |
+| CoreML                      | [`CoreMLBackend`](../reference/nn/backends/coreml.md)         | BHWC         |
+| TF SavedModel, Frozen Graph | [`TensorFlowBackend`](../reference/nn/backends/tensorflow.md) | BHWC         |
+| LiteRT                      | [`LiteRTBackend`](../reference/nn/backends/litert.md)         | BCHW         |
+| NCNN                        | [`NCNNBackend`](../reference/nn/backends/ncnn.md)             | BCHW         |
+| PaddlePaddle                | [`PaddleBackend`](../reference/nn/backends/paddle.md)         | BCHW         |
+| MNN                         | [`MNNBackend`](../reference/nn/backends/mnn.md)               | BCHW         |
+| ExecuTorch                  | [`ExecuTorchBackend`](../reference/nn/backends/executorch.md) | BCHW         |
+
+Three things the `YOLO()` route handles for you and a direct call does not:
+
+- **Input layout**: `CoreMLBackend` and `TensorFlowBackend` expect BHWC. Transpose first with `im.permute(0, 2, 3, 1)`; a BCHW tensor raises a shape mismatch.
+- **Autograd**: wrap calls in `torch.inference_mode()`. `TorchScriptBackend` returns a tensor that still carries a [gradient](https://www.ultralytics.com/glossary/gradient-descent) graph.
+- **Post-processing**: without metadata a backend leaves `task` as `None` and `names` empty. `LiteRTBackend` still denormalizes any 3-D output by image size on the assumption it holds YOLO boxes, which is wrong for a non-YOLO model with a 3-D output. Two-dimensional outputs such as classifier logits are unaffected.
 
 ## Known Limitations
 
 - **Multi-input support is uneven**: `torch2onnx` and `torch2openvino` accept a tuple or list of example tensors for models with multiple inputs. `torch2torchscript`, `torch2coreml`, `torch2ncnn`, `torch2paddle`, and `torch2executorch` assume a single input tensor.
 - **ExecuTorch needs `flatc`**: The ExecuTorch runtime requires the FlatBuffers compiler. Install with `brew install flatbuffers` on macOS or `apt install flatbuffers-compiler` on Ubuntu.
-- **No inference via Ultralytics**: Exported non-YOLO models cannot be loaded back through `YOLO()` for inference. Use the native runtime for each format ([ONNX Runtime](../integrations/onnx.md), [OpenVINO Runtime](../integrations/openvino.md), etc.).
+- **No embedded metadata**: the exports above carry no Ultralytics task or input-size metadata, so `YOLO()` cannot infer either and needs both passed explicitly. See [Run Your Exported Model](#run-your-exported-model).
 - **YOLO-only formats**: [Axelera](../integrations/axelera.md) and [Sony IMX500](../integrations/sony-imx500.md) exports require YOLO-specific model attributes and are not available for generic models.
 - **Platform-specific formats**: [TensorRT](../integrations/tensorrt.md) requires an NVIDIA GPU. [RKNN](../integrations/rockchip-rknn.md) requires the `rknn-toolkit2` SDK (Linux only). [Edge TPU](../integrations/edge-tpu.md) requires the `edgetpu_compiler` binary (Linux only).
 
@@ -323,4 +362,4 @@ Yes, for several formats. Pass `quantize=16` for FP16 or `quantize=8` for INT8 w
 
 ### How do I verify an exported model matches the original?
 
-Run the original PyTorch model and the exported model on the same input, then compare outputs. Load the exported file with the matching backend (for example, [`ONNXBackend`](../reference/nn/backends/onnx.md) for ONNX) and check the maximum absolute difference. For FP32 exports it is typically around `1e-5` and should stay well under `1e-4`; larger gaps point to unsupported ops, a wrong input shape, or a model not in eval mode. See [Verify Your Exported Model](#verify-your-exported-model) for a runnable example.
+Run the original PyTorch model and the exported model on the same input, then compare outputs. Load the exported file with the matching backend (for example, [`ONNXBackend`](../reference/nn/backends/onnx.md) for ONNX) and check the maximum absolute difference. Judge the gap against the format's own baseline. For the ResNet-18 example above, FP32 ONNX, TF SavedModel and LiteRT sit near `1e-6`, TorchScript at `0`, and NCNN near `1e-2` because its CPU runtime defaults to FP16. A much larger gap points to unsupported ops, a wrong input shape, or a model not in eval mode. See [Verify Your Exported Model](#verify-your-exported-model) for a runnable example.

--- a/docs/en/guides/export-non-yolo-models.md
+++ b/docs/en/guides/export-non-yolo-models.md
@@ -301,7 +301,7 @@ results = YOLO("resnet18.onnx", task="classify")("path/to/image.jpg", imgsz=224)
 print(results[0].probs.top1)
 ```
 
-`imgsz` matters when the export has a fixed input shape: the ONNX and TF SavedModel exports above reject the default of 640, while the TorchScript and NCNN ones accept any size. Which applies depends on the model and the export arguments, so check your own export.
+`imgsz` matters when the export has a fixed input shape: the ONNX and TF SavedModel exports above reject the default of 640. The TorchScript and NCNN exports above do accept other sizes, but neither exporter guarantees it: both trace from the example tensor, so a model that flattens into a `Linear` layer stays fixed. Check your own export.
 
 The value is then rounded up to a multiple of the model stride, which is 32 without metadata. A fixed-shape export at 200x200 is therefore fed 224x224 and rejected even though `imgsz=200` matches it. For input sizes that are not multiples of 32, call the backend directly.
 

--- a/docs/en/guides/export-non-yolo-models.md
+++ b/docs/en/guides/export-non-yolo-models.md
@@ -303,6 +303,8 @@ print(results[0].probs.top1)
 
 `imgsz` matters when the export has a fixed input shape: the ONNX and TF SavedModel exports above reject the default of 640, while the TorchScript and NCNN ones accept any size. Which applies depends on the model and the export arguments, so check your own export.
 
+The value is then rounded up to a multiple of the model stride, which is 32 without metadata. A fixed-shape export at 200x200 is therefore fed 224x224 and rejected even though `imgsz=200` matches it. For input sizes that are not multiples of 32, call the backend directly.
+
 ### Calling a Backend Directly
 
 For raw tensors without Ultralytics [preprocessing](https://www.ultralytics.com/glossary/data-preprocessing) and post-processing, use the per-format classes in [`ultralytics.nn.backends`](../reference/nn/backends/base.md), as the [verification example](#verify-your-exported-model) above does. Each takes the exported artifact and a device, and is callable:
@@ -319,6 +321,8 @@ For raw tensors without Ultralytics [preprocessing](https://www.ultralytics.com/
 | PaddlePaddle                | [`PaddleBackend`](../reference/nn/backends/paddle.md)         | BCHW         |
 | MNN                         | [`MNNBackend`](../reference/nn/backends/mnn.md)               | BCHW         |
 | ExecuTorch                  | [`ExecuTorchBackend`](../reference/nn/backends/executorch.md) | BCHW         |
+
+`TensorFlowBackend` covers two formats and defaults to `format="saved_model"`, so pass `format="pb"` for a frozen graph.
 
 Three things the `YOLO()` route handles for you and a direct call does not:
 


### PR DESCRIPTION
## summary

- The guide told readers that exported non-YOLO models "cannot be loaded back through `YOLO()` for inference". They can. Replaced with the real constraint: these exports carry no Ultralytics task or input-size metadata, so `task` and `imgsz` must be passed explicitly.
- Added a "Run Your Exported Model" section covering the `YOLO()` round trip and the per-format classes in `ultralytics.nn.backends`, with the three contracts that differ between the two routes: input layout (`CoreMLBackend` and `TensorFlowBackend` take BHWC), autograd (`TorchScriptBackend` returns a tensor still carrying a gradient graph), and post-processing on metadata-less models.
- Corrected the TF SavedModel output tree: `onnx2saved_model()` emits an INT8 `.tflite` only with `quantize=8`, and the default call also writes `assets/` and `fingerprint.pb`.
- Scoped the numerical-parity tolerance per format instead of one global "well under `1e-4`" claim, in both the tip and the FAQ, and pointed the two `torch2onnx()` reference links at `utils/export/engine.md`, where the function is defined.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the non-YOLO export guide to document loading exports through `YOLO()`, explain direct backend usage, correct SavedModel outputs, and replace broad parity claims with format-specific guidance.

### 📊 Key Changes

- Added a **Run Your Exported Model** section showing `YOLO("model", task=..., imgsz=...)` usage and explaining missing task/input-size metadata, fixed-shape behavior, stride rounding, and direct backend alternatives.
- Documented the per-format backend classes in `ultralytics.nn.backends`, including BCHW versus BHWC inputs, `TensorFlowBackend` frozen-graph selection, autograd handling, and metadata-less post-processing.
- Corrected the TensorFlow SavedModel and LiteRT output tree to include `assets/` and `fingerprint.pb`; INT8 output is now documented as conditional on `quantize=8`.
- Replaced the global FP32 parity tolerance with format-specific examples, including approximately `1e-6` for ONNX, TensorFlow SavedModel, and LiteRT, `0` for TorchScript, and approximately `1e-2` for NCNN.
- Updated `torch2onnx()` links to the `utils/export/engine.md` reference.

### 🎯 Purpose & Impact

- Users can load non-YOLO exports through `YOLO()` when they provide the task and, where required, the exported input size.
- Direct backend callers now have documented input-layout, autograd, and post-processing requirements.
- The guide’s SavedModel file listings and numerical-comparison guidance now match the documented export behavior and format-specific baselines.