### PR TITLE
Remove `[export]` from edge-device install guides

### DIFF
--- a/docs/en/guides/deepstream-nvidia-jetson.md
+++ b/docs/en/guides/deepstream-nvidia-jetson.md
@@ -59,7 +59,7 @@ Here we are using [marcoslucianops/DeepStream-Yolo](https://github.com/marcosluc
     pip install -U pip
     git clone https://github.com/ultralytics/ultralytics
     cd ultralytics
-    pip install -e ".[export]" onnxslim
+    pip install -e . onnx onnxslim
     ```
 
 2.  Clone the DeepStream-Yolo repository

--- a/docs/en/guides/nvidia-dgx-spark.md
+++ b/docs/en/guides/nvidia-dgx-spark.md
@@ -112,7 +112,7 @@ For a native installation without Docker, follow these steps.
 
 ### Install Ultralytics Package
 
-Here we will install Ultralytics package on DGX Spark with optional dependencies so that we can export the [PyTorch](https://www.ultralytics.com/glossary/pytorch) models to other different formats. We will mainly focus on [NVIDIA TensorRT exports](../integrations/tensorrt.md) because TensorRT will make sure we can get the maximum performance out of the DGX Spark.
+Here we will install the Ultralytics package on DGX Spark. Export dependencies are installed automatically the first time you export a model, so only the base package is needed here. We will mainly focus on [NVIDIA TensorRT exports](../integrations/tensorrt.md) because TensorRT will make sure we can get the maximum performance out of the DGX Spark.
 
 1. Update packages list, install pip and upgrade to latest
 
@@ -122,10 +122,10 @@ Here we will install Ultralytics package on DGX Spark with optional dependencies
     pip install -U pip
     ```
 
-2. Install `ultralytics` pip package with optional dependencies
+2. Install `ultralytics` pip package
 
     ```bash
-    pip install ultralytics[export]
+    pip install ultralytics
     ```
 
 3. Reboot the device

--- a/docs/en/guides/nvidia-jetson.md
+++ b/docs/en/guides/nvidia-jetson.md
@@ -128,7 +128,7 @@ For a native installation without Docker, please refer to the steps below.
 
 #### Install Ultralytics Package
 
-Here we will install Ultralytics package on the Jetson with optional dependencies so that we can export the [PyTorch](https://www.ultralytics.com/glossary/pytorch) models to other different formats. We will mainly focus on [NVIDIA TensorRT exports](../integrations/tensorrt.md) because TensorRT will make sure we can get the maximum performance out of the Jetson devices.
+Here we will install the Ultralytics package on the Jetson. Export dependencies are installed automatically the first time you export a model, so only the base package is needed here. We will mainly focus on [NVIDIA TensorRT exports](../integrations/tensorrt.md) because TensorRT will make sure we can get the maximum performance out of the Jetson devices.
 
 1. Update packages list, install pip and upgrade to latest
 
@@ -138,10 +138,10 @@ Here we will install Ultralytics package on the Jetson with optional dependencie
     pip install -U pip
     ```
 
-2. Install `ultralytics` pip package with optional dependencies
+2. Install `ultralytics` pip package
 
     ```bash
-    pip install ultralytics[export]
+    pip install ultralytics
     ```
 
 3. Reboot the device
@@ -174,7 +174,7 @@ pip install https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxr
 
 #### Install Ultralytics Package
 
-Here we will install Ultralytics package on the Jetson with optional dependencies so that we can export the [PyTorch](https://www.ultralytics.com/glossary/pytorch) models to other different formats. We will mainly focus on [NVIDIA TensorRT exports](../integrations/tensorrt.md) because TensorRT will make sure we can get the maximum performance out of the Jetson devices.
+Here we will install the Ultralytics package on the Jetson. Export dependencies are installed automatically the first time you export a model, so only the base package is needed here. We will mainly focus on [NVIDIA TensorRT exports](../integrations/tensorrt.md) because TensorRT will make sure we can get the maximum performance out of the Jetson devices.
 
 1. Update packages list, install pip and upgrade to latest
 
@@ -184,10 +184,10 @@ Here we will install Ultralytics package on the Jetson with optional dependencie
     pip install -U pip
     ```
 
-2. Install `ultralytics` pip package with optional dependencies
+2. Install `ultralytics` pip package
 
     ```bash
-    pip install ultralytics[export]
+    pip install ultralytics
     ```
 
 3. Reboot the device
@@ -243,7 +243,7 @@ pip install https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxr
 
 #### Install Ultralytics Package
 
-Here we will install Ultralytics package on the Jetson with optional dependencies so that we can export the PyTorch models to other different formats. We will mainly focus on [NVIDIA TensorRT exports](../integrations/tensorrt.md) because TensorRT will make sure we can get the maximum performance out of the Jetson devices.
+Here we will install the Ultralytics package on the Jetson. Export dependencies are installed automatically the first time you export a model, so only the base package is needed here. We will mainly focus on [NVIDIA TensorRT exports](../integrations/tensorrt.md) because TensorRT will make sure we can get the maximum performance out of the Jetson devices.
 
 1. Update packages list, install pip and upgrade to latest
 
@@ -253,10 +253,10 @@ Here we will install Ultralytics package on the Jetson with optional dependencie
     pip install -U pip
     ```
 
-2. Install `ultralytics` pip package with optional dependencies
+2. Install `ultralytics` pip package
 
     ```bash
-    pip install ultralytics[export]
+    pip install ultralytics
     ```
 
 3. Reboot the device

--- a/docs/en/guides/raspberry-pi.md
+++ b/docs/en/guides/raspberry-pi.md
@@ -74,7 +74,7 @@ The Docker image already includes Ultralytics, so you can go straight to [export
 
 #### Install Ultralytics Package
 
-Here we will install Ultralytics package on the Raspberry Pi with optional dependencies so that we can export the [PyTorch](https://www.ultralytics.com/glossary/pytorch) models to other formats.
+Here we will install the Ultralytics package on the Raspberry Pi. Export dependencies for formats such as [NCNN](../integrations/ncnn.md) are installed automatically the first time you export a [PyTorch](https://www.ultralytics.com/glossary/pytorch) model, so only the base package is needed here.
 
 1. Update packages list, install pip and upgrade to latest
 
@@ -84,10 +84,10 @@ Here we will install Ultralytics package on the Raspberry Pi with optional depen
     pip install -U pip
     ```
 
-2. Install `ultralytics` pip package with optional dependencies
+2. Install `ultralytics` pip package
 
     ```bash
-    pip install ultralytics[export]
+    pip install ultralytics
     ```
 
 3. Reboot the device
@@ -422,9 +422,9 @@ To set up Ultralytics YOLO26 on a Raspberry Pi without Docker, follow these step
     sudo apt install python3-pip -y
     pip install -U pip
     ```
-2. Install the Ultralytics package with optional dependencies:
+2. Install the Ultralytics package:
     ```bash
-    pip install ultralytics[export]
+    pip install ultralytics
     ```
 3. Reboot the device to apply changes:
     ```bash


### PR DESCRIPTION
The extra installs unnecessary, large, conflict prone dependencies that are breaking things for users that are simply trying to install Ultralytics:

https://forums.raspberrypi.com/viewtopic.php?t=387759
https://forum.core-electronics.com.au/t/problems-installing-ultralytics-packages-on-pi-5/22693/8
https://forum.core-electronics.com.au/t/getting-started-with-yolo-object-and-animal-recognition-on-the-raspberry-pi/20923/57
https://forum.core-electronics.com.au/t/multiple-false-detections-for-yolo-using-conda-and-ultralytics/23748/5

Export can auto install the required dependencies.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated edge-device installation guides to install the base Ultralytics package instead of the `[export]` extra, while documenting that export dependencies are installed when needed.

### 📊 Key Changes
- Replaced `pip install ultralytics[export]` with `pip install ultralytics` in Raspberry Pi, NVIDIA Jetson, and NVIDIA DGX Spark guides.
- Updated the DeepStream NVIDIA Jetson command to install `onnx` and `onnxslim` directly with the editable Ultralytics package.
- Revised installation text to state that export dependencies are installed automatically during the first model export.
- Added Raspberry Pi guidance that this behavior also applies to formats such as NCNN.

### 🎯 Purpose & Impact
- Edge-device setup instructions now avoid installing the full `[export]` dependency group up front, reducing the packages installed during initial setup.
- Users can install the base package first and obtain export dependencies when exporting a model.