### PR TITLE
Use Platform SDK for login while preserving Python 3.8+

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,13 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import json
+import os
 import shutil
 import subprocess
 import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
+from threading import Thread
 
 import pytest
 from PIL import Image
@@ -55,23 +58,62 @@ def test_settings_migration(tmp_path: Path, api_key: str) -> None:
     assert "neptune" not in settings
 
 
-def test_platform_login(monkeypatch) -> None:
-    """Verify Platform login saves valid keys and logout removes them."""
-    import requests
+@pytest.mark.parametrize(
+    "status,body",
+    [
+        (200, '{"username":"tester"}'),
+        (200, "{}"),
+        (201, '{"username":"tester"}'),
+        (302, '{"username":"tester"}'),
+        (401, "ul_secret"),
+        (500, "ul_secret"),
+    ],
+)
+def test_platform_login(tmp_path: Path, status: int, body: str) -> None:
+    """Verify real login clients persist only validated keys and never retry through another endpoint."""
+    from ultralytics.utils import SettingsManager
 
-    from ultralytics import cfg
+    received = []
 
-    class Response:
-        status_code = 200
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            received.append((self.path, self.headers.get("Authorization")))
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(body.encode())
 
-    settings = {"api_key": ""}
-    monkeypatch.setattr(cfg, "SETTINGS", settings)
-    monkeypatch.setattr(requests, "get", lambda *args, **kwargs: Response())
+        def log_message(self, *args):
+            pass
 
-    cfg.handle_yolo_login(["login", "ul_valid"])
-    assert settings["api_key"] == "ul_valid"
-    cfg.handle_yolo_login(["logout"])
-    assert settings["api_key"] == ""
+    settings_file = tmp_path / "Ultralytics" / "settings.json"
+    SettingsManager(settings_file)["api_key"] = "ul_previous"
+    command = [sys.executable, "-c", "from ultralytics.cfg import entrypoint; entrypoint()"]
+    with HTTPServer(("127.0.0.1", 0), Handler) as server:
+        thread = Thread(target=server.serve_forever)
+        thread.start()
+        env = dict(
+            os.environ,
+            YOLO_CONFIG_DIR=str(tmp_path),
+            ULTRALYTICS_PLATFORM_URL=f"http://127.0.0.1:{server.server_port}",
+            ULTRALYTICS_API_KEY="ul_environment",
+        )
+        try:
+            result = subprocess.run(
+                [*command, "login", "ul_supplied"], env=env, capture_output=True, text=True, check=True
+            )
+            subprocess.run([*command, "login", ""], env=env, check=True)
+        finally:
+            server.shutdown()
+            thread.join()
+    expected = "ul_supplied" if status == 200 and (sys.version_info < (3, 11) or "username" in body) else "ul_previous"
+    assert json.loads(settings_file.read_text())["api_key"] == expected
+    assert received == [
+        ("/api/account/summary" if sys.version_info >= (3, 11) else "/api/settings", "Bearer ul_supplied")
+    ]
+    assert "ul_secret" not in result.stdout + result.stderr
+    subprocess.run([*command, "logout"], env=env, check=True)
+    assert json.loads(settings_file.read_text())["api_key"] == ""
 
 
 def test_cli_imports_defer_torchvision() -> None:

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -726,6 +726,45 @@ def handle_yolo_login(args: list[str]) -> None:
     if len(args) < 2:
         LOGGER.info(f"Get an API key from {api_key_url} and then run 'yolo login API_KEY'.")
         return
+    if not args[1]:
+        LOGGER.warning("Invalid API key")
+        return
+
+    if sys.version_info >= (3, 11):
+        try:
+            import httpx
+
+            from ultralytics import APIConnectionError, APIError, Platform
+        except ImportError:
+            LOGGER.warning("Install the Platform SDK with 'pip install -U ultralytics-platform'.")
+            return
+
+        try:
+            responses = []
+            with Platform(
+                api_key=args[1],
+                base_url=PLATFORM_URL,
+                timeout=30,
+                max_retries=0,
+                http_client=httpx.Client(timeout=30, event_hooks={"response": [responses.append]}),
+            ) as client:
+                account = client.account.summary()
+            if responses[0].status_code != 200 or not (
+                isinstance(account, dict) and isinstance(account.get("username"), str) and account["username"]
+            ):
+                LOGGER.warning("Authentication failed: expected HTTP 200 with account information.")
+                return
+        except APIError as e:
+            LOGGER.warning(
+                "Invalid API key" if e.status_code == 401 else f"Authentication failed (HTTP {e.status_code})."
+            )
+            return
+        except (APIConnectionError, ValueError):
+            LOGGER.warning("Authentication request failed; check your connection and the Platform server response.")
+            return
+        SETTINGS["api_key"] = args[1]
+        LOGGER.info("New authentication successful ✅")
+        return
 
     import requests  # scoped as slow import
 


### PR DESCRIPTION
`yolo login API_KEY` now validates through the Platform SDK on Python 3.11+, while Python 3.8–3.10 keep the existing REST login. SDK login saves the supplied key only after HTTP 200 with account information containing a nonempty username. It uses the configured Platform host, makes one request, and closes the client. Empty keys, rejected credentials, malformed responses, and connection failures preserve the previous saved key; diagnostics omit response bodies and credentials. Guidance and logout remain offline.

The change extends the existing login handler without changing dependencies, public commands, or adding a dispatcher. Preserving the supported legacy login requires retaining its REST block. The patch adds 39 production lines; the remaining net 42 lines replace a REST mock with one parameterized regression test using real HTTP clients, an isolated settings directory, and the CLI in subprocesses. This covers the high-risk credential persistence gap without a client factory, transport adapter, or shared testing framework.

Simpler option considered: save the key when `account.summary()` returns without an exception.
Rejected because: the SDK returns account-shaped JSON for HTTP 201/302 too; the real-server test verifies those responses cannot authenticate. A public HTTPX response hook records the status without a custom callback.

Simpler option considered: omit the empty-key check.
Rejected because: the SDK substitutes `ULTRALYTICS_API_KEY` for an empty supplied key. The test keeps the server live and requires that empty-key login makes no second request.

Validation:
- Python 3.8.20 and 3.10.20 without the SDK, and Python 3.11.15 with the SDK: six real HTTP login cases per interpreter passed, including success, missing account information, 201, 302, 401, and 500; empty-key and offline logout checks are included.
- Existing CLI special modes, settings migration, and deferred imports: four checks passed per interpreter.
- Focused checks with real clients covered malformed JSON/account values, connection failure, safe diagnostics, SDK client closure, offline imports, and missing-SDK installation guidance.
- Ruff formatting and diff whitespace checks pass. Ruff 0.16.6 reports two pre-existing BLE001 findings in unchanged settings/value parsing code; checking the base reproduces both. No new lint findings.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
`yolo login API_KEY` now uses the Platform SDK on Python 3.11+ and saves credentials only after a validated HTTP 200 account response, while Python 3.8–3.10 retain REST login behavior.

### 📊 Key Changes
- Empty API keys are rejected before any authentication request.
- Python 3.11+ login uses the configured Platform host, performs one SDK request without retries, and requires nonempty account username data before updating settings.
- SDK login preserves the previously saved key for rejected credentials, non-200 responses, malformed responses, connection failures, or missing SDK installations.
- Authentication diagnostics avoid exposing response bodies or credentials; SDK client resources are closed after the request.
- CLI tests now use a real local HTTP server and cover successful, malformed, non-200, empty-key, logout, and version-specific login behavior.

### 🎯 Purpose & Impact
- Python 3.11+ users receive stricter credential validation before saved keys are replaced, while Python 3.8–3.10 login, guidance, logout, commands, and dependencies remain unchanged.