### PR TITLE
Document DEEPX SDK dependency installation

### DIFF
--- a/docs/en/integrations/deepx.md
+++ b/docs/en/integrations/deepx.md
@@ -57,7 +57,21 @@ To install the required packages, run:
         pip install ultralytics
         ```
 
-The `dx_com` compiler package will be automatically installed from the DEEPX SDK repository on first export. For detailed instructions and best practices related to the installation process, check our [Ultralytics Installation guide](../quickstart.md). While installing the required packages for YOLO, if you encounter any difficulties, consult our [Common Issues guide](../guides/yolo-common-issues.md) for solutions and tips.
+The `dx_com` compiler is automatically installed from the [DEEPX SDK repository](https://sdk.deepx.ai/release/dxcom/v2.3.0/index.html) on first export. The current export workflow uses DX-COM 2.3.0, which provides wheels for Python 3.8–3.12 on x86-64 Linux with glibc 2.31 or newer.
+
+The compiler's PyPI releases are yanked. To preinstall the export dependencies, supply the SDK wheel page with `--find-links`; this works with both `pip` and `uv pip`:
+
+```bash
+pip install "ultralytics[export-deepx]" --find-links https://sdk.deepx.ai/release/dxcom/v2.3.0/index.html
+```
+
+For an editable repository install, replace `"ultralytics[export-deepx]"` with `-e ".[export-base,export-deepx]"`. To reproduce the Python 3.12 environment and smoke export used by CI, run the existing environment builder from the repository root:
+
+```bash
+ULTRALYTICS_ISOLATED_VENVS=.venvs python .github/scripts/create-export-env.py --env isolated-deepx
+```
+
+The environment builder requires [uv](https://docs.astral.sh/uv/getting-started/installation/) and an installed Ultralytics checkout. It installs the compiler from the SDK source and applies the tested dependency constraints automatically.
 
 ### Usage
 

--- a/docs/en/integrations/deepx.md
+++ b/docs/en/integrations/deepx.md
@@ -68,7 +68,7 @@ pip install "ultralytics[export-deepx]" --find-links https://sdk.deepx.ai/releas
 For an editable repository install, replace `"ultralytics[export-deepx]"` with `-e ".[export-base,export-deepx]"`. To reproduce the Python 3.12 environment and smoke export used by CI, run the existing environment builder from the repository root:
 
 ```bash
-ULTRALYTICS_ISOLATED_VENVS=.venvs python .github/scripts/create-export-env.py --env isolated-deepx
+ULTRALYTICS_ISOLATED_VENVS="$PWD/.venvs" python .github/scripts/create-export-env.py --env isolated-deepx
 ```
 
 The environment builder requires [uv](https://docs.astral.sh/uv/getting-started/installation/) and an installed Ultralytics checkout. It installs the compiler from the SDK source and applies the tested dependency constraints automatically.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,15 +236,15 @@ docstring-code-format = true
 [tool.uv.sources]
 dx_com = [
     # retrieved from sdk.deepx.ai/release/dxcom/v2.3.0/index.html
-    { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp38-cp38-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.8'" },
-    { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp39-cp39-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.9'" },
-    { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp310-cp310-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.10'" },
-    { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp311-cp311-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.11'" },
-    { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp312-cp312-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.12'" },
+    { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp38-cp38-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.8' and platform_machine == 'x86_64'" },
+    { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp39-cp39-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.9' and platform_machine == 'x86_64'" },
+    { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp310-cp310-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.10' and platform_machine == 'x86_64'" },
+    { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp311-cp311-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.11' and platform_machine == 'x86_64'" },
+    { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp312-cp312-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.12' and platform_machine == 'x86_64'" },
     # python 3.13 + is only supported starting with dx_com 2.4.0
     # retrieved from sdk.deepx.ai/release/dxcom/v2.4.0/index.html
-    { url = "https://sdk.deepx.ai/release/dxcom/v2.4.0/dx_com-2.4.0-cp313-cp313-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.13'" },
-    { url = "https://sdk.deepx.ai/release/dxcom/v2.4.0/dx_com-2.4.0-cp314-cp314-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.14'" },
+    { url = "https://sdk.deepx.ai/release/dxcom/v2.4.0/dx_com-2.4.0-cp313-cp313-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.13' and platform_machine == 'x86_64'" },
+    { url = "https://sdk.deepx.ai/release/dxcom/v2.4.0/dx_com-2.4.0-cp314-cp314-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.14' and platform_machine == 'x86_64'" },
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,6 +233,20 @@ target-version = "py38"
 [tool.ruff.format]
 docstring-code-format = true
 
+[tool.uv.sources]
+dx_com = [
+    # retrieved from sdk.deepx.ai/release/dxcom/v2.3.0/index.html
+    { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp38-cp38-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.8'" },
+    { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp39-cp39-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.9'" },
+    { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp310-cp31ß-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.10'" },
+    { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp311-cp311-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.11'" },
+    { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp312-cp312-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.12'" },
+    # python 3.13 + is only supported starting with dx_com 2.4.0
+    # retrieved from sdk.deepx.ai/release/dxcom/v2.4.0/index.html
+    { url = "https://sdk.deepx.ai/release/dxcom/v2.4.0/dx_com-2.4.0-cp313-cp313-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.13'" },
+    { url = "https://sdk.deepx.ai/release/dxcom/v2.4.0/dx_com-2.4.0-cp314-cp314-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.14'" },
+]
+
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,20 +233,6 @@ target-version = "py38"
 [tool.ruff.format]
 docstring-code-format = true
 
-[tool.uv.sources]
-dx_com = [
-    # retrieved from sdk.deepx.ai/release/dxcom/v2.3.0/index.html
-    { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp38-cp38-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.8' and platform_machine == 'x86_64'" },
-    { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp39-cp39-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.9' and platform_machine == 'x86_64'" },
-    { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp310-cp310-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.10' and platform_machine == 'x86_64'" },
-    { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp311-cp311-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.11' and platform_machine == 'x86_64'" },
-    { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp312-cp312-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.12' and platform_machine == 'x86_64'" },
-    # python 3.13 + is only supported starting with dx_com 2.4.0
-    # retrieved from sdk.deepx.ai/release/dxcom/v2.4.0/index.html
-    { url = "https://sdk.deepx.ai/release/dxcom/v2.4.0/dx_com-2.4.0-cp313-cp313-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.13' and platform_machine == 'x86_64'" },
-    { url = "https://sdk.deepx.ai/release/dxcom/v2.4.0/dx_com-2.4.0-cp314-cp314-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.14' and platform_machine == 'x86_64'" },
-]
-
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -238,7 +238,7 @@ dx_com = [
     # retrieved from sdk.deepx.ai/release/dxcom/v2.3.0/index.html
     { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp38-cp38-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.8'" },
     { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp39-cp39-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.9'" },
-    { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp310-cp31ß-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.10'" },
+    { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp310-cp310-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.10'" },
     { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp311-cp311-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.11'" },
     { url = "https://sdk.deepx.ai/release/dxcom/v2.3.0/dx_com-2.3.0-cp312-cp312-manylinux_2_31_x86_64.whl", marker = "platform_system == 'Linux' and python_version == '3.12'" },
     # python 3.13 + is only supported starting with dx_com 2.4.0


### PR DESCRIPTION
Manual DEEPX dependency installation fails against PyPI because the compiler releases are yanked. Document the SDK `--find-links` option already used by first-export auto-installation and the isolated CI environment, with the editable-install equivalent and the existing CI environment builder command.

This changes only the DEEPX installation guide and retains the current DX-COM 2.3.0 workflow. No wheel URL matrix, dependency configuration, or runtime behavior is added.

Validation: reproduced the PyPI resolution failure; verified the vendor wheel index and Python/platform compatibility; successfully resolved the editable `export-base,export-deepx` install with the documented SDK source for Python 3.12 / Linux x86-64. Prettier and whitespace checks pass. Full compiler execution was not repeated locally.
