### PR TITLE
Speed up PIL and ndarray prediction sources with cv2 color conversion

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -433,9 +433,24 @@ def test_predict_ndarray_channels():
     assert gray.ndim == 2, "Expected a 2D grayscale array for this test"
     assert len(model(source=gray, imgsz=32, verbose=False)) == 1  # 2D ndarray auto-expanded to 3 channels
     assert len(model(source=gray.astype("float64"), imgsz=32, verbose=False)) == 1  # non-OpenCV dtype also works
+    bgra = np.zeros((8, 8, 4), dtype="float64")
+    assert LoadPilAndNumpy(bgra, channels=3).im0[0].shape == (8, 8, 3)  # non-OpenCV dtype also falls back for BGRA
     for source_channels, model_channels in ((1, 3), (2, 1), (2, 3), (3, 1), (4, 1), (4, 3)):
         im = np.zeros((8, 8, source_channels), dtype=np.uint8)
         assert LoadPilAndNumpy(im, channels=model_channels).im0[0].shape == (8, 8, model_channels)
+
+
+def test_single_check_channel_order_and_contiguity():
+    """Test LoadPilAndNumpy._single_check() keeps BGR order and C-contiguous output through cv2 conversions."""
+    from ultralytics.data.loaders import LoadPilAndNumpy
+
+    check = LoadPilAndNumpy._single_check
+    rgb = Image.fromarray(np.full((2, 2, 3), (10, 20, 30), dtype=np.uint8))  # PIL is R, G, B
+    bgra = np.full((2, 2, 4), (10, 20, 30, 255), dtype=np.uint8)  # ndarray is already B, G, R, A
+    gray = np.full((2, 2, 1), 42, dtype=np.uint8)
+    for im, expected in ((check(rgb, 3), (30, 20, 10)), (check(bgra, 3), (10, 20, 30)), (check(gray, 3), (42, 42, 42))):
+        assert tuple(im[0, 0].tolist()) == expected
+        assert im.flags["C_CONTIGUOUS"]
 
 
 @pytest.mark.slow

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -550,25 +550,30 @@ class LoadPilAndNumpy:
         pil = isinstance(im, Image.Image)
         if pil:
             flag = "L" if channels == 1 else "RGB"
-            im = np.asarray(im.convert(flag))
-            im = im[..., None] if flag == "L" else im[..., ::-1]
+            im = np.asarray(im if im.mode == flag else im.convert(flag))  # convert() copies even when mode matches
+            if flag == "L":
+                im = im[..., None]
         im = np.atleast_3d(im)
         # Both routes validate here: a zero dimension divides by zero in LetterBox, and a batched array reads
-        # shape[2] as a channel count it is not. Raised rather than asserted so `python -O` keeps the check.
+        # shape[2] as a channel count it is not. Raised rather than asserted so `python -O` keeps the check, and
+        # ahead of the cvtColor calls, which assert on an empty input instead of raising this message.
         if im.ndim != 3 or not all(im.shape):
             raise ValueError(f"Expected a single (H, W, C) image, but got array of shape {im.shape}")
         if pil:
-            return np.ascontiguousarray(im)
+            return im if channels == 1 else cv2.cvtColor(im, cv2.COLOR_RGB2BGR)
         c = im.shape[2]
         if c == channels:
             return im
         if c == 2:  # gray + alpha
             im, c = im[..., :1], 1
+        u8 = im.dtype == np.uint8  # cvtColor rejects dtypes NumPy indexing accepts, float64 among them
         if c == 1:
+            if u8 and channels == 3:
+                return cv2.cvtColor(im[..., 0], cv2.COLOR_GRAY2BGR)
             return np.repeat(im, channels, axis=2)
         if channels == 1:
             return cv2.cvtColor(im, cv2.COLOR_BGRA2GRAY if c == 4 else cv2.COLOR_BGR2GRAY)[..., None]
-        return np.ascontiguousarray(im[..., :3])
+        return cv2.cvtColor(im, cv2.COLOR_BGRA2BGR) if u8 and c == 4 else np.ascontiguousarray(im[..., :3])
 
     def __len__(self) -> int:
         """Return the length of the 'im0' attribute, representing the number of loaded images."""


### PR DESCRIPTION
## Summary

`LoadPilAndNumpy._single_check()` normalizes the prediction sources that are not files or streams: a `PIL.Image`, a list of paths (`autocast_list()` turns those into PIL images), or a NumPy array whose channel count does not match the model. Two things on that path cost more than they need to.

For PIL input it builds the BGR array as `np.ascontiguousarray(im[..., ::-1])`. Reversing the last axis gives a negative-stride view, and materializing it is an element-wise strided copy. On 100 `val2017` photos it costs 0.78-0.82 ms/image, against 0.039-0.042 ms for `cv2.cvtColor(im, cv2.COLOR_RGB2BGR)`. It also calls `im.convert(flag)` unconditionally, and `Image.convert()` opens with `if not mode or (mode == self.mode and not matrix): return self.copy()`, so an image that already arrives as RGB is copied in full for nothing. The two together take `_single_check()` from 0.84-0.93 ms to 0.14-0.15 ms on those images.

The repo already has this conversion in the fast form — `imread_pil()` in `ultralytics/utils/patches.py` and the PIL branch of `ultralytics/models/llm.py` both use `cv2.cvtColor(np.asarray(img.convert("RGB")), cv2.COLOR_RGB2BGR)`. This brings `_single_check()` in line with them. The two NumPy branches follow from the same idea: `np.repeat()` on a single-channel array is `COLOR_GRAY2BGR` (0.36-0.37 ms -> 0.022-0.025 ms) and the `[..., :3]` copy of a BGRA array is `COLOR_BGRA2BGR` (0.79-0.87 ms -> 0.049 ms), on the same photos.

Every branch this patch touches stays C-contiguous. The review on #25521 asked for exactly that guarantee on these two return paths. This patch takes it the other way round: instead of dropping `np.ascontiguousarray()` and handing back the negative-stride view, the strided view is never built in the first place. Checked on the eight return paths that build a new array, the two flagged there among them:

```
OK  PIL RGB -> 3ch                shape=(37, 53, 3)  strides=(159, 3, 1)  C_CONTIGUOUS=True  from_numpy=True
OK  PIL RGBA -> 3ch               shape=(37, 53, 3)  strides=(159, 3, 1)  C_CONTIGUOUS=True  from_numpy=True
OK  ndarray BGRA (H,W,4) -> 3ch   shape=(37, 53, 3)  strides=(159, 3, 1)  C_CONTIGUOUS=True  from_numpy=True
```

`cvtColor` does not accept every dtype NumPy indexing does, so the two NumPy fast paths are guarded on `uint8` and fall back to the previous code otherwise — `test_predict_ndarray_channels` covers that with float64 grayscale and float64 BGRA arrays. The zero-dimension check stays ahead of the conversions, which assert on an empty input instead of raising the `ValueError` that names the shape.

## Measurements

End to end through `model.predict()`, `imgsz=640`. The pre-patch and post-patch implementations are swapped in the same process and timed in alternating rounds, so model, images and device state are the same for both arms. Medians of 13 rounds (7 for the x50 cases), min-max in brackets, 64 `val2017` JPEGs.

L4, Xeon 2.20GHz 8 vCPU, torch 2.9.1+cu129, OpenCV 5.0.0, Pillow 12.3.0:

| workload | before | after | |
| --- | --- | --- | --- |
| yolo11n, 32 BGRA ndarrays | 182.0 ms [181.1-182.6] | 127.9 ms [127.2-130.1] | −29.7% |
| yolo11n, 32 grayscale ndarrays | 160.3 ms [159.8-160.9] | 124.9 ms [124.7-125.4] | −22.1% |
| yolo11n, 16 image paths | 143.5 ms [142.6-144.9] | 117.2 ms [116.2-118.1] | −18.4% |
| yolo11s, 16 image paths | 180.3 ms [179.3-180.7] | 153.9 ms [153.0-154.5] | −14.7% |
| yolo11n, 64 image paths | 615.4 ms [611.9-631.8] | 525.5 ms [507.6-531.6] | −14.6% |
| yolo11s, 64 image paths | 769.6 ms [766.2-774.3] | 666.2 ms [660.5-687.0] | −13.4% |
| yolo11n, one `PIL.Image` x50 | 690.0 ms [685.3-696.6] | 600.5 ms [597.1-618.2] | −13.0% |
| yolo11s, one `PIL.Image` x50 | 673.1 ms [669.5-682.5] | 587.1 ms [581.8-602.4] | −12.8% |

RTX 4060 Laptop, torch 2.13.0+cu130, same script and images: −17.7% (yolo11n, one `PIL.Image` x50), −14.7% (BGRA), −13.5% (yolo11s, one `PIL.Image` x50), −10.7% / −7.0% (16 / 64 paths, yolo11n), −8.7% / −7.8% (16 / 64 paths, yolo11s), −8.4% (grayscale).

### On CPU

The work removed is CPU work, so `device="cpu"` benefits too, but proportionally less: inference there is 40-160 ms/image and dwarfs the couple of ms saved. Same harness, 16 images, `torch.set_num_threads(8)`, medians of 11 interleaved rounds:

| machine | workload | before | after | | saved |
| --- | --- | --- | --- | --- | --- |
| Intel Xeon 2.80GHz, 8 vCPU | yolo11n, one `PIL.Image` x16 | 710.4 ms | 675.6 ms | −4.9% | 2.17 ms/img of 44.4 |
| Intel Xeon 2.80GHz, 8 vCPU | yolo11n, 16 image paths | 741.9 ms | 711.9 ms | −4.1% | 1.88 ms/img of 46.4 |
| Ampere Altra, 8 vCPU (arm64) | yolo11n, one `PIL.Image` x16 | 1253.7 ms | 1211.0 ms | −3.4% | 2.67 ms/img of 78.4 |
| Ampere Altra, 8 vCPU (arm64) | yolo11n, 16 BGRA ndarrays | 1055.0 ms | 1019.8 ms | −3.3% | 2.20 ms/img of 65.9 |
| Ampere Altra, 8 vCPU (arm64) | yolo11s, 16 image paths | 2567.1 ms | 2522.7 ms | −1.7% | 2.78 ms/img of 160.4 |
| Intel Xeon 2.80GHz, 8 vCPU | yolo11s, 16 image paths | 1511.2 ms | 1485.8 ms | −1.7% | 1.59 ms/img of 94.4 |

So: −1.7% to −4.9% on CPU, shrinking as the model grows, against −7% to −30% on GPU. The saved milliseconds per image are the same in both, only the denominator changes.

### Why the ratio varies

The saving is a fixed slice of CPU work, and how big that slice is depends on the microarchitecture — a strided element-wise copy and a SIMD `cvtColor` do not scale together. `_single_check()` on a PIL RGB photo, 8 vCPU, single-threaded, three runs each (run-to-run spread under 2%):

| CPU | SIMD | before | after | |
| --- | --- | --- | --- | --- |
| AMD EPYC 7B13 | AVX2 | 1.74 ms | 0.17 ms | 10.0x |
| Ampere Altra (arm64) | NEON | 2.65 ms | 0.33 ms | 8.0x |
| Intel Xeon 2.20GHz | AVX-512 | 1.95 ms | 0.35 ms | 5.6x |
| Intel Xeon Platinum 8481C | AVX-512 | 1.48 ms | 0.29 ms | 5.1x |
| Intel Xeon 2.80GHz | AVX-512 | 1.75 ms | 0.35 ms | 5.0x |

Individual conversions land between 12.2x and 41.8x across those five. The end-to-end wall-clock saving matches this isolated cost on both CPU machines — 1.88 ms/image measured end to end on the Intel Xeon against 1.40 ms isolated, 1.72 ms against 2.32 ms on the Ampere — which is the check that the wall-clock difference is this change and not drift.

### Where the saving does and doesn't show up

`_single_check()` runs inside `LoadPilAndNumpy.__init__`, which `setup_source()` calls at `predictor.py:320` — before the three profilers are built at line 328. So the saving does **not** appear in the `preprocess` figure that `Results.speed` reports and `verbose=True` prints — that timer covers `predictor.preprocess()` only. It shows up in the wall-clock time of the `predict()` call, which is what the tables above measure.

## Correctness

Output is byte-for-byte the same. Every A/B round above compares `boxes.data` with `torch.equal` and `orig_img` with `np.array_equal`; all matched, on both machines.

I also compared the old and new function directly on 338 inputs, matching on values, shape, dtype and the `writeable` / `C_CONTIGUOUS` flags of the result:

- 38 over real files — the 12 formats in COCO12-Formats (AVIF, BMP, DNG, HEIC, JP2, JPEG, JPG, MPO, PNG, TIF, TIFF, WebP) plus PNG/TIFF re-encodings of the same photo in modes P, L, RGBA, LA, 1, CMYK and I;16.
- 108 over PIL modes RGB, L, RGBA, P, CMYK, I;16, LA, 1 and F, a PIL image carrying `info["transparency"]`, zero-size PIL images, and assorted ndarray shapes.
- 192 over ndarrays: 8 dtypes x 6 shapes x 4 channel counts, gray+alpha and 5-channel among them.

## Tests

The existing predict-source tests (`test_predict_img`, `test_predict_gray_and_4ch`, `test_predict_ndarray_channels`, `test_multichannel`, `test_grayscale`) assert result counts or output shape, and the ones that reach `_single_check()` directly build their inputs with `np.zeros(...)`. A channel-order slip on this path — `COLOR_BGR2RGB` where `COLOR_RGB2BGR` belongs — would therefore be silent across the whole suite while corrupting the default `model(pil_image)` path.

`test_single_check_channel_order_and_contiguity` pins that: distinguishable per-channel values through the PIL, BGRA and grayscale branches, plus `C_CONTIGUOUS` on each result. Twelve lines, in memory, no fixtures, in the file that already covers this area. The float64 BGRA line added to `test_predict_ndarray_channels` pins the dtype fallback the same way.

Both pass on `main` without this patch as well — they guard invariants the change has to preserve rather than proving a fix, which is why they are two small assertions in existing territory instead of a regression suite.

`pytest tests/test_python.py -k "predict or source or load or channel or gray or multichannel or preprocess or single_check"` -> 40 passed, 2 skipped, and 5 pre-existing `test_grayscale` failures from a local onnxruntime binding error that reproduce identically without this patch.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Optimizes PIL and NumPy prediction-source normalization by using OpenCV color conversions where supported and avoiding unnecessary PIL copies.

### 📊 Key Changes
- Reuses matching PIL image modes and applies `cv2.COLOR_RGB2BGR` for three-channel PIL inputs.
- Uses OpenCV conversions for `uint8` grayscale and BGRA NumPy arrays while retaining the existing NumPy fallbacks for unsupported dtypes.
- Preserves zero-dimension validation before conversion and keeps converted outputs C-contiguous.
- Adds tests covering channel order, contiguity, and float64 BGRA fallback behavior.

### 🎯 Purpose & Impact
Prediction sources with PIL, grayscale, or BGRA inputs require less preprocessing work while maintaining the expected channel order and handling non-OpenCV-compatible dtypes through the previous fallback paths.