### PR TITLE
Keep a nonzero fraction from selecting zero images

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -110,6 +110,13 @@ def test_build_yolo_dataset_hyp_isolated():
     assert cfg.mosaic == DEFAULT_CFG.mosaic
 
 
+def test_dataset_fraction_selects_at_least_one_image():
+    """Test a fraction that rounds down to zero images still selects one, as get_split_fraction() promises."""
+    data = check_det_dataset("coco8.yaml")
+    cfg = get_cfg(overrides={"data": "coco8.yaml", "imgsz": 32, "fraction": 0.05})  # 4 images, rounds to 0
+    assert len(data_build.build_yolo_dataset(cfg, data["train"], batch=1, data=data, mode="train").im_files) == 1
+
+
 def test_cfg_rejects_fuzzed_values():
     """Test invalid overrides fail in config validation."""
     with pytest.raises(TypeError, match="degrees"):
@@ -1897,6 +1904,9 @@ def test_classification_fraction_samples_across_classes(tmp_path):
     samples = ClassificationDataset(tmp_path, args, augment=True).samples
 
     assert np.bincount([sample[1] for sample in samples]).tolist() == [2, 2, 2]
+
+    args.fraction = 0.01  # rounds down to zero images
+    assert len(ClassificationDataset(tmp_path, args, augment=True).samples) == 1
 
 
 @pytest.fixture

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -110,13 +110,6 @@ def test_build_yolo_dataset_hyp_isolated():
     assert cfg.mosaic == DEFAULT_CFG.mosaic
 
 
-def test_dataset_fraction_selects_at_least_one_image():
-    """Test a fraction that rounds down to zero images still selects one, as get_split_fraction() promises."""
-    data = check_det_dataset("coco8.yaml")
-    cfg = get_cfg(overrides={"data": "coco8.yaml", "imgsz": 32, "fraction": 0.05})  # 4 images, rounds to 0
-    assert len(data_build.build_yolo_dataset(cfg, data["train"], batch=1, data=data, mode="train").im_files) == 1
-
-
 def test_cfg_rejects_fuzzed_values():
     """Test invalid overrides fail in config validation."""
     with pytest.raises(TypeError, match="degrees"):
@@ -1904,12 +1897,6 @@ def test_classification_fraction_samples_across_classes(tmp_path):
     samples = ClassificationDataset(tmp_path, args, augment=True).samples
 
     assert np.bincount([sample[1] for sample in samples]).tolist() == [2, 2, 2]
-
-    args.fraction = 0.01  # rounds down to zero images
-    assert len(ClassificationDataset(tmp_path, args, augment=True).samples) == 1
-
-    args.fraction = [1, 1, 0]  # a zero test fraction still selects nothing
-    assert ClassificationDataset(tmp_path, args, augment=False, prefix="test").samples == []
 
 
 @pytest.fixture

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1908,6 +1908,9 @@ def test_classification_fraction_samples_across_classes(tmp_path):
     args.fraction = 0.01  # rounds down to zero images
     assert len(ClassificationDataset(tmp_path, args, augment=True).samples) == 1
 
+    args.fraction = [1, 1, 0]  # a zero test fraction still selects nothing
+    assert ClassificationDataset(tmp_path, args, augment=False, prefix="test").samples == []
+
 
 @pytest.fixture
 def image():

--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -197,7 +197,7 @@ class BaseDataset(Dataset):
             assert im_files, f"{self.prefix}No images found in {img_path}. {FORMATS_HELP_MSG}"
         except Exception as e:
             raise FileNotFoundError(f"{self.prefix}Error loading data from {img_path}\n{HELP_URL}") from e
-        count = self.fraction if isinstance(self.fraction, int) else round(len(im_files) * self.fraction)
+        count = self.fraction if isinstance(self.fraction, int) else max(1, round(len(im_files) * self.fraction))
         im_files = im_files[:count] if count < len(im_files) else im_files
         check_file_speeds(im_files, prefix=self.prefix)  # check image read speeds
         return im_files

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -1176,7 +1176,7 @@ class ClassificationDataset:
 
         # Initialize attributes
         fraction = 1.0 if is_ndjson else get_split_fraction(args.fraction, prefix or ("train" if augment else "val"))
-        count = fraction if isinstance(fraction, int) else round(len(self.samples) * fraction)
+        count = fraction if isinstance(fraction, int) else max(1, round(len(self.samples) * fraction))
         self.samples = (
             [self.samples[i] for i in np.linspace(0, len(self.samples) - 1, count, dtype=int)]
             if count < len(self.samples)

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -1176,7 +1176,9 @@ class ClassificationDataset:
 
         # Initialize attributes
         fraction = 1.0 if is_ndjson else get_split_fraction(args.fraction, prefix or ("train" if augment else "val"))
-        count = fraction if isinstance(fraction, int) else max(1, round(len(self.samples) * fraction))
+        count = (
+            fraction if isinstance(fraction, int) else max(1, round(len(self.samples) * fraction)) if fraction else 0
+        )
         self.samples = (
             [self.samples[i] for i in np.linspace(0, len(self.samples) - 1, count, dtype=int)]
             if count < len(self.samples)

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -1176,9 +1176,7 @@ class ClassificationDataset:
 
         # Initialize attributes
         fraction = 1.0 if is_ndjson else get_split_fraction(args.fraction, prefix or ("train" if augment else "val"))
-        count = (
-            fraction if isinstance(fraction, int) else max(1, round(len(self.samples) * fraction)) if fraction else 0
-        )
+        count = fraction if isinstance(fraction, int) else max(int(fraction > 0), round(len(self.samples) * fraction))
         self.samples = (
             [self.samples[i] for i in np.linspace(0, len(self.samples) - 1, count, dtype=int)]
             if count < len(self.samples)


### PR DESCRIPTION
Positive fractions can round to zero and discard every image, crashing detection or classification dataset loading. Clamp the count at the existing dataset owners while preserving integer counts and the explicit zero test split. The complete change is two replaced lines, with no new helper, argument, or test code.

Validation: real COCO8 dataset construction at nine fractions/counts; real classification ImageFolder sampling, including a zero test split; existing classification sampling and dataset construction tests. No mocked platform, device, or dataset state.
