### PR TITLE
Fix Zensical 0.0.58 docs validation

### DIFF
--- a/docs/en/guides/data-collection-and-annotation.md
+++ b/docs/en/guides/data-collection-and-annotation.md
@@ -1,7 +1,7 @@
 ---
 title: CV Data Collection and Annotation Guide
 comments: true
-description: Learn data collection and annotation for computer vision: set up classes, source unbiased data, choose annotation types and formats, and run quality control.
+description: "Learn data collection and annotation for computer vision: set up classes, source unbiased data, choose annotation types and formats, and run quality control."
 keywords: What is Data Annotation, Data Annotation Tools, Annotating Data, Avoiding Bias in Data Collection, Ethical Data Collection, Annotation Strategies
 ---
 

--- a/docs/en/guides/deepstream-nvidia-jetson.md
+++ b/docs/en/guides/deepstream-nvidia-jetson.md
@@ -1,5 +1,5 @@
 ---
-title: YOLO26 on Jetson: DeepStream & TensorRT
+title: YOLO26 on Jetson DeepStream & TensorRT
 comments: true
 description: Learn how to deploy Ultralytics YOLO26 on NVIDIA Jetson devices using TensorRT and DeepStream SDK. Explore performance benchmarks and maximize AI capabilities.
 keywords: Ultralytics, YOLO26, NVIDIA Jetson, JetPack, AI deployment, embedded systems, deep learning, TensorRT, DeepStream SDK, computer vision

--- a/docs/en/guides/model-deployment-practices.md
+++ b/docs/en/guides/model-deployment-practices.md
@@ -1,7 +1,7 @@
 ---
 title: YOLO26 Model Deployment Best Practices
 comments: true
-description: Best practices for deploying YOLO26: choose cloud, edge, or local environments, optimize with pruning and quantization, and secure your deployed models.
+description: "Best practices for deploying YOLO26: choose cloud, edge, or local environments, optimize with pruning and quantization, and secure your deployed models."
 keywords: YOLO26, model deployment, best practices, edge deployment, cloud deployment, quantization, pruning, Docker, model security
 ---
 

--- a/docs/en/guides/preprocessing-annotated-data.md
+++ b/docs/en/guides/preprocessing-annotated-data.md
@@ -1,7 +1,7 @@
 ---
 title: Preprocessing Annotated CV Data
 comments: true
-description: Preprocess annotated computer vision data with YOLO26: resize, normalize, augment, and split datasets to boost training accuracy and reduce overfitting.
+description: "Preprocess annotated computer vision data with YOLO26: resize, normalize, augment, and split datasets to boost training accuracy and reduce overfitting."
 keywords: data preprocessing, computer vision, image resizing, image normalization, data augmentation, train validation test split, data leakage, exploratory data analysis, YOLO26, Ultralytics
 ---
 

--- a/docs/en/guides/raspberry-pi.md
+++ b/docs/en/guides/raspberry-pi.md
@@ -1,5 +1,5 @@
 ---
-title: YOLO26 on Raspberry Pi: Setup & Benchmarks
+title: YOLO26 on Raspberry Pi Setup & Benchmarks
 comments: true
 description: Deploy Ultralytics YOLO26 on Raspberry Pi 4 and 5 with install steps, NCNN export for fastest inference, camera setup, and benchmarks across eight formats.
 keywords: Ultralytics, YOLO26, Raspberry Pi, setup, guide, benchmarks, computer vision, object detection, NCNN, Docker, camera modules

--- a/docs/en/help/FAQ.md
+++ b/docs/en/help/FAQ.md
@@ -1,5 +1,5 @@
 ---
-title: YOLO FAQ: Common Questions & Solutions
+title: YOLO FAQ Common Questions & Solutions
 comments: true
 description: Explore common questions and solutions related to Ultralytics YOLO, from hardware requirements to model fine-tuning and real-time detection.
 keywords: Ultralytics, YOLO, FAQ, object detection, hardware requirements, fine-tuning, ONNX, TensorFlow, real-time detection, model accuracy

--- a/docs/en/models/rtdetr.md
+++ b/docs/en/models/rtdetr.md
@@ -1,5 +1,5 @@
 ---
-title: RT-DETR: Real-Time Detection Transformer
+title: RT-DETR Real-Time Detection Transformer
 comments: true
 description: Explore Baidu's RT-DETR, a Vision Transformer-based real-time object detector offering high accuracy and adaptable inference speed. Learn more with Ultralytics.
 keywords: RT-DETR, Baidu, Vision Transformer, real-time object detection, PaddlePaddle, Ultralytics, pretrained models, decoder layer index, query count, AI, machine learning, computer vision

--- a/docs/en/models/yolov10.md
+++ b/docs/en/models/yolov10.md
@@ -1,5 +1,5 @@
 ---
-title: YOLOv10: NMS-Free Object Detection
+title: YOLOv10 NMS-Free Object Detection
 comments: true
 description: Discover YOLOv10 for real-time object detection, eliminating NMS and boosting efficiency. Achieve top performance with a low computational cost.
 keywords: YOLOv10, real-time object detection, NMS-free, deep learning, Tsinghua University, Ultralytics, machine learning, neural networks, performance optimization

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dev = [
     "pytest-cov",
     "pytest-xdist>=3.0.0",
     "coverage[toml]",
-    "zensical==0.0.58; python_version >= '3.10'",
+    "zensical>=0.0.58; python_version >= '3.10'",
     "minijinja>=2.0.0", # render docs macros without mkdocs-macros-plugin
 ]
 export-base = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dev = [
     "pytest-cov",
     "pytest-xdist>=3.0.0",
     "coverage[toml]",
-    "zensical>=0.0.53; python_version >= '3.10'",
+    "zensical==0.0.58; python_version >= '3.10'",
     "minijinja>=2.0.0", # render docs macros without mkdocs-macros-plugin
 ]
 export-base = [


### PR DESCRIPTION
## Summary

- require Zensical 0.0.58 or newer for docs validation
- remove YAML separator colons from five page titles
- quote three description scalars that contain colon-space sequences

## Validation

- python docs/build_docs.py with Python 3.14 and Zensical 0.0.58
- parsed all docs/en frontmatter with PyYAML
- Prettier 3.8.5 check on all changed Markdown files
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated documentation validation requirements and frontmatter formatting to support Zensical 0.0.58 or newer.

### 📊 Key Changes

- Raised the development dependency requirement from `zensical>=0.0.53` to `zensical>=0.0.58` for Python 3.10 and newer.
- Removed colon separators from the titles of five documentation pages to satisfy validation.
- Quoted three descriptions containing colon-space sequences so they remain valid YAML scalars.
- Updated affected pages across the guides, help, and models documentation sections.

### 🎯 Purpose & Impact

- Documentation frontmatter now conforms to the validation requirements used by Zensical 0.0.58 and newer.
- The affected page titles and descriptions retain their meaning while using YAML-compatible formatting.
- No runtime or user-facing product behavior changes.