### PR TITLE
Reduce validation dataloader memory with prefetch 2 per worker

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.138"
+__version__ = "8.4.139"
 
 import importlib
 import os

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -373,7 +373,7 @@ def build_dataloader(
         shuffle=shuffle and sampler is None,
         num_workers=nw,
         sampler=sampler,
-        prefetch_factor=4 if nw > 0 else None,  # increase over default 2
+        prefetch_factor=(4 if shuffle else 2) if nw > 0 else None,  # validation holds fewer batches between passes
         pin_memory=pin_memory,
         collate_fn=getattr(dataset, "collate_fn", None),
         worker_init_fn=seed_worker,


### PR DESCRIPTION
Halve the validation loaders' `prefetch_factor` from 4 to 2. Training loaders keep 4.

Between validation passes the infinite validation loader holds `workers × prefetch_factor` batches queued for the whole training epoch (#25827). The queue depth does not change how fast a validation pass starts, since the first batches are already built either way, so a shallower queue frees memory at no speed cost. `shuffle` is what distinguishes the two loader kinds in `build_dataloader`: training loaders shuffle, validation loaders do not.

## Profile: validation prefetch 4 vs 2 vs 1

NVIDIA GH200 480GB, Python 3.14.7, torch 2.14.0+cu130, fresh uv venv, `yolo26n.pt`, `imgsz=640`, `workers=8`, `seed=0`, `deterministic=True`, 100 epochs, two repetitions per cell with run order alternated. Training prefetch fixed at 4 in every run; only the validation loader varies. "In flight" is `_send_idx - _rcvd_idx` on the validation iterator measured after every validation; shared memory is `Shmem` from `/proc/meminfo` at the same moment.

| Dataset | Val workers | Val prefetch | Wall time (s) | Mean | Val batches in flight after each validation | Shared memory after validation | Best mAP50-95 |
|---|---|---|---|---|---|---|---|
| coco128 b16 | 4 | 4 (main) | 162.2, 161.5 | 161.8 | 16 | 1.90 GB | 0.69422 |
| coco128 b16 | 4 | **2** | 157.6, 163.1 | 160.4 | 8 | 1.51 GB | 0.69422 |
| coco128 b16 | 4 | 1 | 161.2, 155.5 | 158.3 | 4 | 1.32 GB | 0.69422 |
| coco8 b1 | 2 | 4 (main) | 80.5, 79.8 | 80.2 | 8 | 154 MB | 0.67221 |
| coco8 b1 | 2 | **2** | 79.0, 82.6 | 80.8 | 4 | 146 MB | 0.67221 |
| coco8 b1 | 2 | 1 | 79.2, 82.1 | 80.6 | 2 | 141 MB | 0.67221 |

Per-epoch metrics are identical across all twelve runs. Wall times for all three settings fall inside the same ±3 s band on both datasets. Retained batches scale linearly with prefetch, at about 48 MB per retained batch of 32 images on coco128, so prefetch 2 halves what main holds between validations; for the 20-worker, 337 MB-per-batch case reported in #25827 that is roughly 27 GB down to 13.5 GB.

Prefetch 1 measured the same speed and would free another half, but also halves the queue depth during the validation pass itself, so it is left for a separate decision with evidence from a larger validation set.

Classification validation loaders currently shuffle by default and therefore keep prefetch 4; they are unchanged here.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Validation dataloaders now use a prefetch factor of 2 instead of 4 to reduce queued batch memory between validation passes, while training dataloaders remain unchanged.

### 📊 Key Changes

- Updated `build_dataloader()` to select `prefetch_factor=2` when `shuffle=False`, which identifies the validation loader path.
- Preserved `prefetch_factor=4` for shuffled training loaders.
- Kept `prefetch_factor=None` when no worker processes are used.
- Bumped the package version from `8.4.138` to `8.4.139`.

### 🎯 Purpose & Impact

- Validation loaders retain fewer prefetched batches between passes, reducing their queued memory usage.
- Classification validation loaders remain unchanged because they currently shuffle by default.
- Training data loading behavior is unchanged.