### PR TITLE
List the Platform export formats on their own page instead of rendering the package export table

### DIFF
--- a/docs/en/platform/api/index.md
+++ b/docs/en/platform/api/index.md
@@ -1614,7 +1614,7 @@ POST /api/models/{owner}/{project}/{model}/exports
 
 | Field     | Type   | Required    | Description                                                                                                                                                                                               |
 | --------- | ------ | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `format`  | string | Yes         | Target export format (see table below)                                                                                                                                                                    |
+| `format`  | string | Yes         | Target export format (see [supported formats](../train/models.md#supported-formats))                                                                                                                      |
 | `gpuType` | string | Conditional | Required when `format` is `engine`; use a supported [GPU or Jetson target](../train/models.md#nvidia-jetson-tensorrt-targets)                                                                             |
 | `args`    | object | No          | Export options: `imgsz`, `quantize`, `dynamic`, `simplify`, `opset`, `conf`, `iou`, `batch`, `workspace`, `nms`, `optimize`, `keras`, and `name` (device target for RKNN, QNN, Hailo, and Ascend formats) |
 
@@ -1641,10 +1641,8 @@ is already in flight returns `409`.
 
 **Supported Formats:**
 
-Use the `format` argument from the shared export table below. PyTorch is the source format and is not an API export
-target.
-
-{% include "macros/export-table.md" %}
+`format` accepts the 20 values listed under [supported formats](../train/models.md#supported-formats). PyTorch is the
+source format and is not an API export target.
 
 ### Get Export Status
 

--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -46,7 +46,7 @@ graph LR
 | **Upload**   | Images (50MB), videos (1GB), and dataset files (ZIP, TAR including `.tar.gz`/`.tgz`, NDJSON) from your machine, a URL, cloud storage, or an on-premise host                                                                                  |
 | **Annotate** | Manual annotation tools for 6 task types, plus [Smart Annotation](data/annotation.md#smart-annotation) with SAM and YOLO models for detect, segment, semantic, and OBB (see [supported task types](data/annotation.md#supported-task-types)) |
 | **Train**    | Cloud GPUs (24 on all plans + 2 Pro/Enterprise-only: B200, B300), real-time metrics, project organization                                                                                                                                    |
-| **Export**   | [20 deployment formats](../modes/export.md) (ONNX, TensorRT, CoreML, LiteRT, Hailo, Ascend, etc.; see [supported formats](train/models.md#supported-formats))                                                                                |
+| **Export**   | 20 deployment formats (ONNX, TensorRT, CoreML, LiteRT, Hailo, Ascend, etc.; see [supported formats](train/models.md#supported-formats))                                                                                                      |
 | **Deploy**   | 42 global regions with dedicated endpoints, scale-to-zero by default (single active instance), and monitoring                                                                                                                                |
 
 **What you can do:**
@@ -54,7 +54,7 @@ graph LR
 - **Upload** images, videos, and dataset files to create training datasets
 - **Visualize** annotations with interactive overlays for the 6 YOLO task types supported by the annotation editor (see [supported task types](data/annotation.md#supported-task-types))
 - **Train** models on cloud GPUs (24 on all plans, 26 with Pro or Enterprise for B200 and B300) with real-time metrics
-- **Export** to [20 deployment formats](../modes/export.md) (ONNX, TensorRT, CoreML, LiteRT, Hailo, Ascend, etc.)
+- **Export** to [20 deployment formats](train/models.md#supported-formats) (ONNX, TensorRT, CoreML, LiteRT, Hailo, Ascend, etc.)
 - **Deploy** to 42 global regions with one-click dedicated endpoints
 - **Monitor** training progress, deployment health, and usage metrics
 - **Connect** cloud storage, annotation tools, and Slack through [integrations](integrations/index.md)
@@ -456,8 +456,6 @@ See [Annotation](data/annotation.md) for the complete guide.
 
 ### What export formats are supported?
 
-The Platform supports the same 20 deployment formats as Ultralytics Export mode. PyTorch is the source format; each row with a `format` argument is an export target.
-
-{% include "macros/export-table.md" %}
+The Platform exports to 20 deployment formats; see [supported formats](train/models.md#supported-formats) for the list and the per-format restrictions.
 
 See [Models Export](train/models.md#export-model), the [Export mode guide](../modes/export.md), and the [Integrations index](../integrations/index.md) for format-specific options.

--- a/docs/en/platform/train/models.md
+++ b/docs/en/platform/train/models.md
@@ -241,7 +241,7 @@ Connect [Slack alerts](../integrations/slack.md) to receive a message when an ex
 
 ### Supported Formats
 
-The Platform supports export to [20 deployment formats](../../modes/export.md#export-formats): ONNX, TorchScript, OpenVINO, TensorRT, CoreML, TF SavedModel, TF GraphDef, LiteRT, TF Edge TPU, PaddlePaddle, NCNN, MNN, RKNN, Qualcomm (QNN), IMX500, Axelera, ExecuTorch, DeepX, Hailo, and Huawei Ascend.
+The Platform supports export to 20 deployment formats, listed with the `format` value the [API](../api/index.md#create-export) takes: ONNX (`onnx`), TorchScript (`torchscript`), OpenVINO (`openvino`), TensorRT (`engine`), CoreML (`coreml`), TF SavedModel (`saved_model`), TF GraphDef (`pb`), LiteRT (`litert`), TF Edge TPU (`edgetpu`), PaddlePaddle (`paddle`), NCNN (`ncnn`), MNN (`mnn`), RKNN (`rknn`), Qualcomm QNN (`qnn`), IMX500 (`imx`), Axelera (`axelera`), ExecuTorch (`executorch`), DeepX (`deepx`), Hailo (`hailo`), and Huawei Ascend (`ascend`).
 
 ### Format Selection Guide
 
@@ -416,7 +416,7 @@ Remove a model you no longer need:
 - [**Inference**](../deploy/inference.md): Test models in the browser with the Predict tab
 - [**Endpoints**](../deploy/endpoints.md): Deploy models to production with dedicated endpoints
 - [**Cloud Training**](cloud-training.md): Configure and run training jobs on cloud GPUs
-- [**Export Formats**](../../modes/export.md): Full guide to all 20 export formats
+- [**Export Formats**](../../modes/export.md): Full guide to every export format and its options
 
 ## FAQ
 


### PR DESCRIPTION
## summary

- the Platform overview and API pages rendered the package export table, which now carries 21 targets including Core AI, while the Platform exports 20 formats and its API rejects `coreai`; both pages now point at the Platform's own supported-formats list instead, and that list carries each format's `format` value so the API page loses nothing
- the four places that used the package export guide as the definition of the Platform's 20 formats link to the Platform list or drop the count, so a package format addition no longer changes a Platform claim

## measured

| check | before | after |
| --- | --- | --- |
| `macros/export-table.md` target rows rendered on `platform/index.md` and `platform/api/index.md` | 21 (incl. `coreai`) | 0 includes |
| Platform export formats (portal `ExportFormatSchema`) vs `train/models.md` supported-formats list | 20 vs 20 | unchanged, now the single owner with `format` values |
| formats shown on a Platform page but absent from the Platform schema | `coreai` | none |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Platform documentation now uses its own 20-format supported-formats list, including API `format` values, instead of rendering the package export table that also contains `coreai`.

### 📊 Key Changes

- Removed the shared export-table include from the Platform overview and API documentation.
- Added links from Platform export descriptions and the API `format` field to the Platform supported-formats list.
- Listed all 20 Platform export formats with the exact `format` values accepted by the export API.
- Updated references that described Platform formats as the same as the package export formats.

### 🎯 Purpose & Impact

- Platform pages no longer display `coreai` as an available Platform export target.
- API users can find the accepted `format` values in the Platform-owned list.
- Package export format additions will no longer automatically change the documented Platform format count or list.