### PR TITLE
Keep the caller's depth model unfused across calibrate() and warn when pretrained weights are fused

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -342,7 +342,8 @@ class Model(torch.nn.Module):
         """Save the current model state to a file.
 
         This method exports the model's checkpoint (ckpt) to the specified filename. It includes metadata such as the
-        date, Ultralytics version, license information, and a link to the documentation.
+        date, Ultralytics version, license information, and a link to the documentation. The module is written as held
+        in memory: layers folded by ``predict()``, ``val()`` or ``fuse()`` stay folded, so training from the file transfers less.
 
         Args:
             filename (str | Path): The name of the file to save the model to.
@@ -647,6 +648,8 @@ class Model(torch.nn.Module):
         self._check_is_pytorch_model()
         if self.task != "depth":
             raise ValueError(f"calibrate() is only supported for depth models (task='depth'), got task={self.task!r}.")
+        from copy import deepcopy
+
         from ultralytics.models.yolo.depth.calibrate import _depth_head, fit_calibration_selective
 
         if _depth_head(self.model) is None:
@@ -655,7 +658,7 @@ class Model(torch.nn.Module):
         if data is not None:
             args["data"] = data
         validator = self._smart_load("validator")(args=args, _callbacks=self.callbacks)
-        validator(model=self.model)  # builds the dataloader and reports metrics with the current calibration
+        validator(model=deepcopy(self.model))  # the validator fuses what it runs, so it gets a copy
         res = fit_calibration_selective(
             self.model, validator.dataloader, validator.device, max_depth=validator.data.get("max_depth") or 100.0
         )

--- a/ultralytics/models/yolo/depth/calibrate.py
+++ b/ultralytics/models/yolo/depth/calibrate.py
@@ -152,7 +152,6 @@ def _collect_logpairs(
     a0, b0 = float(head.cal_a), float(head.cal_b)
     head.cal_a.fill_(1.0)
     head.cal_b.fill_(0.0)
-    model = model.to(device).eval()
     _rewind(dataloader)
     rng = np.random.default_rng(0)
     pairs = []
@@ -209,16 +208,14 @@ def fit_calibration_selective(
     if head is None:
         LOGGER.warning("calibrate: no Depth head with cal buffers found; skipping.")
         return None
-    pairs = _collect_logpairs(model, dataloader, device, max_images, max_depth)
+    pairs = _collect_logpairs(model.to(device).float().eval(), dataloader, device, max_images, max_depth)
     if len(pairs) < 2:
         LOGGER.warning("calibrate: fewer than 2 valid images for fit/score split; calibration skipped.")
         return None
     res = select_calibration_cv(pairs, margin=margin)
     res["images"] = len(pairs)
-    # On CUDA the buffers are inference tensors (the device move ran under inference_mode); reassign instead
-    # of an in-place fill_ so the write is legal and the buffers stay normal/saveable for model.save().
-    head.cal_a = torch.full_like(head.cal_a, res["a"])
-    head.cal_b = torch.full_like(head.cal_b, res["b"])
+    head.cal_a.fill_(res["a"])
+    head.cal_b.fill_(res["b"])
     scores = " ".join(f"{n}={v:.4f}" for n, v in res["cv_scores"].items())
     LOGGER.info(
         f"Depth calibration selected '{res['name']}' (a={res['a']:.4f} b={res['b']:.4f}); CV held-out δ1 {scores}"

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -267,17 +267,9 @@ class BaseModel(torch.nn.Module):
 
         return self
 
-    def is_fused(self, thresh=10):
-        """Check if the model has less than a certain threshold of normalization layers.
-
-        Args:
-            thresh (int, optional): The threshold number of normalization layers.
-
-        Returns:
-            (bool): True if the number of normalization layers in the model is less than the threshold, False otherwise.
-        """
-        bn = tuple(v for k, v in torch.nn.__dict__.items() if "Norm" in k)  # normalization layers, i.e. BatchNorm2d()
-        return sum(isinstance(v, bn) for v in self.modules()) < thresh  # True if < 'thresh' BatchNorm layers in model
+    def is_fused(self):
+        """Return True once fuse() has folded the model's layers for inference."""
+        return any(isinstance(m, (Conv, ConvTranspose)) and not hasattr(m, "bn") for m in self.modules())
 
     def info(self, detailed=False, verbose=True, imgsz=640):
         """Print model information.
@@ -336,6 +328,8 @@ class BaseModel(torch.nn.Module):
                 len_updated_csd += 1
         if verbose:
             LOGGER.info(f"Transferred {len_updated_csd}/{len(self.model.state_dict())} items from pretrained weights")
+            if getattr(model, "is_fused", lambda: False)() and not self.is_fused():
+                LOGGER.warning("Pretrained weights are fused for inference; train from the unfused checkpoint instead.")
 
     def _remap_cls_by_names(self, csd: dict[str, torch.Tensor], src_model: torch.nn.Module, verbose: bool = True):
         """Remap pretrained classification head rows to current class order by name.

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -268,10 +268,11 @@ class BaseModel(torch.nn.Module):
         return self
 
     def is_fused(self):
-        """Return True once fuse() has folded the model's layers for inference."""
-        return any(
-            (isinstance(m, (Conv, ConvTranspose)) and not hasattr(m, "bn"))
-            or (isinstance(m, (RepConv, RepVGGDW)) and not hasattr(m, "conv1"))
+        """Return True once fuse() has nothing left to do."""
+        return not any(
+            (isinstance(m, (Conv, ConvTranspose)) and hasattr(m, "bn"))
+            or (isinstance(m, (RepConv, RepVGGDW)) and hasattr(m, "conv1"))
+            or (isinstance(m, Detect) and getattr(m, "end2end", False) and m.cv2 is not None)
             for m in self.modules()
         )
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -269,7 +269,11 @@ class BaseModel(torch.nn.Module):
 
     def is_fused(self):
         """Return True once fuse() has folded the model's layers for inference."""
-        return any(isinstance(m, (Conv, ConvTranspose)) and not hasattr(m, "bn") for m in self.modules())
+        return any(
+            (isinstance(m, (Conv, ConvTranspose)) and not hasattr(m, "bn"))
+            or (isinstance(m, (RepConv, RepVGGDW)) and not hasattr(m, "conv1"))
+            for m in self.modules()
+        )
 
     def info(self, detailed=False, verbose=True, imgsz=640):
         """Print model information.


### PR DESCRIPTION
## summary

- `Model.calibrate()` hands its validation pass a copy of the caller's module, so the depth model stays unfused and `calibrate()` then `save()` writes a checkpoint that trains like the original file; the fit moves and floats the model before entering inference mode, so its tensors stay normal on accelerators and the reassign that worked around inference-tensor buffers goes with its trigger.
- `BaseModel.load()` warns when the pretrained weights are fused and the receiving model is not, next to the existing `Transferred` line, since a fused donor seeds only the layers that were never folded; `is_fused()` now means `fuse()` has nothing left to do (no `Conv`/`ConvTranspose` with `bn`, no `RepConv`/`RepVGGDW` with `conv1`, no end2end head with its one2many branch) instead of counting normalization layers, which also makes it right for RT-DETR and for a partially fused model; its unused `thresh` parameter is dropped (no caller in the repo, tests, docs or public GitHub code).
- `Model.save()` documents that it writes the module as held in memory, so layers folded by `predict()`, `val()` or `fuse()` stay folded in the file.
- one commit per change, plus two review-repair commits on the predicate.

## measured

cpu unless noted:

| sequence | before | after |
| -- | -- | -- |
| yolo26n-depth `calibrate()` then `save()`: BatchNorm2d in memory / in file | 0 / 0 | 89 / 89 |
| one epoch from that file, tensors transferred | 93/528 | 528/528 |
| `calibrate(device="mps")` then `predict()`: inference tensors in the caller / predictor reuses the caller's module | 0/182, yes | 0/271, yes |
| `half()` or `predict(quantize=16)` then `calibrate()`, cpu and mps | fits, caller ends fp32 | same |
| yolo26n: one epoch from `yolo26n.pt` vs from a file saved after `predict()`, mAP50-95, two seeds | 0.4593 vs 0.0000, only an INFO line | same numbers, warning on the fused file |
| fused donor through `train()` from file, `predict()` then `train()`, `train(pretrained=<fused>)`, `Model.load(<fused>)`, yolo26n-cls, rtdetr-l (322/941), released `yoloe-26n-seg-pf.pt` (132/958) | silent | one warning each |
| unfused donor on the same paths, `verbose=False`, fused receiver taking a fused donor | silent | silent |
| `is_fused()` after `fuse()` on rtdetr-l | False | True |

The copy costs one extra fp32 model for the duration of the validation pass, 25 MB for yolo26n-depth to 228 MB for yolo26x-depth, freed before the fit. `tests/test_engine.py` and the train, calibrate, depth, save, load, fuse and export tests in `tests/test_python.py` pass.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Depth calibration now preserves the caller’s unfused model for saving and training, while fused pretrained weights are detected with a more accurate predicate and reported during loading.

### 📊 Key Changes

- `Model.calibrate()` validates a deep copy of the depth model, then moves the original model to the target device, converts it to floating point, and enters evaluation mode for calibration fitting.
- Calibration parameters are updated directly on normal model buffers, avoiding inference-tensor buffer handling.
- `BaseModel.is_fused()` now checks whether all supported fusion operations have been completed, including convolution, re-parameterized blocks, and end-to-end detection heads; the unused threshold argument was removed.
- `BaseModel.load()` warns when fused pretrained weights are loaded into an unfused model.
- `Model.save()` documents that it writes the model as currently held in memory, including layers already folded by `predict()`, `val()`, or `fuse()`.

### 🎯 Purpose & Impact

- Depth calibration leaves the caller’s model unfused, so a subsequent `save()` retains the structure needed for training.
- Loading fused weights into an unfused model now produces a warning across the affected training and loading paths, while compatible unfused or already-fused combinations remain silent.