### PR TITLE
Preserve prediction save directory in Results copies

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1213,6 +1213,19 @@ def test_results_update_probs():
     assert r.verbose() and r.summary(), "verbose()/summary() raise AttributeError on a raw Tensor probs"
 
 
+def test_results_copy_preserves_save_dir():
+    """Results copy operations preserve the prediction output directory."""
+    from ultralytics.engine.results import Results
+
+    image = np.zeros((8, 8, 3), dtype=np.uint8)
+    boxes = torch.tensor([[0.0, 0.0, 4.0, 4.0, 0.9, 0.0]])
+    result = Results(image, path="image.jpg", names={0: "object"}, boxes=boxes)
+    result.save_dir = "runs/detect/predict"
+
+    for copied in (result[0], result.cpu(), result.numpy(), result.to("cpu")):
+        assert copied.save_dir == result.save_dir
+
+
 def test_labels_and_crops(tmp_path):
     """Test output from prediction args for saving YOLO detection labels and crops."""
     imgs = [SOURCE, ASSETS / "zidane.jpg"]

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1213,19 +1213,6 @@ def test_results_update_probs():
     assert r.verbose() and r.summary(), "verbose()/summary() raise AttributeError on a raw Tensor probs"
 
 
-def test_results_copy_preserves_save_dir():
-    """Results copy operations preserve the prediction output directory."""
-    from ultralytics.engine.results import Results
-
-    image = np.zeros((8, 8, 3), dtype=np.uint8)
-    boxes = torch.tensor([[0.0, 0.0, 4.0, 4.0, 0.9, 0.0]])
-    result = Results(image, path="image.jpg", names={0: "object"}, boxes=boxes)
-    result.save_dir = "runs/detect/predict"
-
-    for copied in (result[0], result.cpu(), result.numpy(), result.to("cpu")):
-        assert copied.save_dir == result.save_dir
-
-
 def test_labels_and_crops(tmp_path):
     """Test output from prediction args for saving YOLO detection labels and crops."""
     imgs = [SOURCE, ASSETS / "zidane.jpg"]

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -469,7 +469,7 @@ class Results(SimpleClass, DataExportMixin):
         return self._apply("to", *args, **kwargs)
 
     def new(self):
-        """Create a new Results object with the same image, path, names, and speed attributes.
+        """Create a new Results object with the same image, path, names, speed, and save directory attributes.
 
         Returns:
             (Results): A new Results object with copied attributes from the original instance.
@@ -478,7 +478,9 @@ class Results(SimpleClass, DataExportMixin):
             >>> results = model("path/to/image.jpg")
             >>> new_result = results[0].new()
         """
-        return Results(orig_img=self.orig_img, path=self.path, names=self.names, speed=self.speed)
+        result = Results(orig_img=self.orig_img, path=self.path, names=self.names, speed=self.speed)
+        result.save_dir = self.save_dir
+        return result
 
     def plot(
         self,


### PR DESCRIPTION
Indexing a prediction result or converting its tensors rebuilt the Results object without its prediction save directory. Copy `save_dir` in the shared `Results.new()` owner so `new()`, indexing, `cpu()`, `numpy()`, and `to()` preserve it.

Validated every affected operation on actual saved YOLO26 predictions for bus.jpg and zidane.jpg, plus Ruff and diff checks. No new arguments or permanent test code.
