### PR TITLE
Hand DDP workers the module the parent trainer prepared

### DIFF
--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -85,7 +85,7 @@ def generate_ddp_file(trainer: BaseTrainer) -> str:
         file.write(
             f"""
 # Ultralytics Multi-GPU training temp file (should be automatically deleted after use)
-from pathlib import Path, PosixPath  # For model arguments stored as Path instead of str
+from pathlib import Path, PosixPath, WindowsPath  # For model arguments stored as Path instead of str
 overrides = {vars(trainer.args)}
 
 if __name__ == "__main__":

--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -6,9 +6,11 @@ import os
 import shutil
 import sys
 import tempfile
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from . import USER_CONFIG_DIR
+from .patches import torch_save
 from .torch_utils import TORCH_1_9
 
 if TYPE_CHECKING:
@@ -66,8 +68,22 @@ def generate_ddp_file(trainer: BaseTrainer) -> str:
         - Training initialization code
     """
     module, name = f"{trainer.__class__.__module__}.{trainer.__class__.__name__}".rsplit(".", 1)
-
-    content = f"""
+    (USER_CONFIG_DIR / "DDP").mkdir(exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        prefix="_temp_",
+        suffix=f"{id(trainer)}.py",
+        mode="w+",
+        encoding="utf-8",
+        dir=USER_CONFIG_DIR / "DDP",
+        delete=False,
+    ) as file:
+        model = ""
+        if hasattr(trainer.model, "yaml"):  # workers rebuild from args, so hand them the module the caller prepared
+            path = Path(file.name).with_suffix(".pt")
+            torch_save({"model": trainer.model, "train_args": vars(trainer.args)}, path)
+            model = f"trainer.model, trainer.args.pretrained = {str(path)!r}, True\n    "
+        file.write(
+            f"""
 # Ultralytics Multi-GPU training temp file (should be automatically deleted after use)
 from pathlib import Path, PosixPath  # For model arguments stored as Path instead of str
 overrides = {vars(trainer.args)}
@@ -79,18 +95,9 @@ if __name__ == "__main__":
     cfg = DEFAULT_CFG_DICT.copy()
     cfg.update(save_dir='')   # handle the extra key 'save_dir'
     trainer = {name}(cfg=cfg, overrides=overrides)
-    results = trainer.train()
+    {model}results = trainer.train()
 """
-    (USER_CONFIG_DIR / "DDP").mkdir(exist_ok=True)
-    with tempfile.NamedTemporaryFile(
-        prefix="_temp_",
-        suffix=f"{id(trainer)}.py",
-        mode="w+",
-        encoding="utf-8",
-        dir=USER_CONFIG_DIR / "DDP",
-        delete=False,
-    ) as file:
-        file.write(content)
+        )
     return file.name
 
 
@@ -141,3 +148,4 @@ def ddp_cleanup(trainer: BaseTrainer, file: str) -> None:
     """
     if f"{id(trainer)}.py" in file:  # if temp_file suffix in file
         os.remove(file)
+        Path(file).with_suffix(".pt").unlink(missing_ok=True)  # the module written for the workers, if any


### PR DESCRIPTION
## summary

- the DDP launcher writes the module the parent trainer holds to a temporary checkpoint next to the generated script, and the workers load it instead of rebuilding from the `model` path, so weights that exist only in memory (a `load(<module>)`, `reset_weights()`, an in-memory class-name alias) reach multi-GPU training the way they reach single-GPU training
- the persisted `model` argument is untouched: the generated script assigns the checkpoint to `trainer.model` right before `train()`, and `ddp_cleanup` removes it together with the script; string models (CLI, `resume`, a bare yaml) take the unchanged path
- second commit: the generated script imports `WindowsPath` next to `PosixPath`, so a `Path`-valued override loads on Windows too

## measured

cpu; no multi-GPU host was available, so the launch is exercised up to the subprocess call and the worker side through its own construction from the generated script and `setup_model()`. w0 is the absolute sum of `model.0.conv.weight`: 0.0 is the zeroed donor, 90.58 the `yolo26n.pt` file, 41.75 the trainer-seeded yaml init.

| sequence | before: worker loads / w0 | after |
| -- | -- | -- |
| `YOLO(pt).load(<zeroed module>).train(device="0,1")` | `yolo26n.pt` / 90.58 | temp checkpoint / 0.0 |
| `YOLO(pt).reset_weights().train(device="0,1")`, parent 42.78 | `yolo26n.pt` / 90.58 | temp checkpoint / 42.78 |
| `YOLO(pt).train(device="0,1")` | `yolo26n.pt` / 90.58 | temp checkpoint / 90.58 |
| `YOLO(yaml).load("yolo26n.pt").train(device="0,1")` | `yolo26n.pt` via `pretrained` / 90.58 | temp checkpoint / 90.58 |
| `YOLO(yaml).train(device="0,1")`, `train(resume=True, device="0,1")` | yaml / `last.pt` | same |
| worker `args.model` in `args.yaml` and checkpoint `train_args` | caller's value | same |
| files left in the DDP temp dir after cleanup | 0 | 0 |
| cost per launch, `torch_save` fp32 | none | yolo26n 44 ms, 10.8 MB; yolo26m 328 ms, 88 MB |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
DDP now passes the parent trainer’s prepared in-memory model to workers through a temporary checkpoint, preserving model state that would otherwise be rebuilt from the model path.

### 📊 Key Changes
- `generate_ddp_file()` saves `trainer.model` and training arguments to a temporary `.pt` file when the model has a `yaml` attribute.
- The generated worker script assigns that checkpoint to `trainer.model` and sets `trainer.args.pretrained` immediately before `train()`.
- `ddp_cleanup()` removes the temporary checkpoint alongside the generated DDP script.
- Generated scripts now import `WindowsPath` in addition to `PosixPath`, allowing `Path`-valued model overrides on Windows.
- String-based model inputs continue through the existing worker initialization path.

### 🎯 Purpose & Impact
- Multi-GPU workers receive in-memory changes such as loaded weights, reset weights, and model configuration aliases instead of reconstructing the model solely from the original path.
- The persisted `model` argument and checkpoint training arguments remain unchanged, while temporary DDP artifacts are cleaned up after launch.