### PR TITLE
Fix grayscale TIFF training channel mismatch

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -461,7 +461,7 @@ def test_predict_gray_and_4ch(tmp_path):
 @pytest.mark.parametrize("channels", (1, 3, 4, 10))
 @pytest.mark.parametrize("flags", (cv2.IMREAD_COLOR, cv2.IMREAD_GRAYSCALE, cv2.IMREAD_UNCHANGED))
 def test_imread_tiff(tmp_path, channels, flags):
-    """Honor single-frame TIFF read flags while preserving multipage multispectral channels."""
+    """Honor grayscale TIFF read flags while preserving color and multispectral channels."""
     from ultralytics.utils.patches import imread
 
     path = tmp_path / "image.tiff"
@@ -470,7 +470,7 @@ def test_imread_tiff(tmp_path, channels, flags):
         assert cv2.imwritemulti(str(path), list(image.transpose(2, 0, 1)))
     else:
         assert cv2.imwrite(str(path), image)
-    expected = image if channels == 10 and flags != cv2.IMREAD_GRAYSCALE else cv2.imread(str(path), flags)
+    expected = image if channels > 1 and flags != cv2.IMREAD_GRAYSCALE else cv2.imread(str(path), flags)
     if expected.ndim == 2:
         expected = expected[..., None]
     np.testing.assert_array_equal(imread(path, flags), expected)

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -438,22 +438,42 @@ def test_predict_gray_and_4ch(tmp_path):
     im = Image.open(SOURCE)
 
     source_grayscale = tmp_path / "grayscale.jpg"
+    source_tiff = tmp_path / "grayscale.tiff"
     source_rgba = tmp_path / "4ch.png"
     source_non_utf = tmp_path / "non_UTF_测试文件_tést_image.jpg"
     source_spaces = tmp_path / "image with spaces.jpg"
 
     im.convert("L").save(source_grayscale)  # grayscale
+    im.convert("L").save(source_tiff)
     im.convert("RGBA").save(source_rgba)  # 4-ch PNG with alpha
     im.save(source_non_utf)  # non-UTF characters in filename
     im.save(source_spaces)  # spaces in filename
 
     # Inference
     model = YOLO(MODEL)
-    for f in source_rgba, source_grayscale, source_non_utf, source_spaces:
+    for f in source_rgba, source_grayscale, source_tiff, source_non_utf, source_spaces:
         for source in Image.open(f), cv2.imread(str(f)), f:
             results = model(source, save=True, verbose=True, imgsz=32)
             assert len(results) == 1, f"Expected 1 result for {f.name}, got {len(results)}"
         f.unlink()  # cleanup
+
+
+@pytest.mark.parametrize("channels", (1, 3, 4, 10))
+@pytest.mark.parametrize("flags", (cv2.IMREAD_COLOR, cv2.IMREAD_GRAYSCALE, cv2.IMREAD_UNCHANGED))
+def test_imread_tiff(tmp_path, channels, flags):
+    """Honor single-frame TIFF read flags while preserving multipage multispectral channels."""
+    from ultralytics.utils.patches import imread
+
+    path = tmp_path / "image.tiff"
+    image = np.full((8, 8, channels), 42, dtype=np.uint8)
+    if channels == 10:
+        assert cv2.imwritemulti(str(path), list(image.transpose(2, 0, 1)))
+    else:
+        assert cv2.imwrite(str(path), image)
+    expected = image if channels == 10 and flags != cv2.IMREAD_GRAYSCALE else cv2.imread(str(path), flags)
+    if expected.ndim == 2:
+        expected = expected[..., None]
+    np.testing.assert_array_equal(imread(path, flags), expected)
 
 
 def test_predict_ndarray_channels():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -438,42 +438,22 @@ def test_predict_gray_and_4ch(tmp_path):
     im = Image.open(SOURCE)
 
     source_grayscale = tmp_path / "grayscale.jpg"
-    source_tiff = tmp_path / "grayscale.tiff"
     source_rgba = tmp_path / "4ch.png"
     source_non_utf = tmp_path / "non_UTF_测试文件_tést_image.jpg"
     source_spaces = tmp_path / "image with spaces.jpg"
 
     im.convert("L").save(source_grayscale)  # grayscale
-    im.convert("L").save(source_tiff)
     im.convert("RGBA").save(source_rgba)  # 4-ch PNG with alpha
     im.save(source_non_utf)  # non-UTF characters in filename
     im.save(source_spaces)  # spaces in filename
 
     # Inference
     model = YOLO(MODEL)
-    for f in source_rgba, source_grayscale, source_tiff, source_non_utf, source_spaces:
+    for f in source_rgba, source_grayscale, source_non_utf, source_spaces:
         for source in Image.open(f), cv2.imread(str(f)), f:
             results = model(source, save=True, verbose=True, imgsz=32)
             assert len(results) == 1, f"Expected 1 result for {f.name}, got {len(results)}"
         f.unlink()  # cleanup
-
-
-@pytest.mark.parametrize("channels", (1, 3, 4, 10))
-@pytest.mark.parametrize("flags", (cv2.IMREAD_COLOR, cv2.IMREAD_GRAYSCALE, cv2.IMREAD_UNCHANGED))
-def test_imread_tiff(tmp_path, channels, flags):
-    """Honor grayscale TIFF read flags while preserving color and multispectral channels."""
-    from ultralytics.utils.patches import imread
-
-    path = tmp_path / "image.tiff"
-    image = np.full((8, 8, channels), 42, dtype=np.uint8)
-    if channels == 10:
-        assert cv2.imwritemulti(str(path), list(image.transpose(2, 0, 1)))
-    else:
-        assert cv2.imwrite(str(path), image)
-    expected = image if channels > 1 and flags != cv2.IMREAD_GRAYSCALE else cv2.imread(str(path), flags)
-    if expected.ndim == 2:
-        expected = expected[..., None]
-    np.testing.assert_array_equal(imread(path, flags), expected)
 
 
 def test_predict_ndarray_channels():
@@ -2184,12 +2164,24 @@ def test_yolov10():
     model(SOURCE)
 
 
-def test_multichannel():
-    """Test YOLO model multi-channel training, validation, and prediction functionality."""
+@pytest.mark.parametrize("grayscale_tiff", (False, True))
+def test_multichannel(tmp_path, grayscale_tiff):
+    """Test training, validation, prediction, and export with multispectral and grayscale TIFF datasets."""
+    data = "coco8-multispectral.yaml"
+    if grayscale_tiff:
+        dataset = check_det_dataset(data)
+        root = shutil.copytree(dataset["path"], tmp_path / "dataset", ignore=shutil.ignore_patterns("*.npy", "*.cache"))
+        for path in Path(root).rglob("*.tiff"):
+            with Image.open(path) as image:
+                frame = image.copy()  # Retain only the first grayscale page.
+            frame.save(path)
+        data = tmp_path / "data.yaml"
+        YAML.save(data, {"path": str(root), "train": "images/train", "val": "images/val", "names": dataset["names"]})
+
     model = YOLO("yolo26n.pt")
-    model.train(data="coco8-multispectral.yaml", epochs=1, imgsz=32, close_mosaic=1, cache="disk")
-    model.val(data="coco8-multispectral.yaml")
-    im = np.zeros((32, 32, 10), dtype=np.uint8)
+    model.train(data=data, epochs=1, imgsz=32, close_mosaic=1, cache="disk")
+    model.val(data=data)
+    im = np.zeros((32, 32, 3 if grayscale_tiff else 10), dtype=np.uint8)
     model.predict(source=im, imgsz=32, save_txt=True, save_crop=True, augment=True)
     model.export(format="onnx")
 

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.139"
+__version__ = "8.4.140"
 
 import importlib
 import os

--- a/ultralytics/utils/patches.py
+++ b/ultralytics/utils/patches.py
@@ -40,16 +40,15 @@ def imread(filename: str | Path, flags: int = cv2.IMREAD_COLOR) -> np.ndarray | 
         return None
     if flags != cv2.IMREAD_GRAYSCALE and filename.lower().endswith((".tiff", ".tif")):
         success, frames = cv2.imdecodemulti(file_bytes, cv2.IMREAD_UNCHANGED)
-        if success:
-            # Handle multi-frame TIFFs and color images
-            return frames[0] if len(frames) == 1 and frames[0].ndim == 3 else np.stack(frames, axis=2)
-        return None
-    else:
-        im = cv2.imdecode(file_bytes, flags)
-        # Fallback for formats OpenCV imdecode may not support (AVIF, HEIC, HEIF)
-        if im is None and filename.lower().endswith(PIL_FALLBACK_SUFFIXES):
-            im = _imread_pil(filename, flags)
-        return im[..., None] if im is not None and im.ndim == 2 else im  # Always ensure 3 dimensions
+        if not success:
+            return None
+        if len(frames) > 1:
+            return np.stack(frames, axis=2)  # Preserve multispectral channels
+    im = cv2.imdecode(file_bytes, flags)
+    # Fallback for formats OpenCV imdecode may not support (AVIF, HEIC, HEIF)
+    if im is None and filename.lower().endswith(PIL_FALLBACK_SUFFIXES):
+        im = _imread_pil(filename, flags)
+    return im[..., None] if im is not None and im.ndim == 2 else im  # Always ensure 3 dimensions
 
 
 # PIL patches ---------------------------------------------------------------------------------------------------------

--- a/ultralytics/utils/patches.py
+++ b/ultralytics/utils/patches.py
@@ -42,8 +42,8 @@ def imread(filename: str | Path, flags: int = cv2.IMREAD_COLOR) -> np.ndarray | 
         success, frames = cv2.imdecodemulti(file_bytes, cv2.IMREAD_UNCHANGED)
         if not success:
             return None
-        if len(frames) > 1:
-            return np.stack(frames, axis=2)  # Preserve multispectral channels
+        if len(frames) > 1 or frames[0].ndim == 3:
+            return frames[0] if len(frames) == 1 else np.stack(frames, axis=2)
     im = cv2.imdecode(file_bytes, flags)
     # Fallback for formats OpenCV imdecode may not support (AVIF, HEIC, HEIF)
     if im is None and filename.lower().endswith(PIL_FALLBACK_SUFFIXES):


### PR DESCRIPTION
Single-frame grayscale TIFFs were decoded with `IMREAD_UNCHANGED` even when callers requested `IMREAD_COLOR`. Two Platform segmentation training jobs consequently built three-channel models but received one-channel image batches and failed at the first convolution.

The TIFF branch retains its existing early returns for color/multichannel and multipage images. Only single-frame grayscale images use the existing flag-aware decoder, preserving declared four-channel datasets and multispectral stacking. The reader change removes one net line; regression coverage extends the existing multichannel training test, with no separate test function. Bumps the package to 8.4.140.

### Evidence and validation

- GPU evidence: September 4, 2026 at 14:25 UTC, previous `ultra5` worker container 65 running 8.4.138. Both affected runs used TIFF training images; read-only inspection reproduced `IMREAD_COLOR` returning one channel. Raw logs: `/tmp/platform-sentry-gpu-20260904/` (not committed).
- The existing `test_multichannel` now runs both its original ten-page multispectral dataset and a temporary copy containing only each TIFF's first grayscale page, with the default three-channel model configuration. Both cases complete training, validation, prediction, and ONNX export (2 passed). The new grayscale case fails against the original reader with `expected input[4, 1, 32, 32] to have 3 channels`, proving it catches the production regression. Cached arrays are excluded from the copy so the reader is exercised. The separate reader test and extra inference additions were removed (8 fewer lines).
- Ruff formatting and `git diff --check` pass. Ruff reports three unchanged BLE001 findings in existing handlers, also present on the untouched base.
- Real four-channel YOLODataset loading and formatting also preserve all four channels. Full CPU training smoke passes on four synthetic grayscale TIFFs: YOLO26n-seg, default three channels, one epoch, image size 64, batch 2, workers 0; training, checkpoint save, and validation completed. Both independent delta reviewers and a fresh cold full-diff reviewer return LGTM at 4221808d5. Automated formatting and review completed successfully without further changes; the automated review also approves that exact head, with zero unresolved threads. The broader CI matrix is still running; no failures are reported. This is an unmerged handoff pending CI.

### Sweep scope and intentionally unchanged items

| Source | Scope | Result |
|---|---|---|
| Sentry | `alpha` and `ultralytics`, seven environments, past 24h plus 14d ingestion trend | Zero accepted errors; quota rejected 4,251 and 346 events. Current issue silence cannot establish health. |
| GPU / SAM | `ultra5`, past 48h; current and previous GPU workers plus SAM API/tunnel | TIFF failure fixed here. Invalid checkpoint rejections and correlated DNS/QUIC disruption are input/infrastructure issues. No SAM 5xx. |
| Vercel | Platform production, past 24h; grouped counts and bounded deployment-specific reads | Cloud source-object 404 confirmed by an authenticated exact-key read and empty prefix listing; external object removed. The pose dataset is now consistent after subsequent user edits; original invalid label producer is unproven. Legacy index error traced to a July preview, absent from production. |
| MongoDB | 155 advisor samples and 24h Atlas resource metrics | No open alerts. Dataset-model counting has a measured read hotspot but no proven minimal correction; no speculative index. |
| Redis | Complete cursor scan and TTL/size census | No missing TTLs or evictions; 1.68 MB in sampled keys. |
| Stripe | Past 7d payments, events, and Mongo reconciliation | All 45 successful Platform payments reconcile; no overdue renewal or stuck webhook records. |
| GCP | Three shared services, 2,868 dedicated services, workers, storage and 7d requests | No stale revisions; workers running. All 3,196 dedicated 429s and 111 no-instance 500s are fixed-capacity shedding. A 10-channel model is incompatible with the RGB prediction path; no speculative multispectral support added. |

Aikido excluded. Evidence exports remain local under `/tmp/platform-sweep-vercel-20260904/`, `/tmp/portal-sweep-mongo-redis-20260904/`, and `/tmp/platform-stripe-gcp-20260904/`. No production data, capacity, or running containers changed.

Checked and refuted: restricted checkpoint loading correctly rejects unsupported `GLOBAL exec`; worker DNS errors correlate with tunnel DNS/QUIC disruption; SAM 400s lack enough response detail to establish a bug; its 404s are predominantly probing. Indexed change-stream waits and Atlas Search synchronization were excluded from query findings. Redis INFO memory/expiry counters are unreliable, so the census uses per-key TTLs and sizes. Stripe stale customer references are healed by the existing customer resolver; no lost refund was observed, although endpoint-specific exhausted delivery history was unavailable. GCS soft-deleted growth is retained checkpoint overwrite churn; retention and capacity are provisioning decisions. Remaining isolated provider timeouts lack a proven code defect.

No Portal code change is justified by the evidence, so this is the only sweep PR. This PR is for review and handoff, not merge. Publish 8.4.140 before advancing the Platform version floors or deploying it.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated TIFF decoding so single-frame grayscale images honor the requested OpenCV read mode, preventing channel mismatches during three-channel training.

### 📊 Key Changes

- Changed `ultralytics.utils.patches.imread` to use the requested decoder flags for single-frame grayscale TIFFs.
- Preserved existing handling for color, multichannel, and multipage TIFFs, including multispectral stacking and four-channel data.
- Extended `test_multichannel` to cover both the existing multispectral dataset and temporary single-frame grayscale TIFF copies through training, validation, prediction, and ONNX export.
- Bumped the package version from `8.4.139` to `8.4.140`.

### 🎯 Purpose & Impact

- Three-channel models can now load single-frame grayscale TIFF training data without receiving one-channel batches at the first convolution.
- Existing multispectral and multichannel TIFF workflows remain covered by the same regression test.