### PR TITLE
fix: remove yanked dependency dx_com

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,10 +130,6 @@ export-executorch = [
     "torch>=2.12.0,<2.13.0; platform_system == 'Linux' and platform_machine == 'aarch64'",
     "numpy<=2.3.5",
 ]
-export-deepx = [
-    "dx_com",
-    "numpy<2",
-]
 export-litert = [  # LiteRT export, Linux x86 and macOS (litert-torch trace + ai-edge-litert/quantizer)
     "litert-torch>=0.9.0; (platform_system == 'Linux' and platform_machine == 'x86_64') or platform_system == 'Darwin'",
     "ai-edge-litert>=2.1.4; (platform_system == 'Linux' and platform_machine == 'x86_64') or platform_system == 'Darwin'",


### PR DESCRIPTION
while testing things for #26038 I had issues with UV, which could not lock due to dx_com being yanked from Pypi https://pypi.org/project/dx-com/#description since this is unrelated to the core changes of #26038 I am opening this in a secondary PR. If there is an alternative source where this should be downloaded instead it could be made to work, at least with uv, by adding that repository.

For security reasons I would strongly advocate against adding runtime installed dependencies from additional sources.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Removed the yanked `dx_com` dependency from the `export-deepx` optional dependency group so package locking no longer attempts to resolve it.

### 📊 Key Changes
- Deleted the `export-deepx` extra from `pyproject.toml`.
- Removed both `dx_com` and its `numpy<2` constraint from the optional dependencies.

### 🎯 Purpose & Impact
- Prevents dependency lock workflows such as `uv` from failing on the yanked `dx_com` package.
- The `export-deepx` installation extra is no longer available.