### PR TITLE
Export a copy of the model before writing its head and names

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -672,6 +672,15 @@ class Exporter:
                 raise ValueError(
                     "IMX export only supported for detection, pose estimation, classification, and segmentation models."
                 )
+        if isinstance(model, WorldModel):
+            LOGGER.warning(
+                "YOLOWorld (original version) export is not supported to any format. "
+                "YOLOWorldv2 models (i.e. 'yolov8s-worldv2.pt') only support export to "
+                "(torchscript, onnx, openvino, engine, coreml) formats. "
+                "See https://docs.ultralytics.com/models/yolo-world for details."
+            )
+            model.clip_model = None  # openvino int8 export error: https://github.com/ultralytics/ultralytics/pull/18445
+        model = deepcopy(model).to(self.device)  # copy before the head and names writes below; the caller keeps its own
         if not hasattr(model, "names"):
             model.names = default_class_names()
         model.names = check_class_names(model.names)
@@ -820,14 +829,6 @@ class Exporter:
             elif self.args.batch != 1:  # see github.com/ultralytics/ultralytics/pull/13420
                 LOGGER.warning("Edge TPU export requires batch size 1, setting batch=1.")
                 self.args.batch = 1
-        if isinstance(model, WorldModel):
-            LOGGER.warning(
-                "YOLOWorld (original version) export is not supported to any format. "
-                "YOLOWorldv2 models (i.e. 'yolov8s-worldv2.pt') only support export to "
-                "(torchscript, onnx, openvino, engine, coreml) formats. "
-                "See https://docs.ultralytics.com/models/yolo-world for details."
-            )
-            model.clip_model = None  # openvino int8 export error: https://github.com/ultralytics/ultralytics/pull/18445
         if self.args.quantize in {8, "w8a16"} and not self.args.data:
             self.args.data = DEFAULT_CFG.data or TASK2DATA[getattr(model, "task", "detect")]  # assign default data
             LOGGER.warning(
@@ -851,7 +852,6 @@ class Exporter:
             file = Path(file.name)
 
         # Update model
-        model = deepcopy(model).to(self.device)
         for p in model.parameters():
             p.requires_grad = False
         model.eval()

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -682,7 +682,9 @@ class Exporter:
             )
             # Keep a cached CLIP encoder out of the export copy: https://github.com/ultralytics/ultralytics/pull/18445
             memo[id(getattr(model, "clip_model", None))] = None
-        model = deepcopy(model, memo).to(self.device)  # copy before the head and names writes below; the caller keeps its own
+        model = deepcopy(model, memo).to(
+            self.device
+        )  # copy before the head and names writes below; the caller keeps its own
         if not hasattr(model, "names"):
             model.names = default_class_names()
         model.names = check_class_names(model.names)

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -672,6 +672,7 @@ class Exporter:
                 raise ValueError(
                     "IMX export only supported for detection, pose estimation, classification, and segmentation models."
                 )
+        memo = {}
         if isinstance(model, WorldModel):
             LOGGER.warning(
                 "YOLOWorld (original version) export is not supported to any format. "
@@ -679,8 +680,9 @@ class Exporter:
                 "(torchscript, onnx, openvino, engine, coreml) formats. "
                 "See https://docs.ultralytics.com/models/yolo-world for details."
             )
-            model.clip_model = None  # openvino int8 export error: https://github.com/ultralytics/ultralytics/pull/18445
-        model = deepcopy(model).to(self.device)  # copy before the head and names writes below; the caller keeps its own
+            # Keep a cached CLIP encoder out of the export copy: https://github.com/ultralytics/ultralytics/pull/18445
+            memo[id(getattr(model, "clip_model", None))] = None
+        model = deepcopy(model, memo).to(self.device)  # copy before the head and names writes below; the caller keeps its own
         if not hasattr(model, "names"):
             model.names = default_class_names()
         model.names = check_class_names(model.names)

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -682,9 +682,7 @@ class Exporter:
             )
             # Keep a cached CLIP encoder out of the export copy: https://github.com/ultralytics/ultralytics/pull/18445
             memo[id(getattr(model, "clip_model", None))] = None
-        model = deepcopy(model, memo).to(
-            self.device
-        )  # copy before the head and names writes below; the caller keeps its own
+        model = deepcopy(model, memo).to(self.device)  # copy before the head and names writes below
         if not hasattr(model, "names"):
             model.names = default_class_names()
         model.names = check_class_names(model.names)

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -199,7 +199,7 @@ def benchmark(
                 exported_model = deepcopy(model)  # PyTorch format
             else:
                 export_data = data if "data" in valid_args else None
-                filename = deepcopy(model).export(
+                filename = model.export(
                     imgsz=imgsz,
                     format=export_format,
                     quantize=quantize,


### PR DESCRIPTION
## summary

- `Exporter.__call__` takes its working copy of the model before the `names` and `end2end` writes instead of 180 lines after them, so the model passed to `export()` keeps its head configuration, its training objective and its class-names object; the five `end2end` branches, the nms gate and the metadata that read them are unchanged and now all see the same copy
- a yoloworld model's cached clip encoder is kept out of the copy through `deepcopy`'s memo instead of being cleared on the caller, so the export still carries no encoder, the caller keeps the one it loaded, and the 577 MiB module is never copied
- `benchmark()` no longer deep-copies the model before each export, since the exporter isolates its own module; the copy for the pytorch row stays because predict fuses in place
- one commit per change

## measured

yolo26n.pt, imgsz=64, cpu. caller = the model object passed to `export()`; artifact = backend output on a zeros input plus metadata (ncnn param/bin md5, onnx graph md5), main vs branch.

| export | caller after export, main | caller after export, branch | artifact |
| --- | --- | --- | --- |
| torchscript `end2end=False` | end2end True -> False, E2ELoss -> v8DetectionLoss | unchanged | identical, metadata end2end=False |
| onnx `end2end=False` | same | unchanged | identical |
| ncnn (disables end2end itself) | same | unchanged | identical |
| torchscript default, torchscript `nms=True` | names object replaced | unchanged | identical, nms warning fires once on both |
| yolov8s-worldv2 after `set_classes`, torchscript | names list -> dict, clip encoder released | unchanged | identical, 0.40 s main / 0.34 s branch |

`benchmark()` with ncnn then torchscript on one model object: both rows succeed and the object is unchanged after both.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

`Exporter.__call__` now copies the model before modifying its head, names, or export settings, preserving the caller’s model while keeping exported artifacts unchanged.

### 📊 Key Changes

- Moved the exporter’s model copy before class-name normalization, end-to-end configuration, and related metadata handling.
- Excluded a YOLOWorld cached CLIP encoder from the copied model through `deepcopy` memoization instead of clearing it on the original model.
- Removed the extra deep copy from non-PyTorch rows in `benchmark()`, while retaining the copy for the PyTorch row because prediction fuses the model in place.
- Preserved the existing YOLOWorld export warning and supported-format behavior.

### 🎯 Purpose & Impact

- Models passed to `export()` retain their original head configuration, training objective, class-names object, and YOLOWorld CLIP encoder after export.
- Benchmark exports now rely on the exporter’s internal isolation, allowing multiple formats to run on the same model object without these export-time mutations.
- Exported artifacts and their associated metadata remain unchanged by this reorganization.