### PR TITLE
Fix DDP unused-gradient crash when a mini-batch has no assigned targets

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1868,6 +1868,80 @@ def test_nn_depth_head_no_dead_parameters():
     assert not unused, f"parameters with no gradient: {unused}"
 
 
+@pytest.mark.parametrize(
+    ("task", "cfg", "extra_kw", "extra_batch", "head_attrs"),
+    [
+        ("detect", "yolo11n.yaml", {}, {}, ("cv2",)),
+        ("pose", "yolo11n-pose.yaml", {"data_kpt_shape": (17, 3)}, {"keypoints": torch.zeros(0, 17, 3)}, ("cv4",)),
+        (
+            "pose",
+            "yolo26n-pose.yaml",
+            {"data_kpt_shape": (17, 3)},
+            {"keypoints": torch.zeros(0, 17, 3)},
+            ("cv4", "cv4_sigma", "flow_model"),
+        ),
+        ("obb", "yolo11n-obb.yaml", {}, {"bboxes": torch.zeros(0, 5)}, ("cv2",)),
+    ],
+)
+def test_detection_loss_empty_targets_keeps_box_head_in_graph(task, cfg, extra_kw, extra_batch, head_attrs):
+    """Box/kpt/flow heads must receive gradient on an empty-target batch — DDP then needs no find_unused_parameters."""
+    from ultralytics.cfg import get_cfg
+    from ultralytics.nn.tasks import DetectionModel, OBBModel, PoseModel
+    from ultralytics.utils import DEFAULT_CFG
+
+    model_cls = {"detect": DetectionModel, "pose": PoseModel, "obb": OBBModel}[task]
+    model = model_cls(cfg, **extra_kw).train()
+    model.args = get_cfg(DEFAULT_CFG)
+    batch = {
+        "img": torch.rand(2, 3, 64, 64),
+        "batch_idx": torch.zeros(0),
+        "cls": torch.zeros(0, 1),
+        "bboxes": torch.zeros(0, 4),
+        **extra_batch,
+    }
+    model.loss(batch)[0].sum().backward()
+    head = model.model[-1]
+    unused = [f"{attr}.{n}" for attr in head_attrs for n, p in getattr(head, attr).named_parameters() if p.grad is None]
+    assert not unused, f"parameters with no gradient: {unused}"
+
+
+def test_pose26_rle_zero_keeps_flow_model_in_graph_with_visible_target():
+    """A batch with a real target box but no visible keypoints must still route gradient through the RLE flow model —
+    the same DDP requirement, triggered by keypoint visibility rather than by an empty batch.
+    """
+    from ultralytics.cfg import get_cfg
+    from ultralytics.nn.tasks import PoseModel
+    from ultralytics.utils import DEFAULT_CFG
+
+    model = PoseModel("yolo26n-pose.yaml", data_kpt_shape=(17, 3)).train()
+    model.args = get_cfg(DEFAULT_CFG)
+    batch = {
+        "img": torch.rand(1, 3, 64, 64),
+        "batch_idx": torch.zeros(1),
+        "cls": torch.zeros(1, 1),
+        "bboxes": torch.tensor([[0.5, 0.5, 0.2, 0.2]]),
+        "keypoints": torch.zeros(1, 17, 3),  # v=0 for every keypoint -> kpt_mask.any() is False
+    }
+    model.loss(batch)[0].sum().backward()
+    unused = [n for n, p in model.model[-1].flow_model.named_parameters() if p.grad is None]
+    assert not unused, f"flow_model parameters with no gradient despite a real target box: {unused}"
+
+
+def test_detr_loss_empty_targets_keeps_box_head_in_graph():
+    """DETR box head must receive gradient on an empty-target batch — same DDP requirement."""
+    from ultralytics.models.utils.loss import DETRLoss
+
+    box_head = torch.nn.Linear(4, 4)
+    pred_bboxes = box_head(torch.rand(1, 1, 5, 4))  # (layers, bs, nq, 4)
+    pred_scores = torch.rand(1, 1, 5, 3, requires_grad=True)
+    batch = {"cls": torch.zeros(0, dtype=torch.long), "bboxes": torch.zeros(0, 4), "gt_groups": [0]}
+
+    loss = DETRLoss(nc=3, aux_loss=False)(pred_bboxes, pred_scores, batch)
+    sum(loss.values()).backward()
+
+    assert box_head.weight.grad is not None, "box head left disconnected from autograd on an empty-target batch"
+
+
 def test_classification_fraction_samples_across_classes(tmp_path):
     """Sample classification fractions across the class-major ImageFolder ordering."""
     from ultralytics.data.dataset import ClassificationDataset

--- a/ultralytics/models/utils/loss.py
+++ b/ultralytics/models/utils/loss.py
@@ -142,8 +142,9 @@ class DETRLoss(nn.Module):
 
         loss = {}
         if len(gt_bboxes) == 0:
-            loss[name_bbox] = torch.tensor(0.0, device=self.device)
-            loss[name_giou] = torch.tensor(0.0, device=self.device)
+            # WARNING: lines below prevent Multi-GPU DDP 'unused gradient' PyTorch errors, do not remove
+            loss[name_bbox] = pred_bboxes[..., :0].sum()
+            loss[name_giou] = pred_bboxes[..., :0].sum()
             return loss
 
         loss[name_bbox] = self.loss_gain["bbox"] * F.l1_loss(pred_bboxes, gt_bboxes, reduction="sum") / len(gt_bboxes)

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -453,6 +453,9 @@ class v8DetectionLoss:
                 imgsz,
                 stride_tensor,
             )
+        # WARNING: line below prevents Multi-GPU DDP 'unused gradient' PyTorch errors, do not remove
+        else:
+            loss[0] += pred_distri[..., :0].sum()
 
         loss[0] *= self.hyp.box  # box gain
         loss[1] *= self.hyp.cls  # cls gain
@@ -705,6 +708,9 @@ class v8PoseLoss(v8DetectionLoss):
                 target_bboxes,
                 pred_kpts,
             )
+        # WARNING: line below prevents Multi-GPU DDP 'unused gradient' PyTorch errors, do not remove
+        else:
+            loss[1] += pred_kpts[..., :0].sum()
 
         loss[1] *= self.hyp.pose  # pose gain
         loss[2] *= self.hyp.kobj  # kobj gain
@@ -881,6 +887,11 @@ class PoseLoss26(v8PoseLoss):
             loss[2] = keypoints_loss[1]
             if self.rle_loss is not None:
                 loss[5] = keypoints_loss[2]
+        # WARNING: lines below prevent Multi-GPU DDP 'unused gradient' PyTorch errors, do not remove
+        else:
+            loss[1] += pred_kpts[..., :0].sum()
+            if self.rle_loss is not None:
+                loss[5] += self._rle_zero(pred_kpts)
 
         loss[1] *= self.hyp.pose  # pose gain
         loss[2] *= self.hyp.kobj  # kobj gain
@@ -898,6 +909,10 @@ class PoseLoss26(v8PoseLoss):
         y[..., 1] += anchor_points[:, [1]]
         return y
 
+    def _rle_zero(self, pred_kpt: torch.Tensor) -> torch.Tensor:
+        """Return a zero RLE loss keeping `pred_kpt` and the flow model in the graph, for Multi-GPU DDP."""
+        return pred_kpt[..., :0].sum() + sum(p[..., :0].sum() for p in self.flow_model.parameters())
+
     def calculate_rle_loss(self, pred_kpt: torch.Tensor, gt_kpt: torch.Tensor, kpt_mask: torch.Tensor) -> torch.Tensor:
         """Calculate the RLE (Residual Log-likelihood Estimation) loss for keypoints.
 
@@ -910,7 +925,7 @@ class PoseLoss26(v8PoseLoss):
             (torch.Tensor): The RLE loss.
         """
         if not kpt_mask.any():
-            return pred_kpt[..., :0].sum()
+            return self._rle_zero(pred_kpt)
 
         pred_kpt_visible = pred_kpt[kpt_mask]
         gt_kpt_visible = gt_kpt[kpt_mask]
@@ -924,12 +939,12 @@ class PoseLoss26(v8PoseLoss):
         pred_sigma = pred_sigma.sigmoid()
         error = (pred_coords - gt_coords) / (pred_sigma + 1e-9)
         if not error.numel():
-            return pred_kpt[..., :0].sum()
+            return self._rle_zero(pred_kpt)
 
         # Filter out NaN and Inf values that would propagate into the loss
         valid_mask = ~(torch.isnan(error) | torch.isinf(error)).any(dim=-1)
         if not valid_mask.any():
-            return pred_kpt[..., :0].sum()
+            return self._rle_zero(pred_kpt)
 
         error = error[valid_mask]
         error = error.clamp(-100, 100)  # Prevent numerical instability
@@ -1117,7 +1132,7 @@ class v8OBBLoss(v8DetectionLoss):
                 pred_bboxes, target_bboxes, fg_mask, weight, target_scores_sum
             )  # angle loss
         else:
-            loss[0] += (pred_angle * 0).sum()
+            loss[0] += (pred_angle * 0).sum() + pred_distri[..., :0].sum()
 
         loss[0] *= self.hyp.box  # box gain
         loss[1] *= self.hyp.cls  # cls gain


### PR DESCRIPTION
`v8DetectionLoss` drops the box branch out of the autograd graph whenever the assigner produces no positive anchors:

```python
# ultralytics/utils/loss.py:444
if fg_mask.sum():
    loss[0], loss[2] = self.bbox_loss(pred_distri, ...)
```

`pred_distri` is then never consumed, so every parameter of the box head — `cv2`, plus `one2one_cv2` on YOLO26 — receives no gradient on that step. The same holds for `pred_kpts` in `v8PoseLoss` and `PoseLoss26`, and for the `RealNVP` flow model in the three early returns of `calculate_rle_loss`.

The neighbouring branches are already guarded against exactly this: `loss[1] += (proto * 0).sum() + (pred_masks * 0).sum()` for the segmentation masks (`:556` and `:646`, commented "do not remove"), `loss[0] += (pred_angle * 0).sum()` for OBB's angle head (`:1120`), and `dec_bboxes + 0 * self.denoising_class_embed.weight.sum()` for RT-DETR's denoising embedding (`head.py:1615`). The box branch, which every detection-family task shares, was never covered.

RT-DETR has the same gap a second time, independently: `DETRLoss._get_loss_bbox` (`ultralytics/models/utils/loss.py:144`) substitutes a fresh detached `torch.tensor(0.0)` for `loss_bbox`/`loss_giou` when a sub-batch has no ground-truth boxes, throwing away the connection to `pred_bboxes` that `HungarianMatcher` (`models/utils/ops.py:111`) had already reduced to an empty but graph-connected slice. On `rtdetr-l` that leaves 43 parameters without a gradient — `dec_bbox_head`, `enc_bbox_head` and `denoising_class_embed`.

The new guards use `x[..., :0].sum()` rather than `(x * 0).sum()`. Both keep the tensor in the graph, but summing an empty slice stays exactly `0.0` where `0 * inf` is `nan`, so a non-finite value in an otherwise-unused prediction cannot corrupt the reported loss — which is what the existing `# inf sums may lead to nan loss` comments are warning about. It is also the idiom `calculate_rle_loss` already uses a few lines below.

## What it changes in practice

So `find_unused_parameters=True` is currently required because of this: with it off, DDP raises `Expected to have finished reduction in the prior iteration` on the first sub-batch with no targets. Verified on 2× L4 with NCCL and on 2 ranks with gloo on CPU, feeding rank 1 a no-target batch at iteration 2:

| DDP configuration | before | after |
|---|---|---|
| `find_unused_parameters=True` (default) | passes | passes |
| `static_graph=True` on an eager model | RuntimeError | passes |
| neither | RuntimeError | passes |

One thing to be clear about the scope: `compile=True` training is **not** broken today, because the inductor backward returns exact zeros for those parameters where eager returns `None` (measured: `grad-None=24` eager vs `all-zero-grad=24` compiled on the same batch), so DDP's hooks fire and `static_graph=True` holds. `yolo train ... device=0,1 compile=True mosaic=0` completed 6 epochs at `batch=4` and 3 at `batch=2` on 2× L4. What the guards remove is the dependence on that. `attempt_compile()` returns the model **uncompiled** when `torch.compile` is missing, when inductor finds no C++ compiler, or when compilation raises — logged only as `torch.compile failed, continuing uncompiled` — while `trainer.py:400-405` still sets `static_graph=True, find_unused_parameters=False` from `self.args.compile`. Running the real trainer through that documented branch on 2× L4 gives `RuntimeError: Expected to have finished reduction ... not compatible with static_graph set to True`, `Parameter indices which did not receive grad for rank 0: 189 ... 212`, and the run exits 1. With this patch the identical command completes and validates.

Grad-requiring parameters left without a gradient on a batch with no ground-truth objects, before → after:

| task | yolo11n | yolo26n |
|---|---|---|
| detect | 24 → 0 | 48 → 0 |
| segment | 24 → 0 | 48 → 0 |
| pose | 48 → 0 | 180 → 0 |
| obb | 24 → 0 | 48 → 0 |

`yolo26x.pt` detect 48 → 0, `rtdetr-l` 43 → 0, `yolo11n-cls` already 0. On `yolo26x` these are `model.23.cv2` (DDP indices 426..449) and `model.23.one2one_cv2` (492..515) — 48 of the 90 indices in the "did not receive grad" traceback from https://github.com/ultralytics/ultralytics/issues/24612 (rank 2, 426..515). The other 42 (`model.23.cv3`, 450..491) receive gradient unconditionally from the classification BCE term regardless of `fg_mask`, so this fix does not explain those.

## Behaviour

This is inert: loss values and loss items are bit-identical in every one of the eight task/model combinations above, targets or not. Gradients are bit-identical too, except that a parameter which previously had no path at all to the loss now gets an exact zero instead of `None` — on the box/keypoint heads when a batch has no assigned targets, and, separately, on `PoseLoss26`'s flow model whenever the assigned target's keypoints are all invisible (`kpt_mask` all `False`), which can happen on a batch that does have a target box.

A 10-epoch single-GPU run (`seed=0`, `deterministic=True`) on a 32-image dataset where 16 images carry no labels gives an identical sha256 over every tensor in `last.pt` (sorted key order) and identical mAP at `batch=4` (3.7% of steps take the new branch) and at `batch=2` (22.4%); the checkpoint file itself is never byte-identical run-to-run because it embeds `datetime.now()` (`trainer.py:756`).

## Tests

Three, folded into `tests/test_python.py` next to `test_nn_depth_head_no_dead_parameters`, whose docstring already states the same requirement ("Every head parameter receives gradient — DDP then needs no find_unused_parameters"). One is parametrized across detect, pose, pose26 (also asserting `cv4_sigma` and `flow_model`, since PoseLoss26 has its own separate no-target branch), and obb — `v8OBBLoss.loss()` reimplements the box branch rather than reusing `v8DetectionLoss`, so it needed its own case. A second isolates the RLE-specific trigger: a batch with a real target box but no visible keypoints, which drops `flow_model` out of the graph independently of `fg_mask`. The third covers `DETRLoss` directly. All three build their input in memory, need no network or fixtures, and were checked against `main` without the fix: all six cases fail there and pass here. The DDP failure itself needs two GPUs, which the suite can't test.

`tests/test_cuda.py`: 7 passed, 1 skipped. `tests/test_python.py -k "train or loss or pose or obb or seg or empty_targets or rle"`: 39 passed, plus the `test_train_scratch` failure already present on unpatched `main`.

I left `find_unused_parameters=not bool(self.args.compile)` alone. With these guards it is no longer required for the models above, but on 2× L4 turning it off is worth +0.10% / +0.09% / −0.12% per step for yolo11n/s/m over 6 interleaved A/B rounds — inside the noise, so it buys nothing worth the risk.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Preserves autograd connections for detection, pose, OBB, RLE, and RT-DETR box branches when no targets or valid keypoints are available, preventing unused-gradient DDP failures.

### 📊 Key Changes
- Adds graph-preserving empty-slice loss terms for detection box distributions, pose keypoints, and OBB box heads.
- Keeps YOLO26 pose `flow_model` parameters connected during empty-target and zero-visible-keypoint RLE paths.
- Updates RT-DETR empty-ground-truth box and GIoU losses to remain connected to `pred_bboxes`.
- Adds regression tests covering detection, pose, YOLO26 pose, OBB, RLE, and RT-DETR empty-target cases.

### 🎯 Purpose & Impact
- Ensures affected parameters receive zero gradients instead of no gradient on these branches, allowing DDP configurations that require consistent gradient participation to complete. No user-facing change to loss values is intended.