### PR TITLE
Seed tuning iterations from the model the caller loaded

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -923,7 +923,7 @@ class Model(torch.nn.Module):
 
             custom = {}  # method defaults
             args = {**self.overrides, **custom, **kwargs, "mode": "train"}  # highest priority args on the right
-            return Tuner(args=args, _callbacks=self.callbacks)(iterations=iterations)
+            return Tuner(args=args, model=self.model, _callbacks=self.callbacks)(iterations=iterations)
 
     def _apply(self, fn) -> Model:
         """Apply a function to model parameters, buffers, and tensors.

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -78,12 +78,12 @@ class Tuner:
         >>> model.tune(space={"lr0": (1e-5, 1e-2), "momentum": (0.7, 0.98)})
     """
 
-    def __init__(self, args, model, _callbacks: dict | None = None):
+    def __init__(self, args, model=None, _callbacks: dict | None = None):
         """Initialize the Tuner with configurations.
 
         Args:
             args (dict): Configuration for hyperparameter evolution.
-            model (torch.nn.Module): Base model whose weights seed each iteration.
+            model (torch.nn.Module, optional): Base model whose weights seed each iteration, built from args if None.
             _callbacks (dict | None, optional): Callback functions to be executed during tuning.
         """
         self.space = args.pop("space", None) or {  # key: (min, max, gain(optional))
@@ -120,6 +120,10 @@ class Tuner:
         mongodb_collection = args.pop("mongodb_collection", "tuner_results")
 
         self.args = get_cfg(overrides=args)
+        if model is None:
+            from ultralytics import YOLO
+
+            model = YOLO(self.args.model).model
         self.model = model
         self.args.exist_ok = self.args.resume  # resume w/ same tune_dir
         self.tune_dir = get_save_dir(self.args, name=self.args.name or "tune")

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -78,13 +78,13 @@ class Tuner:
         >>> model.tune(space={"lr0": (1e-5, 1e-2), "momentum": (0.7, 0.98)})
     """
 
-    def __init__(self, args, model=None, _callbacks: dict | None = None):
+    def __init__(self, args, _callbacks: dict | None = None, *, model=None):
         """Initialize the Tuner with configurations.
 
         Args:
             args (dict): Configuration for hyperparameter evolution.
-            model (torch.nn.Module, optional): Base model whose weights seed each iteration, built from args if None.
             _callbacks (dict | None, optional): Callback functions to be executed during tuning.
+            model (torch.nn.Module, optional): Base model whose weights seed each iteration, built from args if None.
         """
         self.space = args.pop("space", None) or {  # key: (min, max, gain(optional))
             # 'optimizer': tune.choice(['SGD', 'Adam', 'AdamW', 'NAdam', 'RAdam', 'RMSProp']),

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -24,7 +24,7 @@ from datetime import datetime
 import numpy as np
 
 from ultralytics.cfg import CFG_INT_KEYS, TASK2METRIC, get_cfg, get_save_dir
-from ultralytics.utils import DEFAULT_CFG, LOGGER, YAML, callbacks, colorstr, remove_colorstr
+from ultralytics.utils import LOGGER, YAML, callbacks, colorstr, remove_colorstr
 from ultralytics.utils.checks import check_requirements
 from ultralytics.utils.plotting import plot_tune_results
 
@@ -41,6 +41,7 @@ class Tuner:
         tune_dir (Path): Directory where evolution logs and results will be saved.
         tune_file (Path): Path to the NDJSON file where evolution logs are saved.
         args (SimpleNamespace): Configuration arguments for the tuning process.
+        model (torch.nn.Module): Base model whose weights seed each iteration.
         callbacks (dict): Callback functions to be executed during tuning.
         prefix (str): Prefix string for logging messages.
         mongodb (MongoClient): Optional MongoDB client for distributed tuning.
@@ -77,11 +78,12 @@ class Tuner:
         >>> model.tune(space={"lr0": (1e-5, 1e-2), "momentum": (0.7, 0.98)})
     """
 
-    def __init__(self, args=DEFAULT_CFG, _callbacks: dict | None = None):
+    def __init__(self, args, model, _callbacks: dict | None = None):
         """Initialize the Tuner with configurations.
 
         Args:
             args (dict): Configuration for hyperparameter evolution.
+            model (torch.nn.Module): Base model whose weights seed each iteration.
             _callbacks (dict | None, optional): Callback functions to be executed during tuning.
         """
         self.space = args.pop("space", None) or {  # key: (min, max, gain(optional))
@@ -118,6 +120,7 @@ class Tuner:
         mongodb_collection = args.pop("mongodb_collection", "tuner_results")
 
         self.args = get_cfg(overrides=args)
+        self.model = model
         self.args.exist_ok = self.args.resume  # resume w/ same tune_dir
         self.tune_dir = get_save_dir(self.args, name=self.args.name or "tune")
         self.args.name, self.args.exist_ok, self.args.resume = (None, False, False)  # reset to not affect training
@@ -472,7 +475,6 @@ class Tuner:
             iterations (int): The number of generations to run the evolution for.
             cleanup (bool): Whether to delete iteration weights to reduce storage space during tuning.
         """
-        from ultralytics import YOLO
         from ultralytics.engine.trainer import MultiTrainer
 
         t0 = time.time()
@@ -498,8 +500,7 @@ class Tuner:
             data = train_args.pop("data")
             if not isinstance(data, (list, tuple)):
                 data = [data]
-            model = YOLO(train_args["model"])
-            trainer = MultiTrainer(None, {**train_args, "data": data}, model.model)
+            trainer = MultiTrainer(None, {**train_args, "data": data}, self.model)
             raw_metrics = trainer.train()
             failed_datasets = [dataset for dataset, metrics in raw_metrics.items() if not metrics]
             metric = TASK2METRIC[train_args["task"]]


### PR DESCRIPTION
Model.tune() rebuilt its donor from the model path, discarding weights loaded or modified in memory. Pass the loaded module through Tuner to the existing MultiTrainer owner, and remove per-iteration model reconstruction. Direct Tuner(args) calls still build once; existing positional callback calls remain valid because the model argument is keyword-only.

Validation: existing positional callback and supplied-model constructor paths; a real one-epoch COCO8 tuning iteration retained an in-memory donor with a zeroed first convolution. No new tests or compatibility wrapper.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Tuning now reuses the model already loaded by the caller so in-memory weights are preserved across tuning iterations instead of rebuilding the model from its path.

### 📊 Key Changes

- `Model.tune()` passes `self.model` to `Tuner`.
- `Tuner` accepts an optional keyword-only `model` argument and stores it as the iteration seed model.
- Direct `Tuner(args)` calls build the model once from `args.model` when no model is supplied.
- Each tuning iteration passes the stored model to `MultiTrainer` instead of reconstructing it from `train_args["model"]`.
- The `DEFAULT_CFG` import was removed because `Tuner` now requires `args`.

### 🎯 Purpose & Impact

- Weight changes made to the in-memory model, including modifications before tuning, are retained as the starting point for training iterations.
- Tuning no longer discards the caller’s loaded model by creating a separate model from its path for every iteration.
- Existing positional callback arguments remain valid because `model` is keyword-only.