### PR TITLE
Allow skipping W&B model artifacts

### DIFF
--- a/docs/en/integrations/weights-biases.md
+++ b/docs/en/integrations/weights-biases.md
@@ -110,6 +110,8 @@ Before diving into the usage instructions for YOLO26 model training with Weights
 | project  | `None`  | Specifies the name of the project logged locally and in W&B. This way you can group multiple runs together.        |
 | name     | `None`  | The name of the training run. This determines the name used to create subfolders and the name used for W&B logging |
 
+Set `WANDB_LOG_MODEL=false` to log metrics without uploading the best checkpoint as a model artifact.
+
 !!! tip "Enable or Disable Weights & Biases"
 
     If you want to enable or disable Weights & Biases logging in Ultralytics, you can use the `yolo settings` command. By default, Weights & Biases logging is disabled.

--- a/ultralytics/utils/callbacks/wb.py
+++ b/ultralytics/utils/callbacks/wb.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-from ultralytics.utils import SETTINGS, TESTS_RUNNING
+from ultralytics.utils import SETTINGS, TESTS_RUNNING, env_bool
 from ultralytics.utils.torch_utils import model_info_for_loggers
 
 try:
@@ -167,8 +167,8 @@ def on_train_end(trainer):
     """Save the best model as an artifact and log final plots at the end of training."""
     _log_plots(trainer.validator.plots, step=trainer.epoch + 1)
     _log_plots(trainer.plots, step=trainer.epoch + 1)
-    art = wb.Artifact(type="model", name=f"run_{wb.run.id}_model")
-    if trainer.best.exists():
+    if env_bool("WANDB_LOG_MODEL", True) and trainer.best.exists():
+        art = wb.Artifact(type="model", name=f"run_{wb.run.id}_model")
         art.add_file(trainer.best)
         wb.run.log_artifact(art, aliases=["best"])
     # Check if we actually have plots to save


### PR DESCRIPTION
Large training jobs can fill W&B artifact storage even when users only need scalar experiment tracking.

- Respect `WANDB_LOG_MODEL=false` before creating or uploading the best-checkpoint artifact.
- Keep existing behavior by default and document the opt-out next to the W&B training arguments.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

W&B training runs can now skip best-checkpoint model artifacts when `WANDB_LOG_MODEL=false`, while retaining artifact logging by default.

### 📊 Key Changes

- `on_train_end` checks `WANDB_LOG_MODEL` before creating or uploading the best model artifact.
- The setting defaults to `true`, preserving existing behavior when the variable is unset.
- W&B integration documentation now describes `WANDB_LOG_MODEL=false` for metrics-only logging.

### 🎯 Purpose & Impact

- Users can log training metrics and plots without uploading the best checkpoint as a W&B model artifact by setting `WANDB_LOG_MODEL=false`.
- With the default configuration, the best checkpoint continues to be uploaded under the `best` alias.