### PR TITLE
Flatten channels_last Muon updates in memory order instead of copying

### DIFF
--- a/ultralytics/optim/muon.py
+++ b/ultralytics/optim/muon.py
@@ -96,20 +96,25 @@ def muon_update(
         updates = list(momentums)
     buckets = {}  # group matrices transposed to rows <= cols by (rows, scale) for batched orthogonalization
     for i, u in enumerate(updates):
-        m = u.view(len(u), -1) if u.ndim > 2 else u
+        # flatten NHWC updates in memory order so they stay views: permuting columns permutes the orthogonalized
+        # columns identically, and the write-back below restores NCHW
+        nhwc = u.ndim == 4 and not u.is_contiguous()
+        m = u.permute(0, 2, 3, 1).flatten(1) if nhwc else (u.flatten(1) if u.ndim > 2 else u)
         transpose = m.size(0) > m.size(1)
         if transpose:
             m = m.transpose(0, 1)
         scale = max(1, grads[i].size(-2) / grads[i].size(-1)) ** 0.5
-        buckets.setdefault((m.size(0), scale, m.device, m.dtype), []).append((i, m, transpose))
+        buckets.setdefault((m.size(0), scale, m.device, m.dtype), []).append((i, m, transpose, nhwc))
     for (_, scale, _, _), items in buckets.items():
-        n = max(m.size(1) for _, m, _ in items)
+        n = max(m.size(1) for _, m, _, _ in items)
         # zero-pad columns so different shapes share one batched call (zeros stay zero through Newton-Schulz)
-        X = torch.stack([torch.nn.functional.pad(m, (0, n - m.size(1))) for _, m, _ in items])
+        X = torch.stack([torch.nn.functional.pad(m, (0, n - m.size(1))) for _, m, _, _ in items])
         X = zeropower_via_newtonschulz5(X).to(grads[items[0][0]].dtype).mul_(scale)
-        for j, (i, m, transpose) in enumerate(items):
+        for j, (i, m, transpose, nhwc) in enumerate(items):
             x = X[j, :, : m.size(1)]
-            updates[i] = (x.T if transpose else x).reshape(grads[i].shape)
+            x = x.T if transpose else x
+            s = grads[i].shape
+            updates[i] = x.reshape(s[0], *s[2:], s[1]).permute(0, 3, 1, 2) if nhwc else x.reshape(s)
     return updates[0] if single else updates
 
 

--- a/ultralytics/optim/muon.py
+++ b/ultralytics/optim/muon.py
@@ -96,7 +96,7 @@ def muon_update(
         updates = list(momentums)
     buckets = {}  # group matrices transposed to rows <= cols by (rows, scale) for batched orthogonalization
     for i, u in enumerate(updates):
-        m = u.reshape(len(u), -1) if u.ndim > 2 else u
+        m = u.view(len(u), -1) if u.ndim > 2 else u
         transpose = m.size(0) > m.size(1)
         if transpose:
             m = m.transpose(0, 1)


### PR DESCRIPTION
Reverts #26013 and fixes the crash at the line that causes it.

`muon_update()` flattens updates with more than two dimensions before orthogonalization. It used `u.view(len(u), -1)`, which cannot view an NHWC tensor as a matrix, so MuSGD crashed once #26007 made `channels_last` the CUDA training default. #26013 swapped `view` for `reshape`, which copies every NHWC conv update into NCHW on every step.

Flatten in memory order instead:

```python
nhwc = u.ndim == 4 and not u.is_contiguous()
m = u.permute(0, 2, 3, 1).flatten(1) if nhwc else (u.flatten(1) if u.ndim > 2 else u)
```

`permute(0, 2, 3, 1)` of a channels_last tensor is its own memory order, so the flatten stays a view and nothing is copied. It reorders the matrix columns, which is safe. Newton-Schulz satisfies `NS(MP) = NS(M)P` for any permutation `P`, since `(MP)(MP)^T = MM^T`. The write-back reshapes to NHWC and permutes back, undoing the reorder.

## Correctness

NCHW results are bitwise identical to `main` on CPU and CUDA, with and without Nesterov. The NHWC path differs only by bfloat16 reduction order. Rerunning Newton-Schulz in float32 brings the two column orders to within `1.4e-6` relative, and orthogonalization quality is unchanged (singular value spread `1.4450` against `1.4462`).

## Speed

`MuSGD.step()` median over 40 steps, 11 interleaved rounds, repeated twice. RTX PRO 6000 Blackwell, torch 2.11.0+cu128, real YOLO26 Muon parameter shapes.

| Model | main NHWC | this PR NHWC | main NCHW | this PR NCHW |
| --- | --- | --- | --- | --- |
| yolo26n | 4.35 ms | 4.18 ms | 4.15 ms | 4.11 ms |
| yolo26s | 5.83 ms | 5.62 ms | 5.52 ms | 5.54 ms |
| yolo26m | 12.86 ms | 12.64 ms | 12.64 ms | 12.64 ms |
| yolo26x | 27.82 ms | 27.36 ms | 27.37 ms | 27.38 ms |

On `main`, channels_last costs more per step than NCHW. With this PR the two are the same, so the copy is gone rather than made cheaper.

The numbers cover the optimizer step alone. Epoch time on coco128 at batch 16 and imgsz 640 did not move outside run to run noise, because these launches overlap with the backward pass.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated `muon_update()` to flatten 4D channels-last updates in memory order, avoiding the crash and per-step tensor copies introduced by reshaping them.

### 📊 Key Changes

- Detects non-contiguous 4D updates and flattens them after permuting dimensions to preserve their channels-last memory order.
- Tracks channels-last updates through batched Newton–Schulz orthogonalization and restores their original layout during write-back.
- Keeps the existing flattening and write-back behavior for NCHW and lower-dimensional updates.
- Removes the need to copy channels-last convolution updates into NCHW format on every optimizer step.

### 🎯 Purpose & Impact

- MuSGD can process channels-last CUDA updates without the previous `view()` crash or the copying caused by `reshape()`.
- Reported benchmarks show channels-last optimizer-step time matching NCHW performance more closely, while overall epoch time remained within run-to-run noise.
- The reported NCHW results are bitwise identical to `main`; channels-last results differ only due to bfloat16 reduction order.