### PR TITLE
Reload the checkpoint donor when inference fused the loaded module

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -857,7 +857,7 @@ class Model(torch.nn.Module):
             src = loaded if isinstance(loaded, (str, Path)) else getattr(donor, "pt_path", None)
             if src:
                 donor, _ = load_checkpoint(src)
-                donor.yaml = self.model.yaml  # weights only, the architecture stays the facade's
+                donor.yaml = self.model.yaml  # trainers build the model from .yaml and take the module as weights
                 if len(donor.names) == len(self.model.names):
                     donor.names = self.model.names
         if isinstance(args.get("data"), (list, tuple)):  # fine-tune a single base model across multiple datasets

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -13,7 +13,6 @@ from PIL import Image
 
 from ultralytics.cfg import QUANTIZE_ALIASES, TASK2DATA, _handle_deprecation, get_cfg, get_save_dir
 from ultralytics.engine.results import Results
-from ultralytics.nn.modules import Conv, ConvTranspose
 from ultralytics.nn.tasks import BaseModel, guess_model_task, load_checkpoint, yaml_model_load
 from ultralytics.utils import (
     ARGV,
@@ -835,7 +834,7 @@ class Model(torch.nn.Module):
         if (
             pretrained is True
             and loaded is not False
-            and any(isinstance(m, (Conv, ConvTranspose)) and not hasattr(m, "bn") for m in donor.modules())
+            and any(m.forward == getattr(m, "forward_fuse", None) for m in donor.modules())
         ):
             # predict() and val() fuse the loaded module in place, so its tensors can no longer seed training
             src = loaded if isinstance(loaded, (str, Path)) else getattr(donor, "pt_path", None)

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -337,8 +337,9 @@ class Model(torch.nn.Module):
         if isinstance(weights, (str, Path)):
             self.overrides["pretrained"] = weights  # remember the weights for DDP training
             weights, self.ckpt = load_checkpoint(weights)
-        else:
-            self.model.pt_path = None  # in-memory weights have no file to reload from
+        else:  # in-memory weights have no file to reload from
+            self.model.pt_path = None
+            self.overrides.pop("pretrained", None)
         self.model.load(weights)
         return self
 

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -336,8 +336,8 @@ class Model(torch.nn.Module):
         if isinstance(weights, (str, Path)):
             self.overrides["pretrained"] = weights  # remember the weights for DDP training
             weights, self.ckpt = load_checkpoint(weights)
-        else:  # in-memory weights have no file to reload from
-            self.model.pt_path = None
+        else:  # in-memory weights have no file to reload from, nor a run to resume
+            self.model.pt_path = self.ckpt_path = None
             self.overrides.pop("pretrained", None)
         self.model.load(weights)
         return self
@@ -829,7 +829,12 @@ class Model(torch.nn.Module):
         }  # method defaults
         args = {**overrides, **custom, **kwargs, "mode": "train"}  # prioritizes rightmost args
         if args.get("resume") is True:  # resume=True (boolean) uses current model as checkpoint
-            if self.ckpt and self.ckpt.get("epoch", -1) >= 0 and self.ckpt.get("optimizer") is not None:
+            if (
+                self.ckpt_path
+                and self.ckpt
+                and self.ckpt.get("epoch", -1) >= 0
+                and self.ckpt.get("optimizer") is not None
+            ):
                 args["resume"] = self.ckpt_path
             else:
                 LOGGER.warning(

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -13,7 +13,7 @@ from PIL import Image
 
 from ultralytics.cfg import QUANTIZE_ALIASES, TASK2DATA, _handle_deprecation, get_cfg, get_save_dir
 from ultralytics.engine.results import Results
-from ultralytics.nn.modules import Conv
+from ultralytics.nn.modules import Conv, ConvTranspose
 from ultralytics.nn.tasks import BaseModel, guess_model_task, load_checkpoint, yaml_model_load
 from ultralytics.utils import (
     ARGV,
@@ -337,6 +337,8 @@ class Model(torch.nn.Module):
         if isinstance(weights, (str, Path)):
             self.overrides["pretrained"] = weights  # remember the weights for DDP training
             weights, self.ckpt = load_checkpoint(weights)
+        else:
+            self.model.pt_path = None  # in-memory weights have no file to reload from
         self.model.load(weights)
         return self
 
@@ -826,13 +828,19 @@ class Model(torch.nn.Module):
             "task": self.task,
         }  # method defaults
         args = {**overrides, **custom, **kwargs, "mode": "train"}  # prioritizes rightmost args
+        pretrained = kwargs.get("pretrained", overrides.get("pretrained", True) if kwargs.get("cfg") else True)
         donor = self.model  # pretrained weights, kept in memory so class renames before train() carry over
         loaded = self.overrides.get("pretrained")
-        if loaded is not False and any(isinstance(m, Conv) and not hasattr(m, "bn") for m in donor.modules()):
+        if (
+            pretrained is True
+            and loaded is not False
+            and any(isinstance(m, (Conv, ConvTranspose)) and not hasattr(m, "bn") for m in donor.modules())
+        ):
             # predict() and val() fuse the loaded module in place, so its tensors can no longer seed training
             src = loaded if isinstance(loaded, (str, Path)) else getattr(donor, "pt_path", None)
             if src:
                 donor, _ = load_checkpoint(src)
+                donor.yaml = self.model.yaml  # weights only, the architecture stays the facade's
                 if len(donor.names) == len(self.model.names):
                     donor.names = self.model.names
         if isinstance(args.get("data"), (list, tuple)):  # fine-tune a single base model across multiple datasets
@@ -847,7 +855,6 @@ class Model(torch.nn.Module):
             )
             self.metrics = self.trainer.train()
             return self.metrics
-        pretrained = kwargs.get("pretrained", overrides.get("pretrained", True) if kwargs.get("cfg") else True)
         if args.get("resume") is True:  # resume=True (boolean) uses current model as checkpoint
             if self.ckpt and self.ckpt.get("epoch", -1) >= 0 and self.ckpt.get("optimizer") is not None:
                 args["resume"] = self.ckpt_path

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -13,6 +13,7 @@ from PIL import Image
 
 from ultralytics.cfg import QUANTIZE_ALIASES, TASK2DATA, _handle_deprecation, get_cfg, get_save_dir
 from ultralytics.engine.results import Results
+from ultralytics.nn.modules import Conv
 from ultralytics.nn.tasks import BaseModel, guess_model_task, load_checkpoint, yaml_model_load
 from ultralytics.utils import (
     ARGV,
@@ -309,6 +310,7 @@ class Model(torch.nn.Module):
                 m.reset_parameters()
         for p in self.model.parameters():
             p.requires_grad = True
+        self.overrides["pretrained"] = False  # a fresh init seeds nothing, here or in a DDP child
         return self
 
     def load(self, weights: str | Path = "yolo26n.pt") -> Model:
@@ -824,6 +826,15 @@ class Model(torch.nn.Module):
             "task": self.task,
         }  # method defaults
         args = {**overrides, **custom, **kwargs, "mode": "train"}  # prioritizes rightmost args
+        donor = self.model  # pretrained weights, kept in memory so class renames before train() carry over
+        loaded = self.overrides.get("pretrained")
+        if loaded is not False and any(isinstance(m, Conv) and not hasattr(m, "bn") for m in donor.modules()):
+            # predict() and val() fuse the loaded module in place, so its tensors can no longer seed training
+            src = loaded if isinstance(loaded, (str, Path)) else getattr(donor, "pt_path", None)
+            if src:
+                donor, _ = load_checkpoint(src)
+                if len(donor.names) == len(self.model.names):
+                    donor.names = self.model.names
         if isinstance(args.get("data"), (list, tuple)):  # fine-tune a single base model across multiple datasets
             from ultralytics.engine.trainer import MultiTrainer
 
@@ -831,7 +842,7 @@ class Model(torch.nn.Module):
             self.trainer = MultiTrainer(
                 (trainer or self._smart_load("trainer")) if use_python_trainer else None,
                 args,
-                self.model,
+                donor,
                 _callbacks=self.callbacks,
             )
             self.metrics = self.trainer.train()
@@ -851,7 +862,7 @@ class Model(torch.nn.Module):
         self.trainer = (trainer or self._smart_load("trainer"))(overrides=args, _callbacks=self.callbacks)
         if not args.get("resume") and self.ckpt:
             # Reuse the already-loaded checkpoint model to avoid re-resolving remote weight sources during trainer setup.
-            weights = None if pretrained is False else self.model
+            weights = None if pretrained is False else donor
             if isinstance(pretrained, (str, Path)):
                 weights, _ = load_checkpoint(pretrained)
             self.trainer.model = self.trainer.get_model(weights=weights, cfg=self.model.yaml)

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -828,11 +828,23 @@ class Model(torch.nn.Module):
             "task": self.task,
         }  # method defaults
         args = {**overrides, **custom, **kwargs, "mode": "train"}  # prioritizes rightmost args
+        if args.get("resume") is True:  # resume=True (boolean) uses current model as checkpoint
+            if self.ckpt and self.ckpt.get("epoch", -1) >= 0 and self.ckpt.get("optimizer") is not None:
+                args["resume"] = self.ckpt_path
+            else:
+                LOGGER.warning(
+                    f"model '{self.ckpt_path}' is not a resumable training checkpoint "
+                    f"(missing epoch/optimizer state). Use 'resume' only to continue incomplete training. "
+                    f"Starting new training instead."
+                )
+                args["resume"] = False
+
         pretrained = kwargs.get("pretrained", overrides.get("pretrained", True) if kwargs.get("cfg") else True)
         donor = self.model  # pretrained weights, kept in memory so class renames before train() carry over
         loaded = self.overrides.get("pretrained")
         if (
             pretrained is True
+            and not args.get("resume")
             and loaded is not False
             and any(m.forward == getattr(m, "forward_fuse", None) for m in donor.modules())
         ):
@@ -855,17 +867,6 @@ class Model(torch.nn.Module):
             )
             self.metrics = self.trainer.train()
             return self.metrics
-        if args.get("resume") is True:  # resume=True (boolean) uses current model as checkpoint
-            if self.ckpt and self.ckpt.get("epoch", -1) >= 0 and self.ckpt.get("optimizer") is not None:
-                args["resume"] = self.ckpt_path
-            else:
-                LOGGER.warning(
-                    f"model '{self.ckpt_path}' is not a resumable training checkpoint "
-                    f"(missing epoch/optimizer state). Use 'resume' only to continue incomplete training. "
-                    f"Starting new training instead."
-                )
-                args["resume"] = False
-
         self.trainer = (trainer or self._smart_load("trainer"))(overrides=args, _callbacks=self.callbacks)
         if not args.get("resume") and self.ckpt:
             # Reuse the already-loaded checkpoint model to avoid re-resolving remote weight sources during trainer setup.


### PR DESCRIPTION
## summary

- `predict()` and `val()` fuse the loaded module in place, and `Model.train()` hands that same module to the trainer as the pretrained donor, so a fine-tune started after either transferred 108 of 708 tensors and trained from near scratch with only a log line as a trace
- `Model.train()` now reads the donor back from its checkpoint file when any module carries the forward that `fuse()` installs, before both the single-dataset and the multi-dataset trainer. the reloaded donor supplies weights only: it keeps the facade's architecture and in-memory class names, so renaming `model.model.names` before training still transfers classification rows by alias, and the facade's module and predictor are left as they were
- the reload is skipped when the run seeds from elsewhere: `pretrained=False`, a `pretrained` path, a resumed run, a model after `reset_weights()`, or weights loaded from an in-memory object, which has no file to stand in for it and no run to resume
- the footprint covers `Conv`, `ConvTranspose`, `RepConv` and `RepVGGDW` alike, unlike `is_fused()`, which counts every normalization layer and stays false on a fused RT-DETR

## measured

cpu, coco8, one epoch, tensors `BaseModel.load` transfers into the fresh training model, before and after:

| sequence | before | after |
| --- | --- | --- |
| `predict()` or `val()`, then `train()`: yolo26n / -seg / -cls / rtdetr-l | 108/708, 128/844, 39/236, 322/941 | 708/708, 844/844, 234/236, 941/941 |
| same, `train(data=[coco8, coco8])`, python trainer and cli subprocess | 108/708 per dataset | 708/708 per dataset |
| `YOLO("yolo26n.yaml").load("yolo26n.pt")`, `predict()`, `train()` | 108/708 | 708/708 |
| `predict()`, rename `model.model.names`, `train()`: rows remapped by name | 80/80 of 108/708 | 80/80 of 708/708 |
| `calibrate()` then `train()`, yolo26n-depth | 93/528 | 528/528 |
| `YOLO("yolo26n.pt").load("yolo11n.pt")`, `predict()`, `train()` and `train(data=[...])` on both arms: parameters of the trained model, weights | 2,572,280 (yolo26n), 108/708 from neither | 2,572,280 (yolo26n), 402/708 from yolo11n |
| custom yaml of `TorchVision`, `ConvTranspose` and `RTDETRDecoder` with no `Conv`, `predict()`, `train()` | 335/341 | 341/341 |
| `set_classes()`, `predict()`, `train()`: yolov8s-worldv2 / yoloe-26n-seg | 409/412, 958/958 | same |
| `reset_weights()` or `load(<module>)` with a `predict()` before or after it, then `train()` | 108/708 of the in-memory weights | same |
| `YOLO(<mid-run last.pt>)`, `predict()`, `train(resume=True)` | resumes | resumes, no extra read |
| `train()` alone, `pretrained=False`, `pretrained="yolo26n.pt"`, `train()` then `predict()` then `train()`, `yolo train model=ul://...` | unchanged, no extra read | unchanged, no extra read |
| extra checkpoint read, only on a fused module that will seed the run | none | 15 ms for yolo26n |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

`Model.train()` now reloads an unfused checkpoint donor after inference-time fusion so subsequent training can receive the original weights without replacing the in-memory model configuration.

### 📊 Key Changes

- Detects fused modules through `forward_fuse` and reloads the donor checkpoint before both single-dataset and multi-dataset training.
- Preserves the current model’s YAML configuration and class names on the reloaded donor, allowing class-name aliases to continue remapping classification weights.
- Skips donor reloads for explicit non-pretrained runs, alternate pretrained paths, resumed runs, models reset with `reset_weights()`, and in-memory weight loads without a checkpoint file.
- Marks `reset_weights()` as `pretrained=False` and clears checkpoint metadata for in-memory `load()` calls.
- Resolves `resume=True` to the current checkpoint only when epoch and optimizer state are available; otherwise, it warns and starts a new run.

### 🎯 Purpose & Impact

- Training after `predict()`, `val()`, or `calibrate()` can use the original checkpoint weights instead of the fused in-memory module, including through multi-dataset trainers.
- The facade model and predictor remain unchanged while the reloaded donor supplies training weights.
- Runs that do not seed training from a reloadable checkpoint retain their existing behavior; the additional checkpoint read occurs only for eligible fused donors.