### PR TITLE
Normalize augmentation overrides after restoring resume arguments

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -129,11 +129,11 @@ class BaseTrainer:
             _callbacks (dict, optional): Dictionary of callback functions.
         """
         self.args = get_cfg(cfg, overrides)
+        self.check_resume(overrides)
         if getattr(self.args, "augmentations", None) and not isinstance(self.args.augmentations[0], dict):
             import albumentations as A
 
             self.args.augmentations = [A.to_dict(t) for t in self.args.augmentations]  # YAML/pickle-safe, DDP-safe
-        self.check_resume(overrides)
         self.args.device = parse_device(self.args.device)  # canonical string, resolves '-1' auto-selection once
         self.device = select_device(self.args.device)
         self.accelerator = get_torch_device_backend(self.device) if self.device.type not in {"cpu", "mps"} else None


### PR DESCRIPTION
Resuming training with `augmentations=[A.HorizontalFlip(...), ...]` crashes while writing `args.yaml` with `yaml.representer.RepresenterError: cannot represent an object`. `BaseTrainer` normalized the initial arguments before `check_resume()` replaced them with checkpoint arguments and raw caller overrides.

Move the existing `check_resume(overrides)` call before augmentation normalization so the final effective arguments are serialized once at their existing owner. One line relocated; no new helper, exception guard, or compatibility path.

Found while reproducing the resumed segmentation configuration in #25832, following the serialization change in #25891. **This fixes a separate reproducible resume crash; it does not establish the cause of #25832's reported memory freeze or close that issue.**

Validation on ultra5 (RTX PRO 6000 Blackwell, Python 3.12.3, torch 2.11.0+cu128):

- Actually trained YOLO11n-seg on COCO128-seg with the reporter's ten Albumentations transforms, batch 8, 640px, three workers, AMP off, plotting/checkpoint saving enabled; interrupted after the fifth saved epoch.
- Current main failed on that checkpoint with raw augmentation overrides before training. The changed owner resumed epochs 6–20, restored training state, completed validation and saved checkpoints, and shut down workers normally.
- Five real trainer-construction/YAML round-trip cases passed: fresh raw transforms; resume with raw overrides; resume with saved transforms; explicit empty overrides; already serialized dictionary overrides.
- Ruff formatting and `git diff --check` pass. The file's two unrelated existing BLE001 findings remain unchanged.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

`BaseTrainer` now restores resume arguments before normalizing augmentation objects, preventing raw augmentation overrides from failing during `args.yaml` serialization.

### 📊 Key Changes

- Moved `self.check_resume(overrides)` ahead of augmentation normalization in `ultralytics/engine/trainer.py`.
- Normalizes the final effective `augmentations` arguments after checkpoint arguments and caller overrides have been applied.
- Preserves the existing conversion of Albumentations objects to YAML/pickle-safe dictionaries without adding new helpers or exception handling.
- Validation covered fresh, resumed, saved, empty, and already serialized augmentation configurations.

### 🎯 Purpose & Impact

- Resumed training with raw Albumentations overrides can proceed through argument serialization instead of raising `yaml.representer.RepresenterError`.
- The change addresses the reproducible resume serialization crash; it does not resolve or determine the cause of the separate memory-freeze report in issue #25832.