### PR TITLE
Replace ModelEMA with torch.optim.swa_utils.AveragedModel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to AI coding agents (Claude Code, etc.) when working with code in this repository. CLAUDE.md is a symlink to this file.
 
-Ultralytics (`ultralytics` on PyPI, AGPL-3.0) is the official Python package for YOLO-family vision models — detection, instance and semantic segmentation, classification, pose, oriented boxes, and tracking — plus training, validation, benchmarking, export to 20 deployment formats, and the `yolo` CLI. Supported floors are Python>=3.8 with PyTorch>=1.8.
+Ultralytics (`ultralytics` on PyPI, AGPL-3.0) is the official Python package for YOLO-family vision models — detection, instance and semantic segmentation, classification, pose, oriented boxes, and tracking — plus training, validation, benchmarking, export to 20 deployment formats, and the `yolo` CLI. Supported floors are Python>=3.8 with PyTorch>=1.8; training requires PyTorch>=2.1.
 
 ## Core Principles (CRITICAL)
 
@@ -71,7 +71,7 @@ python docs/build_docs.py
 yolo predict model=yolo26n.pt
 ```
 
-- CI (`ci.yml`) runs tests on Python 3.13 across ubuntu-latest, macos-26, windows-latest, and ubuntu-24.04-arm, plus a floor job on Python 3.8 with torch 1.8.0.
+- CI (`ci.yml`) runs tests on Python 3.13 across ubuntu-latest, macos-26, windows-latest, and ubuntu-24.04-arm, plus a floor job on Python 3.8 with torch 1.8.0 where training tests skip.
 - `pyproject.toml` pytest `addopts` includes `--doctest-modules`, so pointing pytest at `ultralytics/` runs docstring doctests — CI only runs `tests/`, so package doctests are NOT exercised in CI.
 - `tests/test_exports.py` is partitioned by `--export-env` (env ids from `export_formats()`); omitting the flag runs ALL export formats. GPU tests live in `tests/test_cuda.py` and skip without CUDA.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ See below for quickstart installation and usage examples. For comprehensive guid
 <details open>
 <summary>Install</summary>
 
-Install the `ultralytics` package, including all [requirements](https://github.com/ultralytics/ultralytics/blob/main/pyproject.toml), in a [**Python>=3.8**](https://www.python.org/) environment with [**PyTorch>=1.8**](https://pytorch.org/get-started/locally/).
+Install the `ultralytics` package, including all [requirements](https://github.com/ultralytics/ultralytics/blob/main/pyproject.toml), in a [**Python>=3.8**](https://www.python.org/) environment with [**PyTorch>=1.8**](https://pytorch.org/get-started/locally/). Training requires PyTorch>=2.1.
 
 [![PyPI - Version](https://img.shields.io/pypi/v/ultralytics?logo=pypi&logoColor=white)](https://pypi.org/project/ultralytics/) [![Ultralytics Downloads](https://static.pepy.tech/badge/ultralytics)](https://clickpy.clickhouse.com/dashboard/ultralytics) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ultralytics?logo=python&logoColor=gold)](https://pypi.org/project/ultralytics/)
 

--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -313,7 +313,8 @@ import torch
 
 from ultralytics import RTDETR
 from ultralytics.models.rtdetr.train import RTDETRTrainer
-from ultralytics.utils.torch_utils import TORCH_2_0
+from ultralytics.nn.distill_model import DistillationModel
+from ultralytics.utils.torch_utils import unwrap_model
 
 
 class CustomClipTrainer(RTDETRTrainer):
@@ -325,13 +326,16 @@ class CustomClipTrainer(RTDETRTrainer):
         """Run an optimizer step with a configurable gradient-norm clip."""
         self.scaler.unscale_(self.optimizer)
         if self.clip_grad_norm > 0:
-            kwargs = {"foreach": False} if self.device.type == "npu" and TORCH_2_0 else {}
+            kwargs = {"foreach": False} if self.device.type == "npu" else {}
             torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=self.clip_grad_norm, **kwargs)
         self.scaler.step(self.optimizer)
         self.scaler.update()
         self.optimizer.zero_grad()
         if self.ema:
-            self.ema.update(self.model)
+            model = unwrap_model(self.model)
+            if isinstance(model, DistillationModel):
+                model = torch.nn.Sequential(model.student_model, model.projector)
+            self.ema.update_parameters(model)
 
 
 model = RTDETR("rtdetr-l.pt")

--- a/docs/en/guides/yolo-common-issues.md
+++ b/docs/en/guides/yolo-common-issues.md
@@ -30,7 +30,7 @@ This guide covers the most common problems you'll hit when working with Ultralyt
 Installation errors can arise due to various reasons, such as incompatible versions, missing dependencies, or incorrect environment setups. First, check to make sure you are doing the following:
 
 - You're using Python 3.8 or later as recommended.
-- Ensure that you have the correct version of [PyTorch](https://www.ultralytics.com/glossary/pytorch) (1.8 or later) installed.
+- Ensure that you have the correct version of [PyTorch](https://www.ultralytics.com/glossary/pytorch) (1.8 or later, 2.1 or later for training) installed.
 - Consider using virtual environments to avoid conflicts.
 - Follow the [official installation guide](../quickstart.md) step by step.
 

--- a/docs/en/guides/yolo-common-issues.md
+++ b/docs/en/guides/yolo-common-issues.md
@@ -288,7 +288,7 @@ Most YOLO26 issues trace back to a handful of causes: version mismatches, datase
 
 ### How do I resolve installation errors with YOLO26?
 
-Installation errors can often be due to compatibility issues or missing dependencies. Ensure you use Python 3.8 or later and have PyTorch 1.8 or later installed. It's beneficial to use virtual environments to avoid conflicts. For a step-by-step installation guide, follow our [official installation guide](../quickstart.md). If you encounter import errors, try a fresh installation or update the library to the latest version.
+Installation errors can often be due to compatibility issues or missing dependencies. Ensure you use Python 3.8 or later and have PyTorch 1.8 or later installed (2.1 or later to train). It's beneficial to use virtual environments to avoid conflicts. For a step-by-step installation guide, follow our [official installation guide](../quickstart.md). If you encounter import errors, try a fresh installation or update the library to the latest version.
 
 ### Why is my YOLO26 model training slow on a single GPU?
 

--- a/docs/en/help/FAQ.md
+++ b/docs/en/help/FAQ.md
@@ -42,7 +42,7 @@ Detailed installation instructions can be found in the [quickstart guide](../qui
 Minimum requirements:
 
 - Python 3.8+
-- [PyTorch](https://www.ultralytics.com/glossary/pytorch) 1.8+
+- [PyTorch](https://www.ultralytics.com/glossary/pytorch) 1.8+ (2.1+ for training)
 - CUDA-compatible GPU (for GPU acceleration)
 
 Recommended setup:

--- a/docs/en/reference/utils/torch_utils.md
+++ b/docs/en/reference/utils/torch_utils.md
@@ -12,10 +12,6 @@ keywords: Ultralytics, torch utils, model optimization, device selection, infere
 
 <br>
 
-## ::: ultralytics.utils.torch_utils.ModelEMA
-
-<br><br><hr><br>
-
 ## ::: ultralytics.utils.torch_utils.EarlyStopping
 
 <br><br><hr><br>
@@ -121,6 +117,10 @@ keywords: Ultralytics, torch utils, model optimization, device selection, infere
 <br><br><hr><br>
 
 ## ::: ultralytics.utils.torch_utils.unset_deterministic
+
+<br><br><hr><br>
+
+## ::: ultralytics.utils.torch_utils.build_ema
 
 <br><br><hr><br>
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,7 @@ from PIL import Image
 
 from tests import CUDA_DEVICE_COUNT, CUDA_IS_AVAILABLE, MODELS, TASK_MODEL_DATA
 from ultralytics.utils import ARM64, ASSETS, DATASETS_DIR, IS_RASPBERRYPI, LINUX, WEIGHTS_DIR, checks
-from ultralytics.utils.torch_utils import TORCH_1_11, TORCH_VERSION
+from ultralytics.utils.torch_utils import TORCH_2_1, TORCH_VERSION
 
 
 def run(cmd: str) -> None:
@@ -88,6 +88,7 @@ def test_cli_imports_defer_torchvision() -> None:
 
 @pytest.mark.parametrize("task,model,data", TASK_MODEL_DATA)
 @pytest.mark.skipif(IS_RASPBERRYPI, reason="Edge devices not intended for training")
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_train(task: str, model: str, data: str) -> None:
     """Test YOLO training for different tasks, models, and datasets."""
     run(f"yolo train {task} model={model} data={data} imgsz=32 epochs=1 cache=disk")
@@ -127,16 +128,17 @@ def test_export(model: str, tmp_path: Path) -> None:
         ("obb", "dota8.yaml", "yolo26n-obb.yaml", WEIGHTS_DIR / "yolo26s-obb.pt"),
     ],
 )
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_distill(task: str, data: str, student: str, teacher: Path) -> None:
     """Test YOLO knowledge distillation training via CLI for supported tasks."""
     run(f"yolo train {task} model={student} distill_model={teacher} data={data} imgsz=32 epochs=1")
 
 
-@pytest.mark.skipif(not TORCH_1_11, reason="RTDETR requires torch>=1.11")
 @pytest.mark.skipif(
     LINUX and ARM64 and checks.IS_PYTHON_3_8 and "2.1.0a0" in TORCH_VERSION,
     reason="RTDETR CPU training produces NaN losses with JetPack 5 torch 2.1.0a0",
 )
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_rtdetr(task: str = "detect", model: Path = WEIGHTS_DIR / "rtdetr-l.pt", data: str = "coco8.yaml") -> None:
     """Test the RTDETR functionality within Ultralytics for detection tasks using specified model and data."""
     # Add comma and spaces to test CLI arg cleanup.

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -18,7 +18,7 @@ from ultralytics.models.yolo import classify, depth, detect, obb, pose, segment,
 from ultralytics.nn.distill_model import DistillationModel
 from ultralytics.nn.tasks import DetectionModel, load_checkpoint
 from ultralytics.utils import ASSETS, DEFAULT_CFG, IS_RASPBERRYPI, WEIGHTS_DIR
-from ultralytics.utils.torch_utils import unwrap_model
+from ultralytics.utils.torch_utils import TORCH_2_1, unwrap_model
 
 
 def test_func(*args, **kwargs):
@@ -77,6 +77,7 @@ def test_export(monkeypatch, tmp_path):
     ],
 )
 @pytest.mark.skipif(IS_RASPBERRYPI, reason="Edge devices not intended for training")
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_task(trainer_cls, validator_cls, predictor_cls, data, model, weights):
     """Test YOLO training, validation, and prediction for various tasks."""
     overrides = {
@@ -126,6 +127,7 @@ def test_task(trainer_cls, validator_cls, predictor_cls, data, model, weights):
 
 
 @pytest.mark.parametrize("task,weight,data", TASK_MODEL_DATA)
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_resume_incomplete(task, weight, data, tmp_path):
     """Test training resumes from an incomplete checkpoint."""
     train_args = {
@@ -161,6 +163,7 @@ def test_resume_incomplete(task, weight, data, tmp_path):
     assert resume_model.trainer.start_epoch == resume_model.trainer.epoch == 1, "resume test failed"
 
 
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_distill_resume(tmp_path: Path):
     """Test knowledge distillation resumes from an incomplete checkpoint."""
     overrides = {
@@ -232,6 +235,7 @@ def test_load_checkpoint_state_dict_rejected(ckpt, tmp_path):
         load_checkpoint(weight)
 
 
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_nan_recovery():
     """Test NaN loss detection and recovery during training."""
     nan_injected = [False]
@@ -249,13 +253,14 @@ def test_nan_recovery():
     assert nan_injected[0], "NaN injection failed"
 
 
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_checkpoint_fp16_overflow():
     """Test a finite model whose weights overflow fp16 is still checkpointed (clamped) instead of skipped."""
 
     def inflate_ema(trainer):
         """Push an EMA weight above the fp16 max (65504) so its fp16 snapshot would otherwise become Inf."""
         if trainer.ema is not None:
-            next(iter(trainer.ema.ema.parameters())).data.flatten()[0] = 1.0e5
+            next(iter(trainer.ema.module.parameters())).data.flatten()[0] = 1.0e5
 
     overrides = {"data": "coco8.yaml", "model": "yolo26n.yaml", "imgsz": 32, "epochs": 2}
     trainer = detect.DetectionTrainer(overrides=overrides)
@@ -267,19 +272,20 @@ def test_checkpoint_fp16_overflow():
         "saved checkpoint contains NaN/Inf"
     )
     # Validation must leave the live EMA fp32 and unchanged; checkpoint serialization may clamp its fp16 copy.
-    ema_param = next(iter(trainer.ema.ema.parameters()))
+    ema_param = next(iter(trainer.ema.module.parameters()))
     assert ema_param.dtype == torch.float32 and torch.isfinite(ema_param).all() and ema_param.flatten()[0] == 1.0e5, (
         "validation corrupted the live EMA"
     )
 
 
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_checkpoint_nonfinite_ema_resync():
     """Test a non-finite EMA on a finite model is resynced (not skipped) so the run still produces a checkpoint."""
 
     def poison_ema(trainer):
         """Make the live fp32 EMA genuinely non-finite while the model stays finite (sticky-NaN on a finite-loss run)."""
         if trainer.ema is not None:
-            next(iter(trainer.ema.ema.parameters())).data.flatten()[0] = float("inf")
+            next(iter(trainer.ema.module.parameters())).data.flatten()[0] = float("inf")
 
     overrides = {"data": "coco8.yaml", "model": "yolo26n.yaml", "imgsz": 32, "epochs": 2}
     trainer = detect.DetectionTrainer(overrides=overrides)
@@ -292,13 +298,14 @@ def test_checkpoint_nonfinite_ema_resync():
     )
 
 
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_checkpoint_nonfinite_ema_and_model_sanitized():
     """Test a tensor non-finite in both EMA and model is sanitized (not skipped) so the run still produces a checkpoint."""
 
     def poison_ema_and_model(trainer):
         """Force the first parameter non-finite in both the live EMA and the model (finite-loss sticky-NaN)."""
         if trainer.ema is not None:
-            next(iter(trainer.ema.ema.parameters())).data.flatten()[0] = float("inf")
+            next(iter(trainer.ema.module.parameters())).data.flatten()[0] = float("inf")
             next(iter(unwrap_model(trainer.model).parameters())).data.flatten()[0] = float("nan")
 
     overrides = {"data": "coco8.yaml", "model": "yolo26n.yaml", "imgsz": 32, "epochs": 1}
@@ -317,6 +324,7 @@ def test_checkpoint_nonfinite_ema_and_model_sanitized():
     [({}, True), ({"pretrained": True}, True), ({"pretrained": False}, False), ({"pretrained": MODEL}, True)],
 )
 @pytest.mark.skipif(IS_RASPBERRYPI, reason="Edge devices not intended for training")
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_train_reuses_loaded_checkpoint_model(monkeypatch, kwargs, uses_weights):
     """Test training reuses loaded checkpoint config while respecting the pretrained argument."""
     model = YOLO("yolo26n.yaml")
@@ -359,6 +367,7 @@ def test_train_reuses_loaded_checkpoint_model(monkeypatch, kwargs, uses_weights)
     assert captured["weights"] is (original_model if uses_weights else None), "Unexpected weights loaded"
 
 
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_train_multi_custom_trainer_metrics_and_failure_keys(monkeypatch, tmp_path):
     """Test custom multi-dataset runs keep memory metrics and unique failure keys."""
     model = YOLO(MODEL)

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -11,9 +11,11 @@ from tests import SOURCE
 from ultralytics import YOLO, download
 from ultralytics.utils import ASSETS_URL, DATASETS_DIR, SETTINGS
 from ultralytics.utils.checks import check_requirements
+from ultralytics.utils.torch_utils import TORCH_2_1
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_tensorboard():
     """Test training with TensorBoard logging enabled."""
     SETTINGS["tensorboard"] = True
@@ -22,6 +24,7 @@ def test_tensorboard():
 
 
 @pytest.mark.skipif(not check_requirements("ray", install=False), reason="ray[tune] not installed")
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_model_ray_tune():
     """Tune YOLO model using Ray for hyperparameter optimization."""
     YOLO("yolo26n-cls.yaml").tune(
@@ -30,6 +33,7 @@ def test_model_ray_tune():
 
 
 @pytest.mark.skipif(not check_requirements("mlflow", install=False), reason="mlflow not installed")
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_mlflow(tmp_path, monkeypatch):
     """Test training with MLflow tracking enabled."""
     import mlflow
@@ -45,6 +49,7 @@ def test_mlflow(tmp_path, monkeypatch):
 
 
 @pytest.mark.skipif(not check_requirements("mlflow", install=False), reason="mlflow not installed")
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_mlflow_keep_run_active(tmp_path, monkeypatch):
     """Ensure MLFLOW_KEEP_RUN_ACTIVE controls whether new MLflow runs remain active."""
     import mlflow

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1875,7 +1875,6 @@ def test_nn_depth_head_export_upsamples_to_input():
     assert head(_depth_head_feats()).shape[-2:] != (256, 256)  # inference returns native head resolution
 
 
-@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_nn_depth_head_no_dead_parameters():
     """Every head parameter receives gradient — DDP then needs no find_unused_parameters."""
     from ultralytics.nn.modules.head import Depth

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -43,7 +43,7 @@ from ultralytics.utils import (
     is_github_action_running,
 )
 from ultralytics.utils.downloads import download, safe_download
-from ultralytics.utils.torch_utils import TORCH_1_10, TORCH_1_11, TORCH_1_13, TORCH_2_1
+from ultralytics.utils.torch_utils import TORCH_1_10, TORCH_1_11, TORCH_1_13, TORCH_2_1, build_ema
 
 
 def test_dataloader_caps_workers_to_batches():
@@ -100,6 +100,19 @@ def test_dataloader_empty_dataset_uses_dataloader_validation():
     """Test empty datasets fail through DataLoader validation instead of worker-cap math."""
     with pytest.raises(ValueError, match="positive integer"):
         build_dataloader([], batch=4, workers=2)
+
+
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
+def test_build_ema_decay_uses_next_update():
+    """Test EMA decay uses the update being applied rather than the previous update count."""
+    model = torch.nn.Linear(1, 1, bias=False)
+    model.weight.data.fill_(1)
+    ema = build_ema(model, decay=0.9, tau=1)
+    ema.update_parameters(model)
+    model.weight.data.zero_()
+    ema.update_parameters(model)
+    assert ema.n_averaged == 2
+    assert ema.module.weight.item() == pytest.approx(0.9 * (1 - np.exp(-2)))
 
 
 def test_build_yolo_dataset_hyp_isolated():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -43,7 +43,7 @@ from ultralytics.utils import (
     is_github_action_running,
 )
 from ultralytics.utils.downloads import download, safe_download
-from ultralytics.utils.torch_utils import TORCH_1_10, TORCH_1_11, TORCH_1_13
+from ultralytics.utils.torch_utils import TORCH_1_10, TORCH_1_11, TORCH_1_13, TORCH_2_1
 
 
 def test_dataloader_caps_workers_to_batches():
@@ -762,6 +762,7 @@ def test_pose_metrics_curves():
 
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")
 @pytest.mark.skipif(IS_JETSON or IS_RASPBERRYPI, reason="Edge devices not intended for training")
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_train_multi():
     """Test fine-tuning a base model across a dataset collection, which triggers MultiTrainer for list/tuple data."""
     model = YOLO(MODEL)
@@ -974,6 +975,7 @@ def test_platform_job_transport(monkeypatch, tmp_path):
 
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")
 @pytest.mark.skipif(IS_JETSON or IS_RASPBERRYPI, reason="Edge devices not intended for training")
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_train_scratch():
     """Test training the YOLO model from scratch on 12 different image types in the COCO12-Formats dataset."""
     model = YOLO(CFG)
@@ -983,6 +985,7 @@ def test_train_scratch():
 
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")
 @pytest.mark.skipif(IS_RASPBERRYPI, reason="Edge devices not intended for training")
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_train_ndjson():
     """Test training the YOLO model using NDJSON format dataset."""
     model = YOLO(WEIGHTS_DIR / "yolo26n.pt")
@@ -991,6 +994,7 @@ def test_train_ndjson():
 
 @pytest.mark.parametrize("scls", [False, True])
 @pytest.mark.skipif(IS_RASPBERRYPI, reason="Edge devices not intended for training")
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_train_pretrained(scls):
     """Test training of the YOLO model starting from a pre-trained checkpoint."""
     model = YOLO(WEIGHTS_DIR / "yolo26n-seg.pt")
@@ -1011,6 +1015,7 @@ def test_all_model_yamls():
 
 
 @pytest.mark.skipif(WINDOWS, reason="Windows slow CI export bug https://github.com/ultralytics/ultralytics/pull/16003")
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_workflow(isolated_model):
     """Test the complete workflow including training, validation, prediction, and exporting."""
     model = YOLO(isolated_model)
@@ -1870,6 +1875,7 @@ def test_nn_depth_head_export_upsamples_to_input():
     assert head(_depth_head_feats()).shape[-2:] != (256, 256)  # inference returns native head resolution
 
 
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_nn_depth_head_no_dead_parameters():
     """Every head parameter receives gradient — DDP then needs no find_unused_parameters."""
     from ultralytics.nn.modules.head import Depth
@@ -1941,6 +1947,7 @@ def test_classify_transforms_train(image, auto_augment, erasing, force_color_jit
 @pytest.mark.slow
 @pytest.mark.skipif(IS_RASPBERRYPI or IS_JETSON, reason="Edge devices not intended for tuning")
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_model_tune():
     """Tune YOLO model for performance improvement."""
     YOLO("yolo26n.pt").tune(
@@ -1954,6 +1961,7 @@ def test_model_tune():
 @pytest.mark.skipif(IS_RASPBERRYPI or IS_JETSON, reason="Edge devices not intended for tuning")
 @pytest.mark.skipif(not ONLINE or not checks.IS_PYTHON_MINIMUM_3_10, reason="environment is offline")
 @pytest.mark.skipif(not checks.check_requirements("ray", install=False), reason="ray[tune] not installed")
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_model_tune_ray():
     """Tune YOLO model for performance improvement."""
     YOLO("yolo26n-cls.pt").tune(
@@ -2004,6 +2012,7 @@ def test_process_mask_native_chunked():
     checks.IS_PYTHON_3_8 and LINUX and ARM64,
     reason="YOLOWorld with CLIP is not supported in Python 3.8 and aarch64 Linux",
 )
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_yolo_world():
     """Test YOLO world models with CLIP support."""
     model = YOLO(WEIGHTS_DIR / "yolov8s-world.pt")  # no YOLO11n-world model yet
@@ -2041,6 +2050,7 @@ def test_yolo_world():
     checks.IS_PYTHON_3_8 and LINUX and ARM64,
     reason="YOLOE with CLIP is not supported in Python 3.8 and aarch64 Linux",
 )
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_yoloe(tmp_path):
     """Test YOLOE models with MobileCLIP support."""
     # Predict
@@ -2151,6 +2161,7 @@ def test_yoloe_visual_prompt_verbose_false(capfd):
     assert "Ultralytics" not in output
 
 
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_yolov10():
     """Test YOLOv10 model training, validation, and prediction functionality."""
     model = YOLO("yolov10n.yaml")
@@ -2161,6 +2172,7 @@ def test_yolov10():
     model(SOURCE)
 
 
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_multichannel():
     """Test YOLO model multi-channel training, validation, and prediction functionality."""
     model = YOLO("yolo26n.pt")
@@ -2172,6 +2184,7 @@ def test_multichannel():
 
 
 @pytest.mark.parametrize("task,model,data", TASK_MODEL_DATA)
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_grayscale(task: str, model: str, data: str, tmp_path) -> None:
     """Test YOLO model grayscale training, validation, and prediction functionality."""
     if IS_RASPBERRYPI and task == "semantic":
@@ -2198,6 +2211,7 @@ def test_grayscale(task: str, model: str, data: str, tmp_path) -> None:
     model.predict(source=im, imgsz=32)
 
 
+@pytest.mark.skipif(not TORCH_2_1, reason="training requires torch>=2.1")
 def test_semantic_polygon_data():
     """Test YOLO semantic segmentation model with polygon data."""
     skip_rpi_semantic()

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -39,7 +39,7 @@ profile: False # (bool) profile ONNX/TensorRT speeds during training for loggers
 freeze: # (int | list, optional) freeze first N layers (int), or specific layer indices or module names like "23.cv2" (list)
 multi_scale: 0.0 # (float) multi-scale range as a fraction of imgsz; sizes are rounded to stride multiples
 compile: False # (bool | str) enable torch.compile() backend='inductor'; True="default", False=off, or "default|reduce-overhead|max-autotune-no-cudagraphs"
-channels_last: # (bool, optional) auto-enable for CUDA training on PyTorch 1.11+ and supported x86 CPU inference
+channels_last: # (bool, optional) auto-enable for CUDA training and supported x86 CPU inference
 
 # Segmentation
 overlap_mask: True # (bool) merge instance masks into one mask during training (segment only)

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -36,6 +36,7 @@ from ultralytics.utils import (
     LOCAL_RANK,
     LOGGER,
     RANK,
+    TORCH_VERSION,
     TQDM,
     YAML,
     callbacks,
@@ -51,12 +52,14 @@ from ultralytics.utils.plotting import plot_results
 from ultralytics.utils.torch_utils import (
     TORCH_1_11,
     TORCH_2_0,
+    TORCH_2_1,
     TORCH_2_4,
     EarlyStopping,
-    ModelEMA,
     attempt_compile,
     autocast,
+    build_ema,
     convert_optimizer_state_dict_to_fp16,
+    copy_attr,
     get_torch_device_backend,
     init_seeds,
     one_cycle,
@@ -92,7 +95,7 @@ class BaseTrainer:
         amp (bool): Whether Automatic Mixed Precision is enabled.
         scaler (torch.amp.GradScaler): Gradient scaler for AMP.
         data (dict): Dataset dictionary containing paths and metadata.
-        ema (ModelEMA): EMA (Exponential Moving Average) of the model.
+        ema (AveragedModel): EMA (Exponential Moving Average) of the model.
         resume (bool): Resume training from a checkpoint.
         lf (callable): Learning rate scheduling function.
         scheduler (torch.optim.lr_scheduler._LRScheduler): Learning rate scheduler.
@@ -129,6 +132,9 @@ class BaseTrainer:
             _callbacks (dict, optional): Dictionary of callback functions.
         """
         self.args = get_cfg(cfg, overrides)
+        assert TORCH_2_1, (
+            f"Training requires torch>=2.1 (found torch=={TORCH_VERSION}); inference and export run on torch>=1.8"
+        )
         if getattr(self.args, "augmentations", None) and not isinstance(self.args.augmentations[0], dict):
             import albumentations as A
 
@@ -411,7 +417,7 @@ class BaseTrainer:
             self.args.batch = self.batch_size = self.auto_batch()
         self._build_train_pipeline()
         self.validator = self.get_validator()
-        self.ema = ModelEMA(self.model)
+        self.ema = build_ema(self.model)
         self.set_class_weights()  # compute class weights after dataloader is ready
         if RANK in {-1, 0}:
             metric_keys = self.validator.metrics.keys + self.label_loss_items(prefix="val")
@@ -598,7 +604,11 @@ class BaseTrainer:
 
             self.run_callbacks("on_train_epoch_end")
             if RANK in {-1, 0}:
-                self.ema.update_attr(self.model, include=["yaml", "nc", "args", "names", "stride", "class_weights"])
+                copy_attr(
+                    self.ema.module,
+                    unwrap_model(self.model),
+                    include=["yaml", "nc", "args", "names", "stride", "class_weights"],
+                )
 
             # Validation
             final_epoch = epoch + 1 >= self.epochs
@@ -723,7 +733,7 @@ class BaseTrainer:
         # save_model would otherwise skip every epoch and the run would finish with no checkpoint on valid input.
         # Resync each poisoned EMA tensor from the live model where finite; any tensor that is non-finite in both is
         # left for the nan_to_num_ pass below, so a usable checkpoint is always written.
-        ema = unwrap_model(self.ema.ema)
+        ema = self.ema.module
         if not all(torch.isfinite(v).all() for v in ema.state_dict().values() if isinstance(v, torch.Tensor)):
             model_sd = unwrap_model(self.model).state_dict()
             for k, v in ema.state_dict().items():
@@ -747,7 +757,7 @@ class BaseTrainer:
                 "best_fitness": self.best_fitness,
                 "model": None,  # resume and final checkpoints derive from EMA
                 "ema": ema,
-                "updates": self.ema.updates,
+                "updates": int(self.ema.n_averaged),
                 "optimizer": convert_optimizer_state_dict_to_fp16(deepcopy(self.optimizer.state_dict())),
                 "scaler": self.scaler.state_dict(),
                 "train_args": vars(self.args),  # save as dict
@@ -856,7 +866,10 @@ class BaseTrainer:
         self.scaler.update()
         self.optimizer.zero_grad()
         if self.ema:
-            self.ema.update(self.model)
+            model = unwrap_model(self.model)
+            if hasattr(model, "teacher_model"):  # the EMA carries no teacher, so average the student stream only
+                model = nn.Sequential(model.student_model, model.projector)
+            self.ema.update_parameters(model)
 
     def preprocess_batch(self, batch):
         """Allow custom preprocessing of model inputs and ground truths depending on task type."""
@@ -872,7 +885,7 @@ class BaseTrainer:
         """
         if self.ema and self.world_size > 1:
             # Sync EMA buffers from rank 0 to all ranks
-            for buffer in self.ema.ema.buffers():
+            for buffer in self.ema.module.buffers():
                 dist.broadcast(buffer, src=0)
         metrics = self.validator(self)
         if metrics is None:
@@ -1012,9 +1025,9 @@ class BaseTrainer:
         if ckpt.get("scaler") is not None:
             self.scaler.load_state_dict(ckpt["scaler"])
         if self.ema and ckpt.get("ema"):
-            self.ema = ModelEMA(self.model)  # validation with EMA creates inference tensors that can't be updated
-            self.ema.ema.load_state_dict(ckpt["ema"].float().state_dict())
-            self.ema.updates = ckpt["updates"]
+            self.ema = build_ema(self.model)  # validation with EMA creates inference tensors that can't be updated
+            self.ema.module.load_state_dict(ckpt["ema"].float().state_dict())
+            self.ema.n_averaged.fill_(ckpt["updates"])
         self.best_fitness = ckpt.get("best_fitness")
 
     def _handle_nan_recovery(self, epoch):

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -45,14 +45,18 @@ from ultralytics.utils import (
     emojis,
 )
 from ultralytics.utils.autobatch import check_train_batch_size
-from ultralytics.utils.checks import check_amp, check_file, check_imgsz, check_model_file_from_stem, print_args
+from ultralytics.utils.checks import (
+    check_amp,
+    check_file,
+    check_imgsz,
+    check_model_file_from_stem,
+    check_version,
+    print_args,
+)
 from ultralytics.utils.dist import ddp_cleanup, generate_ddp_command
 from ultralytics.utils.files import get_latest_run
 from ultralytics.utils.plotting import plot_results
 from ultralytics.utils.torch_utils import (
-    TORCH_1_11,
-    TORCH_2_0,
-    TORCH_2_1,
     TORCH_2_4,
     EarlyStopping,
     attempt_compile,
@@ -132,9 +136,9 @@ class BaseTrainer:
             _callbacks (dict, optional): Dictionary of callback functions.
         """
         self.args = get_cfg(cfg, overrides)
-        assert TORCH_2_1, (
-            f"Training requires torch>=2.1 (found torch=={TORCH_VERSION}); inference and export run on torch>=1.8"
-        )
+        check_version(
+            TORCH_VERSION, "2.1.0", name="torch", hard=True
+        )  # AveragedModel multi_avg_fn; inference runs on 1.8
         if getattr(self.args, "augmentations", None) and not isinstance(self.args.augmentations[0], dict):
             import albumentations as A
 
@@ -324,7 +328,7 @@ class BaseTrainer:
         self.model = self.model.to(self.device)
         # channels_last (NHWC) is CUDA-only: lossless and Tensor-Core friendly there, but numerically wrong
         # on MPS and no benefit on CPU
-        channels_last = self.args.channels_last is True or (self.args.channels_last is None and TORCH_1_11)
+        channels_last = self.args.channels_last is not False
         if channels_last and self.device.type == "cuda":
             self.model = self.model.to(memory_format=torch.channels_last)
         elif self.args.channels_last:
@@ -403,13 +407,12 @@ class BaseTrainer:
         if self.world_size > 1:
             # static_graph=True permits params used >1 time per forward (e.g. flow_model in
             # o2m+o2o pose loss branches) under torch.compile.
-            ddp_kwargs = {"static_graph": bool(self.args.compile)} if TORCH_1_11 else {}
             self.model = nn.parallel.DistributedDataParallel(
                 self.model,
                 device_ids=[self.device.index],
                 broadcast_buffers=False,
                 find_unused_parameters=not bool(self.args.compile),
-                **ddp_kwargs,
+                static_graph=bool(self.args.compile),
             )
 
         # Batch size
@@ -858,7 +861,7 @@ class BaseTrainer:
     def optimizer_step(self):
         """Perform a single step of the training optimizer with gradient clipping and EMA update."""
         self.scaler.unscale_(self.optimizer)  # unscale gradients
-        if self.device.type == "npu" and TORCH_2_0:
+        if self.device.type == "npu":
             torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=10.0, foreach=False)
         else:
             torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=10.0)
@@ -867,7 +870,7 @@ class BaseTrainer:
         self.optimizer.zero_grad()
         if self.ema:
             model = unwrap_model(self.model)
-            if hasattr(model, "teacher_model"):  # the EMA carries no teacher, so average the student stream only
+            if isinstance(model, DistillationModel):  # the EMA carries no teacher, so average the student stream only
                 model = nn.Sequential(model.student_model, model.projector)
             self.ema.update_parameters(model)
 

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -160,7 +160,7 @@ class BaseValidator:
             self.data = trainer.data
             # Keep training validation read-only: inputs may be fp16, but EMA/model weights stay fp32 under autocast.
             self.args.quantize = 16 if (self.device.type != "cpu" and trainer.amp) else None
-            model = trainer.ema.ema or trainer.model
+            model = trainer.ema.module or trainer.model
             if trainer.args.compile and hasattr(model, "_orig_mod"):
                 model = model._orig_mod  # validate non-compiled original model to avoid issues
             model = model.float()

--- a/ultralytics/models/yolo/world/train.py
+++ b/ultralytics/models/yolo/world/train.py
@@ -19,7 +19,7 @@ def on_pretrain_routine_end(trainer) -> None:
     """Set up model classes and text encoder at the end of the pretrain routine."""
     # Set on all ranks: validation runs on every rank, but txt_feats/nc are not DDP buffers so they don't sync
     names = [name.split("/", 1)[0] for name in list(trainer.test_loader.dataset.data["names"].values())]
-    unwrap_model(trainer.ema.ema).set_classes(names, cache_clip_model=False)
+    trainer.ema.module.set_classes(names, cache_clip_model=False)
 
 
 class WorldTrainer(DetectionTrainer):

--- a/ultralytics/models/yolo/yoloe/val.py
+++ b/ultralytics/models/yolo/yoloe/val.py
@@ -155,7 +155,7 @@ class YOLOEDetectValidator(DetectionValidator):
         """
         if trainer is not None:
             self.device = trainer.device
-            model = trainer.ema.ema
+            model = trainer.ema.module
             names = [name.split("/", 1)[0] for name in list(self.dataloader.dataset.data["names"].values())]
 
             if load_vp:

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -727,8 +727,8 @@ def unset_deterministic():
 def build_ema(model: nn.Module, decay: float = 0.9999, tau: int = 2000) -> AveragedModel:
     """Build an Exponential Moving Average (EMA) of a model's parameters and buffers.
 
-    The decay ramps as `decay * (1 - exp(-updates / tau))` so the average tracks the model closely in early training
-    and settles at `decay`, as in https://www.tensorflow.org/api_docs/python/tf/train/ExponentialMovingAverage.
+    The decay ramps as `decay * (1 - exp(-updates / tau))` so the average tracks the model closely in early training and
+    settles at `decay`, as in https://www.tensorflow.org/api_docs/python/tf/train/ExponentialMovingAverage.
 
     Args:
         model (nn.Module): Model to average; compile and parallel wrappers are unwrapped first.

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -748,7 +748,7 @@ def build_ema(model: nn.Module, decay: float = 0.9999, tau: int = 2000) -> Avera
     def update(ema_v: list[torch.Tensor], model_v: list[torch.Tensor], _):
         """Lerp one device/dtype group of EMA tensors toward the model; integer buffers keep their initial values."""
         if ema_v[0].is_floating_point():
-            w = 1 - decay * (1 - math.exp(-int(ema.n_averaged) / tau))  # `n_averaged` lives on CPU, so no device sync
+            w = 1 - decay * (1 - math.exp(-(int(ema.n_averaged) + 1) / tau))  # CPU `n_averaged` counts prior updates
             if ema_v[0].device.type != "npu" and (TORCH_2_4 or ema_v[0].device.type != "mps"):
                 torch._foreach_lerp_(ema_v, model_v, w)  # one kernel launch per group
             else:  # _foreach_lerp_ needs MPS torch>=2.4 and is unavailable on NPU

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -9,7 +9,6 @@ import os
 import random
 import time
 from contextlib import contextmanager
-from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -19,6 +18,7 @@ import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 from torch import nn
+from torch.optim.swa_utils import AveragedModel
 
 from ultralytics import __version__
 from ultralytics.utils import (
@@ -724,78 +724,39 @@ def unset_deterministic():
     os.environ.pop("PYTHONHASHSEED", None)
 
 
-class ModelEMA:
-    """Updated Exponential Moving Average (EMA) implementation.
+def build_ema(model: nn.Module, decay: float = 0.9999, tau: int = 2000) -> AveragedModel:
+    """Build an Exponential Moving Average (EMA) of a model's parameters and buffers.
 
-    Keeps a moving average of everything in the model state_dict (parameters and buffers). For EMA details see
-    References.
+    The decay ramps as `decay * (1 - exp(-updates / tau))` so the average tracks the model closely in early training
+    and settles at `decay`, as in https://www.tensorflow.org/api_docs/python/tf/train/ExponentialMovingAverage.
 
-    To disable EMA set the `enabled` attribute to `False`.
+    Args:
+        model (nn.Module): Model to average; compile and parallel wrappers are unwrapped first.
+        decay (float, optional): Maximum EMA decay rate.
+        tau (int, optional): EMA decay time constant in updates.
 
-    Attributes:
-        ema (nn.Module): Copy of the model in evaluation mode.
-        updates (int): Number of EMA updates.
-        decay (function): Decay function that determines the EMA weight.
-        enabled (bool): Whether EMA is enabled.
-
-    References:
-        - https://github.com/rwightman/pytorch-image-models
-        - https://www.tensorflow.org/api_docs/python/tf/train/ExponentialMovingAverage
+    Returns:
+        (AveragedModel): EMA whose `module` holds the averaged FP32 copy in eval mode and whose `n_averaged` buffer
+            counts the updates applied.
     """
+    ema = AveragedModel(unwrap_model(model), use_buffers=True)
+    if hasattr(ema.module, "teacher_model"):
+        ema.module.teacher_model = None  # DistillationModel: the EMA does not carry a duplicate frozen teacher
+    ema.module.eval().requires_grad_(False)
 
-    def __init__(self, model, decay=0.9999, tau=2000, updates=0):
-        """Initialize EMA for 'model' with given arguments.
-
-        Args:
-            model (nn.Module): Model to create EMA for.
-            decay (float, optional): Maximum EMA decay rate.
-            tau (int, optional): EMA decay time constant.
-            updates (int, optional): Initial number of updates.
-        """
-        self.ema = deepcopy(unwrap_model(model)).eval()  # FP32 EMA
-        if hasattr(self.ema, "teacher_model"):
-            # DistillationModel: strip the teacher so the EMA does not carry a full duplicate copy.
-            self.ema.teacher_model = None
-        self.updates = updates  # number of EMA updates
-        self.decay = lambda x: decay * (1 - math.exp(-x / tau))  # decay exponential ramp (to help early epochs)
-        for p in self.ema.parameters():
-            p.requires_grad_(False)
-        self.enabled = True
-
-    def update(self, model):
-        """Update EMA parameters.
-
-        Args:
-            model (nn.Module): Model to update EMA from.
-        """
-        if self.enabled:
-            self.updates += 1
-            d = self.decay(self.updates)
-
-            msd = unwrap_model(model).state_dict()  # model state_dict
-            ema_v, model_v = [], []
-            for k, v in self.ema.state_dict().items():
-                if v.dtype.is_floating_point:  # true for FP16 and FP32
-                    ema_v.append(v)
-                    model_v.append(msd[k])
-            if (
-                ema_v and TORCH_2_0 and ema_v[0].device.type != "npu" and (TORCH_2_4 or ema_v[0].device.type != "mps")
-            ):  # one kernel launch per op
-                torch._foreach_lerp_(ema_v, model_v, 1 - d)
-            else:  # _foreach_lerp_ needs torch>=2.0, MPS torch>=2.4, and is unavailable on NPU
+    @torch.no_grad()
+    def update(ema_v: list[torch.Tensor], model_v: list[torch.Tensor], _):
+        """Lerp one device/dtype group of EMA tensors toward the model; integer buffers keep their initial values."""
+        if ema_v[0].is_floating_point():
+            w = 1 - decay * (1 - math.exp(-int(ema.n_averaged) / tau))  # `n_averaged` lives on CPU, so no device sync
+            if ema_v[0].device.type != "npu" and (TORCH_2_4 or ema_v[0].device.type != "mps"):
+                torch._foreach_lerp_(ema_v, model_v, w)  # one kernel launch per group
+            else:  # _foreach_lerp_ needs MPS torch>=2.4 and is unavailable on NPU
                 for v, m in zip(ema_v, model_v):
-                    v.mul_(d).add_(m, alpha=1 - d)
+                    v.lerp_(m, w)
 
-    def update_attr(self, model, include=(), exclude=("process_group", "reducer")):
-        """Copy attributes from model to EMA, with options to include/exclude certain attributes.
-
-        Args:
-            model (nn.Module): Model to copy attributes from.
-            include (tuple, optional): Attributes to include.
-            exclude (tuple, optional): Attributes to exclude.
-        """
-        if self.enabled:
-            copy_attr(self.ema, model, include, exclude)
+    ema.multi_avg_fn = update
+    return ema
 
 
 def strip_optimizer(f: str | Path = "best.pt", s: str = "", updates: dict[str, Any] | None = None) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Replaces the custom `ModelEMA` class with PyTorch's `torch.optim.swa_utils.AveragedModel`, configured with `use_buffers=True` and a `multi_avg_fn` that keeps our ramped decay `decay * (1 - exp(-updates / tau))`. The ramp is not available off the shelf (`get_ema_multi_avg_fn` is constant-decay), so a small `build_ema()` in `torch_utils.py` wires it up and is the single owner the trainer calls at setup and on checkpoint reload.

## Changes

- `ultralytics/utils/torch_utils.py`: delete `ModelEMA`, add `build_ema(model, decay, tau)` returning an `AveragedModel` whose `module` is the FP32 EMA copy in eval mode (teacher stripped for `DistillationModel`, as before).
- `ultralytics/engine/trainer.py`: `self.ema = build_ema(self.model)`; `update()` → `update_parameters()`; `update_attr()` → `copy_attr(self.ema.module, unwrap_model(self.model), ...)`; `updates` → `int(self.ema.n_averaged)` in the checkpoint (key name unchanged, old checkpoints resume as before). For distillation the update source is `nn.Sequential(student_model, projector)` because `AveragedModel` zips parameters positionally and the EMA carries no teacher.
- `trainer.ema.ema` → `trainer.ema.module` in the validator, YOLOE val, YOLO-World train, and `tests/test_engine.py`.
- Training now requires torch>=2.1 (`multi_avg_fn` landed in 2.1; `use_buffers` in 1.11). `BaseTrainer.__init__` enforces it with `check_version(..., hard=True)`, and the `TORCH_1_11` / `TORCH_2_0` guards in the trainer that this makes always-true are deleted. Predict, val, export, and track keep the torch>=1.8 floor, so the torch 1.8 CI job skips the training tests (`skipif(not TORCH_2_1)` on 29 tests across the Python, engine, CLI, and integrations suites). README, FAQ, and AGENTS.md document the split floor.

## Breaking change

Third-party callbacks or custom trainers that read `trainer.ema.ema` or `trainer.ema.updates` must switch to `trainer.ema.module` and `trainer.ema.n_averaged`. There is no alias.

## Verification

- `AveragedModel` with the ramped `multi_avg_fn` matches `ModelEMA` on yolo26n over 5 synthetic updates to float precision from the second update onward; the first update differs only by PyTorch's initial copy. JetPack 5's torch 2.1.0a0 already carries `multi_avg_fn`, so Jetson training is unaffected.
- Distillation alignment check: after filling student params/buffers with 1.0 and projector with 2.0, every float tensor in the EMA `state_dict` holds the expected value, zero misaligned keys, zero teacher keys.
- `tests/test_engine.py` checkpoint/NaN-recovery/resume/distill_resume/train_reuses tests and `tests/test_python.py` train_scratch/train_pretrained/workflow/train_multi/grayscale pass locally on torch 2.9.1. The `test_task[Depth...]` failure is a pre-existing numpy histogram error on this machine and fails identically on `main`.

## Follow-up (separate PR)

With training pinned to torch>=2.1, the remaining `TORCH_1_x` / `TORCH_2_0` gates in training-only paths outside the trainer (`dist.py`, `tal.py`, parts of `torch_utils.py`) become dead and can be deleted.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Replaced the custom `ModelEMA` implementation with PyTorch’s `AveragedModel` while preserving Ultralytics’ ramped EMA decay and checkpoint behavior.

### 📊 Key Changes

- Added `build_ema()` in `torch_utils.py`, configuring `AveragedModel` with `use_buffers=True`, FP32 evaluation weights, disabled gradients, and a custom ramped `multi_avg_fn`.
- Updated training, validation, checkpoint loading, and model-specific workflows to use `trainer.ema.module`, `update_parameters()`, and `n_averaged`.
- Added positional student/projector averaging for `DistillationModel` so the EMA excludes the teacher model.
- Enforced PyTorch 2.1 or later for training, while prediction, validation, export, and tracking retain the PyTorch 1.8 floor; training tests now skip on older versions.
- Removed `ModelEMA` from the torch utilities reference documentation and updated custom trainer examples for the new EMA API.

### 🎯 Purpose & Impact

- Training now depends on PyTorch’s `AveragedModel` implementation and requires PyTorch 2.1 or later.
- Third-party callbacks and custom trainers must replace `trainer.ema.ema` with `trainer.ema.module` and `trainer.ema.updates` with `trainer.ema.n_averaged`; no compatibility aliases are provided.
- Checkpoints continue to use the `updates` key, and checkpoint loading restores that value into `n_averaged`.