### PR TITLE
Remove inconsistent `OBB Dataset` in the docs navigation bar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -443,7 +443,7 @@ nav:
           - Imagewoof: datasets/classify/imagewoof.md
           - MNIST: datasets/classify/mnist.md
       - Oriented Bounding Boxes (OBB):
-          - OBB Datasets: datasets/obb/index.md
+          - datasets/obb/index.md
           - DOTA8: datasets/obb/dota8.md
           - DOTA128: datasets/obb/dota128.md
           - DOTAv2: datasets/obb/dota-v2.md


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the MkDocs navigation entry for the Oriented Bounding Boxes (OBB) dataset index to remove the inconsistent `OBB Datasets` label.

### 📊 Key Changes

- Changed the OBB dataset index entry in `mkdocs.yml` from `OBB Datasets` to `datasets/obb/index.md`.
- Kept the `DOTA8`, `DOTA128`, and `DOTAv2` navigation entries unchanged.

### 🎯 Purpose & Impact

- The OBB section no longer uses the inconsistent `OBB Datasets` navigation label; this affects the documentation navigation only.