### PR TITLE
Fix PyTorch 1.9 backend initialization

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -43,7 +43,7 @@ from ultralytics.utils import (
     is_github_action_running,
 )
 from ultralytics.utils.downloads import download, safe_download
-from ultralytics.utils.torch_utils import TORCH_1_11, TORCH_1_13
+from ultralytics.utils.torch_utils import TORCH_1_10, TORCH_1_11, TORCH_1_13
 
 
 def test_dataloader_caps_workers_to_batches():
@@ -222,7 +222,7 @@ def test_autobackend_memory_format(tmp_path):
         expected = cpu_supported and (channels_last is True or (channels_last is None and (LINUX or WINDOWS)))
         assert model[0].weight.is_contiguous(memory_format=torch.channels_last) is expected
         assert backend(torch.zeros(1, 3, 32, 32)).shape == (1, 4, 30, 30)
-    if hasattr(torch, "inference_mode"):
+    if TORCH_1_10:
         with torch.inference_mode():
             model = torch.nn.Sequential(torch.nn.Conv2d(3, 4, 3))
         backend = AutoBackend(model=model, device=torch.device("cpu"))

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -222,11 +222,12 @@ def test_autobackend_memory_format(tmp_path):
         expected = cpu_supported and (channels_last is True or (channels_last is None and (LINUX or WINDOWS)))
         assert model[0].weight.is_contiguous(memory_format=torch.channels_last) is expected
         assert backend(torch.zeros(1, 3, 32, 32)).shape == (1, 4, 30, 30)
-    if TORCH_1_10:
+    if hasattr(torch, "inference_mode"):
         with torch.inference_mode():
             model = torch.nn.Sequential(torch.nn.Conv2d(3, 4, 3))
         backend = AutoBackend(model=model, device=torch.device("cpu"))
-        assert not backend.model[0].weight.is_inference()
+        if TORCH_1_10:
+            assert not backend.model[0].weight.is_inference()
 
     model = YOLO(MODEL)
     model.ckpt["ema"] = model.model  # raw training checkpoints prefer EMA when reloaded

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -619,7 +619,6 @@ class Exporter:
         self.device = select_device("cpu" if self.args.device is None else self.args.device)
 
         # Argument compatibility checks
-        fmt_name = dict(zip(fmts_dict["Argument"], fmts_dict["Format"]))[fmt]
         fmt_keys = dict(zip(fmts_dict["Argument"], fmts_dict["Arguments"]))[fmt]
         validate_args(fmt, self.args, fmt_keys)
         if fmt in {"deepx", "axelera", "imx", "edgetpu", "qnn", "hailo"} and self.args.quantize not in {8, "w8a16"}:
@@ -682,7 +681,7 @@ class Exporter:
             if fmt in {"rknn", "ncnn", "executorch", "paddle", "imx", "edgetpu", "qnn"}:
                 # Disable the end2end branch for formats without top-k support
                 model.end2end = False
-                LOGGER.warning(f"{fmt_name} export does not support end2end models, disabling end2end branch.")
+                LOGGER.warning("This export format does not support end2end models, disabling the end2end branch.")
             if fmt == "litert" and self.args.quantize in {8, "w8a16"}:
                 # Static activation quantization collapses the end2end class-index output; export raw and run NMS later
                 model.end2end = False

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -619,7 +619,9 @@ class Exporter:
         self.device = select_device("cpu" if self.args.device is None else self.args.device)
 
         # Argument compatibility checks
-        fmt_keys = dict(zip(fmts_dict["Argument"], fmts_dict["Arguments"]))[fmt]
+        fmt_index = fmts_dict["Argument"].index(fmt)
+        fmt_name = fmts_dict["Format"][fmt_index]
+        fmt_keys = fmts_dict["Arguments"][fmt_index]
         validate_args(fmt, self.args, fmt_keys)
         if fmt in {"deepx", "axelera", "imx", "edgetpu", "qnn", "hailo"} and self.args.quantize not in {8, "w8a16"}:
             if self.args.quantize == 32:
@@ -679,9 +681,9 @@ class Exporter:
             if self.args.end2end is not None:
                 model.end2end = self.args.end2end
             if fmt in {"rknn", "ncnn", "executorch", "paddle", "imx", "edgetpu", "qnn"}:
-                # Disable end2end branch for certain export formats as they does not support topk
+                # Disable the end2end branch for formats without top-k support
                 model.end2end = False
-                LOGGER.warning(f"{fmt.upper()} export does not support end2end models, disabling end2end branch.")
+                LOGGER.warning(f"{fmt_name} export does not support end2end models, disabling end2end branch.")
             if fmt == "litert" and self.args.quantize in {8, "w8a16"}:
                 # Static activation quantization collapses the end2end class-index output; export raw and run NMS later
                 model.end2end = False

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -619,9 +619,8 @@ class Exporter:
         self.device = select_device("cpu" if self.args.device is None else self.args.device)
 
         # Argument compatibility checks
-        fmt_index = fmts_dict["Argument"].index(fmt)
-        fmt_name = fmts_dict["Format"][fmt_index]
-        fmt_keys = fmts_dict["Arguments"][fmt_index]
+        fmt_name = dict(zip(fmts_dict["Argument"], fmts_dict["Format"]))[fmt]
+        fmt_keys = dict(zip(fmts_dict["Argument"], fmts_dict["Arguments"]))[fmt]
         validate_args(fmt, self.args, fmt_keys)
         if fmt in {"deepx", "axelera", "imx", "edgetpu", "qnn", "hailo"} and self.args.quantize not in {8, "w8a16"}:
             if self.args.quantize == 32:

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -29,7 +29,7 @@ Usage - formats:
                               yolo26n_ncnn_model         # NCNN
                               yolo26n_imx_model          # Sony IMX
                               yolo26n_rknn_model         # Rockchip RKNN
-                              yolo26n_executorch_model   # PyTorch Executorch
+                              yolo26n_executorch_model   # PyTorch ExecuTorch
                               yolo26n_axelera_model      # Axelera AI
                               yolo26n_deepx_model        # DEEPX
                               yolo26n_qnn.onnx           # Qualcomm QNN

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -14,7 +14,7 @@ from torch import nn
 from ultralytics.utils import LINUX, LOGGER, WINDOWS
 from ultralytics.utils.checks import check_suffix
 from ultralytics.utils.downloads import is_url
-from ultralytics.utils.torch_utils import TORCH_1_9, TORCH_1_13, smart_inference_mode
+from ultralytics.utils.torch_utils import TORCH_1_10, TORCH_1_13, smart_inference_mode
 
 from .backends import (
     AscendBackend,
@@ -206,7 +206,7 @@ class AutoBackend(nn.Module):
         format = "pt" if isinstance(model, nn.Module) else self._model_type(model, dnn)
         if (
             isinstance(model, nn.Module)
-            and TORCH_1_9
+            and TORCH_1_10
             and any(x.is_inference() for x in (*model.parameters(), *model.buffers()))
         ):
             model = deepcopy(model)  # retained backends require normal tensors for fusion and later mutation

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -87,11 +87,11 @@ def smart_inference_mode(mode=True):
     def decorate(fn):
         """Apply appropriate torch decorator for inference mode based on torch version."""
         if not mode:
-            return torch.inference_mode(False)(torch.no_grad()(fn)) if TORCH_1_9 else torch.no_grad()(fn)
+            return torch.inference_mode(False)(torch.no_grad()(fn)) if TORCH_1_11 else torch.no_grad()(fn)
         if TORCH_1_9 and torch.is_inference_mode_enabled():
             return fn  # already in inference_mode, act as a pass-through
         else:
-            return (torch.inference_mode if TORCH_1_10 else torch.no_grad)()(fn)
+            return (torch.inference_mode if TORCH_1_11 else torch.no_grad)()(fn)
 
     return decorate
 

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -87,11 +87,19 @@ def smart_inference_mode(mode=True):
     def decorate(fn):
         """Apply appropriate torch decorator for inference mode based on torch version."""
         if not mode:
-            return torch.inference_mode(False)(torch.no_grad()(fn)) if TORCH_1_11 else torch.no_grad()(fn)
+            if TORCH_1_9:
+
+                @functools.wraps(fn)
+                def disable(*args, **kwargs):
+                    with torch.inference_mode(False), torch.no_grad():
+                        return fn(*args, **kwargs)
+
+                return disable
+            return torch.no_grad()(fn)
         if TORCH_1_9 and torch.is_inference_mode_enabled():
             return fn  # already in inference_mode, act as a pass-through
         else:
-            return (torch.inference_mode if TORCH_1_11 else torch.no_grad)()(fn)
+            return (torch.inference_mode if TORCH_1_10 else torch.no_grad)()(fn)
 
     return decorate
 


### PR DESCRIPTION
## Summary

Fix the production channels-last backend owner on PyTorch 1.9, where `Tensor.is_inference()` does not exist.

- Gate inference-tensor normalization with the existing PyTorch 1.10 version constant
- Align the existing real-path assertion with the same API floor
- Preserve automatic channels-last selection, backend ownership, and PyTorch 1.8 behavior unchanged

This fixes the 117 cascading prediction, validation, training, CLI, and solutions failures exposed by the expanded slow matrix on Ubuntu/Python 3.9/PyTorch 1.9.0.

Failure: https://github.com/ultralytics/ultralytics/actions/runs/33321337963/job/99283730533

## Validation

- `test_autobackend_memory_format` passes
- `test_model_forward` passes
- Ruff and `git diff --check` pass
- Expanded PyTorch-version CI will validate the real 1.9 and 1.10 environments

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated PyTorch version gating and inference-mode handling so `AutoBackend` no longer calls `Tensor.is_inference()` on PyTorch 1.9.

### 📊 Key Changes

- `AutoBackend` now normalizes inference tensors only when the existing `TORCH_1_10` version flag is enabled.
- `smart_inference_mode(False)` uses an explicit wrapper for PyTorch 1.9 to combine disabled inference mode with `torch.no_grad()`.
- `test_autobackend_memory_format` only checks `Tensor.is_inference()` on PyTorch 1.10 and newer.
- Updated an exporter warning to use a generic message and corrected the `ExecuTorch` spelling in predictor documentation comments.

### 🎯 Purpose & Impact

- PyTorch 1.9 backend initialization no longer reaches the unavailable `Tensor.is_inference()` API, while the PyTorch 1.8 path continues to use its existing behavior.
- Automatic channels-last selection and backend ownership logic remain unchanged; the test now matches the supported API floor.