### PR TITLE
Skip OpenCV's per-pixel grid in BoT-SORT motion compensation

### DIFF
--- a/ultralytics/trackers/utils/gmc.py
+++ b/ultralytics/trackers/utils/gmc.py
@@ -72,9 +72,7 @@ class GMC:
             self.feature_params = {
                 "maxCorners": 1000,
                 "qualityLevel": 0.01,
-                # 0, not 1: corners land on integer pixels so minDistance=1 can never reject one, yet whenever
-                # candidates exist it selects OpenCV's grid path, allocating one vector per pixel. Same corners.
-                "minDistance": 0,
+                "minDistance": 0,  # integer-pixel corners: 1 rejects nothing but forces a per-pixel grid
                 "blockSize": 3,
                 "useHarrisDetector": False,
                 "k": 0.04,

--- a/ultralytics/trackers/utils/gmc.py
+++ b/ultralytics/trackers/utils/gmc.py
@@ -72,7 +72,9 @@ class GMC:
             self.feature_params = {
                 "maxCorners": 1000,
                 "qualityLevel": 0.01,
-                "minDistance": 1,
+                # 0, not 1: corners land on integer pixels so minDistance=1 can never reject one, yet whenever
+                # candidates exist it selects OpenCV's grid path, allocating one vector per pixel. Same corners.
+                "minDistance": 0,
                 "blockSize": 3,
                 "useHarrisDetector": False,
                 "k": 0.04,


### PR DESCRIPTION
## What

`GMC.apply_sparseoptflow()` detects corners with `cv2.goodFeaturesToTrack(frame, mask=None, **self.feature_params)`, and `feature_params` sets `minDistance=1`. That value cannot reject a single corner, but it does select OpenCV's grid-partitioned rejection path, which allocates one `std::vector<Point2f>` per pixel of the working frame on every call — 2,073,600 of them when GMC runs at 1920x1080, which is what a 4K source gives with the built-in `downscale=2`.

Setting it to `0` selects the equivalent direct path. The corners returned are byte-identical.

## Why the two values return the same corners

`goodFeaturesToTrack` emits corners at integer pixel coordinates — `corners.push_back(Point2f((float)x, (float)y))`, where `x` and `y` are derived from the pixel offset into the eigenvalue image; it does no sub-pixel refinement, that is `cornerSubPix`'s job. The rejection test in the grid branch is `dx*dx + dy*dy < minDistance` after `minDistance *= minDistance`, so with `minDistance=1` it is `< 1`, which cannot hold for two distinct integer points. So every candidate gets accepted, and both branches append candidates in the same response-sorted order and stop at `maxCorners` — the output array matches element for element. The same structure holds in the OpenCL implementation in that file. OpenCV asserts `minDistance >= 0`, so `0` is a supported value, not an out-of-range one.

That argument comes from `modules/imgproc/src/featureselect.cpp`, and it rests on corners being integer-valued. I did not want to assume it generalizes across versions, so I checked it empirically on both OpenCV 4.11.0 and 5.0.0 — the byte-comparison below is what backs the claim on each one.

## Scope

`sparseOptFlow` is the default `gmc_method` for `tracktrack.yaml` — the tracker `model.track()` picks when no `tracker=` argument is passed (`ultralytics/cfg/default.yaml`) — and for `botsort.yaml`, which is the default instead in `ultralytics/solutions`. Both land on this fix by default. `DeepOCSort`'s own config defaults `gmc_method` to `none`, but `sparseOptFlow` is one of its five supported values and goes through the same `GMC` class when a user selects it. `feature_params` is only read at that one call site; the `orb`, `sift` and `ecc` methods do not use it. GMC runs on the original source frame, so its cost scales with the input resolution, not with `imgsz`.

This is worth three lines of diff because the cost is real: on a 1920x1200 clip GMC is **75.4%, 75.6% and 75.4%** of the BoT-SORT frame across three profiling runs, split between `goodFeaturesToTrack` and `calcOpticalFlowPyrLK`, and BoT-SORT costs 4.9x to 5.4x ByteTrack on that clip with almost all of the gap being GMC. I quote the ratio and not the absolute number, because the per-frame figure drifts with thermal state on this laptop (20.6-22.4 ms across the same three runs) and the ratio doesn't.

Note also that `ultralytics/utils/__init__.py:169` sets `cv2.setNumThreads(0)` process-wide, so OpenCV runs single-threaded here — everything above and below is single-threaded.

## Measured

Two machines, different CPU vendor and different OpenCV major version. A/B interleaved in the same process (the parameter is swapped between timed rounds, so model, frames and device state are identical in both arms); median of 5-7 rounds, min-max in brackets. Full logs in the PR thread.

`model.track(..., tracker="botsort.yaml")`, `yolo11n`, end to end:

| Machine | Device | Source | before | after | delta |
|---|---|---|---|---|---|
| i9-13900HX + RTX 4060 | cuda | 1280x720 | 13.561 ms/f | 13.186 | **-2.76%** |
| i9-13900HX + RTX 4060 | cuda | 3840x2160 | 57.520 ms/f | 42.444 | **-26.21%** |
| Xeon 2.20GHz + L4 | cuda | 1280x720 | 39.562 ms/f | 38.682 | **-2.22%** |
| Xeon 2.20GHz + L4 | cuda | 3840x2160 | 128.059 ms/f | 92.537 | **-27.74%** |
| Xeon 2.20GHz + L4 | cpu | 3840x2160 | 143.096 ms/f | 107.079 | **-25.17%** |

Per-round deltas never change sign in any of those five rows; the 4K rows are the tightest (L4 cuda: -27.47% to -27.97%).

**Where it does not show:** `device="cpu"` at 1280x720, where the detector dominates the frame budget, the ~0.6 ms saved is inside run-to-run noise — a 5-round run gave a `-4.89%` median with per-round values spanning `-11.02%` to `+4.38%`. I am not claiming a gain there.

The isolated call, which is what actually changes (reproducible from the repo's own assets, no download):

| GMC working res | 4060 before/after | L4 before/after |
|---|---|---|
| 640x360 | 1.665 / 1.426 ms (-14.3%) | 3.808 / 3.175 ms (-16.6%) |
| 960x600 | 4.097 / 3.396 ms (-17.1%) | 8.792 / 7.146 ms (-18.7%) |
| 1920x1080 | 26.805 / 12.957 ms (-51.7%) | 61.479 / 27.027 ms (-56.0%) |

The saving grows faster than the frame area because the grid is one vector object per pixel, so it is allocator pressure rather than per-corner work.

## Verification

- **Corners byte-identical:** `minDistance=1` vs `0` compared with `tobytes()` on the returned array — 40/40 frames at each of three resolutions on both machines, plus 155 frames of real video across three clips and 30/30 at each of five source resolutions from 1280x720 to 3840x2160.
- **Corners byte-identical off the saturated path too:** every frame above returns exactly `maxCorners=1000` corners, so a separate sweep covers the regime where fewer candidates exist than the cap — blank, uniform, gradient and heavily blurred frames, 2 to 40 isolated squares, 8x8 / 3x3 / single-row frames, crossed with `maxCorners` in {1000, 50, 7, 1}: **56/56 identical**, including the 0-corner cases where both return `None` (OpenCV 4.11.0).
- **Tracker output byte-identical:** full `model.track()` output compared per frame (`boxes.id`, `boxes.xyxy`, `boxes.cls`, `boxes.conf`, `tobytes()`), every frame identical in all six conditions — **540 frames total**:

| Machine | Device | Source | frames | tracked boxes | max track id |
|---|---|---|---|---|---|
| RTX 4060 | cuda | 1280x720 | 120/120 | 1338 | 152 |
| RTX 4060 | cuda | 3840x2160 | 100/100 | 3194 | 556 |
| L4 | cuda | 1280x720 | 120/120 | 1338 | 152 |
| L4 | cuda | 3840x2160 | 100/100 | 3193 | 562 |
| L4 | cpu | 1280x720 | 60/60 | 768 | 52 |
| L4 | cpu | 3840x2160 | 40/40 | 1288 | 250 |

The box and id counts differ slightly between the two machines at 4K (3194/556 vs 3193/562) because the detector resolves a few borderline detections differently on another torch/cuDNN build. That does not weaken the claim: each arm is compared against the unpatched baseline measured on the same machine in the same process, so the comparison is always like-for-like.
- `pytest tests/test_python.py -k track` -> 16 passed.

No test added: the change is output-identical, so a regression test could only assert the literal parameter value or re-derive OpenCV's own corner-selection behavior, neither of which pins anything about this repository. Existing tracker coverage exercises the path.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates GMC sparse optical-flow feature detection to use `minDistance=0`, avoiding OpenCV's per-pixel grid allocation while preserving the same corner-selection behavior.

### 📊 Key Changes
- Changes `ultralytics/trackers/utils/gmc.py` feature parameters from `minDistance=1` to `minDistance=0`.
- Applies to the sparse optical-flow GMC path used by BoT-SORT and other trackers selecting `sparseOptFlow`.
- Retains the existing corner limits, quality threshold, block size, and Harris detector settings.

### 🎯 Purpose & Impact
Reduces memory-allocation overhead during sparse optical-flow motion compensation, particularly at higher input resolutions. No user-facing change to tracking results is intended.