### PR TITLE
Revert live progress bar console experiments

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.134"
+__version__ = "8.4.133"
 
 import importlib
 import os

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.133"
+__version__ = "8.4.134"
 
 import importlib
 import os

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -304,16 +304,11 @@ def on_pretrain_routine_start(trainer):
 
     # Create callback to send console output to Platform
     def send_console_output(content, line_count, chunk_id):
-        """Send batched console output and live progress bar frames to Platform webhook."""
+        """Send batched console output to Platform webhook."""
         _executor.submit(
             _send,
             "console_output",
-            {
-                "chunkId": chunk_id,
-                "content": content,
-                "lineCount": line_count,
-                "progress": ctx["console_logger"].progress_sent,
-            },
+            {"chunkId": chunk_id, "content": content, "lineCount": line_count},
             project,
             name,
             ctx["model_id"],

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -80,8 +80,8 @@ class ConsoleLogger:
         # Deduplication state
         self.last_line = ""
         self.last_time = 0.0
-        self.progress = {}  # live progress bar frames by bar id, held as state instead of buffered as log lines
-        self.progress_sent = {}
+        self.last_progress_line = ""  # Track progress sequence key for deduplication
+        self.last_was_progress = False  # Track if last line was a progress bar
 
     def start_capture(self):
         """Start capturing console output and redirect stdout/stderr.
@@ -93,8 +93,8 @@ class ConsoleLogger:
             return
 
         self.active = True
-        self.stdout_capture = sys.stdout = self._ConsoleCapture(self.original_stdout, self._queue_log)
-        self.stderr_capture = sys.stderr = self._ConsoleCapture(self.original_stderr, self._queue_log)
+        sys.stdout = self._ConsoleCapture(self.original_stdout, self._queue_log)
+        sys.stderr = self._ConsoleCapture(self.original_stderr, self._queue_log)
 
         # Hook Ultralytics logger
         try:
@@ -103,8 +103,8 @@ class ConsoleLogger:
         except Exception:
             pass
 
-        # Background flush thread: carries live progress frames in every mode, batched lines when batching
-        if not (self.flush_thread and self.flush_thread.is_alive()):  # a worker still sleeping resumes on its own
+        # Start background flush thread for batched mode
+        if self.batch_size > 1:
             self.flush_thread = threading.Thread(target=self._flush_worker, daemon=True)
             self.flush_thread.start()
 
@@ -113,7 +113,6 @@ class ConsoleLogger:
         if not self.active:
             return
 
-        self.stdout_capture.callback = self.stderr_capture.callback = None
         self.active = False
         sys.stdout = self.original_stdout
         sys.stderr = self.original_stderr
@@ -126,12 +125,11 @@ class ConsoleLogger:
                 pass
             self._log_handler = None
 
-        # Final flush, without the frames of any bar that outlived the capture
-        self.progress.clear()
+        # Final flush
         self._flush_buffer()
 
-    def _queue_log(self, text, bar_id):
-        """Queue console text with deduplication and timestamp processing, holding bar frames as state."""
+    def _queue_log(self, text):
+        """Queue console text with deduplication and timestamp processing."""
         if not self.active:
             return
 
@@ -142,20 +140,52 @@ class ConsoleLogger:
             text = text.split("\r")[-1]
         text = text.replace("\x1b[K", "")
 
-        if bar_id is not None:  # a redraw is bar state, so only the frame a bar closed with becomes a log line
-            with self.buffer_lock:
-                if text:
-                    self.progress[str(bar_id)] = text.rstrip()
-                    return
-                text = self.progress.pop(str(bar_id), "")
-
         lines = text.split("\n")
         if lines and lines[-1] == "":
             lines.pop()
 
         for line in lines:
-            if not (line := line.rstrip()):
-                continue  # a bare newline carries nothing once timestamped
+            line = line.rstrip()
+
+            # Skip lines with only thin progress bars (partial progress)
+            if "─" in line:  # Has thin lines but no thick lines
+                continue
+
+            # Only show 100% completion lines for progress bars
+            if " ━━" in line:
+                is_complete = "100%" in line
+
+                # Skip ALL non-complete progress lines
+                if not is_complete:
+                    continue
+
+                # Extract sequence key to deduplicate multiple 100% lines for same sequence
+                parts = line.split()
+                seq_key = ""
+                if parts:
+                    # Check for epoch pattern (X/Y at start)
+                    if "/" in parts[0] and parts[0].replace("/", "").isdigit():
+                        seq_key = parts[0]  # e.g., "1/3"
+                    elif parts[0] == "Class" and len(parts) > 1:
+                        seq_key = f"{parts[0]}_{parts[1]}"  # e.g., "Class_train:" or "Class_val:"
+                    elif parts[0] in ("train:", "val:"):
+                        seq_key = parts[0]  # Phase identifier
+
+                # Skip if we already showed 100% for this sequence
+                if seq_key and self.last_progress_line == f"{seq_key}:done":
+                    continue
+
+                # Mark this sequence as done
+                if seq_key:
+                    self.last_progress_line = f"{seq_key}:done"
+
+                self.last_was_progress = True
+            else:
+                # Skip empty line after progress bar
+                if not line and self.last_was_progress:
+                    self.last_was_progress = False
+                    continue
+                self.last_was_progress = False
 
             # General deduplication
             if line == self.last_line and current_time - self.last_time < 0.1:
@@ -188,13 +218,12 @@ class ConsoleLogger:
                 self._flush_buffer()
 
     def _flush_buffer(self):
-        """Flush buffered lines and current progress bar frames to destination and/or callback."""
+        """Flush buffered lines to destination and/or callback."""
         with self.buffer_lock:
-            if not self.buffer and self.progress == self.progress_sent:
-                return  # nothing new: an idle bar must not flush a chunk of its own
+            if not self.buffer:
+                return
             lines = self.buffer.copy()
             self.buffer.clear()
-            self.progress_sent = dict(self.progress)
             self.chunk_id += 1
             chunk_id = self.chunk_id  # Capture under lock to avoid race
 
@@ -209,7 +238,7 @@ class ConsoleLogger:
                 pass  # Silently ignore callback errors to avoid flooding stderr
 
         # Write to destination (file or API)
-        if self.destination is not None and lines:
+        if self.destination is not None:
             self._write_destination(content)
 
     def _write_destination(self, content):
@@ -240,14 +269,7 @@ class ConsoleLogger:
         def write(self, text):
             """Write text to the original stream and forward it to the capture callback."""
             self.original.write(text)
-            if self.callback:
-                self.callback(text, None)
-
-        def progress(self, bar_id, frame):
-            """Write a TQDM frame to the original stream and report it as bar state instead of a log line."""
-            self.original.write(frame)
-            if self.callback:
-                self.callback(frame, bar_id)
+            self.callback(text)
 
         def flush(self):
             """Flush the wrapped stream to propagate buffered output promptly during console capture."""
@@ -269,7 +291,7 @@ class ConsoleLogger:
 
         def emit(self, record):
             """Format and forward LogRecord messages to the capture callback for unified log streaming."""
-            self.callback(self.format(record) + "\n", None)
+            self.callback(self.format(record) + "\n")
 
 
 class _DriveInfo:

--- a/ultralytics/utils/tqdm.py
+++ b/ultralytics/utils/tqdm.py
@@ -16,7 +16,7 @@ from typing_extensions import Self
 @lru_cache(maxsize=1)
 def is_noninteractive_console() -> bool:
     """Check for known non-interactive console environments."""
-    return "GITHUB_ACTIONS" in os.environ
+    return "GITHUB_ACTIONS" in os.environ or "RUNPOD_POD_ID" in os.environ
 
 
 class TQDM:
@@ -305,11 +305,7 @@ class TQDM:
                 if width > 0:  # a pty opened without a winsize reports 0 columns, so there is no width to fit to
                     progress_str = self._fit(f"{self._fit(self.desc, width - len(fields) - 2)}: {fields}", width)
             # Non-interactive environments avoid the carriage return which creates empty lines
-            frame = progress_str if self.noninteractive else f"\r\033[K{progress_str}"
-            if progress := getattr(self.file, "progress", None):
-                progress(id(self), frame)  # a redraw is bar state, so log consumers keep it out of their log
-            else:
-                self.file.write(frame)
+            self.file.write(progress_str if self.noninteractive else f"\r\033[K{progress_str}")
             self.file.flush()
         except Exception:
             pass
@@ -348,9 +344,6 @@ class TQDM:
                     self._display(final=True)
             else:
                 self._display(final=True)
-
-            if progress := getattr(self.file, "progress", None):
-                progress(id(self), "")  # bar closed: the last frame is now log content
 
             # Cleanup
             if self.leave:


### PR DESCRIPTION
## Summary

- revert #25900 and #25905 in full
- restore `RUNPOD_POD_ID` non-interactive TQDM behavior
- restore completion-only `ConsoleLogger` progress capture
- remove the experimental progress-state webhook contract

Portal counterpart: ultralytics/portal#3851

## Validation

- focused RunPod TQDM check: one final `100%` frame only
- focused `ConsoleLogger` check: incomplete frames dropped, one completed frame retained
- Python syntax compilation passed
- Ruff formatting passed
- full-file Ruff lint matches the 32 pre-existing findings on current `main`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Reverts the live progress-bar console changes, restoring non-interactive RunPod output and completion-only console logging without progress state in Platform webhook payloads.

### 📊 Key Changes

- Treats `RUNPOD_POD_ID` as a non-interactive console environment in `is_noninteractive_console()`.
- Restores direct `TQDM` output and removes its special progress-frame callback handling.
- Updates `ConsoleLogger` to discard incomplete progress frames, retain completed `100%` lines, and deduplicate repeated completion lines.
- Removes progress-state buffering and the `progress` field from `console_output` webhook requests.
- Restores background flushing only for batched logging and simplifies console stream callback handling.

### 🎯 Purpose & Impact

- RunPod progress output no longer uses carriage-return updates and ends with the completed progress frame.
- Console capture omits incomplete progress-bar frames and forwards completed progress lines as normal log content.
- Platform console-output webhooks contain only `chunkId`, `content`, and `lineCount`; the experimental progress-state contract is removed.