### PR TITLE
Reduce TaskAlignedAssigner OOM recovery cost

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.133"
+__version__ = "8.4.134"
 
 import importlib
 import os

--- a/ultralytics/utils/tal.py
+++ b/ultralytics/utils/tal.py
@@ -58,6 +58,7 @@ class TaskAlignedAssigner(nn.Module):
         self.stride = stride if stride is not None else [8, 16, 32]
         self.stride_val = self.stride[1] if len(self.stride) > 1 else self.stride[0]
         self.eps = eps
+        self._oom_warned = False
 
     @torch.no_grad()
     def forward(self, pd_scores, pd_bboxes, anc_points, gt_labels, gt_bboxes, mask_gt):
@@ -98,8 +99,13 @@ class TaskAlignedAssigner(nn.Module):
             if "out of memory" not in str(e).lower():
                 raise
         # Recover outside the except block so e.__traceback__ releases the failed attempt's GPU intermediates.
-        LOGGER.warning("CUDA OutOfMemoryError in TaskAlignedAssigner, retrying with batch_size=1")
         bs, n_max_boxes = self.bs, self.n_max_boxes
+        if not self._oom_warned:
+            LOGGER.warning(
+                f"CUDA out of memory in TaskAlignedAssigner with batch_size={bs} and max_num_obj={n_max_boxes}; "
+                "retrying assignment one image at a time on GPU. Model forward batch size is unchanged."
+            )
+            self._oom_warned = True
         last_gt_idx = (
             mask_gt.squeeze(-1)
             .bool()
@@ -109,10 +115,10 @@ class TaskAlignedAssigner(nn.Module):
             .tolist()
         )
         self.bs = 1
-        results = []
-        for i, self.n_max_boxes in enumerate(last_gt_idx):
-            results.append(
-                self._forward(
+        results = None
+        try:
+            for i, self.n_max_boxes in enumerate(last_gt_idx):
+                result = self._forward(
                     pd_scores[i : i + 1],
                     pd_bboxes[i : i + 1],
                     anc_points,
@@ -120,9 +126,13 @@ class TaskAlignedAssigner(nn.Module):
                     gt_bboxes[i : i + 1, : self.n_max_boxes],
                     mask_gt[i : i + 1, : self.n_max_boxes],
                 )
-            )
-        self.bs, self.n_max_boxes = bs, n_max_boxes
-        return tuple(torch.cat(x, 0) for x in zip(*results))
+                if results is None:
+                    results = tuple(x.new_empty((bs, *x.shape[1:])) for x in result)
+                for output, x in zip(results, result):
+                    output[i] = x[0]
+        finally:
+            self.bs, self.n_max_boxes = bs, n_max_boxes
+        return results
 
     def _forward(self, pd_scores, pd_bboxes, anc_points, gt_labels, gt_bboxes, mask_gt):
         """Compute the task-aligned assignment.

--- a/ultralytics/utils/tal.py
+++ b/ultralytics/utils/tal.py
@@ -83,8 +83,6 @@ class TaskAlignedAssigner(nn.Module):
         """
         self.bs = pd_scores.shape[0]
         self.n_max_boxes = gt_bboxes.shape[1]
-        device = gt_bboxes.device
-
         if self.n_max_boxes == 0:
             return (
                 torch.full_like(pd_scores[..., 0], self.num_classes),
@@ -99,11 +97,32 @@ class TaskAlignedAssigner(nn.Module):
         except RuntimeError as e:
             if "out of memory" not in str(e).lower():
                 raise
-        # Recover outside the except block: exiting it drops e.__traceback__, releasing the failed attempt's GPU
-        # intermediates back to the allocator so the copy-back below can succeed
-        LOGGER.warning("CUDA OutOfMemoryError in TaskAlignedAssigner, using CPU")
-        result = self._forward(*(t.cpu() for t in (pd_scores, pd_bboxes, anc_points, gt_labels, gt_bboxes, mask_gt)))
-        return tuple(t.to(device) for t in result)
+        # Recover outside the except block so e.__traceback__ releases the failed attempt's GPU intermediates.
+        LOGGER.warning("CUDA OutOfMemoryError in TaskAlignedAssigner, retrying with batch_size=1")
+        bs, n_max_boxes = self.bs, self.n_max_boxes
+        last_gt_idx = (
+            mask_gt.squeeze(-1)
+            .bool()
+            .mul(torch.arange(1, n_max_boxes + 1, device=mask_gt.device))
+            .amax(1)
+            .clamp_(min=1)
+            .tolist()
+        )
+        self.bs = 1
+        results = []
+        for i, self.n_max_boxes in enumerate(last_gt_idx):
+            results.append(
+                self._forward(
+                    pd_scores[i : i + 1],
+                    pd_bboxes[i : i + 1],
+                    anc_points,
+                    gt_labels[i : i + 1, : self.n_max_boxes],
+                    gt_bboxes[i : i + 1, : self.n_max_boxes],
+                    mask_gt[i : i + 1, : self.n_max_boxes],
+                )
+            )
+        self.bs, self.n_max_boxes = bs, n_max_boxes
+        return tuple(torch.cat(x, 0) for x in zip(*results))
 
     def _forward(self, pd_scores, pd_bboxes, anc_points, gt_labels, gt_bboxes, mask_gt):
         """Compute the task-aligned assignment.
@@ -137,8 +156,10 @@ class TaskAlignedAssigner(nn.Module):
         # Normalize
         align_metric *= mask_pos
         pos_align_metrics = align_metric.amax(dim=-1, keepdim=True)  # b, max_num_obj
-        pos_overlaps = (overlaps * mask_pos).amax(dim=-1, keepdim=True)  # b, max_num_obj
-        norm_align_metric = (align_metric * pos_overlaps / (pos_align_metrics + self.eps)).amax(-2).unsqueeze(-1)
+        overlaps *= mask_pos
+        pos_overlaps = overlaps.amax(dim=-1, keepdim=True)  # b, max_num_obj
+        align_metric.mul_(pos_overlaps).div_(pos_align_metrics + self.eps)
+        norm_align_metric = align_metric.amax(-2).unsqueeze(-1)
         target_scores = target_scores * norm_align_metric
 
         return target_labels, target_bboxes, target_scores, fg_mask.bool(), target_gt_idx
@@ -165,7 +186,7 @@ class TaskAlignedAssigner(nn.Module):
         # Get topk_metric mask, (b, max_num_obj, h*w)
         mask_topk = self.select_topk_candidates(align_metric, topk_mask=mask_gt.expand(-1, -1, self.topk).bool())
         # Merge all mask to a final mask, (b, max_num_obj, h*w)
-        mask_pos = mask_topk * mask_in_gts * mask_gt
+        mask_pos = mask_topk.mul_(mask_in_gts).mul_(mask_gt.bool())
 
         return mask_pos, align_metric, overlaps
 
@@ -185,19 +206,16 @@ class TaskAlignedAssigner(nn.Module):
         """
         na = pd_bboxes.shape[-2]
         mask_gt = mask_gt.bool()  # b, max_num_obj, h*w
-        overlaps = torch.zeros([self.bs, self.n_max_boxes, na], dtype=pd_bboxes.dtype, device=pd_bboxes.device)
-        bbox_scores = torch.zeros([self.bs, self.n_max_boxes, na], dtype=pd_scores.dtype, device=pd_scores.device)
+        shape = self.bs, self.n_max_boxes, na
+        indices = mask_gt.nonzero(as_tuple=True)
+        bbox_scores = pd_scores[indices[0], indices[2], gt_labels[indices[0], indices[1], 0].long()]
+        overlap_values = self.iou_calculation(gt_bboxes[indices[:2]], pd_bboxes[indices[0], indices[2]])
+        align_values = bbox_scores.pow(self.alpha) * overlap_values.pow(self.beta)
 
-        batch_ind = torch.arange(self.bs, device=pd_scores.device)[:, None]  # b, 1
-        # Get the scores of each grid for each gt cls
-        bbox_scores[mask_gt] = pd_scores[batch_ind, :, gt_labels.squeeze(-1).long()][mask_gt]  # b, max_num_obj, h*w
-
-        # (b, max_num_obj, 1, 4), (b, 1, h*w, 4)
-        pd_boxes = pd_bboxes.unsqueeze(1).expand(-1, self.n_max_boxes, -1, -1)[mask_gt]
-        gt_boxes = gt_bboxes.unsqueeze(2).expand(-1, -1, na, -1)[mask_gt]
-        overlaps[mask_gt] = self.iou_calculation(gt_boxes, pd_boxes)
-
-        align_metric = bbox_scores.pow(self.alpha) * overlaps.pow(self.beta)
+        overlaps = torch.zeros(shape, dtype=pd_bboxes.dtype, device=pd_bboxes.device)
+        align_metric = torch.zeros(shape, dtype=align_values.dtype, device=pd_scores.device)
+        overlaps[indices] = overlap_values
+        align_metric[indices] = align_values
         return align_metric, overlaps
 
     def iou_calculation(self, gt_bboxes, pd_bboxes):
@@ -238,7 +256,7 @@ class TaskAlignedAssigner(nn.Module):
         # Filter invalid bboxes
         count_tensor.masked_fill_(count_tensor > 1, 0)
 
-        return count_tensor.to(metrics.dtype)
+        return count_tensor
 
     def get_targets(self, gt_labels, gt_bboxes, target_gt_idx, fg_mask):
         """Compute target labels, target bounding boxes, and target scores for the positive anchor points.
@@ -306,7 +324,11 @@ class TaskAlignedAssigner(nn.Module):
         gt_bboxes = xywh2xyxy(gt_bboxes_xywh)
 
         lt, rb = gt_bboxes.unsqueeze(2).chunk(2, 3)  # (b, n_boxes, 1, 2) left-top, right-bottom
-        return ((xy_centers - lt > eps) & (rb - xy_centers > eps)).all(3)
+        mask = xy_centers[:, 0] - lt[..., 0] > eps
+        mask &= xy_centers[:, 1] - lt[..., 1] > eps
+        mask &= rb[..., 0] - xy_centers[:, 0] > eps
+        mask &= rb[..., 1] - xy_centers[:, 1] > eps
+        return mask
 
     def select_highest_overlaps(self, mask_pos, overlaps, n_max_boxes, align_metric):
         """Select anchor boxes with highest IoU when assigned to multiple ground truths.
@@ -330,7 +352,7 @@ class TaskAlignedAssigner(nn.Module):
             max_overlaps_idx = overlaps.argmax(1)  # (b, h*w)
             is_max_overlaps = torch.zeros(mask_pos.shape, dtype=mask_pos.dtype, device=mask_pos.device)
             is_max_overlaps.scatter_(1, max_overlaps_idx.unsqueeze(1), 1)
-            mask_pos = torch.where(mask_multi_gts, is_max_overlaps, mask_pos).float()  # (b, n_max_boxes, h*w)
+            mask_pos = torch.where(mask_multi_gts, is_max_overlaps, mask_pos)  # (b, n_max_boxes, h*w)
 
             fg_mask = mask_pos.sum(-2)
 

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -970,10 +970,8 @@ def profile_ops(input, ops, n=10, device=None, max_num_obj=0):
                     if max_num_obj:  # simulate training with predictions per image grid (for AutoBatch)
                         with cuda_memory_usage(device) as cuda_info:
                             anchors = int(sum((x.shape[-1] / s) * (x.shape[-2] / s) for s in m.stride.tolist()))
-                            # Envelope of the detect-loss memory peaks: TaskAlignedAssigner.get_box_metrics holds ~6
-                            # simultaneous (bs, max_num_obj, anchors) fp32 buffers (overlaps, bbox_scores, gathered
-                            # pd_scores, two pow temps + align_metric); the cls path holds ~6 (bs, anchors, nc)
-                            # fp32-equivalents (pred/target + two op temps of the unreduced BCE in v8DetectionLoss:
+                            # Conservative detect-loss envelope: ~6 fp32-equivalents each for TaskAlignedAssigner
+                            # metric/top-k state and the cls path (pred/target + two op temps of unreduced BCE:
                             # ~4 in pure fp32, ~6 under AMP where autocast upcasts both BCE inputs to fp32 copies)
                             sim = (
                                 torch.randn(x.shape[0], 6 * max_num_obj, anchors, device=device, dtype=torch.float32),


### PR DESCRIPTION
## Summary

- retry failed TaskAlignedAssigner batches per image on GPU instead of moving the full assignment to CPU
- warn once per training while reporting the assignment shape and confirming that the model forward batch is unchanged
- trim trailing GT padding, preallocate retry outputs, retain candidate masks as int8, and reuse dense metric buffers
- compute box metrics only for valid anchor/GT pairs

## xView benchmark

RTX PRO 6000 Blackwell, CUDA AMP, cached xView batch 128 at 640 px: 75,357 objects, 4,967 max objects/image, 8,400 anchors.

| Path | Time | Peak allocated |
| --- | ---: | ---: |
| Existing GPU OOM -> CPU | 194.86 s | 85.62 GB |
| Existing per-image GPU | 0.442 s | 1.90 GB |
| Optimized automatic OOM -> per-image GPU | 0.699 s | 58.98 GB |
| Optimized direct per-image GPU | 0.376 s | 1.56 GB |

Warmed bounded chunks of 2/4/8/16/32 images were all slower and used more memory than single-image assignment.

CUDA AMP comparison against the existing whole-batch GPU path was bit-exact for all five outputs. The existing CPU fallback changed two foreground assignments on this batch because CUDA autocast FP32 `pow()` promotion does not follow tensors to CPU.

## Validation

- `uvx ruff check ultralytics/utils/tal.py`
- `uvx ruff format --check ultralytics/utils/tal.py ultralytics/utils/torch_utils.py`
- detection and OBB one-epoch CPU smoke training
- detection and rotated assigner equivalence with default and secondary top-k
- CUDA AMP bit-exact comparison against `main`
- forced repeated OOM recovery emits one warning, restores assigner state, and propagates a per-image OOM to Trainer

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

TaskAlignedAssigner now recovers from GPU out-of-memory errors by retrying assignment one image at a time on the GPU, while reducing temporary memory use during metric computation.

### 📊 Key Changes

- Replaced full-batch CPU fallback with per-image GPU retries that trim trailing ground-truth padding, preallocate batched outputs, and restore assigner state afterward.
- Added a one-time warning containing the assignment batch size and maximum object count, explicitly noting that the model forward batch size remains unchanged.
- Reduced assignment memory use by computing box metrics only for valid anchor/ground-truth pairs, using in-place metric operations, and retaining candidate masks without conversion to the metric dtype.
- Simplified candidate-in-ground-truth masking and removed an unnecessary float conversion when resolving multi-ground-truth assignments.
- Updated the package version from `8.4.133` to `8.4.134` and adjusted operation profiling comments for the revised memory estimate.

### 🎯 Purpose & Impact

- GPU OOM recovery no longer moves the entire assignment operation and its inputs to the CPU; it retries each image independently on the GPU.
- Successful retries return outputs with the original training batch shape, while a per-image OOM remains available to propagate to the trainer.
- Repeated recovery warnings are suppressed after the first warning per assigner instance.
- Assignment state is restored after retry processing, including when a retry raises an error.