### PR TITLE
Enable channels-last SAM prediction on CUDA

### DIFF
--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -456,12 +456,13 @@ class Predictor(BasePredictor):
             >>> predictor.setup_model(model=sam_model, verbose=True)
         """
         device = select_device(self.args.device, verbose=verbose)
-        if self.args.channels_last:
-            LOGGER.warning("'channels_last=True' is not supported for SAM predictors, ignoring.")
+        channels_last = self.args.channels_last and device.type == "cuda"
+        if self.args.channels_last and not channels_last:
+            LOGGER.warning(f"'channels_last=True' is only supported on CUDA, ignoring on '{device.type}'.")
         if model is None:
             model = self.get_model()
         # Move model to device first, then cast dtype, then set eval so any eval-time caches are created on-device.
-        model = model.to(device)
+        model = model.to(device, memory_format=torch.channels_last if channels_last else torch.preserve_format)
         model = model.half() if self.args.quantize == 16 else model.float()
         model.eval()
         self.model = model

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -10,7 +10,6 @@ segmentation tasks.
 
 from __future__ import annotations
 
-import platform
 from collections import OrderedDict, defaultdict
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any
@@ -457,9 +456,7 @@ class Predictor(BasePredictor):
             >>> predictor.setup_model(model=sam_model, verbose=True)
         """
         device = select_device(self.args.device, verbose=verbose)
-        channels_last = (
-            self.args.channels_last is not False and device.type == "cuda" and platform.machine() in {"AMD64", "x86_64"}
-        )
+        channels_last = self.args.channels_last is True and device.type == "cuda"
         if self.args.channels_last and not channels_last:
             LOGGER.warning(f"'channels_last=True' is only supported on CUDA, ignoring on '{device.type}'.")
         if model is None:

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -465,7 +465,10 @@ class Predictor(BasePredictor):
         if model is None:
             model = self.get_model()
         # Move model to device first, then cast dtype, then set eval so any eval-time caches are created on-device.
-        model = model.to(device, memory_format=torch.channels_last if channels_last else torch.preserve_format)
+        memory_format = torch.channels_last if channels_last else torch.preserve_format
+        if self.args.channels_last is False:
+            memory_format = torch.contiguous_format
+        model = model.to(device, memory_format=memory_format)
         model = model.half() if self.args.quantize == 16 else model.float()
         model.eval()
         self.model = model

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -10,6 +10,7 @@ segmentation tasks.
 
 from __future__ import annotations
 
+import platform
 from collections import OrderedDict, defaultdict
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any
@@ -456,7 +457,9 @@ class Predictor(BasePredictor):
             >>> predictor.setup_model(model=sam_model, verbose=True)
         """
         device = select_device(self.args.device, verbose=verbose)
-        channels_last = self.args.channels_last and device.type == "cuda"
+        channels_last = (
+            self.args.channels_last is not False and device.type == "cuda" and platform.machine() in {"AMD64", "x86_64"}
+        )
         if self.args.channels_last and not channels_last:
             LOGGER.warning(f"'channels_last=True' is only supported on CUDA, ignoring on '{device.type}'.")
         if model is None:


### PR DESCRIPTION
## Summary

- honor explicit `channels_last=True` for SAM predictors on CUDA
- keep the default `channels_last=None` behavior unchanged
- make explicit `channels_last=False` restore contiguous layout when a model is reused
- warn and preserve the current layout when explicit `True` is unsupported

## Validation

Validated real SAM2.1-tiny and SAM3 inference on an RTX PRO 6000 Blackwell with the production Python 3.12 / Torch 2.11 / CUDA 12.8 stack. Channels-last was numerically close but performance-neutral on this GPU, so this PR deliberately provides explicit opt-in support only; it does not auto-enable SAM. CPU setup and the True-to-False predictor lifecycle were also validated.

This is the minimal follow-up to the existing native-PyTorch channels-last feature: SAM owns a custom `setup_model()` and therefore bypasses `AutoBackend`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

SAM predictors now support explicit `channels_last=True` on CUDA while preserving or restoring the requested tensor layout in other configurations.

### 📊 Key Changes

- Applies `torch.channels_last` when `channels_last=True` and the selected device is CUDA.
- Uses `torch.contiguous_format` when `channels_last=False`, including when reusing a model after a channels-last setup.
- Preserves the existing layout when `channels_last=None`.
- Warns and ignores `channels_last=True` on unsupported devices, such as CPU.
- Keeps the existing model-to-device, dtype conversion, and evaluation setup sequence.

### 🎯 Purpose & Impact

- SAM users can explicitly opt into channels-last model layout for CUDA inference.
- Explicitly disabling the option restores contiguous layout instead of retaining a previous channels-last layout.
- Unsupported explicit requests no longer silently retain the old warning behavior; they emit a device-specific warning and preserve the current layout.