### PR TITLE
Fix legacy checkpoint and YOLO-World loading

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -246,6 +246,18 @@ def test_restricted_load_threaded():
         list(pool.map(lambda _: torch_safe_load(MODEL, safe_only=True), range(32)))
 
 
+def test_restricted_load_criterion(tmp_path):
+    """Checkpoints saved before 8.4.95 pickle `ema.criterion`; restricted loading must still accept them."""
+    from ultralytics.nn.tasks import DetectionModel, torch_safe_load
+    from ultralytics.utils import DEFAULT_CFG
+
+    model = DetectionModel(CFG, verbose=False)
+    model.args = DEFAULT_CFG
+    model.criterion = model.init_criterion()
+    torch.save({"model": model}, tmp_path / "legacy.pt")
+    assert torch_safe_load(tmp_path / "legacy.pt", safe_only=True)[0]["model"].criterion is not None
+
+
 def test_model_forward():
     """Test the forward pass of the YOLO model."""
     model = YOLO(CFG)

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.137"
+__version__ = "8.4.138"
 
 import importlib
 import os

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -90,6 +90,10 @@ class YOLO(Model):
                 new_instance = RTDETR(self)
                 self.__class__ = type(new_instance)
                 self.__dict__ = new_instance.__dict__
+            elif isinstance(self.model, WorldModel):  # e.g. `ul://…/yolov8l-worldv2`, no suffix for the filename test
+                new_instance = YOLOWorld(self)
+                self.__class__ = type(new_instance)
+                self.__dict__ = new_instance.__dict__
 
     @property
     def task_map(self) -> dict[str, dict[str, Any]]:

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1699,6 +1699,8 @@ class _SafeLoad:
         import torch.nn.modules as torch_nn
 
         import ultralytics.nn.modules as ul_nn
+        import ultralytics.utils.loss as ul_loss
+        import ultralytics.utils.tal as ul_tal
         from ultralytics.nn import tasks as ul_tasks  # noqa: PLW0406
 
         allow = []
@@ -1721,13 +1723,18 @@ class _SafeLoad:
         _scan(ul_nn)  # ultralytics block/conv/head/transformer
         _scan(ul_tasks)  # ultralytics task models
 
+        # Criteria pickled inside pre-8.4.95 checkpoints (`ema.criterion` is stripped at save since then): the plain
+        # loss classes plus the nn.Module box losses and assigners they hold.
+        for mod in (ul_loss, ul_tal):
+            allow += [
+                klass for _, klass in inspect.getmembers(mod, inspect.isclass) if klass.__module__ == mod.__name__
+            ]
+
         # Non-nn.Module data globals in official checkpoints, incl. the pre-8.0.44 `ultralytics.yolo.utils` path.
         allow.append(IterableSimpleNamespace)
         allow.append((IterableSimpleNamespace, "ultralytics.yolo.utils.IterableSimpleNamespace"))
 
         # Legacy/cross-platform aliases (pickled paths with no current class namespace), mirroring temporary_modules().
-        from ultralytics.utils.loss import E2EDetectLoss
-
         def _getattr(obj, name):  # ckpts pickle `Detect.forward` and `InterpolationMode.BILINEAR` via getattr
             if isinstance(obj, type) and not name.startswith("__") and issubclass(obj, (nn.Module, enum.Enum)):
                 return getattr(obj, name)
@@ -1736,7 +1743,7 @@ class _SafeLoad:
         allow += [
             (nn.Identity, "ultralytics.nn.modules.block.Silence"),  # YOLOv9e
             (DetectionModel, "ultralytics.nn.tasks.YOLOv10DetectionModel"),  # YOLOv10
-            (E2EDetectLoss, "ultralytics.utils.loss.v10DetectLoss"),  # YOLOv10
+            (ul_loss.E2EDetectLoss, "ultralytics.utils.loss.v10DetectLoss"),  # YOLOv10
             (_getattr, "builtins.getattr"),  # non-det YOLOv8, YOLO11 ckpts (restrict to nn.Module attrs)
         ]
         if WINDOWS:


### PR DESCRIPTION
## Summary

Two package bugs from the 2026-09-01 Platform sweep (Sentry `alpha` + `ultralytics` projects, `ultra5` GPU worker logs), plus the 8.4.138 bump so the already-merged MuSGD `channels_last` fix (#26013) reaches PyPI — the Platform GPU fleet on 8.4.137 is failing every run that resolves to MuSGD (102 of 106 failed jobs in 48 h).

### 1. Restricted loading rejects every checkpoint saved before 8.4.95

Sentry ALPHA-1MR / ALPHA-1YA (66 events / 14 d): `… references types outside the supported Ultralytics checkpoint format`, `GLOBAL ultralytics.utils.loss.v8DetectionLoss`.

- Cause: checkpoints saved before #25154 (8.4.95) pickle `ema.criterion`. `_SafeLoad._build` registers only `nn.Module` subclasses reachable from `torch.nn`, `ultralytics.nn.modules` and `ultralytics.nn.tasks`, so `v8DetectionLoss`, `BboxLoss`, `DFLoss`, `TaskAlignedAssigner`, `KeypointLoss`, the dice losses, the rotated variants and `v8ClassificationLoss` were never registrable, and `weights_only=True` refused the file.
- Fix: register the classes defined in `ultralytics.utils.loss` and `ultralytics.utils.tal`. Registration is still per-checkpoint (`needed ∩ registry`), so the unpickle cost of ordinary checkpoints is unchanged. RT-DETR criteria (`ultralytics.models.utils`) are deliberately not covered: no production evidence, and RT-DETR cannot build on the torch 1.8 floor.
- Verified: checkpoints saved by a v8.4.94 worktree for detect / segment / pose / OBB / classify / YOLOv10 / YOLO11 all fail restricted loading on `main` and all load with this change. `test_restricted_load_criterion` covers the path and fails without the fix.

### 2. `ul://` and renamed YOLO-World checkpoints load as plain YOLO

Sentry ALPHA-1DM sub-cause (`yolo train model=ul://…/yolov8l-worldv2`) and ALPHA-200 (`custom_yolo_world_1k_ultimate.pt`): `C2fAttn.forward() missing 1 required positional argument: 'guide'`.

- Cause: `YOLO.__init__` picks `YOLOWorld` / `YOLOE` only when `"-world"` / `"yoloe"` is in the filename **and** the suffix is `.pt`/`.yaml`. A `ul://` URI has no suffix and a user-renamed checkpoint has no marker, so the `WorldModel` loads under the `YOLO` class, `DetectionTrainer.get_model` rebuilds a `DetectionModel` from the world YAML, and the first forward fails.
- Fix: after the default load, re-dispatch a loaded `WorldModel` to `YOLOWorld`, exactly as the RTDETR head check below it already does. Filename dispatch is unchanged; four lines.
- Verified: `yolov8s-worldv2.pt` copied to `custom_detector.pt` — before: class `YOLO`, training fails as above; after: class `YOLOWorld`, one-epoch CPU training on `coco8` completes; official `yolov8s-worldv2.pt` still resolves to `YOLOWorld`.

### 3. Version 8.4.137 → 8.4.138

Releases #26013 (MuSGD `.view` → `.reshape` on `channels_last` grads, regression from #26007 in 8.4.137) together with the two fixes above. Release order: this PR → PyPI → the Platform bumps its seven pins (ultralytics/portal#3887 carries the app-side sweep fixes).

## Test plan

- `pytest tests/test_python.py -k "world or yoloe or load or rtdetr or model_forward or model_methods"` — 17 passed; `-k restricted_load` — 2 passed.
- `ruff format --check` / `ruff check` clean on the changed files.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated restricted checkpoint loading and model-type detection so legacy checkpoints and YOLO-World models loaded from suffixless or renamed paths are handled correctly, and bumped the package version to 8.4.138.

### 📊 Key Changes

- Added `ultralytics.utils.loss` and `ultralytics.utils.tal` classes to the restricted-loading registry, allowing pre-8.4.95 checkpoints containing `ema.criterion` to load safely.
- Added regression coverage for restricted loading of checkpoints containing a detection criterion.
- Updated `YOLO` initialization to re-dispatch loaded `WorldModel` instances to `YOLOWorld`, including models loaded from `ul://` URIs or renamed checkpoint files.
- Bumped `__version__` from `8.4.137` to `8.4.138`.

### 🎯 Purpose & Impact

- Legacy checkpoints that previously failed restricted loading because of serialized loss or assignment classes can now be accepted.
- YOLO-World checkpoints without a recognizable filename marker are loaded and trained through `YOLOWorld` instead of being rebuilt as standard YOLO detection models.
- The package release includes the previously merged MuSGD `channels_last` fix referenced in the PR description.