### PR TITLE
Fix Conda CI dependency resolution and install timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,10 +613,11 @@ jobs:
           python-version: ${{ matrix.python }}
           channels: conda-forge
           channel-priority: strict
+          conda-remove-defaults: true
           activate-environment: anaconda-client-env
       - name: Install Ultralytics package from conda-forge
         timeout-minutes: 20
-        run: conda install --yes --override-channels -c conda-forge pytorch-cpu torchvision ultralytics openvino
+        run: conda install --yes pytorch-cpu torchvision ultralytics openvino
       - name: Install pip packages
         run: |
           VERSION=$(python -c "from importlib.metadata import version; print(version('ultralytics'))")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -611,11 +611,12 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v4
         with:
           python-version: ${{ matrix.python }}
-          channels: conda-forge,defaults
-          channel-priority: true
+          channels: conda-forge
+          channel-priority: strict
           activate-environment: anaconda-client-env
       - name: Install Ultralytics package from conda-forge
-        run: conda install -c pytorch -c conda-forge pytorch-cpu torchvision ultralytics openvino
+        timeout-minutes: 20
+        run: conda install --yes --override-channels -c conda-forge pytorch-cpu torchvision ultralytics openvino
       - name: Install pip packages
         run: |
           VERSION=$(python -c "from importlib.metadata import version; print(version('ultralytics'))")


### PR DESCRIPTION
The scheduled [Conda job](https://github.com/ultralytics/ultralytics/actions/runs/33954424824/job/101275017118) timed out after two hours resolving packages across `pytorch`, `conda-forge`, and `defaults`, with libmamba errors while explaining an unsatisfiable solve. Even the preceding successful run spent about 23 minutes installing.

Use only conda-forge with strict channel priority and remove inherited defaults during environment setup. Keep the same packages and tests, make installation noninteractive, and limit that step to 20 minutes so solver hangs fail before exhausting the whole job. This follows [conda-forge channel guidance](https://conda-forge.org/docs/user/transitioning_from_defaults/).

Validation on `e94a715a8bbe17b5535aa469b0dbafe78a6bd444`:

- [Full Conda job passed](https://github.com/ultralytics/ultralytics/actions/runs/33963646144/job/101299788921) on Ubuntu/Python 3.12: installation completed in 94 seconds; benchmark and Python train/val/predict/export smoke tests passed; pytest reported 165 passed and 28 skipped.
- Runner logs confirm inherited defaults were removed, strict priority was applied, and PyTorch 2.13.0 / torchvision 0.28.0 CPU builds came from conda-forge.
- Workflow validation and `git diff --check` passed; comparison against main found no new actionlint diagnostics (21 existing shellcheck/custom runner-label warnings).
- Automated review finding addressed and resolved; formatter passed. Final full-diff review: LGTM, no findings.

All PR checks and the dedicated Conda workflow passed on the reviewed head before merge. Final cold full-diff review: LGTM, no findings; zero unresolved review threads.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the scheduled Conda CI environment to use only `conda-forge` with strict channel priority, while making dependency installation noninteractive and time-limited to prevent long solver hangs.

### 📊 Key Changes
- Removed `defaults` and enabled `conda-remove-defaults: true` in `setup-miniconda`.
- Changed channel priority from flexible to `strict` for `conda-forge`.
- Removed the explicit `pytorch` channel from installation while retaining `pytorch-cpu`, `torchvision`, `ultralytics`, and `openvino`.
- Added `--yes` for noninteractive installation and a 20-minute timeout for the Conda dependency step.

### 🎯 Purpose & Impact
- The scheduled Conda job now resolves dependencies exclusively from `conda-forge` and fails earlier if installation hangs.
- The validated Conda job completed installation in 94 seconds and passed its benchmark, smoke tests, and pytest checks.
- No user-facing change; this updates CI environment setup and dependency installation behavior only.