### PR TITLE
Fix custom callbacks in DDP training

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -26,6 +26,26 @@ def test_func(*args, **kwargs):
     print("callback test passed")
 
 
+def test_generate_ddp_command_reuses_python_entrypoint(tmp_path, monkeypatch):
+    """DDP should rerun a Python entrypoint with its original arguments."""
+    from ultralytics.utils import dist
+
+    script = tmp_path / "train.py"
+    script.touch()
+    trainer = SimpleNamespace(resume=True, save_dir=tmp_path / "run", world_size=2)
+    monkeypatch.setattr(sys.modules["__main__"], "__file__", str(script), raising=False)
+    monkeypatch.setattr(sys, "argv", [str(script), "--data", "data.yaml"])
+    monkeypatch.setattr(dist, "find_free_network_port", lambda: 12345)
+    generate = mock.Mock()
+    monkeypatch.setattr(dist, "generate_ddp_file", generate)
+
+    cmd, file = dist.generate_ddp_command(trainer)
+
+    assert file == str(script.resolve())
+    assert cmd[-3:] == [str(script.resolve()), "--data", "data.yaml"]
+    generate.assert_not_called()
+
+
 def test_export(monkeypatch, tmp_path):
     """Test model exporting functionality by adding a callback and verifying its execution."""
     monkeypatch.chdir(tmp_path)

--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import sys
 import tempfile
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from . import USER_CONFIG_DIR
@@ -102,13 +103,27 @@ def generate_ddp_command(trainer: BaseTrainer) -> tuple[list[str], str]:
 
     Returns:
         cmd (list[str]): The command to execute for distributed training.
-        file (str): Path to the temporary file created for DDP training.
+        file (str): Path to the Python script used for DDP training.
     """
     import __main__  # noqa local import to avoid https://github.com/Lightning-AI/pytorch-lightning/issues/15218
 
     if not trainer.resume:
         shutil.rmtree(trainer.save_dir)  # remove the save_dir
-    file = generate_ddp_file(trainer)
+    main_file = getattr(__main__, "__file__", None)
+    if main_file:
+        main_file = Path(main_file).resolve()
+        argv_file = Path(sys.argv[0]).resolve() if sys.argv and Path(sys.argv[0]).is_file() else None
+        package_root = Path(__file__).resolve().parents[1]
+        try:
+            main_file.relative_to(package_root)
+        except ValueError:
+            use_main_file = main_file == argv_file and main_file.suffix == ".py"
+        else:
+            use_main_file = False
+    else:
+        use_main_file = False
+
+    file = str(main_file) if use_main_file else generate_ddp_file(trainer)
     dist_cmd = "torch.distributed.run" if TORCH_1_9 else "torch.distributed.launch"
     port = find_free_network_port()
     cmd = [
@@ -121,6 +136,8 @@ def generate_ddp_command(trainer: BaseTrainer) -> tuple[list[str], str]:
         f"{port}",
         file,
     ]
+    if use_main_file:
+        cmd.extend(sys.argv[1:])
     return cmd, file
 
 

--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -105,7 +105,7 @@ def generate_ddp_command(trainer: BaseTrainer) -> tuple[list[str], str]:
         cmd (list[str]): The command to execute for distributed training.
         file (str): Path to the Python script used for DDP training.
     """
-    import __main__  # noqa local import to avoid https://github.com/Lightning-AI/pytorch-lightning/issues/15218
+    import __main__
 
     if not trainer.resume:
         shutil.rmtree(trainer.save_dir)  # remove the save_dir


### PR DESCRIPTION
Fix custom callbacks in Python DDP training by rerunning the caller's entrypoint with its original arguments.\n\nFixes #6168.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated Python DDP command generation to reuse the caller’s original script and command-line arguments when running an external Python entrypoint, preserving custom callback execution.

### 📊 Key Changes
- Detects eligible `__main__` Python entrypoints outside the Ultralytics package.
- Uses the resolved entrypoint path instead of generating a temporary DDP file.
- Appends the original `sys.argv` arguments to the distributed launch command.
- Retains temporary DDP file generation for unsupported or package-internal entrypoints.
- Adds a test verifying entrypoint reuse and argument preservation.

### 🎯 Purpose & Impact
Python DDP training launched from a user script now reruns that script with its original arguments, allowing custom callbacks and caller configuration to remain available across distributed workers.