### PR TITLE
Fix MuSGD crash with channels_last: use reshape for non-contiguous grads

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -2192,3 +2192,13 @@ def test_semantic_polygon_data():
     model = YOLO("yolo26n-sem.pt")
     model.train(data="coco8-seg.yaml", epochs=1, imgsz=32, close_mosaic=1)
     model.val(data="coco8-seg.yaml")
+
+
+def test_muon_update_non_contiguous():
+    """muon_update handles non-contiguous grads, e.g. conv weights in channels_last memory format."""
+    from ultralytics.optim.muon import muon_update
+
+    grad = torch.randn(8, 4, 3, 3).to(memory_format=torch.channels_last)
+    assert not grad.is_contiguous()
+    update = muon_update(grad, torch.zeros_like(grad))
+    assert update.shape == grad.shape

--- a/ultralytics/optim/muon.py
+++ b/ultralytics/optim/muon.py
@@ -96,7 +96,7 @@ def muon_update(
         updates = list(momentums)
     buckets = {}  # group matrices transposed to rows <= cols by (rows, scale) for batched orthogonalization
     for i, u in enumerate(updates):
-        m = u.view(len(u), -1) if u.ndim > 2 else u
+        m = u.reshape(len(u), -1) if u.ndim > 2 else u
         transpose = m.size(0) > m.size(1)
         if transpose:
             m = m.transpose(0, 1)


### PR DESCRIPTION
## Description

`muon_update()` calls `u.view(len(u), -1)` to flatten >2D update tensors before orthogonalization. Since #26007 auto-enables `channels_last` memory format for CUDA training, conv weight gradients (and thus momentum buffers) are no longer contiguous, and `.view()` raises:

```
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
```

This crashes any MuSGD training run on CUDA with default settings.

The bug is latent in `muon.py` — explicit `channels_last=True optimizer=MuSGD` crashed the same way on earlier versions; #26007 just made it the default path on CUDA.

## Fix

Replace `.view()` with `.reshape()` in `ultralytics/optim/muon.py`. `reshape` returns a view when possible (zero cost for the contiguous case) and copies only when the tensor is non-contiguous, which is exactly the channels_last case that previously crashed.

## Testing

Reproduced and verified on CUDA:

```bash
# default path since channels_last auto-enable: crashed before this change, now trains normally
yolo detect train data=coco8.yaml model=yolo26n.pt optimizer=MuSGD

# explicit enable, same code path: crashed before, now trains normally
yolo detect train data=coco8.yaml model=yolo26n.pt optimizer=MuSGD channels_last=True

# contiguous path, unaffected before and after (reshape is a no-op view there)
yolo detect train data=coco8.yaml model=yolo26n.pt optimizer=MuSGD channels_last=False
```

- default / `channels_last=True`: crashed with the `RuntimeError` above before this change; training runs after it.
- `channels_last=False`: identical behavior before and after this change.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated `muon_update()` to use `reshape()` instead of `view()` when flattening tensors, allowing MuSGD to process non-contiguous momentum buffers produced by `channels_last` training.

### 📊 Key Changes
- Replaced `u.view(len(u), -1)` with `u.reshape(len(u), -1)` in `ultralytics/optim/muon.py`.
- Preserved the existing flattening behavior for tensors with more than two dimensions.
- Retained the existing handling of two-dimensional tensors and subsequent orthogonalization logic.

### 🎯 Purpose & Impact
Prevents MuSGD training from raising a tensor stride compatibility error when CUDA training uses non-contiguous `channels_last` gradients or momentum buffers; contiguous tensors continue to follow the existing behavior.