### PR TITLE
Fix INT8 export calibration fractions

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -169,6 +169,19 @@ def test_int8_calibration_validates_split():
         exporter.get_int8_calibration_dataloader()
 
 
+def test_int8_calibration_applies_scalar_fraction(tmp_path):
+    """Check a scalar fraction subsets the calibration split instead of silently calibrating on every image."""
+    for split, count in (("train", 2), ("val", 4)):
+        (split_dir := tmp_path / split / "0").mkdir(parents=True)
+        for i in range(count):
+            shutil.copy(SOURCE, split_dir / f"{i}.jpg")
+    exporter = object.__new__(Exporter)
+    exporter.model = SimpleNamespace(task="classify")
+    exporter.args = get_cfg(overrides={"data": str(tmp_path), "split": "val", "fraction": 0.5, "batch": 1})
+    exporter.imgsz = [32]
+    assert len(exporter.get_int8_calibration_dataloader().dataset) == 2
+
+
 def test_export_rknn_batch_expansion(monkeypatch, tmp_path):
     """Check RKNN calibrates batch 1 before Toolkit expands to the requested batch."""
     calls = {}

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -169,17 +169,22 @@ def test_int8_calibration_validates_split():
         exporter.get_int8_calibration_dataloader()
 
 
-def test_int8_calibration_applies_scalar_fraction(tmp_path):
-    """Check a scalar fraction subsets the calibration split instead of silently calibrating on every image."""
-    for split, count in (("train", 2), ("val", 4)):
-        (split_dir := tmp_path / split / "0").mkdir(parents=True)
-        for i in range(count):
-            shutil.copy(SOURCE, split_dir / f"{i}.jpg")
+@pytest.mark.parametrize("task", ["classify", "detect"])
+@pytest.mark.parametrize(("fraction", "expected"), [(2, 2), ([1, 3, 0], 3)])
+def test_int8_calibration_fraction(task, fraction, expected, tmp_path):
+    """Check scalar and list fractions select the requested calibration split size for classification and detection."""
+    data = "coco8.yaml"
+    if task == "classify":
+        for split, count in (("train", 2), ("val", 4)):
+            (split_dir := tmp_path / split / "0").mkdir(parents=True)
+            for i in range(count):
+                shutil.copy(SOURCE, split_dir / f"{i}.jpg")
+        data = str(tmp_path)
     exporter = object.__new__(Exporter)
-    exporter.model = SimpleNamespace(task="classify")
-    exporter.args = get_cfg(overrides={"data": str(tmp_path), "split": "val", "fraction": 0.5, "batch": 1})
+    exporter.model = SimpleNamespace(task=task)
+    exporter.args = get_cfg(overrides={"data": data, "split": "val", "fraction": fraction, "batch": 1})
     exporter.imgsz = [32]
-    assert len(exporter.get_int8_calibration_dataloader().dataset) == 2
+    assert len(exporter.get_int8_calibration_dataloader().dataset) == expected
 
 
 def test_export_rknn_batch_expansion(monkeypatch, tmp_path):

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1003,20 +1003,22 @@ class Exporter:
         LOGGER.info(f"{prefix} collecting INT8 calibration images from 'data={self.args.data}'")
         cfg = deepcopy(self.args)
         cfg.imgsz = max(self.imgsz)
+        split = self.args.split or "val"
         if self.model.task == "classify":
             import torchvision.transforms as T  # scope for faster 'import ultralytics'
 
             data = check_cls_dataset(self.args.data, split=self.args.split)
-            cfg.fraction = get_split_fraction(cfg.fraction, self.args.split or "val")
-            dataset = ClassificationDataset(data[self.args.split or "val"], args=cfg, augment=False)
+            if not isinstance(cfg.fraction, list):
+                cfg.fraction = [cfg.fraction] * 3
+            dataset = ClassificationDataset(data[split], args=cfg, augment=False, prefix=split)
             # INT8 backends divide images by 255, so emit uint8 [0, 255] center-cropped like classify inference
             dataset.torch_transforms = T.Compose([T.Resize(cfg.imgsz), T.CenterCrop(cfg.imgsz), T.PILToTensor()])
         else:
             data = check_det_dataset(self.args.data, split=self.args.split)
-            cfg.fraction = get_split_fraction(cfg.fraction, self.args.split or "val")
+            cfg.fraction = get_split_fraction(cfg.fraction, split) if isinstance(cfg.fraction, list) else cfg.fraction
             dataset = build_yolo_dataset(
                 cfg,
-                data[self.args.split or "val"],
+                data[split],
                 self.args.batch,
                 data,
                 mode="val",


### PR DESCRIPTION
INT8 export resolves `fraction` with the training split rules before it builds the calibration dataset, so a scalar value gets replaced by `1.0` for `val` or `test`. Classification then resolves that value a second time inside `ClassificationDataset`.

On current `main`, `fraction=0.1` ends up calibrating a classification model with the full 3,925-image ImageNette validation split instead of 392 images. Detection has the same scalar problem: `fraction=2` on the four-image COCO8 validation split still uses four images.

So the fix keeps the resolution at the export calibration owner: scalar values now apply directly to the selected calibration split, list values keep the train/val/test semantics from #25966. Classification gets the selected split once, so its dataset only resolves the value once. No new argument, no helper, no change to training datasets.

## Validation

- Real calibration loaders: COCO8 scalar count/ratio select 2/4 images; ImageNette scalar count, scalar ratio, and list forms select 392/3,925 images, with 10/10 classes represented.
- Train/test matrix: two-item lists keep the test split complete, three-item lists apply their test value. Scalars apply to the selected calibration split for detection and classification.
- Two ONNX INT8 aliases pass through the export test: `2 passed` for `int8=True` and `quantize=8`.
- Six CPU ONNX INT8 exports on ImageNette, three fresh processes per variant: wall-time median went from 29.063 s to 4.195 s and peak RSS from 1,879.8 MB to 1,035.0 MB, because the requested 392 images are actually used now.
- The focused existing tests pass, and the Ultralytics formatter plus `git diff --check` are clean.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes INT8 calibration fraction handling so scalar values apply directly to the selected calibration split while list values retain their train/validation/test semantics.

### 📊 Key Changes
- Uses the selected split consistently when building classification and detection calibration datasets.
- Prevents classification scalars from being resolved a second time by normalizing them to per-split values before creating `ClassificationDataset`.
- Preserves split-aware resolution for detection list values while passing scalar values directly to the selected split.
- Passes the selected split as the classification dataset prefix for consistent dataset construction.

### 🎯 Purpose & Impact
INT8 exports now calibrate with the requested scalar fraction on the selected validation or test split, while existing list-based fraction behavior remains unchanged for classification and detection.