### PR TITLE
Fix semantic nc for the default masks/ folder

### DIFF
--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -252,11 +252,7 @@ def build_yolo_dataset(
         dataset = DepthDataset
         pad, rect = 0.0, rect and mode == "train"  # depth val letterbox stretches, so pad and rect_shape are ignored
     elif cfg.task == "semantic":
-        data_path = Path(data.get("path", ""))
-        if "masks_dir" in data or (data_path / "masks").exists():
-            dataset = SemanticDataset
-        else:
-            dataset = PolygonSemanticDataset
+        dataset = SemanticDataset if data.get("masks_dir") else PolygonSemanticDataset
         pad = 0.0  # no pad for semantic
     elif multi_modal:
         dataset = YOLOMultiModalDataset

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -626,8 +626,6 @@ def check_det_dataset(dataset: str, autodownload: bool = True, split: str = "") 
 
     # Set paths
     data["path"] = path  # download scripts
-    if data.get("masks_dir") is None and (path / "masks").is_dir():
-        data["masks_dir"] = "masks"  # PNG semantic masks in the default folder select SemanticDataset
     for k in "train", "val", "test", "minival":
         if data.get(k):  # prepend path
             if isinstance(data[k], str):
@@ -663,6 +661,8 @@ def check_det_dataset(dataset: str, autodownload: bool = True, split: str = "") 
             dt = f"({round(time.time() - t, 1)}s)"
             s = f"success ✅ {dt}, saved to {colorstr('bold', DATASETS_DIR)}" if r in {0, None} else f"failure {dt} ❌"
             LOGGER.info(f"Dataset download {s}\n")
+    if data.get("masks_dir") is None and (path / "masks").is_dir():  # after download so scripts can create it
+        data["masks_dir"] = "masks"  # PNG semantic masks in the default folder select SemanticDataset
     check_font("Arial.ttf" if is_ascii(data["names"]) else "Arial.Unicode.ttf")  # download fonts
 
     return data  # dictionary

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -626,6 +626,8 @@ def check_det_dataset(dataset: str, autodownload: bool = True, split: str = "") 
 
     # Set paths
     data["path"] = path  # download scripts
+    if data.get("masks_dir") is None and (path / "masks").is_dir():
+        data["masks_dir"] = "masks"  # PNG semantic masks in the default folder select SemanticDataset
     for k in "train", "val", "test", "minival":
         if data.get(k):  # prepend path
             if isinstance(data[k], str):


### PR DESCRIPTION
## Summary

- `check_det_dataset` fills `masks_dir: masks` when the dataset root has a `masks/` folder and the YAML omits the key
- `build_yolo_dataset` selects `SemanticDataset` from that one key instead of re-checking the folder
- `add_polygon_background` is unchanged and now sees the same decision as the loader

Net −2 lines, no new abstraction.

## Motivation

Since #24518 `build_yolo_dataset` treated a bare `masks/` folder at the dataset root as PNG-mask mode, as documented in `docs/en/datasets/semantic/index.md`, but `add_polygon_background` only looked at the `masks_dir` key. A multi-class PNG-mask dataset relying on the documented folder default therefore trained with `nc + 1` output channels and a phantom `background` entry in `names` that no mask pixel ever supervises. `nc == 1` datasets and datasets with an explicit `masks_dir` are unaffected.

Reproduced on `main` with a 3-class dataset that has `masks/` but no `masks_dir`: `data["nc"]` is 4, the loader is `SemanticDataset`, the masks contain only ids `{0, 1, 2}`, and after one epoch the head has 4 output channels and the checkpoint `names` include `background`. mIoU is not affected because `SemanticMetrics` averages only over classes present in the ground truth.

The INT8 export calibration path in `Exporter` calls `check_det_dataset` and `build_yolo_dataset` without `add_polygon_background`, so the folder check belongs in `check_det_dataset`, which already resolves `path` and fills `names`/`nc` defaults. With one owner the trainer, validator, and exporter all agree, and `build_yolo_dataset` collapses to a single truthiness check, which also removes the `"masks_dir" in data` vs `data.get("masks_dir")` mismatch between the two call sites.

## Validation

- `ruff check` and `ruff format --check` on `ultralytics/data/build.py` and `ultralytics/data/utils.py`
- `check_det_dataset` → `add_polygon_background` → `build_yolo_dataset` on three synthetic 3-class datasets, `main` vs this branch:

| Dataset | `main` | this branch |
| --- | --- | --- |
| `masks/` folder, no `masks_dir` | nc 4, `SemanticDataset` | nc 3, `SemanticDataset` |
| explicit `masks_dir: masks` | nc 3, `SemanticDataset` | nc 3, `SemanticDataset` |
| polygon labels, no `masks/` | nc 4 with `background`, `PolygonSemanticDataset` | nc 4 with `background`, `PolygonSemanticDataset` |

- 1-epoch CPU training on the `masks/`-only dataset: `main` produces a 4-channel head and `names` with `background`; this branch produces a 3-channel head and the declared 3 names
- CI semantic tests use `cityscapes8.yaml` with an explicit `masks_dir`, which this change leaves untouched; the docs already describe the folder default, so no docs change

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

`check_det_dataset` now records a root-level `masks/` directory as `masks_dir`, allowing semantic dataset loading and class metadata to use the same PNG-mask detection.

### 📊 Key Changes

- Added a post-download check in `check_det_dataset` that sets `data["masks_dir"] = "masks"` when the YAML omits `masks_dir` and the dataset contains a `masks/` directory.
- Simplified `build_yolo_dataset` to select `SemanticDataset` only when `data.get("masks_dir")` is set; otherwise it selects `PolygonSemanticDataset`.
- Ensured datasets using the documented default `masks/` folder retain their declared `nc` and `names` instead of gaining an extra background class.
- Left explicit `masks_dir` configurations and polygon semantic datasets unchanged.

### 🎯 Purpose & Impact

- Multi-class PNG-mask datasets with only a root-level `masks/` folder now use the correct number of output channels and declared class names across dataset checking and loading.
- Trainer, validator, and exporter paths use the same semantic dataset decision.
- No user-facing change for datasets with an explicit `masks_dir` or polygon labels.