### PR TITLE
Optimize SAM image feature extraction

### DIFF
--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -535,6 +535,7 @@ class Predictor(BasePredictor):
         self.segment_all = False
         return results
 
+    @smart_inference_mode()
     def set_image(self, image):
         """Preprocess and set a single image for inference.
 


### PR DESCRIPTION
## Summary
- run direct `SAM`/`SAM2`/`SAM3` `set_image()` feature extraction under inference mode
- avoid retaining an autograd graph for cached image embeddings

## Validation
- `git diff --check`
- RTX PRO 6000 Blackwell, Python 3.12.3, PyTorch 2.11.0+cu128, Ultralytics 8.4.137
- exercised `set_image()` across SAM2.1 tiny/small/base/large and SAM3
- inference-mode outputs feed the existing inference-mode `inference_features()` path without mutation

The model is still constructed outside inference mode by `setup_model()`, so only image feature outputs become inference tensors.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Wrapped SAM image feature extraction in inference mode to prevent autograd graphs from being retained for cached image embeddings.

### 📊 Key Changes
- Added `@smart_inference_mode()` to `Predictor.set_image()` in `ultralytics/models/sam/predict.py`.
- Applied the change to direct `SAM`, `SAM2`, and `SAM3` image setup and feature extraction.
- Kept model construction outside inference mode, so only image feature outputs are inference tensors.

### 🎯 Purpose & Impact
- Cached image embeddings produced by `set_image()` no longer retain an autograd graph, reducing unnecessary memory usage during inference.
- The resulting features remain usable by the existing inference-mode `inference_features()` path without mutation.
- No user-facing API change.