### PR TITLE
Drop the FP32 promise from the export quantize hint on formats that cannot export FP32

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -622,11 +622,6 @@ class Exporter:
         fmt_keys = dict(zip(fmts_dict["Argument"], fmts_dict["Arguments"]))[fmt]
         validate_args(fmt, self.args, fmt_keys)
         if fmt in {"deepx", "axelera", "imx", "edgetpu", "qnn", "hailo"} and self.args.quantize not in {8, "w8a16"}:
-            if self.args.quantize == 32:
-                raise ValueError(
-                    f"{fmt} export only supports INT8, but got an explicit quantize=32 (FP32) request. "
-                    f"See {QUANTIZE_DOCS_URL}"
-                )
             LOGGER.warning(f"{fmt} export requires INT8 quantization, enabling it.")
             self.args.quantize = "w8a16" if fmt == "qnn" else 8
         if fmt in {"axelera", "hailo"} and not self.args.data:

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -464,8 +464,8 @@ def validate_args(format, passed_args, valid_args):
     if passed_args.quantize is not None:  # 32/None (FP32) is universal except FP32_UNSUPPORTED_FORMATS
         options = [label for label, formats in QUANTIZE_PRECISIONS if format in formats]
         if format not in FP32_UNSUPPORTED_FORMATS:
-            options.append("32 (FP32)")
-        hint = f"format='{format}' supports quantize={', '.join(options) or 'none'} (or None for FP32). See {QUANTIZE_DOCS_URL}"
+            options.append("32 or None (FP32)")
+        hint = f"format='{format}' supports quantize={', '.join(options)}. See {QUANTIZE_DOCS_URL}"
         if passed_args.quantize == 16:  # FP16
             assert format in FP16_FORMATS, f"ERROR ❌️ quantize=16 (FP16) is not supported; {hint}"
         elif passed_args.quantize == 8:  # INT8


### PR DESCRIPTION
## summary

- the quantize rejection hint appended "(or None for FP32)" to every format, but for the eight formats that cannot export FP32 an unset `quantize` auto-selects INT8, w8a16 or FP16, so the hint promised the opposite of what unset does; the FP32 option is now listed only where it exists, as `32 or None (FP32)`
- the `quantize=32` raise for the six INT8-only formats was unreachable because `validate_args` rejects that request one line earlier, so it is deleted, finishing the deletion #24950 made for the RKNN twin

## measured

| call | before | after |
| --- | --- | --- |
| `validate_args("hailo", quantize=32)` | `supports quantize=8 (INT8) (or None for FP32)` | `supports quantize=8 (INT8)` |
| `validate_args("ascend", quantize=8)` | `supports quantize=16 (FP16) (or None for FP32)` | `supports quantize=16 (FP16)` |
| `validate_args("qnn", quantize=8)` | `supports quantize='w8a16' (...) (or None for FP32)` | `supports quantize='w8a16' (...)` |
| `validate_args("onnx", quantize="w8a32")` (control) | `..., 32 (FP32) (or None for FP32)` | `..., 32 or None (FP32)` |
| `model.export(format="hailo", quantize=32)` | `AssertionError` from `validate_args`, the `ValueError` below it never raised | unchanged |

22 messages across the 8 formats carried the clause before, 0 after; `tests/test_exports.py --export-env base` 38 passed.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Export quantization validation now lists FP32 only for formats that support it, and removes an unreachable `quantize=32` error branch for INT8-only formats.

### 📊 Key Changes

- Updated `validate_args()` hints to show `32 or None (FP32)` only for formats supporting FP32.
- Removed the misleading `(or None for FP32)` text from the eight formats that cannot export FP32.
- Deleted the unreachable `quantize=32` `ValueError` branch for `deepx`, `axelera`, `imx`, `edgetpu`, `qnn`, and `hailo`, since validation rejects the request first.
- Preserved the existing automatic quantization warning and selection for those INT8-only formats.

### 🎯 Purpose & Impact

- Unsupported formats now report only their actual quantization options, while formats such as ONNX retain the FP32 option in their validation hint.
- `model.export(format="hailo", quantize=32)` continues to fail during argument validation; it no longer reaches the removed downstream error branch.
- The PR context reports 38 passing export tests in the base export environment.