### PR TITLE
Fix tuner metrics for failed datasets

### DIFF
--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -208,6 +208,7 @@ class Tuner:
         hyperparameters: dict[str, float],
         datasets: dict[str, dict],
         save_dirs: dict[str, str] | None = None,
+        failed_datasets: list[str] | None = None,
     ) -> dict:
         """Build one local tuning result record."""
         result = {
@@ -218,6 +219,8 @@ class Tuner:
         }
         if save_dirs:
             result["save_dirs"] = save_dirs
+        if failed_datasets:
+            result["failed_datasets"] = failed_datasets
         return result
 
     def _save_to_mongodb(
@@ -227,6 +230,7 @@ class Tuner:
         metrics: dict,
         datasets: dict[str, dict],
         save_dirs: dict[str, str],
+        failed_datasets: list[str],
     ):
         """Save results to MongoDB with proper type conversion.
 
@@ -236,6 +240,7 @@ class Tuner:
             metrics (dict): Complete training metrics dictionary (mAP, precision, recall, losses, etc.).
             datasets (dict[str, dict]): Per-dataset metrics for the iteration.
             save_dirs (dict[str, str]): Per-dataset training directories for cleanup.
+            failed_datasets (list[str]): Dataset runs that did not produce training metrics.
         """
         try:
             self.collection.insert_one(
@@ -245,6 +250,7 @@ class Tuner:
                     "metrics": metrics,
                     "datasets": datasets,
                     "save_dirs": save_dirs,
+                    "failed_datasets": failed_datasets,
                     "timestamp": datetime.now().astimezone(),
                     "iteration": self.collection.find_one_and_update(
                         {"_id": "defaults"}, {"$inc": {"last_iteration": 1}}, return_document=True
@@ -276,6 +282,7 @@ class Tuner:
                             result.get("hyperparameters", {}),
                             result.get("datasets", {}),
                             result.get("save_dirs"),
+                            result.get("failed_datasets"),
                         ),
                         default=self._json_default,
                     )
@@ -325,7 +332,8 @@ class Tuner:
     def _has_training_metrics(result: dict, require_all: bool = False) -> bool:
         """Return whether a tuning result contains training metrics."""
         datasets = result.get("datasets", {})
-        trained = [bool(metrics) and not metrics.get("failed") for metrics in datasets.values()]
+        failed = set(result.get("failed_datasets", ()))
+        trained = [bool(metrics) and dataset not in failed for dataset, metrics in datasets.items()]
         return bool(trained) and (all(trained) if require_all else any(trained))
 
     @classmethod
@@ -492,10 +500,11 @@ class Tuner:
                 data = [data]
             model = YOLO(train_args["model"])
             trainer = MultiTrainer(None, {**train_args, "data": data}, model.model)
+            raw_metrics = trainer.train()
+            failed_datasets = [dataset for dataset, metrics in raw_metrics.items() if not metrics]
             metric = TASK2METRIC[train_args["task"]]
             dataset_metrics = {
-                dataset: metrics or {metric: 0.0, "fitness": 0.0, "failed": True}
-                for dataset, metrics in trainer.train().items()
+                dataset: metrics or {metric: 0.0, "fitness": 0.0} for dataset, metrics in raw_metrics.items()
             }
             save_dir = [trainer.save_dir / dataset for dataset in dataset_metrics]
             weights_dir = [s / "weights" for s in save_dir]
@@ -508,12 +517,15 @@ class Tuner:
                 mutated_hyp,
                 dataset_metrics,
                 {dataset: str(s) for dataset, s in zip(dataset_metrics, save_dir)},
+                failed_datasets,
             )
             if self._has_training_metrics(result, require_all=True):
                 n_successful += 1
             stop_after_iteration = False
             if self.mongodb:
-                self._save_to_mongodb(fitness, mutated_hyp, metrics, dataset_metrics, result["save_dirs"])
+                self._save_to_mongodb(
+                    fitness, mutated_hyp, metrics, dataset_metrics, result["save_dirs"], failed_datasets
+                )
                 self._sync_mongodb_to_file()
                 total_mongo_iterations = self.collection.count_documents({"fitness": {"$exists": True}})
                 if total_mongo_iterations >= iterations:

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -23,7 +23,7 @@ from datetime import datetime
 
 import numpy as np
 
-from ultralytics.cfg import CFG_INT_KEYS, get_cfg, get_save_dir
+from ultralytics.cfg import CFG_INT_KEYS, TASK2METRIC, get_cfg, get_save_dir
 from ultralytics.utils import DEFAULT_CFG, LOGGER, YAML, callbacks, colorstr, remove_colorstr
 from ultralytics.utils.checks import check_requirements
 from ultralytics.utils.plotting import plot_tune_results
@@ -491,7 +491,10 @@ class Tuner:
                 data = [data]
             model = YOLO(train_args["model"])
             trainer = MultiTrainer(None, {**train_args, "data": data}, model.model)
-            dataset_metrics = {dataset: metrics or {} for dataset, metrics in trainer.train().items()}
+            metric = TASK2METRIC[train_args["task"]]
+            dataset_metrics = {
+                dataset: metrics or {metric: 0.0, "fitness": 0.0} for dataset, metrics in trainer.train().items()
+            }
             save_dir = [trainer.save_dir / dataset for dataset in dataset_metrics]
             weights_dir = [s / "weights" for s in save_dir]
             metrics = trainer.mean_metrics

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -325,7 +325,8 @@ class Tuner:
     def _has_training_metrics(result: dict, require_all: bool = False) -> bool:
         """Return whether a tuning result contains training metrics."""
         datasets = result.get("datasets", {})
-        return bool(datasets) and (all(datasets.values()) if require_all else any(datasets.values()))
+        trained = [bool(metrics) and not metrics.get("failed") for metrics in datasets.values()]
+        return bool(trained) and (all(trained) if require_all else any(trained))
 
     @classmethod
     def _best_result_index(cls, results: list[dict], fitness: np.ndarray) -> int:
@@ -493,7 +494,8 @@ class Tuner:
             trainer = MultiTrainer(None, {**train_args, "data": data}, model.model)
             metric = TASK2METRIC[train_args["task"]]
             dataset_metrics = {
-                dataset: metrics or {metric: 0.0, "fitness": 0.0} for dataset, metrics in trainer.train().items()
+                dataset: metrics or {metric: 0.0, "fitness": 0.0, "failed": True}
+                for dataset, metrics in trainer.train().items()
             }
             save_dir = [trainer.save_dir / dataset for dataset in dataset_metrics]
             weights_dir = [s / "weights" for s in save_dir]


### PR DESCRIPTION
## Summary

- record failed multi-dataset tuning runs with zero task metric and zero fitness
- preserve the existing zero contribution to aggregate fitness
- keep tuning iterations structurally complete when one dataset training fails, including NaN/Inf failures

## Motivation

During a 37-dataset tuning run, both YOLO26n and YOLO27n default-hyperparameter evaluations hit NaN/Inf on the same dataset. `MultiTrainer` correctly continued to the remaining datasets, but `Tuner` serialized the failed dataset as an empty dictionary even though its aggregate calculation already treated that dataset as zero. This left the iteration structurally incomplete and caused completeness checks to reject it.

## Validation

- `pytest -q tests/test_python.py::test_train_multi`
- real `Tuner` path with pretrained YOLO26n on one valid dataset plus one intentional dataset failure: failed dataset persisted as `{"metrics/mAP50-95(B)": 0.0, "fitness": 0.0}` and aggregate fitness was exactly half the valid-dataset fitness
- `ruff format ultralytics/engine/tuner.py`
- `python3 -m py_compile ultralytics/engine/tuner.py`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated hyperparameter tuning to record failed dataset runs with zero task metrics and fitness while preserving complete multi-dataset iteration records.

### 📊 Key Changes
- Failed datasets now receive `{metric: 0.0, "fitness": 0.0}` entries, using the task-specific metric from `TASK2METRIC`.
- Tuning results track failed dataset names locally and in MongoDB records.
- Training-metric checks now distinguish failed datasets from successfully trained datasets.
- MongoDB synchronization preserves the new `failed_datasets` field.

### 🎯 Purpose & Impact
- Multi-dataset tuning iterations remain structurally complete when a dataset fails, including NaN/Inf failures.
- Failed datasets continue contributing zero to aggregate fitness, while valid dataset metrics remain available.
- No change to the aggregate zero contribution for failed datasets.