### PR TITLE
Upgrade CUDA image to Python 3.14 and PyTorch 2.13

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,8 +3,8 @@
 # Builds ultralytics/ultralytics:latest image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
 # Image is CUDA-optimized for YOLO single/multi-GPU training and inference
 
-# Start FROM PyTorch image https://hub.docker.com/r/pytorch/pytorch or nvcr.io/nvidia/pytorch:25.02-py3
-FROM pytorch/pytorch:2.11.0-cuda12.8-cudnn9-runtime
+# Start FROM Python image https://hub.docker.com/_/python
+FROM python:3.14-slim-trixie
 
 # Set environment variables
 # Avoid DDP error "MKL_THREADING_LAYER=INTEL is incompatible with libgomp.so.1 library"
@@ -33,6 +33,11 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# Install the latest stable PyTorch for CUDA (https://pytorch.org/get-started/locally/)
+RUN pip install uv && \
+    uv pip install --system --no-cache torch==2.13.0 torchvision==0.28.0 \
+    --index-url https://download.pytorch.org/whl/cu130
+
 # Create working directory
 WORKDIR /ultralytics
 
@@ -41,7 +46,7 @@ COPY . .
 RUN sed -i'' -e 's/"opencv-python/"opencv-python-headless/' pyproject.toml
 ADD https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26n.pt .
 
-# Install pip packages (uv already installed in base image)
+# Install pip packages
 RUN uv pip install --system --no-cache -e "." albumentations faster-coco-eval && \
     rm -rf tmp /root/.config/Ultralytics/persistent_cache.json
 


### PR DESCRIPTION
## Summary

- move the primary CUDA image to Python 3.14
- upgrade to stable PyTorch 2.13.0 / TorchVision 0.28.0
- use the official CUDA 13.0 wheel index, recommended for Blackwell

## Validation

- Dockerfile diff validation passes
- full image and real CUDA validation is running on an RTX PRO 6000 Blackwell

CUDA 13 requires NVIDIA driver 580.65.06 or newer. This PR intentionally changes only the primary `ultralytics/ultralytics:latest` image owner; Portal GPU and SAM workers inherit it.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

The primary `ultralytics/ultralytics:latest` CUDA image now uses Python 3.14 with PyTorch 2.13.0 and TorchVision 0.28.0 from the CUDA 13.0 wheel index.

### 📊 Key Changes

- Replaced the PyTorch CUDA 12.8 base image with `python:3.14-slim-trixie`.
- Installed `torch==2.13.0` and `torchvision==0.28.0` using `uv` and the official CUDA 13.0 wheel index.
- Updated the dependency installation step to install `uv` in the image before installing the Ultralytics package and related dependencies.
- Kept the image configured to include the YOLO26 model asset and install the existing project dependencies.

### 🎯 Purpose & Impact

- The `ultralytics/ultralytics:latest` image now targets Python 3.14 and CUDA 13.0-compatible PyTorch packages.
- Portal GPU and SAM workers inherit this updated primary image.
- CUDA 13.0 requires NVIDIA driver version 580.65.06 or newer.