### PR TITLE
Bucket Muon matrices by column count and flatten updates in memory order

### DIFF
--- a/ultralytics/optim/muon.py
+++ b/ultralytics/optim/muon.py
@@ -58,7 +58,7 @@ def muon_update(
     """Compute Muon optimizer updates with momentum and orthogonalization.
 
     This function applies momentum to the gradients, optionally uses Nesterov acceleration, and then orthogonalizes the
-    updates using Newton-Schulz iterations. Matrices with the same row count are zero-padded and orthogonalized in a
+    updates using Newton-Schulz iterations. Matrices with the same column count are zero-padded and orthogonalized in a
     single batched call, and momentum math uses fused foreach ops, avoiding per-parameter kernel launch overhead.
     Higher-rank tensors are reshaped before orthogonalization, and each update is scaled based on parameter dimensions.
 
@@ -94,27 +94,22 @@ def muon_update(
         torch._foreach_add_(updates, grads, alpha=1 - beta)
     else:
         updates = list(momentums)
-    buckets = {}  # group matrices transposed to rows <= cols by (rows, scale) for batched orthogonalization
+    buckets = {}  # group matrices by (columns, scale) for batched orthogonalization
     for i, u in enumerate(updates):
-        # flatten NHWC updates in memory order so they stay views: permuting columns permutes the orthogonalized
-        # columns identically, and the write-back below restores NCHW
+        # flatten in the update's own memory order, a view for NCHW and NHWC alike: permuting columns permutes
+        # the orthogonalized columns identically, and the write-back below restores the update's layout
         nhwc = u.ndim == 4 and not u.is_contiguous()
         m = u.permute(0, 2, 3, 1).flatten(1) if nhwc else (u.flatten(1) if u.ndim > 2 else u)
-        transpose = m.size(0) > m.size(1)
-        if transpose:
-            m = m.transpose(0, 1)
         scale = max(1, grads[i].size(-2) / grads[i].size(-1)) ** 0.5
-        buckets.setdefault((m.size(0), scale, m.device, m.dtype), []).append((i, m, transpose, nhwc))
-    for (_, scale, _, _), items in buckets.items():
-        n = max(m.size(1) for _, m, _, _ in items)
-        # zero-pad columns so different shapes share one batched call (zeros stay zero through Newton-Schulz)
-        X = torch.stack([torch.nn.functional.pad(m, (0, n - m.size(1))) for _, m, _, _ in items])
-        X = zeropower_via_newtonschulz5(X).to(grads[items[0][0]].dtype).mul_(scale)
-        for j, (i, m, transpose, nhwc) in enumerate(items):
-            x = X[j, :, : m.size(1)]
-            x = x.T if transpose else x
-            s = grads[i].shape
-            updates[i] = x.reshape(s[0], *s[2:], s[1]).permute(0, 3, 1, 2) if nhwc else x.reshape(s)
+        buckets.setdefault((m.size(1), scale, m.device, m.dtype), []).append((i, m, u.stride()))
+    for (cols, scale, device, dtype), items in buckets.items():
+        # zero-pad rows, not columns, so that different shapes share one batched call (zeros stay zero through
+        # Newton-Schulz) while the fill below and every write-back below stay contiguous
+        X = torch.zeros(len(items), max(m.size(0) for _, m, _ in items), cols, device=device, dtype=dtype)
+        torch._foreach_copy_([X[j, : m.size(0)] for j, (_, m, _) in enumerate(items)], [m for _, m, _ in items])
+        X = zeropower_via_newtonschulz5(X).contiguous().to(grads[items[0][0]].dtype).mul_(scale)
+        for j, (i, m, stride) in enumerate(items):
+            updates[i] = X[j, : m.size(0)].as_strided(grads[i].shape, stride)
     return updates[0] if single else updates
 
 

--- a/ultralytics/optim/muon.py
+++ b/ultralytics/optim/muon.py
@@ -97,19 +97,24 @@ def muon_update(
     buckets = {}  # group matrices by (columns, scale) for batched orthogonalization
     for i, u in enumerate(updates):
         # flatten in the update's own memory order, a view for NCHW and NHWC alike: permuting columns permutes
-        # the orthogonalized columns identically, and the write-back below restores the update's layout
-        nhwc = u.ndim == 4 and not u.is_contiguous()
-        m = u.permute(0, 2, 3, 1).flatten(1) if nhwc else (u.flatten(1) if u.ndim > 2 else u)
+        # the orthogonalized columns identically, and the write-back below restores the update's layout. Any
+        # other layout is materialized row-major and written back row-major.
+        dense = u.is_contiguous()
+        nhwc = not dense and u.ndim == 4 and u.is_contiguous(memory_format=torch.channels_last)
+        m = u.permute(0, 2, 3, 1).flatten(1) if nhwc else (u.flatten(1) if u.ndim > 2 else u.contiguous())
         scale = max(1, grads[i].size(-2) / grads[i].size(-1)) ** 0.5
-        buckets.setdefault((m.size(1), scale, m.device, m.dtype), []).append((i, m, u.stride()))
+        buckets.setdefault((m.size(1), scale, m.device, m.dtype), []).append(
+            (i, m, u.stride() if dense or nhwc else None)
+        )
     for (cols, scale, device, dtype), items in buckets.items():
         # zero-pad rows, not columns, so that different shapes share one batched call (zeros stay zero through
         # Newton-Schulz) while the fill below and every write-back below stay contiguous
         X = torch.zeros(len(items), max(m.size(0) for _, m, _ in items), cols, device=device, dtype=dtype)
-        torch._foreach_copy_([X[j, : m.size(0)] for j, (_, m, _) in enumerate(items)], [m for _, m, _ in items])
+        torch._foreach_add_([X[j, : m.size(0)] for j, (_, m, _) in enumerate(items)], [m for _, m, _ in items])
         X = zeropower_via_newtonschulz5(X).contiguous().to(grads[items[0][0]].dtype).mul_(scale)
         for j, (i, m, stride) in enumerate(items):
-            updates[i] = X[j, : m.size(0)].as_strided(grads[i].shape, stride)
+            x = X[j, : m.size(0)]
+            updates[i] = x.as_strided(grads[i].shape, stride) if stride else x.reshape(grads[i].shape)
     return updates[0] if single else updates
 
 

--- a/ultralytics/optim/muon.py
+++ b/ultralytics/optim/muon.py
@@ -106,10 +106,18 @@ def muon_update(
         buckets.setdefault((m.size(1), scale, m.device, m.dtype), []).append(
             (i, m, u.stride() if dense or nhwc else None)
         )
-    for (cols, scale, device, dtype), items in buckets.items():
+    groups = []  # split each bucket until its row counts span at most 16x, bounding the padding below
+    for key, items in buckets.items():
+        items.sort(key=lambda t: -t[1].size(0))
+        start = 0
+        for j in range(1, len(items) + 1):
+            if j == len(items) or items[start][1].size(0) > 16 * items[j][1].size(0):
+                groups.append((key, items[start:j]))
+                start = j
+    for (cols, scale, device, dtype), items in groups:
         # zero-pad rows, not columns, so that different shapes share one batched call (zeros stay zero through
         # Newton-Schulz) while the fill below and every write-back below stay contiguous
-        X = torch.zeros(len(items), max(m.size(0) for _, m, _ in items), cols, device=device, dtype=dtype)
+        X = torch.zeros(len(items), items[0][1].size(0), cols, device=device, dtype=dtype)
         torch._foreach_add_([X[j, : m.size(0)] for j, (_, m, _) in enumerate(items)], [m for _, m, _ in items])
         X = zeropower_via_newtonschulz5(X).contiguous().to(grads[items[0][0]].dtype).mul_(scale)
         for j, (i, m, stride) in enumerate(items):

--- a/ultralytics/optim/muon.py
+++ b/ultralytics/optim/muon.py
@@ -96,20 +96,25 @@ def muon_update(
         updates = list(momentums)
     buckets = {}  # group matrices transposed to rows <= cols by (rows, scale) for batched orthogonalization
     for i, u in enumerate(updates):
-        m = u.view(len(u), -1) if u.ndim > 2 else u
+        # flatten NHWC updates in memory order so they stay views: permuting columns permutes the orthogonalized
+        # columns identically, and the write-back below restores NCHW
+        nhwc = u.ndim == 4 and not u.is_contiguous()
+        m = u.permute(0, 2, 3, 1).flatten(1) if nhwc else (u.flatten(1) if u.ndim > 2 else u)
         transpose = m.size(0) > m.size(1)
         if transpose:
             m = m.transpose(0, 1)
         scale = max(1, grads[i].size(-2) / grads[i].size(-1)) ** 0.5
-        buckets.setdefault((m.size(0), scale, m.device, m.dtype), []).append((i, m, transpose))
+        buckets.setdefault((m.size(0), scale, m.device, m.dtype), []).append((i, m, transpose, nhwc))
     for (_, scale, _, _), items in buckets.items():
-        n = max(m.size(1) for _, m, _ in items)
+        n = max(m.size(1) for _, m, _, _ in items)
         # zero-pad columns so different shapes share one batched call (zeros stay zero through Newton-Schulz)
-        X = torch.stack([torch.nn.functional.pad(m, (0, n - m.size(1))) for _, m, _ in items])
+        X = torch.stack([torch.nn.functional.pad(m, (0, n - m.size(1))) for _, m, _, _ in items])
         X = zeropower_via_newtonschulz5(X).to(grads[items[0][0]].dtype).mul_(scale)
-        for j, (i, m, transpose) in enumerate(items):
+        for j, (i, m, transpose, nhwc) in enumerate(items):
             x = X[j, :, : m.size(1)]
-            updates[i] = (x.T if transpose else x).reshape(grads[i].shape)
+            x = x.T if transpose else x
+            s = grads[i].shape
+            updates[i] = x.reshape(s[0], *s[2:], s[1]).permute(0, 3, 1, 2) if nhwc else x.reshape(s)
     return updates[0] if single else updates
 
 

--- a/ultralytics/optim/muon.py
+++ b/ultralytics/optim/muon.py
@@ -96,7 +96,7 @@ def muon_update(
         updates = list(momentums)
     buckets = {}  # group matrices transposed to rows <= cols by (rows, scale) for batched orthogonalization
     for i, u in enumerate(updates):
-        m = u.reshape(len(u), -1) if u.ndim > 2 else u
+        m = u.view(len(u), -1) if u.ndim > 2 else u
         transpose = m.size(0) > m.size(1)
         if transpose:
             m = m.transpose(0, 1)


### PR DESCRIPTION
`muon_update()` has two problems on the default CUDA training path.

1. **It copies every conv update on every step.** #26007 made channels_last the CUDA training default, and #26013 replaced a `view` with a `reshape`. Flattening an NHWC tensor to 2D with `reshape` cannot return a view, so every conv update is materialized back into NCHW order on every step.
2. **It breaks the fused parameter add.** Matrices were bucketed by row count and zero-padded out to the widest column count in the bucket. Slicing those padded columns back out leaves every update a strided view, so `torch._foreach_add_(params, updates)` in `MuSGD.step` falls off its fused path and runs one kernel per parameter. On yolo26n that is 126 of 126 parameters.

Both follow from how updates are flattened and grouped. Bucket by column count and pad rows instead, and flatten each update in its own memory order.

- Flattening NHWC as `permute(0, 2, 3, 1).flatten(1)` is a view, so the copy goes away, and it puts the update back in the parameter's memory format.
- Slicing rows keeps a tensor contiguous, so every update comes back dense and `as_strided` hands it the parameter's own layout. That restores the fused add, at 0 of 126 mismatched.
- Filling the batch is one fused add into a zeroed buffer instead of a `pad` per matrix plus a `stack`.
- The transpose bookkeeping goes away. `zeropower_via_newtonschulz5` already transposes internally to keep the Gram matrix small.
- Padded elements drop from 3.3x the real element count to 1.8x.

Grouping by column count alone would pad every member up to the widest, so a bucket holding both a one row matrix and a million row matrix would allocate the product of the two. A bucket is therefore split until its row counts span at most 16x. No shipped model splits at that threshold, so the batched call count and the results are unchanged for all of them.

This supersedes #26013, whose reshape is no longer reachable.

## Correctness

Reordering columns is safe because Newton-Schulz satisfies `NS(MP) = NS(M)P` for a permutation `P`, since `(MP)(MP)^T = MM^T`, and the write-back undoes the reorder. Zero rows contribute exactly zero to `XX^T`, exactly as the zero columns they replace did, and `NS(M^T)^T = NS(M)` holds since `M(M^T M)^2 = (MM^T)^2 M`.

Fixing the copy cannot preserve bits. Flattening in NHWC order hands Newton-Schulz the same matrix with its columns permuted, so the bfloat16 reductions land in a different order. Keeping main's exact bits would mean keeping main's column order, which is the copy.

Results are therefore **not** bitwise identical to `main`. Regrouping changes which matrices share a batched call, so the bfloat16 reductions inside Newton-Schulz land differently. The difference is that rounding and nothing else:

| Case | max relative difference, bfloat16 as shipped | max relative difference, Newton-Schulz rerun in float32 |
| --- | --- | --- |
| yolo26n NCHW | 3.3e-02 | 3.3e-06 |
| yolo26n NHWC | 3.8e-02 | 3.5e-06 |
| yolo26m NCHW | 3.2e-02 | 3.7e-06 |
| yolo26m NHWC | 2.8e-02 | 4.7e-06 |

Neither side is less accurate. Mean relative distance from a float64 reference:

| Case | main | this PR |
| --- | --- | --- |
| yolo26n NCHW | 0.01457 | 0.01429 |
| yolo26n NHWC | 0.01479 | 0.01436 |
| yolo26m NCHW | 0.01303 | 0.01266 |
| yolo26m NHWC | 0.01292 | 0.01254 |

Accuracy is unchanged in training. yolo26n.pt fine-tuned on coco128 for 15 epochs with MuSGD, `deterministic=True`, three seeds:

| Seed | main mAP50-95 | this PR mAP50-95 | main mAP50 | this PR mAP50 |
| --- | --- | --- | --- | --- |
| 0 | 0.59348 | 0.58863 | 0.77967 | 0.77812 |
| 1 | 0.57669 | 0.58099 | 0.77300 | 0.78016 |
| 2 | 0.57811 | 0.58060 | 0.77665 | 0.79185 |
| mean | 0.58276 | 0.58341 | 0.77644 | 0.78338 |

The mean mAP50-95 difference is `+0.00065` against a seed to seed spread of `0.01678`, and its sign changes between seeds.

Shapes the optimizer never produces are handled too. Transposed and gapped 2D, strided 3D, and 4D that is neither contiguous nor channels_last all return correct values, since `as_strided` is used only where the flatten was a view and the buffer therefore holds the update's own memory order. Every other layout is materialized row-major and written back row-major.

## Speed

The optimizer is a small share of a training step, so these numbers support the fix rather than carry it.

`MuSGD.step()` median over 40 steps, 9 interleaved rounds, repeated twice, on an otherwise idle RTX PRO 6000 Blackwell, torch 2.11.0+cu128, real YOLO26 Muon parameter shapes. Both repeats agree to about 0.01 ms.

| Model | main NHWC | this PR NHWC | main NCHW | this PR NCHW |
| --- | --- | --- | --- | --- |
| yolo26n | 4.44 ms | 4.54 ms | 4.16 ms | 4.44 ms |
| yolo26s | 5.81 ms | 4.93 ms | 5.64 ms | 4.92 ms |
| yolo26m | 12.89 ms | 7.31 ms | 12.62 ms | 7.31 ms |
| yolo26x | 27.84 ms | 16.91 ms | 27.34 ms | 16.89 ms |

yolo26n is the one case that does not gain. Column counts take more distinct values than row counts there, so it issues 19 batched calls where `main` issues 11, and at that size the optimizer is bound by kernel launches rather than by the padded arithmetic this removes. yolo26s has the same 126 Muon parameters and gains, so the split is architectural rather than a matter of model size.

The parameter add on its own, with the number of updates whose strides differ from their parameter:

| Model | main | this PR |
| --- | --- | --- |
| yolo26n | 0.407 ms, 126 of 126 mismatched | 0.027 ms, 0 of 126 mismatched |
| yolo26s | 0.451 ms, 126 of 126 mismatched | 0.027 ms, 0 of 126 mismatched |
| yolo26m | 0.654 ms, 136 of 136 mismatched | 0.190 ms, 0 of 136 mismatched |
| yolo26x | 1.141 ms, 190 of 190 mismatched | 0.489 ms, 0 of 190 mismatched |

### Training step

Forward, backward and `MuSGD.step()` in one loop at 640px, channels_last, with `accumulate = round(64 / batch)` as `BaseTrainer` sets it. Median of 8 steps after 3 warmups, 5 interleaved rounds with a fresh model and optimizer per run, same idle GPU. Synthetic input and a summed-output loss, so this covers the compute path and not the data pipeline.

| Model | batch | accumulate | main ms/img | this PR ms/img | speedup |
| --- | --- | --- | --- | --- | --- |
| yolo26n | 16 | 4 | 1.7942 | 1.7855 | 1.005x |
| yolo26n | 32 | 2 | 1.5355 | 1.5289 | 1.004x |
| yolo26n | 64 | 1 | 1.5066 | 1.4986 | 1.005x |
| yolo26m | 16 | 4 | 6.3520 | 6.2648 | 1.014x |
| yolo26m | 32 | 2 | 6.2976 | 6.2113 | 1.014x |
| yolo26m | 64 | 1 | 6.6438 | 6.5584 | 1.013x |

The optimizer runs once per 64 images at every batch size here, since `accumulate` tracks `nbs`. Its cost per image is therefore fixed, and the speedup does not grow with batch. Forward and backward per image is also flat across these sizes, so the share available to take back does not move either.

yolo26n moves by half a percent, which is below what this loop resolves, and the optimizer benchmark above has it marginally slower. Read those three rows as no change.

For yolo26m the size of the effect follows from the optimizer numbers above. It saves 5.3 ms per step, which over 64 images is 0.083 ms per image, predicting `6.352 / (6.352 - 0.083)` or 1.013x against the 1.014x measured.

## Memory

Peak allocated inside `muon_update`, channels_last, where the smaller padding shows up:

| Model | main | this PR | change |
| --- | --- | --- | --- |
| yolo26n | 63.25 MB | 40.53 MB | 0.64x |
| yolo26s | 260.05 MB | 163.09 MB | 0.63x |
| yolo26m | 690.86 MB | 365.87 MB | 0.53x |
| yolo26x | 1821.69 MB | 978.96 MB | 0.54x |

Peak training memory does not move. The optimizer transient sits well below the activation peak, so it never sets the high water mark. `torch.cuda.max_memory_allocated()` over 3 steps after warmup, one process per configuration, channels_last, 640px, repeated twice with identical results:

| Model | batch | main | this PR |
| --- | --- | --- | --- |
| yolo26n | 16 | 4332.51 MB | 4332.51 MB |
| yolo26n | 64 | 16951.94 MB | 16951.94 MB |
| yolo26m | 16 | 16199.57 MB | 16199.57 MB |
| yolo26m | 64 | 63235.92 MB | 63235.92 MB |
| yolo26x | 16 | 30305.15 MB | 30305.15 MB |

yolo26x at batch 64 runs out of memory on both sides of a 94 GB card, so it has no row. The smaller padding buys headroom inside the optimizer step, not a smaller training footprint.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

`muon_update()` now flattens tensors in their memory order, groups matrices by column count with bounded row padding, and restores dense parameter layouts to reduce temporary memory use and recover fused parameter updates.

### 📊 Key Changes

- NHWC tensors are flattened with a view, while unsupported layouts are materialized row-major; transpose bookkeeping was removed.
- Matrices are bucketed by column count and split when row sizes differ by more than 16×, with rows padded in a shared buffer.
- Batched buffer construction now uses a zero-initialized tensor and a fused `torch._foreach_add_` instead of per-matrix padding and stacking.
- Updates are written back using the original parameter strides when the flattening was a view; otherwise they use reshaped row-major storage.
- The `muon_update()` documentation now describes column-based bucketing.

### 🎯 Purpose & Impact

- CUDA MuSGD updates avoid the repeated NHWC-to-NCHW materialization introduced by flattening with `reshape`.
- Parameter updates regain matching dense strides, allowing `torch._foreach_add_` in `MuSGD.step` to use its fused path.
- Temporary memory used by `muon_update()` is reduced through row padding and shared batched buffers; peak training memory is unchanged.
- Newton-Schulz results are not bitwise identical to `main` because flattening order and batching change bfloat16 reduction order, while the PR reports unchanged training accuracy.