### PR TITLE
Add YOLOv8 RKNN inference example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,7 @@ All C++ examples live under [`./cpp`](./cpp) and support every YOLO task and gen
 | [YOLOv8 SAHI Video Inference](https://github.com/RizwanMunawar/ultralytics/blob/main/examples/YOLOv8-SAHI-Inference-Video/yolov8_sahi.py) | SAHI                  | [Muhammad Rizwan Munawar](https://github.com/RizwanMunawar) ([See also SAHI Guide](https://docs.ultralytics.com/guides/sahi-tiled-inference))       |
 | [YOLOv8 Region Counter](https://github.com/RizwanMunawar/ultralytics/blob/main/examples/YOLOv8-Region-Counter/yolov8_region_counter.py)   | Region Counting       | [Muhammad Rizwan Munawar](https://github.com/RizwanMunawar) ([See also Region Counting Guide](https://docs.ultralytics.com/guides/region-counting)) |
 | [YOLOv8 on NVIDIA Jetson (TensorRT and DeepStream)](https://wiki.seeedstudio.com/YOLOv8-DeepStream-TRT-Jetson/)                           | TensorRT / DeepStream | [Lakshantha](https://github.com/lakshanthad) ([See also DeepStream Guide](https://docs.ultralytics.com/guides/deepstream-nvidia-jetson))            |
+| [YOLOv8 RKNN Inference](./YOLOv8-RKNN-Inference)                                                                                          | RKNN                  | [lszSamLin](https://github.com/lszSamLin)                                                                                                           |
 
 ### Rust
 

--- a/examples/YOLOv8-RKNN-Inference/README.md
+++ b/examples/YOLOv8-RKNN-Inference/README.md
@@ -50,7 +50,7 @@ the top and stair-stepped (see the discussion in
    git clone https://github.com/ultralytics/ultralytics.git
    cd ultralytics/examples/YOLOv8-RKNN-Inference
    pip install -r requirements.txt
-   pip install -e ../..  # local ultralytics package, imported by export_onnx.py
+   pip install -e ../.. # local ultralytics package, imported by export_onnx.py
    ```
 
 ## 🚀 Usage

--- a/examples/YOLOv8-RKNN-Inference/README.md
+++ b/examples/YOLOv8-RKNN-Inference/README.md
@@ -1,0 +1,124 @@
+# YOLOv8 - RKNN Inference
+
+This repository provides an example implementation for running [Ultralytics YOLOv8](https://docs.ultralytics.com/models/yolov8) models on Rockchip RKNN NPUs (e.g. RK3566, RK3568, RK3576, RK3588) using [rknn-toolkit2](https://github.com/airockchip/rknn-toolkit2). It includes:
+
+- `export_onnx.py` — export a YOLOv8 `.pt` to a **separate-head** ONNX graph for RKNN INT8 quantization,
+- `rknn_inference.py` — image and video inference with a `.rknn` model (runs on the PC simulator or on the NPU device),
+- `requirements.txt` — Python dependencies.
+
+> **Tested on**: Orange Pi 5 Max (RK3588). Use `--target rk3588` when running on the device.
+
+> The scripts are adapted from the author's `detect_rknn.py` / `detect_video_rknn.py` /
+> `export_6out_onnx.py` (image / video inference and separate-head export).
+
+## Why a separate-head ONNX?
+
+The default Ultralytics ONNX export decodes the boxes and concatenates all
+predictions into a single `[1, 4+nc, 8400]` tensor. The separate-head export keeps
+per-scale tensors instead:
+
+```
+6-output (recommended):  [box(1, 4*reg_max, h, w), Sigmoid(cls)(1, nc, h, w)] x 3
+9-output:                [box, cls_logit, score_sum] x 3
+```
+
+Keeping `Sigmoid(cls)` fused in the graph (without `score_sum`) lets rknn-toolkit2
+fuse the sigmoid into the preceding convolution during INT8 quantization. This
+preserves the confidence scale — otherwise the INT8 confidence is compressed at
+the top and stair-stepped (see the discussion in
+[airockchip/rknn_model_zoo yolov8](https://github.com/airockchip/rknn_model_zoo/tree/main/examples/yolov8)).
+
+## ⚙️ Installation
+
+1. **rknn-toolkit2** — not pip-installable; download it from Rockchip:
+
+   ```bash
+   git clone https://github.com/airockchip/rknn-toolkit2.git
+   cd rknn-toolkit2/rknn-toolkit2
+   pip install -r packages/requirements_cp310-*.txt
+   pip install packages/rknn_toolkit2-*-cp310-*.whl
+   ```
+
+   `rknn-toolkit2` runs on the PC (simulator) or drives an RKNPU device over the
+   network (via `--target`). This example uses the `rknn.api.RKNN` interface; to
+   run on-device with the lite runtime (`rknnlite.api.RKNNLite`), adapt the
+   `load_rknn()` helper accordingly.
+
+2. **Example dependencies**:
+
+   ```bash
+   git clone https://github.com/ultralytics/ultralytics.git
+   cd ultralytics/examples/YOLOv8-RKNN-Inference
+   pip install -r requirements.txt
+   pip install -e ../..  # local ultralytics package, imported by export_onnx.py
+   ```
+
+## 🚀 Usage
+
+### 1. Export the separate-head ONNX
+
+```bash
+python export_onnx.py yolov8n.pt yolov8n_6out.onnx           # 6-output (recommended)
+python export_onnx.py yolov8n.pt yolov8n_9out.onnx --heads 9 # 9-output
+```
+
+`--imgsz` defaults to 640 and must match the size used for conversion and
+inference (pass the same value to `rknn_inference.py --imgsz`).
+
+### 2. Convert ONNX to RKNN (with rknn-toolkit2)
+
+Use the following minimal script (or the `convert.py` from
+[airockchip/rknn_model_zoo](https://github.com/airockchip/rknn_model_zoo)):
+
+```python
+from rknn.api import RKNN
+
+target_platform = "rk3588"  # RK3566 / RK3568 / RK3576 / RK3588 - your board
+rknn = RKNN(verbose=False)
+rknn.config(mean_values=[[0, 0, 0]], std_values=[[255, 255, 255]], target_platform=target_platform)
+rknn.load_onnx(model="yolov8n_6out.onnx")
+rknn.build(do_quantization=True, dataset="./dataset.txt")  # list of calibration images
+rknn.export_rknn("yolov8n_6out.rknn")
+rknn.release()
+```
+
+Set `target_platform` to your board and pass the **same** value to `--target` at
+inference time. Use a calibration dataset that matches your deployment
+preprocessing (letterbox gray-114) so the INT8 confidence is not flattened — see
+the rknn_model_zoo yolov8 README, section "Quantization notes".
+
+### 3. Run inference
+
+On the PC (simulator):
+
+```bash
+python rknn_inference.py --model yolov8n_6out.rknn --image bus.jpg [img2.jpg ...]
+python rknn_inference.py --model yolov8n_6out.rknn --video demo.mp4 --out result.avi
+```
+
+On an NPU device (e.g. RK3588):
+
+```bash
+python rknn_inference.py --model yolov8n_6out.rknn --target rk3588 --image bus.jpg
+```
+
+The 6-output and 9-output layouts (3 or 4 scales) are detected automatically from
+the model's output count. Annotated results are saved next to the input
+(`*_rknn.jpg` / `*_rknn.avi`).
+
+## 🖼️ Expected Results
+
+Running the exported 6-output `yolov8n` on a standard test image such as
+[`ultralytics/assets/bus.jpg`](../../assets/bus.jpg) produces output similar to:
+
+```
+person @ (211 241 283 507) 0.88
+person @ (109 235 224 536) 0.88
+person @ (477 223 560 521) 0.87
+bus   @ (99 135 550 456) 0.85
+```
+
+## 🤝 Contributing
+
+This example is part of the Ultralytics community examples. Contributions are
+welcome — see the repository [contributing guidelines](../../CONTRIBUTING.md).

--- a/examples/YOLOv8-RKNN-Inference/export_onnx.py
+++ b/examples/YOLOv8-RKNN-Inference/export_onnx.py
@@ -1,0 +1,129 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+"""
+Export a YOLOv8 model to a separate-head ONNX graph for RKNN.
+
+Adapted from the author's `export_6out_onnx.py`, extended with a `--heads 9`
+option for the 9-output layout.
+
+Ultralytics' default ONNX export decodes the boxes and concatenates everything
+into a single `[1, 4+nc, 8400]` tensor. For RKNN INT8 quantization it is often
+better to keep the *separate* per-scale outputs:
+
+  6-output (recommended):  [box, Sigmoid(cls)] x 3 scales
+  9-output:                [box, cls_logit, score_sum] x 3 scales
+
+where `box` are raw DFL logits [1, 4*reg_max, h, w]. Keeping `Sigmoid(cls)`
+fused in the graph (no `score_sum`) lets rknn-toolkit2 fuse the sigmoid into the
+convolution during quantization, preserving the INT8 confidence scale
+(see examples/yolov8 in https://github.com/airockchip/rknn_model_zoo).
+
+The matching post-processing is in `rknn_inference.py` (layout auto-detected
+from the output count). Convert the exported ONNX to RKNN with rknn-toolkit2:
+
+    python convert.py yolov8n_6out.onnx rk3588 i8 yolov8n_6out.rknn
+
+Usage:
+    python export_onnx.py yolov8n.pt yolov8n_6out.onnx            # 6-output
+    python export_onnx.py yolov8n.pt yolov8n_9out.onnx --heads 9  # 9-output
+"""
+
+import argparse
+
+import torch
+from torch import nn
+
+
+def export_onnx(pt_path, onnx_path, imgsz=640, opset=17, heads=6):
+    """Export a YOLOv8 model to a separate-head ONNX graph.
+
+    Args:
+        pt_path: Input PyTorch model path.
+        onnx_path: Output ONNX path.
+        imgsz: Square input size.
+        opset: ONNX opset version.
+        heads: Outputs per branch for a 3-scale model (6 or 9); the total output
+            count scales with the detection layers (8 or 12 for a 4-scale model).
+    """
+    from ultralytics import YOLO
+
+    model = YOLO(pt_path)
+    detect_model = model.model
+    detect_model.eval()
+
+    detect = detect_model.model[-1]  # Detect head
+    backbone = detect_model.model[:-1]
+
+    class YOLOv8SeparateHeads(nn.Module):
+        """Rerun the backbone and output [box, (score_sum,) Sigmoid(cls)] per branch."""
+
+        def __init__(self, backbone, detect, heads):
+            super().__init__()
+            self.backbone = backbone
+            self.detect = detect
+            self.heads = heads
+
+        def forward(self, x):
+            y = []
+            detect_inputs = []
+            for layer in self.backbone:
+                if layer.f != -1:
+                    if isinstance(layer.f, int):
+                        x = y[layer.f] if layer.f >= 0 else x
+                    elif isinstance(layer.f, (list, tuple)):
+                        x = [y[j] if j >= 0 else x for j in layer.f]
+                x = layer(x)
+                if hasattr(layer, "i") and layer.i in self.detect.f:
+                    detect_inputs.append(x)
+                y.append(x)
+
+            outputs = []
+            for i in range(self.detect.nl):
+                feat = detect_inputs[i]
+                box_out = self.detect.cv2[i](feat)  # [1, 4*reg_max, h, w]
+                cls_out = self.detect.cv3[i](feat)  # [1, nc, h, w]
+                cls_prob = torch.sigmoid(cls_out)
+                if self.heads == 9:
+                    score_sum = torch.clip(cls_prob.sum(dim=1, keepdim=True), 0, 1)
+                    outputs.extend([box_out, cls_out, score_sum])
+                else:
+                    outputs.extend([box_out, cls_prob])
+            return tuple(outputs)
+
+    wrapper = YOLOv8SeparateHeads(backbone, detect, heads)
+    wrapper.eval()
+
+    per_scale = heads // 3  # 6 -> 2 (box, cls), 9 -> 3 (box, cls, score_sum)
+    n_out = per_scale * detect.nl  # e.g. 6/9 for 3 scales, 8/12 for 4 scales
+    dummy = torch.randn(1, 3, imgsz, imgsz)
+    output_names = [f"output{i}" for i in range(n_out)]
+    torch.onnx.export(
+        wrapper,
+        dummy,
+        onnx_path,
+        input_names=["images"],
+        output_names=output_names,
+        opset_version=opset,
+        do_constant_folding=True,
+        verbose=False,
+        dynamo=False,
+    )
+
+    import onnx
+
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    print(f"ONNX export succeeded: {onnx_path} ({n_out}-output)")
+    for out in onnx_model.graph.output:
+        shape = [d.dim_value for d in out.type.tensor_type.shape.dim]
+        print(f"  {out.name}: {shape}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Export YOLOv8 to a separate-head ONNX")
+    parser.add_argument("model", help="input .pt path")
+    parser.add_argument("output", help="output .onnx path")
+    parser.add_argument("--imgsz", type=int, default=640, help="square input size, must match --imgsz at inference")
+    parser.add_argument("--opset", type=int, default=17)
+    parser.add_argument("--heads", type=int, choices=[6, 9], default=6, help="outputs per branch x 3 scales (6 or 9)")
+    args = parser.parse_args()
+    export_onnx(args.model, args.output, args.imgsz, args.opset, args.heads)

--- a/examples/YOLOv8-RKNN-Inference/export_onnx.py
+++ b/examples/YOLOv8-RKNN-Inference/export_onnx.py
@@ -41,8 +41,8 @@ def export_onnx(pt_path, onnx_path, imgsz=640, opset=17, heads=6):
         onnx_path: Output ONNX path.
         imgsz: Square input size.
         opset: ONNX opset version.
-        heads: Outputs per branch for a 3-scale model (6 or 9); the total output
-            count scales with the detection layers (8 or 12 for a 4-scale model).
+        heads: Outputs per branch for a 3-scale model (6 or 9); the total output count scales with the detection layers
+            (8 or 12 for a 4-scale model).
     """
     from ultralytics import YOLO
 

--- a/examples/YOLOv8-RKNN-Inference/export_onnx.py
+++ b/examples/YOLOv8-RKNN-Inference/export_onnx.py
@@ -105,7 +105,7 @@ def export_onnx(pt_path, onnx_path, imgsz=640, opset=17, heads=6):
         opset_version=opset,
         do_constant_folding=True,
         verbose=False,
-        dynamo=False,
+        **({"dynamo": False} if torch.__version__ >= "2.4" else {}),
     )
 
     import onnx

--- a/examples/YOLOv8-RKNN-Inference/requirements.txt
+++ b/examples/YOLOv8-RKNN-Inference/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+opencv-python

--- a/examples/YOLOv8-RKNN-Inference/requirements.txt
+++ b/examples/YOLOv8-RKNN-Inference/requirements.txt
@@ -1,2 +1,3 @@
 numpy
+onnx
 opencv-python

--- a/examples/YOLOv8-RKNN-Inference/rknn_inference.py
+++ b/examples/YOLOv8-RKNN-Inference/rknn_inference.py
@@ -1,0 +1,343 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+"""
+YOLOv8 RKNN inference with rknn-toolkit2.
+
+Supports the *separate-head* model layout produced by `export_onnx.py`:
+  - 6-output: [box, Sigmoid(cls)] x scales
+  - 9-output: [box, cls_logit, score_sum] x scales
+The layout and the number of scales (3 or 4) are detected automatically from
+the model's output count.
+
+This script merges the author's `detect_rknn.py` (image) and
+`detect_video_rknn.py` (video) examples into one entry point, with COCO labels
+and gray-114 letterbox (matching the rknn_model_zoo calibration).
+
+Requires a `.rknn` model, which is converted from the separate-head ONNX with
+Rockchip's rknn-toolkit2 (not pip-installable, see the README for the download
+and conversion steps).
+
+Usage:
+    python rknn_inference.py --model yolov8n_6out.rknn --image bus.jpg [img2.jpg ...]
+    python rknn_inference.py --model yolov8n_6out.rknn --video demo.mp4 --out result.mp4
+"""
+
+import argparse
+import os
+
+import cv2
+import numpy as np
+
+IMG_SIZE = (640, 640)  # (w, h)
+OBJ_THRESH = 0.25
+NMS_THRESH = 0.45
+REG_MAX = 16
+PAD_COLOR = 114  # gray-114 letterbox, matching the rknn_model_zoo calibration
+
+# Default to the COCO label set so the example works out of the box with yolov8n.
+COCO_NAMES = (
+    "person",
+    "bicycle",
+    "car",
+    "motorcycle",
+    "airplane",
+    "bus",
+    "train",
+    "truck",
+    "boat",
+    "traffic light",
+    "fire hydrant",
+    "stop sign",
+    "parking meter",
+    "bench",
+    "bird",
+    "cat",
+    "dog",
+    "horse",
+    "sheep",
+    "cow",
+    "elephant",
+    "bear",
+    "zebra",
+    "giraffe",
+    "backpack",
+    "umbrella",
+    "handbag",
+    "tie",
+    "suitcase",
+    "frisbee",
+    "skis",
+    "snowboard",
+    "sports ball",
+    "kite",
+    "baseball bat",
+    "baseball glove",
+    "skateboard",
+    "surfboard",
+    "tennis racket",
+    "bottle",
+    "wine glass",
+    "cup",
+    "fork",
+    "knife",
+    "spoon",
+    "bowl",
+    "banana",
+    "apple",
+    "sandwich",
+    "orange",
+    "broccoli",
+    "carrot",
+    "hot dog",
+    "pizza",
+    "donut",
+    "cake",
+    "chair",
+    "couch",
+    "potted plant",
+    "bed",
+    "dining table",
+    "toilet",
+    "tv",
+    "laptop",
+    "mouse",
+    "remote",
+    "keyboard",
+    "cell phone",
+    "microwave",
+    "oven",
+    "toaster",
+    "sink",
+    "refrigerator",
+    "book",
+    "clock",
+    "vase",
+    "scissors",
+    "teddy bear",
+    "hair drier",
+    "toothbrush",
+)
+
+
+def sigmoid(x):
+    """Return the element-wise logistic sigmoid of ``x``."""
+    return 1.0 / (1.0 + np.exp(-x))
+
+
+def letter_box(im, new_shape=IMG_SIZE, pad_color=PAD_COLOR):
+    """Resize with aspect ratio preserved and pad to new_shape."""
+    h, w = im.shape[:2]
+    r = min(new_shape[1] / w, new_shape[0] / h)
+    new_unpad = (round(w * r), round(h * r))
+    dw, dh = new_shape[1] - new_unpad[0], new_shape[0] - new_unpad[1]
+    dw, dh = dw / 2, dh / 2
+    if (w, h) != new_unpad:
+        im = cv2.resize(im, new_unpad, interpolation=cv2.INTER_LINEAR)
+    top, bottom = round(dh - 0.1), round(dh + 0.1)
+    left, right = round(dw - 0.1), round(dw + 0.1)
+    im = cv2.copyMakeBorder(im, top, bottom, left, right, cv2.BORDER_CONSTANT, value=(pad_color, pad_color, pad_color))
+    return im, r, (dw, dh)
+
+
+def dfl_decode(box):
+    """Box [1, 4*reg_max, h, w] -> [1, 4, h, w] (distribution focal loss)."""
+    n, _c, h, w = box.shape
+    prob = box.reshape(n, 4, REG_MAX, h, w)
+    prob = np.exp(prob - prob.max(axis=2, keepdims=True))
+    prob = prob / prob.sum(axis=2, keepdims=True)
+    acc = np.arange(REG_MAX, dtype=np.float32).reshape(1, 1, REG_MAX, 1, 1)
+    return (prob * acc).sum(axis=2)
+
+
+def post_process(outputs, conf=OBJ_THRESH, nms=NMS_THRESH):
+    """Decode the separate-head outputs into (xyxy, scores, classes).
+
+    outputs: fp32 tensors, either [box, cls, score_sum] x scales (9-output, cls
+             is logit) or [box, cls] x scales (6-output, cls is already Sigmoid).
+    Returns boxes in the letterboxed input space, or (None, None, None).
+    """
+    # 6-output is [box, Sigmoid(cls)] x scales; 9-output is [box, cls_logit, score_sum]
+    # x scales. Infer the outputs-per-scale from the total count (3 or 4 scales).
+    if len(outputs) % 3 == 0 and len(outputs) // 3 in (3, 4):
+        per, n_scales = 3, len(outputs) // 3  # 9-output: cls is logit
+    else:
+        per, n_scales = 2, len(outputs) // 2  # 6-output: cls is already Sigmoid
+    all_boxes, all_scores, all_classes = [], [], []
+    for i in range(n_scales):
+        box = dfl_decode(outputs[i * per])  # [1, 4, h, w]
+        cls = outputs[i * per + 1]
+        if per == 3:
+            cls = sigmoid(cls)  # 9-output: cls is logit
+        _, _, gh, gw = box.shape
+        stride = IMG_SIZE[0] // gw
+        jx, jy = np.meshgrid(np.arange(gw), np.arange(gh))
+        x1 = (-box[0, 0] + jx + 0.5) * stride
+        y1 = (-box[0, 1] + jy + 0.5) * stride
+        x2 = (box[0, 2] + jx + 0.5) * stride
+        y2 = (box[0, 3] + jy + 0.5) * stride
+
+        cls_max = cls[0].max(axis=0)  # [h, w]
+        cls_id = cls[0].argmax(axis=0)
+        mask = cls_max > conf
+        if mask.any():
+            all_boxes.append(np.stack([x1, y1, x2, y2], axis=-1)[mask])
+            all_scores.append(cls_max[mask])
+            all_classes.append(cls_id[mask])
+
+    if not all_boxes:
+        return None, None, None
+    boxes = np.concatenate(all_boxes)
+    scores = np.concatenate(all_scores)
+    classes = np.concatenate(all_classes)
+
+    # Class-wise NMS
+    nboxes, nscores, nclasses = [], [], []
+    for c in np.unique(classes):
+        idx = np.where(classes == c)[0]
+        b, s = boxes[idx], scores[idx]
+        x, y = b[:, 0], b[:, 1]
+        w, h = b[:, 2] - b[:, 0], b[:, 3] - b[:, 1]
+        areas = w * h
+        order = s.argsort()[::-1]
+        keep = []
+        while order.size > 0:
+            k = order[0]
+            keep.append(k)
+            xx1 = np.maximum(x[k], x[order[1:]])
+            yy1 = np.maximum(y[k], y[order[1:]])
+            xx2 = np.minimum(x[k] + w[k], x[order[1:]] + w[order[1:]])
+            yy2 = np.minimum(y[k] + h[k], y[order[1:]] + h[order[1:]])
+            inter = np.maximum(0.0, xx2 - xx1 + 1e-5) * np.maximum(0.0, yy2 - yy1 + 1e-5)
+            ovr = inter / (areas[k] + areas[order[1:]] - inter)
+            order = order[np.where(ovr <= nms)[0] + 1]
+        nboxes.append(b[keep])
+        nscores.append(s[keep])
+        nclasses.append(classes[idx][keep])
+    return np.concatenate(nboxes), np.concatenate(nscores), np.concatenate(nclasses)
+
+
+def unmap_box(boxes, ratio, pad):
+    """Map letterboxed coordinates back to the original image."""
+    dw, dh = pad
+    return (boxes - np.array([dw, dh, dw, dh])) / ratio
+
+
+def draw(image, boxes, scores, classes, names):
+    """Draw detection boxes and labels on ``image`` in place."""
+    for b, s, c in zip(boxes, scores, classes):
+        h, w = image.shape[:2]
+        x1, y1, x2, y2 = [int(v) for v in np.clip(b, 0, [w, h, w, h])]
+        label = f"{names[int(c)] if int(c) < len(names) else str(int(c))} {s:.2f}"
+        print(f"  {label} @ ({x1} {y1} {x2} {y2})")
+        cv2.rectangle(image, (x1, y1), (x2, y2), (255, 0, 0), 2)
+        cv2.putText(image, label, (x1, max(y1 - 6, 12)), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 0, 255), 2)
+
+
+def inference(rknn, img_src, names, conf, nms):
+    """Run one frame; returns the annotated BGR image."""
+    img_lb, ratio, pad = letter_box(img_src.copy())
+    input_data = cv2.cvtColor(img_lb, cv2.COLOR_BGR2RGB)
+    input_data = input_data[np.newaxis, ...]  # [1, h, w, 3] static-batch input
+    outputs = rknn.inference(inputs=[input_data])
+    outputs = [o.astype(np.float32) for o in outputs]
+    boxes, scores, classes = post_process(outputs, conf, nms)
+    img_draw = img_src.copy()
+    if boxes is not None:
+        draw(img_draw, unmap_box(boxes, ratio, pad), scores, classes, names)
+    else:
+        print("  no detections")
+    return img_draw
+
+
+def load_rknn(model_path, target):
+    """Load a .rknn model and init the runtime; returns the RKNN object."""
+    from rknn.api import RKNN
+
+    rknn = RKNN(verbose=False)
+    assert rknn.load_rknn(model_path) == 0, f"failed to load model: {model_path}"
+    if target:
+        assert rknn.init_runtime(target=target) == 0, f"NPU init failed for {target}"
+    else:
+        assert rknn.init_runtime() == 0, "runtime init failed (simulator)"
+    return rknn
+
+
+def run_image(args, rknn, names):
+    """Run inference on each image in ``args.image`` and save the annotated results."""
+    for img_path in args.image:
+        img_src = cv2.imread(img_path)
+        if img_src is None:
+            print(f"cannot read {img_path}")
+            continue
+        print(f"\n[{os.path.basename(img_path)}] {os.path.basename(args.model)}:")
+        img_draw = inference(rknn, img_src, names, args.conf, args.nms)
+        out = args.out_dir or os.path.dirname(img_path)
+        out_path = os.path.join(out, f"{os.path.splitext(os.path.basename(img_path))[0]}_rknn.jpg")
+        cv2.imwrite(out_path, img_draw)
+        print(f"  result saved: {out_path}")
+
+
+def run_video(args, rknn, names):
+    """Run inference on a video and write the annotated result to ``args.out``."""
+    cap = cv2.VideoCapture(args.video)
+    if not cap.isOpened():
+        print(f"cannot open video: {args.video}")
+        return
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    out = args.out or os.path.join(
+        os.path.dirname(args.video), f"{os.path.splitext(os.path.basename(args.video))[0]}_rknn.avi"
+    )
+    writer = cv2.VideoWriter(out, cv2.VideoWriter_fourcc(*"XVID"), fps, (width, height))
+    frame_id = 0
+    while True:
+        ok, frame = cap.read()
+        if not ok:
+            break
+        img_draw = inference(rknn, frame, names, args.conf, args.nms)
+        writer.write(img_draw)
+        frame_id += 1
+        if frame_id % 30 == 1:
+            print(f"  frame {frame_id}")
+    cap.release()
+    writer.release()
+    print(f"video result saved: {out}")
+
+
+def main():
+    """Parse command-line arguments and run image/video inference."""
+    global IMG_SIZE  # --imgsz overrides the 640x640 default
+    parser = argparse.ArgumentParser(description="YOLOv8 RKNN inference")
+    parser.add_argument("--model", required=True, help=".rknn model path")
+    parser.add_argument(
+        "--imgsz",
+        type=int,
+        default=IMG_SIZE[0],
+        help="square input size, must match the size used at export/conversion",
+    )
+    parser.add_argument("--image", nargs="+", help="input image path(s)")
+    parser.add_argument("--video", help="input video path")
+    parser.add_argument("--target", default=None, help="NPU target (e.g. rk3588); omit to run the PC simulator")
+    parser.add_argument("--conf", type=float, default=OBJ_THRESH)
+    parser.add_argument("--nms", type=float, default=NMS_THRESH)
+    parser.add_argument("--out_dir", default=None, help="image result directory")
+    parser.add_argument("--out", default=None, help="video result path")
+    args = parser.parse_args()
+
+    if not args.image and not args.video:
+        parser.error("provide --image or --video")
+
+    IMG_SIZE = (args.imgsz, args.imgsz)
+    names = list(COCO_NAMES)
+    rknn = load_rknn(args.model, args.target)
+    try:
+        if args.image:
+            run_image(args, rknn, names)
+        if args.video:
+            run_video(args, rknn, names)
+    finally:
+        rknn.release()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/YOLOv8-RKNN-Inference/rknn_inference.py
+++ b/examples/YOLOv8-RKNN-Inference/rknn_inference.py
@@ -153,8 +153,8 @@ def post_process(outputs, imgsz, conf=OBJ_THRESH, nms=NMS_THRESH):
 
     outputs: fp32 tensors, either [box, cls, score_sum] x scales (9-output, cls
              is logit) or [box, cls] x scales (6-output, cls is already Sigmoid).
-    imgsz: square input size (w, h); used for stride decoding.
-    Returns boxes in the letterboxed input space, or (None, None, None).
+    imgsz: square input size (w, h); used for stride decoding. Returns boxes in the letterboxed input space, or (None,
+    None, None).
     """
     # 6-output is [box, Sigmoid(cls)] x scales; 9-output is [box, cls_logit, score_sum]
     # x scales. Infer the outputs-per-scale from the total count (3 or 4 scales).

--- a/examples/YOLOv8-RKNN-Inference/rknn_inference.py
+++ b/examples/YOLOv8-RKNN-Inference/rknn_inference.py
@@ -123,7 +123,7 @@ def sigmoid(x):
     return 1.0 / (1.0 + np.exp(-x))
 
 
-def letter_box(im, new_shape=IMG_SIZE, pad_color=PAD_COLOR):
+def letter_box(im, new_shape, pad_color=PAD_COLOR):
     """Resize with aspect ratio preserved and pad to new_shape."""
     h, w = im.shape[:2]
     r = min(new_shape[1] / w, new_shape[0] / h)
@@ -148,11 +148,12 @@ def dfl_decode(box):
     return (prob * acc).sum(axis=2)
 
 
-def post_process(outputs, conf=OBJ_THRESH, nms=NMS_THRESH):
+def post_process(outputs, imgsz, conf=OBJ_THRESH, nms=NMS_THRESH):
     """Decode the separate-head outputs into (xyxy, scores, classes).
 
     outputs: fp32 tensors, either [box, cls, score_sum] x scales (9-output, cls
              is logit) or [box, cls] x scales (6-output, cls is already Sigmoid).
+    imgsz: square input size (w, h); used for stride decoding.
     Returns boxes in the letterboxed input space, or (None, None, None).
     """
     # 6-output is [box, Sigmoid(cls)] x scales; 9-output is [box, cls_logit, score_sum]
@@ -168,7 +169,7 @@ def post_process(outputs, conf=OBJ_THRESH, nms=NMS_THRESH):
         if per == 3:
             cls = sigmoid(cls)  # 9-output: cls is logit
         _, _, gh, gw = box.shape
-        stride = IMG_SIZE[0] // gw
+        stride = imgsz[0] // gw
         jx, jy = np.meshgrid(np.arange(gw), np.arange(gh))
         x1 = (-box[0, 0] + jx + 0.5) * stride
         y1 = (-box[0, 1] + jy + 0.5) * stride
@@ -232,14 +233,14 @@ def draw(image, boxes, scores, classes, names):
         cv2.putText(image, label, (x1, max(y1 - 6, 12)), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 0, 255), 2)
 
 
-def inference(rknn, img_src, names, conf, nms):
+def inference(rknn, img_src, names, conf, nms, imgsz):
     """Run one frame; returns the annotated BGR image."""
-    img_lb, ratio, pad = letter_box(img_src.copy())
+    img_lb, ratio, pad = letter_box(img_src.copy(), new_shape=imgsz)
     input_data = cv2.cvtColor(img_lb, cv2.COLOR_BGR2RGB)
     input_data = input_data[np.newaxis, ...]  # [1, h, w, 3] static-batch input
     outputs = rknn.inference(inputs=[input_data])
     outputs = [o.astype(np.float32) for o in outputs]
-    boxes, scores, classes = post_process(outputs, conf, nms)
+    boxes, scores, classes = post_process(outputs, imgsz, conf, nms)
     img_draw = img_src.copy()
     if boxes is not None:
         draw(img_draw, unmap_box(boxes, ratio, pad), scores, classes, names)
@@ -261,7 +262,7 @@ def load_rknn(model_path, target):
     return rknn
 
 
-def run_image(args, rknn, names):
+def run_image(args, rknn, names, imgsz):
     """Run inference on each image in ``args.image`` and save the annotated results."""
     for img_path in args.image:
         img_src = cv2.imread(img_path)
@@ -269,14 +270,14 @@ def run_image(args, rknn, names):
             print(f"cannot read {img_path}")
             continue
         print(f"\n[{os.path.basename(img_path)}] {os.path.basename(args.model)}:")
-        img_draw = inference(rknn, img_src, names, args.conf, args.nms)
+        img_draw = inference(rknn, img_src, names, args.conf, args.nms, imgsz)
         out = args.out_dir or os.path.dirname(img_path)
         out_path = os.path.join(out, f"{os.path.splitext(os.path.basename(img_path))[0]}_rknn.jpg")
         cv2.imwrite(out_path, img_draw)
         print(f"  result saved: {out_path}")
 
 
-def run_video(args, rknn, names):
+def run_video(args, rknn, names, imgsz):
     """Run inference on a video and write the annotated result to ``args.out``."""
     cap = cv2.VideoCapture(args.video)
     if not cap.isOpened():
@@ -294,7 +295,7 @@ def run_video(args, rknn, names):
         ok, frame = cap.read()
         if not ok:
             break
-        img_draw = inference(rknn, frame, names, args.conf, args.nms)
+        img_draw = inference(rknn, frame, names, args.conf, args.nms, imgsz)
         writer.write(img_draw)
         frame_id += 1
         if frame_id % 30 == 1:
@@ -306,13 +307,12 @@ def run_video(args, rknn, names):
 
 def main():
     """Parse command-line arguments and run image/video inference."""
-    global IMG_SIZE  # --imgsz overrides the 640x640 default
     parser = argparse.ArgumentParser(description="YOLOv8 RKNN inference")
     parser.add_argument("--model", required=True, help=".rknn model path")
     parser.add_argument(
         "--imgsz",
         type=int,
-        default=IMG_SIZE[0],
+        default=640,
         help="square input size, must match the size used at export/conversion",
     )
     parser.add_argument("--image", nargs="+", help="input image path(s)")
@@ -327,14 +327,14 @@ def main():
     if not args.image and not args.video:
         parser.error("provide --image or --video")
 
-    IMG_SIZE = (args.imgsz, args.imgsz)
+    imgsz = (args.imgsz, args.imgsz)
     names = list(COCO_NAMES)
     rknn = load_rknn(args.model, args.target)
     try:
         if args.image:
-            run_image(args, rknn, names)
+            run_image(args, rknn, names, imgsz)
         if args.video:
-            run_video(args, rknn, names)
+            run_video(args, rknn, names, imgsz)
     finally:
         rknn.release()
 


### PR DESCRIPTION
## Summary

Add a community example for running [Ultralytics YOLOv8](https://docs.ultralytics.com/models/yolov8) on Rockchip RKNN NPUs (RK3566 / RK3568 / RK3576 / RK3588) with [rknn-toolkit2](https://github.com/airockchip/rknn-toolkit2):

- `export_onnx.py` — export a YOLOv8 `.pt` to a **separate-head** ONNX graph for RKNN INT8 quantization. The default export concatenates everything into one `[1, 4+nc, 8400]` tensor; the separate-head layout keeps per-scale tensors and fuses `Sigmoid(cls)` into the graph, which preserves the INT8 confidence scale (6-output recommended, 9-output optional).
- `rknn_inference.py` — image and video inference with a `.rknn` model, on the PC simulator or on the NPU device (`--target`). The layout (6/9-output) and the number of scales (3 or 4) are detected automatically from the model's output count.
- `README.md` / `requirements.txt` — setup, conversion and usage docs.

Tested on Orange Pi 5 Max (RK3588).

## Addresses review feedback from #25986

This is a resubmission of the example from [ultralytics #25986](https://github.com/ultralytics/ultralytics/pull/25986), updated to resolve every review comment from that PR:

| #25986 review comment | Fix in this PR |
|---|---|
| `target_platform` hard-coded to `rk3588` in the README conversion script | `target_platform` is now a documented variable; README states it must match `--target` at inference |
| `rknn_inference.py` fed a 3-D HWC array to the runtime | Adds the batch dimension (`[1, h, w, 3]`) before `rknn.inference()` |
| Example install missed the local `ultralytics` package that `export_onnx.py` imports | Added `pip install -e ../..` to the install steps |
| Output naming / post-processing hard-coded for 3 scales (P2/P6 models have 4) | Output count derived from `detect.nl` in the exporter; `post_process()` infers `per` and `n_scales` from the total count (handles 6/8/9/12 outputs) |
| Exporter exposed `--imgsz` but inference always resized to 640 | `rknn_inference.py` now accepts `--imgsz` and uses it for letterboxing and stride decoding; README documents that export/conversion/inference sizes must match |

## Files

| File | Change |
|---|---|
| `examples/YOLOv8-RKNN-Inference/export_onnx.py` | new — separate-head ONNX export (6/9-output) |
| `examples/YOLOv8-RKNN-Inference/rknn_inference.py` | new — image/video inference, layout auto-detection |
| `examples/YOLOv8-RKNN-Inference/README.md` | new — setup, conversion, usage |
| `examples/YOLOv8-RKNN-Inference/requirements.txt` | new |
| `examples/README.md` | add the example to the community Python table |

## Usage

```shell
cd examples/YOLOv8-RKNN-Inference
python export_onnx.py yolov8n.pt yolov8n_6out.onnx           # 6-output (recommended)
# convert to RKNN with rknn-toolkit2 (see README), then:
python rknn_inference.py --model yolov8n_6out.rknn --image bus.jpg
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a YOLOv8 RKNN community example for exporting separate-head ONNX models and running image or video inference on Rockchip NPUs with rknn-toolkit2.

### 📊 Key Changes
- Adds `export_onnx.py` with 6-output and optional 9-output separate-head export modes, supporting models with three or four detection scales.
- Adds `rknn_inference.py` for PC simulator or device inference, including automatic output-layout detection, letterbox preprocessing, DFL decoding, class-wise NMS, and image/video result writing.
- Adds setup, conversion, calibration, target-device, and matching image-size documentation in `README.md`, plus example dependencies.
- Registers the RKNN example in the community Python examples table.

### 🎯 Purpose & Impact
Provides a documented workflow for converting YOLOv8 models to RKNN and running them on Rockchip RK3566, RK3568, RK3576, and RK3588 hardware or the PC simulator, with configurable input sizes and device targets.