### PR TITLE
Reload the checkpoint donor when inference fused the loaded module

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -309,6 +309,7 @@ class Model(torch.nn.Module):
                 m.reset_parameters()
         for p in self.model.parameters():
             p.requires_grad = True
+        self.overrides["pretrained"] = False  # a fresh init seeds nothing, here or in a DDP child
         return self
 
     def load(self, weights: str | Path = "yolo26n.pt") -> Model:
@@ -335,6 +336,9 @@ class Model(torch.nn.Module):
         if isinstance(weights, (str, Path)):
             self.overrides["pretrained"] = weights  # remember the weights for DDP training
             weights, self.ckpt = load_checkpoint(weights)
+        else:  # in-memory weights have no file to reload from
+            self.model.pt_path = None
+            self.overrides.pop("pretrained", None)
         self.model.load(weights)
         return self
 

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -824,19 +824,6 @@ class Model(torch.nn.Module):
             "task": self.task,
         }  # method defaults
         args = {**overrides, **custom, **kwargs, "mode": "train"}  # prioritizes rightmost args
-        if isinstance(args.get("data"), (list, tuple)):  # fine-tune a single base model across multiple datasets
-            from ultralytics.engine.trainer import MultiTrainer
-
-            use_python_trainer = trainer is not None or self.callbacks != callbacks.get_default_callbacks()
-            self.trainer = MultiTrainer(
-                (trainer or self._smart_load("trainer")) if use_python_trainer else None,
-                args,
-                self.model,
-                _callbacks=self.callbacks,
-            )
-            self.metrics = self.trainer.train()
-            return self.metrics
-        pretrained = kwargs.get("pretrained", overrides.get("pretrained", True) if kwargs.get("cfg") else True)
         if args.get("resume") is True:  # resume=True (boolean) uses current model as checkpoint
             if self.ckpt and self.ckpt.get("epoch", -1) >= 0 and self.ckpt.get("optimizer") is not None:
                 args["resume"] = self.ckpt_path
@@ -848,10 +835,38 @@ class Model(torch.nn.Module):
                 )
                 args["resume"] = False
 
+        pretrained = kwargs.get("pretrained", overrides.get("pretrained", True) if kwargs.get("cfg") else True)
+        donor = self.model  # pretrained weights, kept in memory so class renames before train() carry over
+        loaded = self.overrides.get("pretrained")
+        if (
+            pretrained is True
+            and not args.get("resume")
+            and loaded is not False
+            and any(m.forward == getattr(m, "forward_fuse", None) for m in donor.modules())
+        ):
+            # predict() and val() fuse the loaded module in place, so its tensors can no longer seed training
+            src = loaded if isinstance(loaded, (str, Path)) else getattr(donor, "pt_path", None)
+            if src:
+                donor, _ = load_checkpoint(src)
+                donor.yaml = self.model.yaml  # trainers build the model from .yaml and take the module as weights
+                if len(donor.names) == len(self.model.names):
+                    donor.names = self.model.names
+        if isinstance(args.get("data"), (list, tuple)):  # fine-tune a single base model across multiple datasets
+            from ultralytics.engine.trainer import MultiTrainer
+
+            use_python_trainer = trainer is not None or self.callbacks != callbacks.get_default_callbacks()
+            self.trainer = MultiTrainer(
+                (trainer or self._smart_load("trainer")) if use_python_trainer else None,
+                args,
+                donor,
+                _callbacks=self.callbacks,
+            )
+            self.metrics = self.trainer.train()
+            return self.metrics
         self.trainer = (trainer or self._smart_load("trainer"))(overrides=args, _callbacks=self.callbacks)
         if not args.get("resume") and self.ckpt:
             # Reuse the already-loaded checkpoint model to avoid re-resolving remote weight sources during trainer setup.
-            weights = None if pretrained is False else self.model
+            weights = None if pretrained is False else donor
             if isinstance(pretrained, (str, Path)):
                 weights, _ = load_checkpoint(pretrained)
             self.trainer.model = self.trainer.get_model(weights=weights, cfg=self.model.yaml)

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -336,7 +336,7 @@ class Model(torch.nn.Module):
         if isinstance(weights, (str, Path)):
             self.overrides["pretrained"] = weights  # remember the weights for DDP training
             weights, self.ckpt = load_checkpoint(weights)
-        else:  # in-memory weights have no file to reload from
+        else:  # no file to reload from; ckpt stays, it routes this module to the trainer
             self.model.pt_path = None
             self.overrides.pop("pretrained", None)
         self.model.load(weights)


### PR DESCRIPTION
## summary

- `predict()` and `val()` fuse the loaded module in place, and `Model.train()` hands that same module to the trainer as the pretrained donor, so a fine-tune started after either transferred 108 of 708 tensors and trained from near scratch with only a log line as a trace
- `Model.train()` now reads the donor back from its checkpoint file when a module carries the forward that `fuse()` installs, keeps the facade's architecture and in-memory class names on it, and skips the reload when the run seeds from elsewhere: `pretrained=False`, a `pretrained` path, a resumed run, `reset_weights()`, or weights loaded from an object
- `Model.load()` with a module or state dict clears `pt_path` and the `pretrained` override, so neither `train()` nor a DDP child replaces those weights with the file they came from; `self.ckpt` stays, because its truthiness is what routes the in-memory module to the trainer, and clearing it seeds `load(<module>).train()` from the file instead

## measured

cpu, coco8, one epoch, tensors `BaseModel.load` transfers into the fresh training model:

| sequence | before | after |
| --- | --- | --- |
| `predict()` or `val()`, then `train()`: yolo26n / -seg / -cls / rtdetr-l | 108/708, 128/844, 39/236, 322/941 | 708/708, 844/844, 234/236, 941/941 |
| same, then `train(data=[coco8, coco8])`, python trainer and cli subprocess | 108/708 per dataset | 708/708 per dataset |
| `predict()`, rename `model.model.names`, `train()`: rows remapped by name | 80/80 of 108/708 | 80/80 of 708/708 |
| `YOLO("yolo26n.pt").load("yolo11n.pt")`, `predict()`, `train()`: architecture, weights | yolo26n, 108/708 from neither | yolo26n, 402/708 from yolo11n |
| `reset_weights()`, `load(<module>)`, `resume=True`, `pretrained=False`, `train()` alone | unchanged | unchanged, no extra read |
| `load(<module>)`, `predict()`, `train()`: no file describes the weights | 108/708 | 108/708 |
| `load(<module>)` carrying a zeroed tensor, `train()`: that tensor at `on_train_start` | 0, in-memory weights | 0, in-memory weights; 90.6 from the file once `load()` clears `self.ckpt` |
| `predict()`, `save(p)`, `YOLO(p).train()`: the file itself is fused, tracked separately | 108/708 | 108/708 |
| `YOLO("yolo26n.yaml").load(<module>)`, `train()`: loaded weights reach the trainer, tracked separately | no | no |
| extra checkpoint read, only on a fused module that seeds the run | none | 15 ms for yolo26n |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

`Model.train()` now reloads an unfused checkpoint donor when inference has fused the in-memory model, preventing subsequent fine-tuning from using the incomplete fused weights.

### 📊 Key Changes

- Detects fused modules during training and reloads their checkpoint before passing the donor to the trainer.
- Preserves the current model architecture configuration and class names on the reloaded donor.
- Applies the same donor-selection logic to multi-dataset training through `MultiTrainer`.
- Skips checkpoint reloading for resumed runs, `pretrained=False`, explicit alternate pretrained paths, reset weights, and in-memory module or state-dict loads.
- `reset_weights()` now disables pretrained initialization, while `load()` clears the file path and pretrained override for in-memory weights.

### 🎯 Purpose & Impact

- Fine-tuning after `predict()` or `val()` can receive the complete checkpoint weights instead of the fused module’s reduced set of transferable tensors.
- In-memory weights remain authoritative when loaded directly, while checkpoint-backed models can be reloaded only when the training setup requires it.