### PR TITLE
Fix distributed tuning fitness dataset labels

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1248,7 +1248,8 @@ class MultiTrainer:
                     f"\n{colorstr('blue', 'bold', f'MultiTrainer {i + 1}/{len(datasets)}:')} fine-tuning on {data}"
                 )
                 path = Path(str(data))
-                name = path.parent.resolve().name if path.stem == "data" and path.parent.name else path.stem
+                parent = path.parent.name
+                name = Path(os.path.abspath(path.parent)).name if path.stem == "data" and parent else path.stem
                 run_name = name
                 try:
                     overrides = {

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1247,7 +1247,8 @@ class MultiTrainer:
                 LOGGER.info(
                     f"\n{colorstr('blue', 'bold', f'MultiTrainer {i + 1}/{len(datasets)}:')} fine-tuning on {data}"
                 )
-                name = Path(str(data)).stem
+                path = Path(str(data))
+                name = path.parent.name if path.stem == "data" and path.parent.name else path.stem
                 run_name = name
                 try:
                     overrides = {

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1248,7 +1248,7 @@ class MultiTrainer:
                     f"\n{colorstr('blue', 'bold', f'MultiTrainer {i + 1}/{len(datasets)}:')} fine-tuning on {data}"
                 )
                 path = Path(str(data))
-                name = path.parent.name if path.stem == "data" and path.parent.name else path.stem
+                name = path.parent.resolve().name if path.stem == "data" and path.parent.name else path.stem
                 run_name = name
                 try:
                     overrides = {

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -261,7 +261,7 @@ class Tuner:
         resume, mutation, and plotting on the same local source of truth when using distributed tuning.
         """
         try:
-            all_results = list(self.collection.find({"fitness": {"$exists": True}}).sort("_id", 1))
+            all_results = list(self.collection.find({"fitness": {"$exists": True}}).sort("iteration", 1))
             if not all_results:
                 return
             last_iteration = max(r["iteration"] for r in all_results)


### PR DESCRIPTION
### Summary

Preserve dataset identity and iteration order in distributed multi-dataset tuning results.

### Problem

- `MultiTrainer` derives every run name from the YAML stem. Local datasets commonly use paths such as `/datasets/annopage/data.yaml` and `/datasets/airbus/data.yaml`, which become `data` and `data-2`. Distributed workers with different local materializations then write inconsistent per-dataset Mongo keys, and `tune_fitness.png` renders the same datasets twice.
- Mongo synchronization sorts results by `_id`, which follows asynchronous completion order. The fitness plot consequently labels the first completed result as “Initial” and computes “Best so far” out of iteration order.

### Solution

- Use the parent directory name when a dataset YAML has the generic `data` stem. Existing names such as `coco8.yaml` and a bare `data.yaml` are unchanged.
- Write distributed NDJSON results in `iteration` order. Mutation history intentionally retains completion order.

### Validation

- `/home/ubuntu/ul37/data/airbus-aircraft-detection-674bf4d2/data.yaml` -> `airbus-aircraft-detection-674bf4d2`
- `coco8.yaml` -> `coco8`
- `data.yaml` -> `data`
- Reconstructed a 319-result distributed collection: dataset rows fall from 74 to the correct 37 and “Initial” resolves to iteration 1 (`0.43985`) rather than first completion (`0.4191`).
- `ruff format --check ultralytics/engine/trainer.py ultralytics/engine/tuner.py`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Distributed multi-dataset tuning now preserves dataset-specific run names and orders synchronized fitness results by iteration, producing consistent dataset identities and plots.

### 📊 Key Changes

- `MultiTrainer` uses the parent directory name when a dataset YAML has the generic `data` filename, while preserving names such as `coco8` and bare `data`.
- Distributed MongoDB synchronization sorts fitness results by `iteration` instead of MongoDB `_id`, so results follow tuning order rather than asynchronous completion order.
- Mutation history continues to retain completion order while synchronized result files use iteration order.

### 🎯 Purpose & Impact

- Prevents different dataset paths that both end in `data.yaml` from being merged under the same run name across distributed workers.
- Ensures fitness plots identify the initial result and calculate progress from tuning iteration order, avoiding duplicated dataset rows and completion-order labeling.