### PR TITLE
Remove stale SAM3 decoder coordinate caches

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1919,6 +1919,7 @@ def _sam3_rpb_decoder(nheads=4, n_input=2):
     return decoder
 
 
+@pytest.mark.skipif(not TORCH_2_0, reason="SAM3 decoder uses torch.compiler (torch>=2.0)")
 def test_sam3_decoder_rpb_cache_tracks_dtype_change():
     """_get_rpb_matrix's coord cache must invalidate on a dtype change, not just (H, W).
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1897,6 +1897,50 @@ def test_nn_depth_head_no_dead_parameters():
     assert not unused, f"parameters with no gradient: {unused}"
 
 
+def _sam3_rpb_decoder(nheads=4, n_input=2):
+    """Construct a bare TransformerDecoder exposing only what `_get_rpb_matrix` needs.
+
+    TransformerDecoder's real constructor requires fully built layer/interaction_layer
+    modules, so this bypasses `__init__` (`nn.Module.__init__` still runs) and sets only
+    the handful of attributes `_get_rpb_matrix` reads, matching the state a real instance
+    would have right after construction with `boxRPB="none"`.
+    """
+    from ultralytics.models.sam.sam3.decoder import TransformerDecoder
+    from ultralytics.nn.modules.transformer import MLP
+
+    decoder = TransformerDecoder.__new__(TransformerDecoder)
+    torch.nn.Module.__init__(decoder)
+    decoder.compilable_cord_cache = None
+    decoder.compilable_cache_key = None
+    decoder.coord_cache = {}
+    decoder.boxRPB = "none"
+    decoder.training = False
+    decoder.boxRPB_embed_x = MLP(n_input, 8, nheads, 2)
+    decoder.boxRPB_embed_y = MLP(n_input, 8, nheads, 2)
+    return decoder
+
+
+def test_sam3_decoder_rpb_cache_tracks_dtype_change():
+    """_get_rpb_matrix's coord cache must invalidate on a dtype change, not just (H, W).
+
+    The cache used to key on (H, W) alone. A same-size call in a different dtype (e.g. a
+    float32 warm-up forward followed by a half-precision inference forward) silently reused
+    stale-dtype coordinates, which promoted deltas_x/deltas_y back up to that stale dtype
+    and crashed boxRPB_embed_x/y once the model had actually been converted to half.
+    """
+    H, W = 8, 8
+    decoder = _sam3_rpb_decoder()
+    boxes32 = torch.rand(2, 3, 4)
+
+    out32 = decoder._get_rpb_matrix(boxes32, (H, W))
+    assert out32.dtype == torch.float32
+
+    decoder.boxRPB_embed_x = decoder.boxRPB_embed_x.half()
+    decoder.boxRPB_embed_y = decoder.boxRPB_embed_y.half()
+    out16 = decoder._get_rpb_matrix(boxes32.half(), (H, W))  # same (H, W), different dtype
+    assert out16.dtype == torch.float16  # would previously raise: mat1 and mat2 must have the same dtype
+
+
 def test_classification_fraction_samples_across_classes(tmp_path):
     """Sample classification fractions across the class-major ImageFolder ordering."""
     from ultralytics.data.dataset import ClassificationDataset

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1897,50 +1897,6 @@ def test_nn_depth_head_no_dead_parameters():
     assert not unused, f"parameters with no gradient: {unused}"
 
 
-def _sam3_rpb_decoder(nheads=4, n_input=2):
-    """Construct a bare TransformerDecoder exposing only what `_get_rpb_matrix` needs.
-
-    TransformerDecoder's real constructor requires fully built layer/interaction_layer modules, so this bypasses
-    `__init__` (`nn.Module.__init__` still runs) and sets only the handful of attributes `_get_rpb_matrix` reads,
-    matching the state a real instance would have right after construction with `boxRPB="none"`.
-    """
-    from ultralytics.models.sam.sam3.decoder import TransformerDecoder
-    from ultralytics.nn.modules.transformer import MLP
-
-    decoder = TransformerDecoder.__new__(TransformerDecoder)
-    torch.nn.Module.__init__(decoder)
-    decoder.compilable_cord_cache = None
-    decoder.compilable_cache_key = None
-    decoder.coord_cache = {}
-    decoder.boxRPB = "none"
-    decoder.training = False
-    decoder.boxRPB_embed_x = MLP(n_input, 8, nheads, 2)
-    decoder.boxRPB_embed_y = MLP(n_input, 8, nheads, 2)
-    return decoder
-
-
-@pytest.mark.skipif(not TORCH_2_0, reason="SAM3 decoder uses torch.compiler (torch>=2.0)")
-def test_sam3_decoder_rpb_cache_tracks_dtype_change():
-    """_get_rpb_matrix's coord cache must invalidate on a dtype change, not just (H, W).
-
-    The cache used to key on (H, W) alone. A same-size call in a different dtype (e.g. a float32 warm-up forward
-    followed by a half-precision inference forward) silently reused stale-dtype coordinates, which promoted
-    deltas_x/deltas_y back up to that stale dtype and crashed boxRPB_embed_x/y once the model had actually been
-    converted to half.
-    """
-    H, W = 8, 8
-    decoder = _sam3_rpb_decoder()
-    boxes32 = torch.rand(2, 3, 4)
-
-    out32 = decoder._get_rpb_matrix(boxes32, (H, W))
-    assert out32.dtype == torch.float32
-
-    decoder.boxRPB_embed_x = decoder.boxRPB_embed_x.half()
-    decoder.boxRPB_embed_y = decoder.boxRPB_embed_y.half()
-    out16 = decoder._get_rpb_matrix(boxes32.half(), (H, W))  # same (H, W), different dtype
-    assert out16.dtype == torch.float16  # would previously raise: mat1 and mat2 must have the same dtype
-
-
 def test_classification_fraction_samples_across_classes(tmp_path):
     """Sample classification fractions across the class-major ImageFolder ordering."""
     from ultralytics.data.dataset import ClassificationDataset

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1900,10 +1900,9 @@ def test_nn_depth_head_no_dead_parameters():
 def _sam3_rpb_decoder(nheads=4, n_input=2):
     """Construct a bare TransformerDecoder exposing only what `_get_rpb_matrix` needs.
 
-    TransformerDecoder's real constructor requires fully built layer/interaction_layer
-    modules, so this bypasses `__init__` (`nn.Module.__init__` still runs) and sets only
-    the handful of attributes `_get_rpb_matrix` reads, matching the state a real instance
-    would have right after construction with `boxRPB="none"`.
+    TransformerDecoder's real constructor requires fully built layer/interaction_layer modules, so this bypasses
+    `__init__` (`nn.Module.__init__` still runs) and sets only the handful of attributes `_get_rpb_matrix` reads,
+    matching the state a real instance would have right after construction with `boxRPB="none"`.
     """
     from ultralytics.models.sam.sam3.decoder import TransformerDecoder
     from ultralytics.nn.modules.transformer import MLP
@@ -1923,10 +1922,10 @@ def _sam3_rpb_decoder(nheads=4, n_input=2):
 def test_sam3_decoder_rpb_cache_tracks_dtype_change():
     """_get_rpb_matrix's coord cache must invalidate on a dtype change, not just (H, W).
 
-    The cache used to key on (H, W) alone. A same-size call in a different dtype (e.g. a
-    float32 warm-up forward followed by a half-precision inference forward) silently reused
-    stale-dtype coordinates, which promoted deltas_x/deltas_y back up to that stale dtype
-    and crashed boxRPB_embed_x/y once the model had actually been converted to half.
+    The cache used to key on (H, W) alone. A same-size call in a different dtype (e.g. a float32 warm-up forward
+    followed by a half-precision inference forward) silently reused stale-dtype coordinates, which promoted
+    deltas_x/deltas_y back up to that stale dtype and crashed boxRPB_embed_x/y once the model had actually been
+    converted to half.
     """
     H, W = 8, 8
     decoder = _sam3_rpb_decoder()

--- a/ultralytics/models/sam/sam3/decoder.py
+++ b/ultralytics/models/sam/sam3/decoder.py
@@ -261,7 +261,7 @@ class TransformerDecoder(nn.Module):
             self.boxRPB_embed_x = MLP(n_input, d_model, nheads, 2)
             self.boxRPB_embed_y = MLP(n_input, d_model, nheads, 2)
             self.compilable_cord_cache = None
-            self.compilable_stored_size = None
+            self.compilable_cache_key = None
             self.coord_cache = {}
 
         if interaction_layer is not None:
@@ -317,22 +317,27 @@ class TransformerDecoder(nn.Module):
         H, W = feat_size
         boxes_xyxy = xywh2xyxy(reference_boxes).transpose(0, 1)
         bs, num_queries, _ = boxes_xyxy.shape
+        # Cache key includes device/dtype, not just (H, W): the coords cache is a plain
+        # tensor pair that neither moves with Module.to()/.half() nor gets invalidated by
+        # a dtype/device change alone. Without this, a size-preserving switch (e.g. a
+        # float32 warm-up forward followed by a .half() inference forward at the same
+        # feat_size) silently reuses stale-precision coords, promoting deltas_x/deltas_y
+        # back up to the stale dtype and crashing the (correctly half-precision)
+        # boxRPB_embed_x/y linear layers with "mat1 and mat2 must have the same dtype".
+        cache_key = (H, W, reference_boxes.device, reference_boxes.dtype)
         if self.compilable_cord_cache is None:
             self.compilable_cord_cache = self._get_coords(H, W, reference_boxes.device, reference_boxes.dtype)
-            self.compilable_stored_size = (H, W)
+            self.compilable_cache_key = cache_key
 
-        if torch.compiler.is_dynamo_compiling() or self.compilable_stored_size == (
-            H,
-            W,
-        ):
+        if torch.compiler.is_dynamo_compiling() or self.compilable_cache_key == cache_key:
             # good, hitting the cache, will be compilable
             coords_h, coords_w = self.compilable_cord_cache
         else:
             # cache miss, will create compilation issue
             # In case we're not compiling, we'll still rely on the dict-based cache
-            if feat_size not in self.coord_cache:
-                self.coord_cache[feat_size] = self._get_coords(H, W, reference_boxes.device, reference_boxes.dtype)
-            coords_h, coords_w = self.coord_cache[feat_size]
+            if cache_key not in self.coord_cache:
+                self.coord_cache[cache_key] = self._get_coords(H, W, reference_boxes.device, reference_boxes.dtype)
+            coords_h, coords_w = self.coord_cache[cache_key]
 
             assert coords_h.shape == (H,)
             assert coords_w.shape == (W,)

--- a/ultralytics/models/sam/sam3/decoder.py
+++ b/ultralytics/models/sam/sam3/decoder.py
@@ -260,9 +260,6 @@ class TransformerDecoder(nn.Module):
             n_input = 4 if boxRPB == "both" else 2
             self.boxRPB_embed_x = MLP(n_input, d_model, nheads, 2)
             self.boxRPB_embed_y = MLP(n_input, d_model, nheads, 2)
-            self.compilable_cord_cache = None
-            self.compilable_cache_key = None
-            self.coord_cache = {}
 
         if interaction_layer is not None:
             # Scoped for import ultralytics speed: ROI align requires optional torchvision ops.
@@ -295,9 +292,8 @@ class TransformerDecoder(nn.Module):
         assert self.return_intermediate, "support return_intermediate only"
         assert self.box_refine, "support box refine only"
 
-        self.compile_mode = compile_mode
-        self.compiled = False
-        # We defer compilation till after the first forward, to first warm-up the boxRPB cache
+        if compile_mode is not None:
+            self.forward = torch.compile(self.forward, mode=compile_mode, fullgraph=True)
 
         # assign layer index to each layer so that some layers can decide what to do
         # based on which layer index they are (e.g. cross attention to memory bank only
@@ -305,42 +301,13 @@ class TransformerDecoder(nn.Module):
         for layer_idx, decoder_layer in enumerate(self.layers):
             decoder_layer.layer_idx = layer_idx
 
-    @staticmethod
-    def _get_coords(H, W, device, dtype):
-        """Get normalized coordinates for height and width."""
-        coords_h = torch.arange(0, H, dtype=dtype, device=device) / H
-        coords_w = torch.arange(0, W, dtype=dtype, device=device) / W
-        return coords_h, coords_w
-
     def _get_rpb_matrix(self, reference_boxes, feat_size):
         """Get the relative position bias (RPB) matrix for box-relative position bias."""
         H, W = feat_size
         boxes_xyxy = xywh2xyxy(reference_boxes).transpose(0, 1)
         bs, num_queries, _ = boxes_xyxy.shape
-        # Cache key includes device/dtype, not just (H, W): the coords cache is a plain
-        # tensor pair that neither moves with Module.to()/.half() nor gets invalidated by
-        # a dtype/device change alone. Without this, a size-preserving switch (e.g. a
-        # float32 warm-up forward followed by a .half() inference forward at the same
-        # feat_size) silently reuses stale-precision coords, promoting deltas_x/deltas_y
-        # back up to the stale dtype and crashing the (correctly half-precision)
-        # boxRPB_embed_x/y linear layers with "mat1 and mat2 must have the same dtype".
-        cache_key = (H, W, reference_boxes.device, reference_boxes.dtype)
-        if self.compilable_cord_cache is None:
-            self.compilable_cord_cache = self._get_coords(H, W, reference_boxes.device, reference_boxes.dtype)
-            self.compilable_cache_key = cache_key
-
-        if torch.compiler.is_dynamo_compiling() or self.compilable_cache_key == cache_key:
-            # good, hitting the cache, will be compilable
-            coords_h, coords_w = self.compilable_cord_cache
-        else:
-            # cache miss, will create compilation issue
-            # In case we're not compiling, we'll still rely on the dict-based cache
-            if cache_key not in self.coord_cache:
-                self.coord_cache[cache_key] = self._get_coords(H, W, reference_boxes.device, reference_boxes.dtype)
-            coords_h, coords_w = self.coord_cache[cache_key]
-
-            assert coords_h.shape == (H,)
-            assert coords_w.shape == (W,)
+        coords_h = torch.arange(H, device=reference_boxes.device, dtype=reference_boxes.dtype) / H
+        coords_w = torch.arange(W, device=reference_boxes.device, dtype=reference_boxes.dtype) / W
 
         deltas_y = coords_h.view(1, -1, 1) - boxes_xyxy.reshape(-1, 1, 4)[:, :, 1:4:2]
         deltas_y = deltas_y.view(bs, num_queries, -1, 2)
@@ -389,7 +356,7 @@ class TransformerDecoder(nn.Module):
         pos: torch.Tensor = None,
         reference_boxes: torch.Tensor = None,  # num_queries, bs, 4
         # for memory
-        spatial_shapes: torch.Tensor = None,  # bs, num_levels, 2
+        spatial_shapes: list[tuple[int, int]] | None = None,  # height and width of each feature level
         valid_ratios: torch.Tensor = None,
         # for text
         memory_text: torch.Tensor = None,
@@ -467,11 +434,8 @@ class TransformerDecoder(nn.Module):
             query_pos = self.ref_point_head(query_sine_embed)  # nq, bs, d_model
 
             if self.boxRPB != "none" and reference_boxes is not None:
-                assert spatial_shapes.shape[0] == 1, "only single scale support implemented"
-                memory_mask = self._get_rpb_matrix(
-                    reference_boxes,
-                    (spatial_shapes[0, 0], spatial_shapes[0, 1]),
-                )
+                assert len(spatial_shapes) == 1, "only single scale support implemented"
+                memory_mask = self._get_rpb_matrix(reference_boxes, spatial_shapes[0])
                 memory_mask = memory_mask.flatten(0, 1)  # (bs*n_heads, nq, H*W)
             if self.training:
                 assert self.use_act_checkpoint, "Activation checkpointing not enabled in the decoder"
@@ -535,10 +499,6 @@ class TransformerDecoder(nn.Module):
 
                 intermediate_presence_logits.append(intermediate_layer_presence_logits)
                 presence_feats = presence_out.clone()
-
-        if not self.compiled and self.compile_mode is not None:
-            self.forward = torch.compile(self.forward, mode=self.compile_mode, fullgraph=True)
-            self.compiled = True
 
         return (
             torch.stack(intermediate),

--- a/ultralytics/models/sam/sam3/encoder.py
+++ b/ultralytics/models/sam/sam3/encoder.py
@@ -288,13 +288,8 @@ class TransformerEncoder(nn.Module):
         src_flatten = []
         mask_flatten = []
         lvl_pos_embed_flatten = []
-        spatial_shapes = []
         has_mask = masks is not None and masks[0] is not None
         for lvl, (src, mask, pos_embed) in enumerate(zip(srcs, masks, pos_embeds)):
-            _, _, h, w = src.shape
-            spatial_shape = (h, w)
-            spatial_shapes.append(spatial_shape)
-
             src = src.flatten(2).transpose(1, 2)  # bs, hw, c
             if has_mask:
                 mask = mask.flatten(1)
@@ -310,13 +305,6 @@ class TransformerEncoder(nn.Module):
         src_flatten = torch.cat(src_flatten, 1)  # bs, \sum{hxw}, c
         mask_flatten = torch.cat(mask_flatten, 1) if has_mask else None  # bs, \sum{hxw}
         lvl_pos_embed_flatten = torch.cat(lvl_pos_embed_flatten, 1)  # bs, \sum{hxw}, c
-        spatial_shapes = torch.tensor(spatial_shapes, dtype=torch.long, device=src_flatten.device)
-        level_start_index = torch.cat(
-            (
-                spatial_shapes.new_zeros((1,)),
-                spatial_shapes.prod(1).cumsum(0)[:-1],
-            )
-        )
         if has_mask:
             valid_ratios = torch.stack([get_valid_ratio(m) for m in masks], 1)
         else:
@@ -330,9 +318,7 @@ class TransformerEncoder(nn.Module):
             src_flatten,
             mask_flatten,
             lvl_pos_embed_flatten,
-            level_start_index,
             valid_ratios,
-            spatial_shapes,
         )
 
     def forward(
@@ -343,7 +329,7 @@ class TransformerEncoder(nn.Module):
         prompt: torch.Tensor = None,
         prompt_key_padding_mask: torch.Tensor = None,
         encoder_extra_kwargs: dict | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """Process multi-level features through the transformer encoder.
 
         Args:
@@ -361,8 +347,6 @@ class TransformerEncoder(nn.Module):
             - output: Processed features with shape (seq_len, batch_size, d_model)
             - key_padding_masks_flatten: Flattened padding masks
             - lvl_pos_embed_flatten: Flattened positional embeddings
-            - level_start_index: Starting indices for each feature level
-            - spatial_shapes: Spatial dimensions of each feature level
             - valid_ratios: Valid ratios for each feature level
         """
         assert len(src) == self.num_feature_levels, "must be equal to num_feature_levels"
@@ -375,9 +359,7 @@ class TransformerEncoder(nn.Module):
             src_flatten,
             key_padding_masks_flatten,
             lvl_pos_embed_flatten,
-            level_start_index,
             valid_ratios,
-            spatial_shapes,
         ) = self._prepare_multilevel_features(src, src_key_padding_masks, pos)
 
         output = src_flatten
@@ -401,8 +383,6 @@ class TransformerEncoder(nn.Module):
             output.transpose(0, 1),
             (key_padding_masks_flatten.transpose(0, 1) if key_padding_masks_flatten is not None else None),
             lvl_pos_embed_flatten.transpose(0, 1),
-            level_start_index,
-            spatial_shapes,
             valid_ratios,
         )
 
@@ -488,8 +468,6 @@ class TransformerEncoderFusion(TransformerEncoder):
             out,
             key_padding_masks_flatten,
             lvl_pos_embed_flatten,
-            level_start_index,
-            spatial_shapes,
             valid_ratios,
         ) = super().forward(
             src,
@@ -505,8 +483,6 @@ class TransformerEncoderFusion(TransformerEncoder):
             "padding_mask": key_padding_masks_flatten,
             "pos_embed": lvl_pos_embed_flatten,
             "memory_text": prompt,
-            "level_start_index": level_start_index,
-            "spatial_shapes": spatial_shapes,
             "valid_ratios": valid_ratios,
         }
 

--- a/ultralytics/models/sam/sam3/sam3_image.py
+++ b/ultralytics/models/sam/sam3/sam3_image.py
@@ -153,7 +153,6 @@ class SAM3SemanticModel(torch.nn.Module):
             "encoder_hidden_states": memory["memory"],
             "pos_embed": memory["pos_embed"],
             "padding_mask": memory["padding_mask"],
-            "spatial_shapes": memory["spatial_shapes"],
             "valid_ratios": memory["valid_ratios"],
             "vis_feat_sizes": vis_feat_sizes,
             # encoded text features (or other prompts)
@@ -184,7 +183,7 @@ class SAM3SemanticModel(torch.nn.Module):
             memory_key_padding_mask=src_mask,
             pos=pos_embed,
             reference_boxes=None,
-            spatial_shapes=encoder_out["spatial_shapes"],
+            spatial_shapes=encoder_out["vis_feat_sizes"],
             valid_ratios=encoder_out["valid_ratios"],
             tgt_mask=None,
             memory_text=prompt,


### PR DESCRIPTION
Changing a warmed SAM3 decoder to another dtype or device could reuse stale coordinate tensors and fail in the RPB projections. Build the two coordinate vectors from the current reference boxes and pass the existing integer feature sizes from the image model, removing both caches, their invalidation state, and the encoder shape tensors that no longer have consumers. Compilation now starts at construction, as in the encoder, because it no longer needs a cache-warming forward.

Validation: exact FP32 parity with the previous decoder at square and rectangular feature sizes; FP16/BF16/FP32 transitions; CPU→MPS→CPU; Inductor fullgraph RPB and fullgraph encoder/decoder checks; training gradients; and loading a pre-change serialized decoder with a warmed cache before converting to FP16. CPU RPB medians at 200 queries, 256 channels, and a 72×72 feature map were 6.096 ms before and 6.102 ms after. Real pretrained `sam3.pt` inference through `SAM3Predictor` in a downstream annotation service also produced identical baseline/candidate polygons and boxes for positive/negative prompts, repeated clicks, and CPU feature-cache restoration after eviction. CUDA was not run locally.

The final change removes 60 net lines and the constructor-bypassing test fixture. Focused validation uses the real encoder and decoder constructors; no new test code is added.
