### PR TITLE
Remove redundant regression scaffolding

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -373,18 +373,15 @@ def test_predict_img(model_name):
     assert len(model(batch, imgsz=32, classes=0)) == len(batch)  # multiple sources in a batch
 
 
-@pytest.mark.parametrize(
-    ("model_name", "bgr", "imgsz"),
-    [("yolo11n.pt", [0, 127, 255], 32), ("yolo11n-grayscale.pt", [127], 32), ("yolo26n-cls.pt", [0, 127, 255], 224)],
-)
-def test_preprocess_values(model_name, bgr, imgsz):
+@pytest.mark.parametrize(("model_name", "bgr"), [("yolo11n.pt", [0, 127, 255]), ("yolo11n-grayscale.pt", [127])])
+def test_preprocess_values(model_name, bgr):
     """Check predictor channel order and normalization with known pixel values."""
     model = YOLO(WEIGHTS_DIR / model_name)
     im = np.full((32, 32, len(bgr)), bgr, dtype=np.uint8)
-    model(im, imgsz=imgsz, verbose=False)  # classify at 224 keeps the checkpoint's own transforms
+    model(im, imgsz=32, verbose=False)  # build predictor through the public path
     out = model.predictor.preprocess([im])
     expected = torch.tensor([bgr[::-1]], device=out.device, dtype=out.dtype) / 255
-    assert out.shape == (1, len(bgr), imgsz, imgsz) and out.is_contiguous()
+    assert out.shape == (1, len(bgr), 32, 32) and out.is_contiguous()
     assert torch.equal(out[:, :, 0, 0], expected)
 
 
@@ -1871,80 +1868,6 @@ def test_nn_depth_head_no_dead_parameters():
     assert not unused, f"parameters with no gradient: {unused}"
 
 
-@pytest.mark.parametrize(
-    ("task", "cfg", "extra_kw", "extra_batch", "head_attrs"),
-    [
-        ("detect", "yolo11n.yaml", {}, {}, ("cv2",)),
-        ("pose", "yolo11n-pose.yaml", {"data_kpt_shape": (17, 3)}, {"keypoints": torch.zeros(0, 17, 3)}, ("cv4",)),
-        (
-            "pose",
-            "yolo26n-pose.yaml",
-            {"data_kpt_shape": (17, 3)},
-            {"keypoints": torch.zeros(0, 17, 3)},
-            ("cv4", "cv4_sigma", "flow_model"),
-        ),
-        ("obb", "yolo11n-obb.yaml", {}, {"bboxes": torch.zeros(0, 5)}, ("cv2",)),
-    ],
-)
-def test_detection_loss_empty_targets_keeps_box_head_in_graph(task, cfg, extra_kw, extra_batch, head_attrs):
-    """Box/kpt/flow heads must receive gradient on an empty-target batch — DDP then needs no find_unused_parameters."""
-    from ultralytics.cfg import get_cfg
-    from ultralytics.nn.tasks import DetectionModel, OBBModel, PoseModel
-    from ultralytics.utils import DEFAULT_CFG
-
-    model_cls = {"detect": DetectionModel, "pose": PoseModel, "obb": OBBModel}[task]
-    model = model_cls(cfg, **extra_kw).train()
-    model.args = get_cfg(DEFAULT_CFG)
-    batch = {
-        "img": torch.rand(2, 3, 64, 64),
-        "batch_idx": torch.zeros(0),
-        "cls": torch.zeros(0, 1),
-        "bboxes": torch.zeros(0, 4),
-        **extra_batch,
-    }
-    model.loss(batch)[0].sum().backward()
-    head = model.model[-1]
-    unused = [f"{attr}.{n}" for attr in head_attrs for n, p in getattr(head, attr).named_parameters() if p.grad is None]
-    assert not unused, f"parameters with no gradient: {unused}"
-
-
-def test_pose26_rle_zero_keeps_flow_model_in_graph_with_visible_target():
-    """A batch with a real target box but no visible keypoints must still route gradient through the RLE flow model —
-    the same DDP requirement, triggered by keypoint visibility rather than by an empty batch.
-    """
-    from ultralytics.cfg import get_cfg
-    from ultralytics.nn.tasks import PoseModel
-    from ultralytics.utils import DEFAULT_CFG
-
-    model = PoseModel("yolo26n-pose.yaml", data_kpt_shape=(17, 3)).train()
-    model.args = get_cfg(DEFAULT_CFG)
-    batch = {
-        "img": torch.rand(1, 3, 64, 64),
-        "batch_idx": torch.zeros(1),
-        "cls": torch.zeros(1, 1),
-        "bboxes": torch.tensor([[0.5, 0.5, 0.2, 0.2]]),
-        "keypoints": torch.zeros(1, 17, 3),  # v=0 for every keypoint -> kpt_mask.any() is False
-    }
-    model.loss(batch)[0].sum().backward()
-    unused = [n for n, p in model.model[-1].flow_model.named_parameters() if p.grad is None]
-    assert not unused, f"flow_model parameters with no gradient despite a real target box: {unused}"
-
-
-def test_detr_loss_empty_targets_keeps_box_head_in_graph():
-    """DETR box head must receive gradient on an empty-target batch — same DDP requirement."""
-    from ultralytics.models.utils.loss import DETRLoss
-
-    box_head = torch.nn.Linear(4, 4)
-    pred_bboxes = box_head(torch.rand(1, 1, 5, 4))  # (layers, bs, nq, 4)
-    pred_scores = torch.rand(1, 1, 5, 3, requires_grad=True)
-    batch = {"cls": torch.zeros(0, dtype=torch.long), "bboxes": torch.zeros(0, 4), "gt_groups": [0]}
-
-    loss = DETRLoss(nc=3, aux_loss=False)(pred_bboxes, pred_scores, batch)
-    sum(loss.values()).backward()
-
-    assert box_head.weight.grad is not None, "box head left disconnected from autograd on an empty-target batch"
-
-
 def test_classification_fraction_samples_across_classes(tmp_path):
     """Sample classification fractions across the class-major ImageFolder ordering."""
     from ultralytics.data.dataset import ClassificationDataset
@@ -2269,13 +2192,3 @@ def test_semantic_polygon_data():
     model = YOLO("yolo26n-sem.pt")
     model.train(data="coco8-seg.yaml", epochs=1, imgsz=32, close_mosaic=1)
     model.val(data="coco8-seg.yaml")
-
-
-def test_muon_update_non_contiguous():
-    """muon_update handles non-contiguous grads, e.g. conv weights in channels_last memory format."""
-    from ultralytics.optim.muon import muon_update
-
-    grad = torch.randn(8, 4, 3, 3).to(memory_format=torch.channels_last)
-    assert not grad.is_contiguous()
-    update = muon_update(grad, torch.zeros_like(grad))
-    assert update.shape == grad.shape

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -515,12 +515,11 @@ class Model(torch.nn.Module):
             not self.predictor
             or self.predictor.args.device != args.get("device", self.predictor.args.device)
             or self.predictor.args.channels_last != args.get("channels_last", self.predictor.args.channels_last)
-            or self.predictor.requested_quantize != QUANTIZE_ALIASES.get(str(q := args.get("quantize")).lower(), q)
+            or self.predictor.args.quantize != QUANTIZE_ALIASES.get(str(q := args.get("quantize")).lower(), q)
         ):
             self.predictor = (predictor or self._smart_load("predictor"))(overrides=args, _callbacks=self.callbacks)
             self.predictor.setup_model(model=self.model, verbose=is_cli)
         else:  # only update args if predictor is already setup
-            kwargs.pop("quantize", None)  # unchanged by definition here, and args holds the achieved precision
             save_keys = ("project", "name", "save_dir", "exist_ok")
             prev_save_args = tuple(getattr(self.predictor.args, k, None) for k in save_keys)
             setup_keys = ("device", "dnn", "data", "end2end", "compile", "channels_last", "quantize")

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -128,7 +128,6 @@ class BasePredictor:
             _callbacks (dict, optional): Dictionary of callback functions.
         """
         self.args = get_cfg(cfg, overrides)
-        self.requested_quantize = self.args.quantize  # setup_model overwrites args.quantize with the achieved value
         self.save_dir = get_save_dir(self.args)
         if self.args.conf is None:
             self.args.conf = 0.25  # default conf=0.25
@@ -437,7 +436,6 @@ class BasePredictor:
         )
 
         self.device = self.model.device  # update device
-        self.args.quantize = 16 if self.model.fp16 else None  # record actual inference precision
         if hasattr(self.model, "imgsz") and not getattr(self.model, "dynamic", False):
             self.args.imgsz = self.model.imgsz  # reuse imgsz from export metadata
         self.model.eval()


### PR DESCRIPTION
## Summary

- delete 74 lines of gradient-proxy tests added by #26012 and rely on the existing real DDP training coverage
- delete the standalone MuSGD test added by #26013; the production fix remains the one-token view-to-reshape replacement
- restore the existing preprocessing test instead of expanding it for #26023
- remove #26022's parallel requested_quantize state and keep the canonical request in the existing predictor.args.quantize owner
- leave #26008 and #26028 unchanged

This cleanup is 5 additions and 95 deletions. It adds no files, tests, arguments, helpers, flags, or compatibility paths.

## Validation

- direct non-contiguous channels-last muon_update validation
- empty-target gradient validation for detect, pose, YOLO26 pose/RLE, OBB, and DETR owners
- public warm-predictor FP32 to FP16 to default transitions, including invalid quantize rejection
- classification device preprocessing compared with the original torchvision pipeline
- python3 -m pytest -q tests/test_python.py::test_preprocess_values tests/test_python.py::test_model_embeddings (3 passed)
- uvx ruff check --ignore BLE001 tests/test_python.py ultralytics/engine/model.py ultralytics/engine/predictor.py
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Removed redundant regression tests and simplified predictor quantization state handling while preserving the existing production fixes and preprocessing coverage.

### 📊 Key Changes
- Deleted standalone gradient-connectivity tests covering detection, pose, YOLO26 pose/RLE, OBB, and DETR losses.
- Removed the non-contiguous-gradient MuSGD test; the corresponding production implementation remains unchanged.
- Restored `test_preprocess_values` to its original YOLO11 and grayscale cases with a fixed image size, removing the YOLO26 classification expansion.
- Removed `Predictor.requested_quantize` and stopped overwriting `predictor.args.quantize` with achieved FP16 precision.
- Updated `Model.predict()` to compare quantization requests using the canonical `predictor.args.quantize` value.

### 🎯 Purpose & Impact
- Test coverage is reduced to remove redundant regression scaffolding; no new tests, helpers, flags, or compatibility paths are added.
- Predictor quantization state now remains owned by `predictor.args.quantize`, simplifying repeated prediction setup and quantization-request comparisons.
- No user-facing change to the retained production fixes or the restored preprocessing behavior.