### PR TITLE
Preserve project names in multi-dataset training

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1251,12 +1251,11 @@ class MultiTrainer:
                     overrides = {
                         **self.args,
                         "data": data,
-                        "project": str(self.save_dir),  # nest per-dataset runs inside the sweep directory
                         "name": name,
                         "resume": False,
                     }
                     run = SimpleNamespace(
-                        project=overrides["project"],
+                        project=str(self.save_dir),  # nest per-dataset runs inside the sweep directory
                         name=overrides["name"],
                         task=overrides.get("task"),
                         mode="train",


### PR DESCRIPTION
Multi-dataset training currently replaces the configured project name with its incremented local sweep path even though each child already receives an exact save directory. W&B therefore creates a different project every time the same multi-dataset training is run again.

For example, with `project="benchmarks"` and `data=["coco8.yaml", "VOC.yaml"]`:

- before: the first launch uses W&B project `<runs-path>-benchmarks-multitrain`, while the next uses `<runs-path>-benchmarks-multitrain-2`
- after: both launches use W&B project `benchmarks`
- local outputs still increment under `benchmarks/multitrain` and `benchmarks/multitrain-2`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Multi-dataset training now preserves the configured `project` name for child runs while keeping their local outputs nested under the incremented multi-training directory.

### 📊 Key Changes
- Removed the `project` override that replaced the configured project with `self.save_dir`.
- Kept each child run’s local directory nesting by setting `run.project` to `str(self.save_dir)`.
- Preserved the configured project name for integrations such as W&B across repeated multi-dataset launches.

### 🎯 Purpose & Impact
- Repeated multi-dataset training runs can use the same configured W&B project instead of generating project names from incremented local paths.
- Local outputs continue to use the multi-training directory structure, such as `benchmarks/multitrain` and `benchmarks/multitrain-2`.