### PR TITLE
Document torchvision NMS fast path in predict FAQ

### DIFF
--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -974,7 +974,7 @@ Ultralytics YOLO can process a wide range of data sources, including individual 
 
 To optimize inference speed and manage memory efficiently, you can use the streaming mode by setting `stream=True` in the predictor's call method. The streaming mode generates a memory-efficient generator of `Results` objects instead of loading all frames into memory. For processing long videos or large datasets, streaming mode is particularly useful. Learn more about [streaming mode](#key-features-of-predict-mode).
 
-On very large images with dense same-class detections, NMS performance also matters: [`non_max_suppression()`](../reference/utils/nms.md) runs on the faster `torchvision.ops.nms` kernel whenever `torchvision` is imported, and the standard predict and val pipelines import it automatically during model warmup. If your custom pipeline calls `non_max_suppression()` directly, add `import torchvision` before inference — the pure-torch fallback can be over 20× slower on such scenes.
+On very large images with dense same-class detections, NMS performance also matters: on non-XPU devices, [`non_max_suppression()`](../reference/utils/nms.md) runs on the faster `torchvision.ops.nms` kernel whenever `torchvision` is imported, and the standard predict and val pipelines import it automatically during model warmup. If your custom pipeline calls `non_max_suppression()` directly, add `import torchvision` before inference — the pure-torch fallback can be over 20× slower on such scenes.
 
 ### What inference arguments does Ultralytics YOLO support?
 

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -974,6 +974,8 @@ Ultralytics YOLO can process a wide range of data sources, including individual 
 
 To optimize inference speed and manage memory efficiently, you can use the streaming mode by setting `stream=True` in the predictor's call method. The streaming mode generates a memory-efficient generator of `Results` objects instead of loading all frames into memory. For processing long videos or large datasets, streaming mode is particularly useful. Learn more about [streaming mode](#key-features-of-predict-mode).
 
+On very large images with dense same-class detections, NMS performance also matters: [`non_max_suppression()`](../reference/utils/nms.md) runs on the faster `torchvision.ops.nms` kernel whenever `torchvision` is imported, and the standard predict and val pipelines import it automatically during model warmup. If your custom pipeline calls `non_max_suppression()` directly, add `import torchvision` before inference — the pure-torch fallback can be over 20× slower on such scenes.
+
 ### What inference arguments does Ultralytics YOLO support?
 
 The `model.predict()` method in YOLO supports various arguments such as `conf`, `iou`, `imgsz`, `device`, and more. These arguments allow you to customize the inference process, setting parameters like confidence thresholds, image size, and the device used for computation. Detailed descriptions of these arguments can be found in the [inference arguments](#inference-arguments) section.


### PR DESCRIPTION
## Summary

Adds a note to the [predict-mode FAQ](https://docs.ultralytics.com/modes/predict/#how-do-i-optimize-yolo-inference-speed-and-memory-usage) speed entry documenting that `non_max_suppression()` runs on the `torchvision.ops.nms` kernel whenever `torchvision` is imported, that the standard predict/val pipelines import it automatically during model warmup, and that custom pipelines calling `non_max_suppression()` directly should `import torchvision` first.

## Motivation

This is the docs note promised in https://github.com/ultralytics/ultralytics/discussions/22109 ("We'll add a note in the docs that importing torchvision before inference switches to torchvision.ops.nms") and explicitly requested by the reporter there. It was never added — the torchvision NMS dispatch is currently not documented anywhere in the docs.

Measured on current main (8.4.142, AMD Ryzen 7 5700X / RTX 4060 Ti, torch 2.14.0+cu130) on a dense 5120×5120 scene (~537k anchors, ~12k candidates above conf):

-   CPU: NMS 17.9 s without torchvision imported vs 0.8 s with (22×)
-   CUDA: 25.5 s vs 0.037 s (689×)

The standard `predict()`/`val()` paths already preload torchvision during `AutoBackend.warmup()` (#25023), so this note targets releases before that fix and custom pipelines that call `non_max_suppression()` directly. Full measurements are posted in the discussion linked above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Documents the torchvision NMS fast path in the predict-mode FAQ so users understand how to enable it in custom inference pipelines.

### 📊 Key Changes
- Adds a note explaining that `non_max_suppression()` uses `torchvision.ops.nms` when `torchvision` is imported.
- Documents that standard predict and val pipelines import `torchvision` during model warmup.
- Advises custom pipelines to import `torchvision` before calling `non_max_suppression()` directly.
- Warns that the pure-Torch fallback can be substantially slower on large, dense images.

### 🎯 Purpose & Impact
This is a documentation-only change that clarifies NMS dispatch and provides a workflow recommendation for improving inference performance in custom pipelines; no runtime code is modified.