### PR TITLE
Use save argument for W&B model artifacts

### DIFF
--- a/docs/en/integrations/weights-biases.md
+++ b/docs/en/integrations/weights-biases.md
@@ -109,6 +109,7 @@ Before diving into the usage instructions for YOLO26 model training with Weights
 | -------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
 | project  | `None`  | Specifies the name of the project logged locally and in W&B. This way you can group multiple runs together.        |
 | name     | `None`  | The name of the training run. This determines the name used to create subfolders and the name used for W&B logging |
+| save     | `True`  | Determines whether to upload the best checkpoint as a W&B model artifact.                                          |
 
 !!! tip "Enable or Disable Weights & Biases"
 

--- a/docs/en/integrations/weights-biases.md
+++ b/docs/en/integrations/weights-biases.md
@@ -110,8 +110,6 @@ Before diving into the usage instructions for YOLO26 model training with Weights
 | project  | `None`  | Specifies the name of the project logged locally and in W&B. This way you can group multiple runs together.        |
 | name     | `None`  | The name of the training run. This determines the name used to create subfolders and the name used for W&B logging |
 
-Set `WANDB_LOG_MODEL=false` to log metrics without uploading the best checkpoint as a model artifact.
-
 !!! tip "Enable or Disable Weights & Biases"
 
     If you want to enable or disable Weights & Biases logging in Ultralytics, you can use the `yolo settings` command. By default, Weights & Biases logging is disabled.

--- a/ultralytics/utils/callbacks/wb.py
+++ b/ultralytics/utils/callbacks/wb.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-from ultralytics.utils import SETTINGS, TESTS_RUNNING, env_bool
+from ultralytics.utils import SETTINGS, TESTS_RUNNING
 from ultralytics.utils.torch_utils import model_info_for_loggers
 
 try:
@@ -167,8 +167,8 @@ def on_train_end(trainer):
     """Save the best model as an artifact and log final plots at the end of training."""
     _log_plots(trainer.validator.plots, step=trainer.epoch + 1)
     _log_plots(trainer.plots, step=trainer.epoch + 1)
-    if env_bool("WANDB_LOG_MODEL", True) and trainer.best.exists():
-        art = wb.Artifact(type="model", name=f"run_{wb.run.id}_model")
+    art = wb.Artifact(type="model", name=f"run_{wb.run.id}_model")
+    if trainer.args.save and trainer.best.exists():
         art.add_file(trainer.best)
         wb.run.log_artifact(art, aliases=["best"])
     # Check if we actually have plots to save

--- a/ultralytics/utils/callbacks/wb.py
+++ b/ultralytics/utils/callbacks/wb.py
@@ -167,8 +167,8 @@ def on_train_end(trainer):
     """Save the best model as an artifact and log final plots at the end of training."""
     _log_plots(trainer.validator.plots, step=trainer.epoch + 1)
     _log_plots(trainer.plots, step=trainer.epoch + 1)
-    art = wb.Artifact(type="model", name=f"run_{wb.run.id}_model")
     if trainer.args.save and trainer.best.exists():
+        art = wb.Artifact(type="model", name=f"run_{wb.run.id}_model")
         art.add_file(trainer.best)
         wb.run.log_artifact(art, aliases=["best"])
     # Check if we actually have plots to save


### PR DESCRIPTION
## Summary

- fully revert the `WANDB_LOG_MODEL` environment variable and documentation from #25979
- reuse the existing training `save` argument so `save=False` skips the W&B checkpoint upload
- preserve model artifact uploads by default with `save=True`

## Validation

- `uvx ruff check ultralytics/utils/callbacks/wb.py`
- `uvx ruff format --check ultralytics/utils/callbacks/wb.py`
- focused callback smoke check covering both `save=False` and `save=True`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

The W&B integration now uses the training `save` argument to control model artifact uploads, replacing the separate `WANDB_LOG_MODEL` setting.

### 📊 Key Changes

- Removed `WANDB_LOG_MODEL` handling from the W&B callback and documentation.
- W&B uploads the best checkpoint only when `trainer.args.save` is enabled and the checkpoint exists.
- Added the `save` training argument to the W&B documentation, with a default of `True`.
- Metric and plot logging remains unchanged.

### 🎯 Purpose & Impact

- `save=False` skips uploading the best checkpoint as a W&B model artifact.
- `save=True` preserves the default best-checkpoint upload behavior.
- Users no longer configure W&B model artifact uploads through `WANDB_LOG_MODEL`.