### PR TITLE
Respect dataset object counts when selecting max_det

### DIFF
--- a/docs/en/reference/models/yolo/detect/val.md
+++ b/docs/en/reference/models/yolo/detect/val.md
@@ -14,4 +14,8 @@ keywords: YOLO validation, detection validation, YOLO metrics, Ultralytics, obje
 
 ## ::: ultralytics.models.yolo.detect.val.DetectionValidator
 
+<br><br><hr><br>
+
+## ::: ultralytics.models.yolo.detect.val.check_det_dataset_max_det
+
 <br><br>

--- a/docs/en/reference/models/yolo/detect/val.md
+++ b/docs/en/reference/models/yolo/detect/val.md
@@ -14,8 +14,4 @@ keywords: YOLO validation, detection validation, YOLO metrics, Ultralytics, obje
 
 ## ::: ultralytics.models.yolo.detect.val.DetectionValidator
 
-<br><br><hr><br>
-
-## ::: ultralytics.models.yolo.detect.val.check_det_dataset_max_det
-
 <br><br>

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.134"
+__version__ = "8.4.135"
 
 import importlib
 import os

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -212,9 +212,9 @@ class DetectionTrainer(BaseTrainer):
     def _build_train_pipeline(self):
         """Build the training pipeline and align the default detection limit with observed dataset object counts."""
         super()._build_train_pipeline()
-        from ultralytics.models.yolo.detect.val import check_det_dataset_max_det
-
-        check_det_dataset_max_det(self.args, {"train": self.train_loader.dataset, "val": self.test_loader.dataset})
+        yolo.detect.DetectionValidator._check_max_det(
+            self.args, {"train": self.train_loader.dataset, "val": self.test_loader.dataset}
+        )
         model = unwrap_model(self.model)
         if getattr(model, "end2end", False):
             model.set_head_attr(max_det=self.args.max_det)

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -212,12 +212,12 @@ class DetectionTrainer(BaseTrainer):
     def _build_train_pipeline(self):
         """Build the training pipeline and align the default detection limit with observed dataset object counts."""
         super()._build_train_pipeline()
-        yolo.detect.DetectionValidator._check_max_det(
-            self.args, {"train": self.train_loader.dataset, "val": self.test_loader.dataset}
-        )
-        model = unwrap_model(self.model)
-        if getattr(model, "end2end", False):
-            model.set_head_attr(max_det=self.args.max_det)
+        if self.args.task in {"detect", "segment", "pose", "obb"}:
+            datasets = {"train": self.train_loader.dataset, "val": self.test_loader.dataset}
+            yolo.detect.DetectionValidator._check_max_det(self.args, datasets)
+            model = unwrap_model(self.model)
+            if getattr(model, "end2end", False):
+                model.set_head_attr(max_det=self.args.max_det)
 
     def progress_string(self):
         """Return a formatted string of training progress with epoch, GPU memory, loss, instances and size."""

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -209,6 +209,16 @@ class DetectionTrainer(BaseTrainer):
             self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
         )
 
+    def _build_train_pipeline(self):
+        """Build the training pipeline and align the default detection limit with observed dataset object counts."""
+        super()._build_train_pipeline()
+        from ultralytics.models.yolo.detect.val import check_det_dataset_max_det
+
+        check_det_dataset_max_det(self.args, {"train": self.train_loader.dataset, "val": self.test_loader.dataset})
+        model = unwrap_model(self.model)
+        if getattr(model, "end2end", False):
+            model.set_head_attr(max_det=self.args.max_det)
+
     def progress_string(self):
         """Return a formatted string of training progress with epoch, GPU memory, loss, instances and size."""
         return ("\n" + "%11s" * (4 + len(self.loss_names))) % (

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -72,6 +72,7 @@ class DetectionValidator(BaseValidator):
                     for subset in getattr(dataset, "datasets", [dataset])
                     if hasattr(subset, "labels")
                     for label in subset.labels
+                    if isinstance(label, dict) and "cls" in label
                 ),
                 default=0,
             )
@@ -85,8 +86,7 @@ class DetectionValidator(BaseValidator):
         message = (
             f"Dataset images contain up to {observed} objects ({split_counts}), but max_det={args.max_det}. "
             "This mismatch can cap recall and produce invalid validation metrics."
-            " Raising max_det may increase validation time and memory usage, but cannot increase model output capacity;"
-            " low-resolution, query-limited, or exported models may still cap recall."
+            " Raising it may increase validation cost but cannot increase model or export capacity, which may cap recall."
         )
         if args.max_det == DEFAULT_CFG.max_det:
             args.max_det = observed

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -85,14 +85,12 @@ class DetectionValidator(BaseValidator):
         message = (
             f"Dataset images contain up to {observed} objects ({split_counts}), but max_det={args.max_det}. "
             "This mismatch can cap recall and produce invalid validation metrics."
+            " Raising max_det may increase validation time and memory usage, but cannot increase model output capacity;"
+            " low-resolution, query-limited, or exported models may still cap recall."
         )
         if args.max_det == DEFAULT_CFG.max_det:
             args.max_det = observed
-            message += (
-                f" Setting max_det={observed} to match the observed maximum. "
-                "This may increase validation time and memory usage, and does not increase the model's output "
-                "capacity, so low-resolution, query-limited, or exported models may still cap recall."
-            )
+            message += f" Setting max_det={observed} to match the observed maximum."
         else:
             message += f" Keeping the user-specified max_det={args.max_det}."
         if RANK in {-1, 0}:

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -72,7 +72,7 @@ class DetectionValidator(BaseValidator):
                     for subset in getattr(dataset, "datasets", [dataset])
                     if hasattr(subset, "labels")
                     for label in subset.labels
-                    if isinstance(label, dict) and isinstance(label.get("cls"), (list, tuple, np.ndarray, torch.Tensor))
+                    if isinstance(label, dict) and getattr(label.get("cls"), "ndim", 0) > 0
                 ),
                 default=0,
             )

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -72,7 +72,7 @@ class DetectionValidator(BaseValidator):
                     for subset in getattr(dataset, "datasets", [dataset])
                     if hasattr(subset, "labels")
                     for label in subset.labels
-                    if isinstance(label, dict) and "cls" in label
+                    if isinstance(label, dict) and isinstance(label.get("cls"), (list, tuple, np.ndarray, torch.Tensor))
                 ),
                 default=0,
             )

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -13,10 +13,34 @@ import torch.distributed as dist
 from ultralytics.data import build_dataloader, build_yolo_dataset, converter
 from ultralytics.data.utils import get_split_fraction
 from ultralytics.engine.validator import BaseValidator
-from ultralytics.utils import LOGGER, RANK, nms, ops
+from ultralytics.utils import DEFAULT_CFG, LOGGER, RANK, nms, ops
 from ultralytics.utils.checks import check_requirements
 from ultralytics.utils.metrics import ConfusionMatrix, DetMetrics, box_iou
 from ultralytics.utils.plotting import plot_images
+
+
+def check_det_dataset_max_det(args, datasets: dict[str, torch.utils.data.Dataset]) -> None:
+    """Warn when dataset object counts exceed max_det and raise the default limit to the observed maximum."""
+    maxima = {
+        split: max(len(label["cls"]) for subset in getattr(dataset, "datasets", [dataset]) for label in subset.labels)
+        for split, dataset in datasets.items()
+    }
+    observed = max(maxima.values())
+    if observed <= args.max_det:
+        return
+
+    split_counts = ", ".join(f"{split}={count}" for split, count in maxima.items())
+    message = (
+        f"Dataset images contain up to {observed} objects ({split_counts}), but max_det={args.max_det}. "
+        "This mismatch can cap recall and produce invalid validation metrics."
+    )
+    if args.max_det == DEFAULT_CFG.max_det:
+        args.max_det = observed
+        message += f" Setting max_det={observed} to match the observed maximum."
+    else:
+        message += f" Keeping the user-specified max_det={args.max_det}."
+    if RANK in {-1, 0}:
+        LOGGER.warning(message)
 
 
 class DetectionValidator(BaseValidator):
@@ -83,6 +107,8 @@ class DetectionValidator(BaseValidator):
         Args:
             model (torch.nn.Module): Model to validate.
         """
+        if not self.training:
+            check_det_dataset_max_det(self.args, {self.args.split or "val": self.dataloader.dataset})
         val = self.data.get(self.args.split, "")  # validation path
         self.is_coco = (
             isinstance(val, str)
@@ -95,6 +121,9 @@ class DetectionValidator(BaseValidator):
         self.names = model.names
         self.nc = len(model.names)
         self.end2end = getattr(model, "end2end", False)
+        native_model = model.model if getattr(model, "format", None) == "pt" else model
+        if self.end2end and hasattr(native_model, "set_head_attr"):
+            native_model.set_head_attr(max_det=self.args.max_det, agnostic_nms=self.args.agnostic_nms)
         self.seen = 0
         self.jdict = []
         self.is_custom_json = self.args.save_json and self.args.task == "detect" and not (self.is_coco or self.is_lvis)

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -19,30 +19,6 @@ from ultralytics.utils.metrics import ConfusionMatrix, DetMetrics, box_iou
 from ultralytics.utils.plotting import plot_images
 
 
-def check_det_dataset_max_det(args, datasets: dict[str, torch.utils.data.Dataset]) -> None:
-    """Warn when dataset object counts exceed max_det and raise the default limit to the observed maximum."""
-    maxima = {
-        split: max(len(label["cls"]) for subset in getattr(dataset, "datasets", [dataset]) for label in subset.labels)
-        for split, dataset in datasets.items()
-    }
-    observed = max(maxima.values())
-    if observed <= args.max_det:
-        return
-
-    split_counts = ", ".join(f"{split}={count}" for split, count in maxima.items())
-    message = (
-        f"Dataset images contain up to {observed} objects ({split_counts}), but max_det={args.max_det}. "
-        "This mismatch can cap recall and produce invalid validation metrics."
-    )
-    if args.max_det == DEFAULT_CFG.max_det:
-        args.max_det = observed
-        message += f" Setting max_det={observed} to match the observed maximum."
-    else:
-        message += f" Keeping the user-specified max_det={args.max_det}."
-    if RANK in {-1, 0}:
-        LOGGER.warning(message)
-
-
 class DetectionValidator(BaseValidator):
     """A class extending the BaseValidator class for validation based on a detection model.
 
@@ -86,6 +62,32 @@ class DetectionValidator(BaseValidator):
         self.niou = self.iouv.numel()
         self.metrics = DetMetrics()
 
+    @staticmethod
+    def _check_max_det(args, datasets: dict[str, torch.utils.data.Dataset]) -> None:
+        """Warn when dataset object counts exceed max_det and raise the default limit to the observed maximum."""
+        maxima = {
+            split: max(
+                len(label["cls"]) for subset in getattr(dataset, "datasets", [dataset]) for label in subset.labels
+            )
+            for split, dataset in datasets.items()
+        }
+        observed = max(maxima.values())
+        if observed <= args.max_det:
+            return
+
+        split_counts = ", ".join(f"{split}={count}" for split, count in maxima.items())
+        message = (
+            f"Dataset images contain up to {observed} objects ({split_counts}), but max_det={args.max_det}. "
+            "This mismatch can cap recall and produce invalid validation metrics."
+        )
+        if args.max_det == DEFAULT_CFG.max_det:
+            args.max_det = observed
+            message += f" Setting max_det={observed} to match the observed maximum."
+        else:
+            message += f" Keeping the user-specified max_det={args.max_det}."
+        if RANK in {-1, 0}:
+            LOGGER.warning(message)
+
     def preprocess(self, batch: dict[str, Any]) -> dict[str, Any]:
         """Preprocess batch of images for YOLO validation.
 
@@ -108,7 +110,7 @@ class DetectionValidator(BaseValidator):
             model (torch.nn.Module): Model to validate.
         """
         if not self.training:
-            check_det_dataset_max_det(self.args, {self.args.split or "val": self.dataloader.dataset})
+            self._check_max_det(self.args, {self.args.split or "val": self.dataloader.dataset})
         val = self.data.get(self.args.split, "")  # validation path
         self.is_coco = (
             isinstance(val, str)

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -67,7 +67,13 @@ class DetectionValidator(BaseValidator):
         """Warn when dataset object counts exceed max_det and raise the default limit to the observed maximum."""
         maxima = {
             split: max(
-                len(label["cls"]) for subset in getattr(dataset, "datasets", [dataset]) for label in subset.labels
+                (
+                    len(label["cls"])
+                    for subset in getattr(dataset, "datasets", [dataset])
+                    if hasattr(subset, "labels")
+                    for label in subset.labels
+                ),
+                default=0,
             )
             for split, dataset in datasets.items()
         }

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -88,7 +88,11 @@ class DetectionValidator(BaseValidator):
         )
         if args.max_det == DEFAULT_CFG.max_det:
             args.max_det = observed
-            message += f" Setting max_det={observed} to match the observed maximum."
+            message += (
+                f" Setting max_det={observed} to match the observed maximum. "
+                "This may increase validation time and memory usage, and does not increase the model's output "
+                "capacity, so low-resolution, query-limited, or exported models may still cap recall."
+            )
         else:
             message += f" Keeping the user-specified max_det={args.max_det}."
         if RANK in {-1, 0}:


### PR DESCRIPTION
## Summary

- warn when observed train or validation object counts exceed `max_det`
- raise the unchanged default to the largest observed train/validation image count
- preserve non-default user limits while warning that validation recall may be capped
- propagate the resolved limit to native end-to-end heads before validation

Related to #25992.

## Validation

- `uvx ruff format ultralytics/models/yolo/detect/train.py ultralytics/models/yolo/detect/val.py`
- `uvx ruff check --ignore BLE001 ultralytics/models/yolo/detect/train.py ultralytics/models/yolo/detect/val.py` (the ignored rule is an existing unrelated exception handler)
- focused default/override, concatenated-dataset, training-pipeline, and end-to-end propagation checks
- `python3 -m pytest tests/test_python.py::test_nn_detect_head_export_clamps_max_det tests/test_python.py::test_nms_end2end_classes_before_max_det -q`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Detection, segmentation, pose, and OBB workflows now compare `max_det` with observed train/validation object counts and adjust or preserve the limit to avoid mismatches.

### 📊 Key Changes

- Added `DetectionValidator._check_max_det()` to inspect object counts across regular and concatenated datasets.
- Automatically raises `max_det` to the largest observed count when the default value is insufficient.
- Preserves explicitly configured lower limits while warning that recall and validation metrics may be capped.
- Runs the check during training pipeline setup and standalone validation, and propagates the resolved `max_det` to native end-to-end model heads.
- Updates end-to-end validation heads with both `max_det` and `agnostic_nms` settings.

### 🎯 Purpose & Impact

- Default training and validation runs can use a detection limit that covers the largest observed image object count, while explicit user limits remain unchanged and generate warnings when they are lower.
- Native end-to-end heads receive the resolved validation settings before evaluation.
- The package version is updated from `8.4.134` to `8.4.135`.