### PR TITLE
Train a yaml-built model from weights loaded in memory

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -41,7 +41,7 @@ class Model(torch.nn.Module):
         predictor (BasePredictor): The predictor object used for making predictions.
         model (torch.nn.Module): The underlying PyTorch model.
         trainer (BaseTrainer): The trainer object used for training the model.
-        ckpt (dict): The checkpoint data if the model is loaded from a *.pt file.
+        ckpt (dict): The checkpoint data of the loaded weights, if any.
         cfg (str): The configuration of the model if loaded from a *.yaml file.
         ckpt_path (str): The path to the checkpoint file.
         overrides (dict): A dictionary of overrides for model configuration.
@@ -311,14 +311,14 @@ class Model(torch.nn.Module):
             p.requires_grad = True
         return self
 
-    def load(self, weights: str | Path = "yolo26n.pt") -> Model:
+    def load(self, weights: str | Path | dict | torch.nn.Module = "yolo26n.pt") -> Model:
         """Load parameters from the specified weights file into the model.
 
         This method supports loading weights from a file or directly from a weights object. It matches parameters by
         name and shape and transfers them to the model.
 
         Args:
-            weights (str | Path): Path to the weights file or a weights object.
+            weights (str | Path | dict | torch.nn.Module): Path to the weights file, a checkpoint dict or a module.
 
         Returns:
             (Model): The instance of the class with loaded weights.
@@ -334,8 +334,11 @@ class Model(torch.nn.Module):
         self._check_is_pytorch_model()
         if isinstance(weights, (str, Path)):
             self.overrides["pretrained"] = weights  # remember the weights for DDP training
-            weights, self.ckpt = load_checkpoint(weights)
+            weights, ckpt = load_checkpoint(weights)
+        else:
+            ckpt = {**weights, "model": self.model} if isinstance(weights, dict) else {"model": self.model}
         self.model.load(weights)
+        self.ckpt = ckpt  # train() seeds from self.model only while this is set
         return self
 
     def save(self, filename: str | Path = "saved_model.pt") -> None:

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -315,7 +315,7 @@ class BaseModel(torch.nn.Module):
             weights (dict | torch.nn.Module): The pre-trained weights to be loaded.
             verbose (bool, optional): Whether to log the transfer progress.
         """
-        model = weights["model"] if isinstance(weights, dict) else weights  # torchvision models are not dicts
+        model = (weights.get("ema") or weights["model"]) if isinstance(weights, dict) else weights  # ema first
         csd = model.float().state_dict()  # checkpoint state_dict as FP32
 
         # Remap classification head rows by class-name when nc differs (e.g. Obj365 -> COCO fine-tune)


### PR DESCRIPTION
## summary

- `Model.load()` now records a module or checkpoint-dict load in `self.ckpt`, the marker `train()` already uses to hand the loaded model to the trainer, so `YOLO("x.yaml").load(module).train()` seeds from the loaded weights instead of rebuilding from the yaml
- the marker is written after the transfer succeeds and points at the model's own module, so no caller object is retained and a passed dict is copied rather than aliased
- the `load()` signature names the accepted object types and the `ckpt` attribute docstring says when it is set
- `BaseModel.load()` takes the `ema` module of a checkpoint dict when `model` is `None`, as `load_checkpoint()` does, so a trainer's `last.pt` dict loads instead of raising; one commit per change

## measured

cpu, coco8, yolo26n. the donor carries a zeroed `model.0.conv.weight`; w0 is its absolute sum at `on_train_start`, so 0.0 means the loaded weights reached the trainer, 41.75 the yaml init and 90.58 the `yolo26n.pt` file.

| sequence | before | after |
| -- | -- | -- |
| `YOLO(yaml).load(module).train()` | 41.75, trainer built its own model | 0.0 |
| `YOLO(yaml).load(ckpt_dict).train()` | 41.75 | 0.0 |
| `YOLO(yaml).load(torch.load("last.pt")).train()` | `AttributeError: 'NoneType' object has no attribute 'float'` | 90.58, the ema weights, one transfer |
| `YOLO(yaml).train()`, two runs with `seed=0, deterministic=True` | identical weights | identical weights |
| `YOLO(yaml).load("yolo26n.pt")`, `YOLO(pt).load(module)`, `pretrained=False`, `pretrained="yolo26n.pt"` | 90.58 / 0.0 / 41.75 / 90.58 | same |
| `YOLO(last.pt).load(module).train(resume=True)` | resumes `last.pt`, loaded weights dropped | not-resumable warning, new run from the loaded weights |
| `save()` after `YOLO(pt).load(module)` | keeps the old file's epoch, optimizer and train_args | writes the current model and metadata only |
| donor object retained in `self.ckpt` after `load(module)` | n/a | no |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

`Model.load()` now preserves in-memory module and checkpoint-dict loads for training, while checkpoint loading prefers EMA weights when available.

### 📊 Key Changes

- Expanded `Model.load()` to accept checkpoint dictionaries and `torch.nn.Module` objects in addition to file paths.
- Records a copied checkpoint marker after successful weight transfer so `train()` initializes the trainer from the loaded model rather than rebuilding from YAML.
- Stores the model’s own module in the marker for in-memory loads instead of retaining the caller’s object.
- Updated `BaseModel.load()` to use a checkpoint dictionary’s `ema` module when present, falling back to `model`.
- Clarified the `ckpt` attribute and `load()` parameter documentation.

### 🎯 Purpose & Impact

- `YOLO("model.yaml").load(module).train()` and the equivalent checkpoint-dictionary workflow now train from the transferred weights.
- Loading a trainer checkpoint dictionary containing EMA weights now succeeds and transfers those EMA weights.
- In-memory loads no longer retain the donor object in `self.ckpt`; subsequent saves use the current model metadata rather than stale checkpoint metadata.
- Resume training after loading a separate module is treated as a new, non-resumable run instead of silently restoring the original checkpoint state.