### PR TITLE
Name the YOLO26n vs YOLO11n baseline for the 43% CPU figure

### DIFF
--- a/docs/en/help/FAQ.md
+++ b/docs/en/help/FAQ.md
@@ -130,7 +130,7 @@ Key distinctions include:
 - [End-to-End NMS-Free Inference](../guides/end2end-detection.md): YOLO26 is natively end-to-end, producing predictions directly without non-maximum suppression (NMS), reducing latency and simplifying deployment.
 - DFL Removal: YOLO26 removes the Distribution Focal Loss module, simplifying export and improving compatibility with edge and low-power devices.
 - MuSGD Optimizer: A hybrid of SGD and Muon (inspired by Moonshot AI's Kimi K2) for more stable training and faster convergence.
-- CPU Performance: YOLO26 delivers up to 43% faster CPU inference, making it ideal for devices without GPUs.
+- CPU Performance: YOLO26n runs up to 43% faster than YOLO11n on CPU ONNX inference (Intel Xeon CPU @ 2.00 GHz), making it ideal for devices without GPUs.
 - Task-Specific Optimizations: Enhanced segmentation with semantic loss and multi-scale protos, RLE for precision pose estimation, and improved OBB decoding with angle loss.
 - Tasks: Both models support [object detection](https://www.ultralytics.com/glossary/object-detection) and instance segmentation, while YOLO26 also adds [semantic segmentation](../tasks/semantic.md) for dense pixel-level prediction and [monocular depth estimation](../tasks/depth.md) for per-pixel depth. Both models also support classification, pose estimation, and oriented object detection (OBB) in a unified framework.
 

--- a/docs/en/integrations/onnx.md
+++ b/docs/en/integrations/onnx.md
@@ -6,9 +6,9 @@ keywords: YOLO26, ONNX, model export, Ultralytics, ONNX Runtime, machine learnin
 
 # ONNX Export for YOLO26 Models
 
-???+ tip "~43% faster inference."
+???+ tip "~43% faster CPU inference"
 
-    - Exporting the Ultralytics YOLO26 model to ONNX can deliver up to a 43% boost in inference speed, enabling faster and more efficient deployment.
+    - YOLO26n runs up to 43% faster than YOLO11n on CPU ONNX inference (Intel Xeon CPU @ 2.00 GHz). See the [YOLO26 model page](../models/yolo26.md) for the full comparison.
 
 Often, when deploying [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) models, you'll need a model format that's both flexible and compatible with multiple platforms.
 

--- a/docs/en/integrations/onnx.md
+++ b/docs/en/integrations/onnx.md
@@ -6,7 +6,7 @@ keywords: YOLO26, ONNX, model export, Ultralytics, ONNX Runtime, machine learnin
 
 # ONNX Export for YOLO26 Models
 
-???+ tip "~43% faster CPU inference"
+???+ tip "~43% faster CPU ONNX inference: YOLO26n vs YOLO11n"
 
     - YOLO26n runs up to 43% faster than YOLO11n on CPU ONNX inference (Intel Xeon CPU @ 2.00 GHz). See the [YOLO26 model page](../models/yolo26.md) for the full comparison.
 


### PR DESCRIPTION
## summary

- The ONNX integration page credited the export format with the 43% figure ("Exporting the Ultralytics YOLO26 model to ONNX can deliver up to a 43% boost in inference speed"). The figure is a model-vs-model comparison at a fixed export format, so it now reads as YOLO26n against YOLO11n on CPU ONNX with the hardware named, and links to the YOLO26 model page.
- The FAQ entry stated the figure without saying which format or hardware it was measured on; it now carries the same baseline as `models/yolo26.md` and `guides/end2end-detection.md`.
- Every remaining occurrence of 43% in `docs/en/` already names the YOLO26n-vs-YOLO11n CPU ONNX baseline.

## measured

Median of 30 predictions on `bus.jpg`, CPU, `results[0].speed["inference"]`, ONNX Runtime 1.29.0:

| axis | yolo26n | yolo11n |
| --- | --- | --- |
| PyTorch | 21.56 ms | 21.46 ms |
| ONNX | 16.67 ms | 17.94 ms |
| ONNX vs PyTorch | +29.3% | +19.6% |

The export step speeds up both models by a similar amount, which is a different axis from the published 43% (YOLO26n vs YOLO11n, both in ONNX, Intel Xeon CPU @ 2.00 GHz).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the ONNX integration page and FAQ to identify the 43% performance figure as a YOLO26n-versus-YOLO11n CPU ONNX comparison on an Intel Xeon CPU.

### 📊 Key Changes

- Replaced the generic “43% faster inference” wording on the [ONNX export page](https://docs.ultralytics.com/integrations/onnx/) with the specific YOLO26n versus YOLO11n CPU ONNX comparison.
- Updated the FAQ to state that YOLO26n runs up to 43% faster than YOLO11n on CPU ONNX inference.
- Added the hardware context: Intel Xeon CPU @ 2.00 GHz.
- Linked the ONNX performance note to the [YOLO26 model page](https://docs.ultralytics.com/models/yolo26/) for the full comparison.

### 🎯 Purpose & Impact

- Documentation now distinguishes the model-to-model CPU ONNX comparison from the separate speed improvements provided by exporting models from PyTorch to ONNX.
- No software or runtime behavior changed.