### PR TITLE
Honor the pretrained argument after reset_weights() and in MultiTrainer

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -323,7 +323,6 @@ def test_train_reuses_loaded_checkpoint_model(monkeypatch, kwargs, uses_weights)
     model.ckpt = {"checkpoint": True}
     model.ckpt_path = "/tmp/fake.pt"
     model.overrides["model"] = "ul://glenn-jocher/m2/exp-14"
-    model.overrides["pretrained"] = False
     original_model = model.model
     captured = {}
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -312,52 +312,6 @@ def test_checkpoint_nonfinite_ema_and_model_sanitized():
     )
 
 
-@pytest.mark.parametrize(
-    "kwargs,uses_weights",
-    [({}, True), ({"pretrained": True}, True), ({"pretrained": False}, False), ({"pretrained": MODEL}, True)],
-)
-@pytest.mark.skipif(IS_RASPBERRYPI, reason="Edge devices not intended for training")
-def test_train_reuses_loaded_checkpoint_model(monkeypatch, kwargs, uses_weights):
-    """Test training reuses loaded checkpoint config while respecting the pretrained argument."""
-    model = YOLO("yolo26n.yaml")
-    model.ckpt = {"checkpoint": True}
-    model.ckpt_path = "/tmp/fake.pt"
-    model.overrides["model"] = "ul://glenn-jocher/m2/exp-14"
-    original_model = model.model
-    captured = {}
-
-    class FakeTrainer:
-        def __init__(self, overrides=None, _callbacks=None):
-            self.overrides = overrides
-            self.callbacks = _callbacks
-            self.model = None
-            self.validator = SimpleNamespace(metrics=None)
-            self.best = MODEL.parent / "nonexistent-best.pt"
-            self.last = MODEL
-            captured["trainer"] = self
-
-        def get_model(self, cfg=None, weights=None, verbose=True):
-            captured["cfg"] = cfg
-            captured["weights"] = weights
-            return original_model
-
-        def train(self):
-            return None
-
-    monkeypatch.setattr("ultralytics.engine.model.checks.check_pip_update_available", lambda: None)
-    monkeypatch.setattr(model, "_smart_load", lambda key: FakeTrainer)
-    monkeypatch.setattr(
-        "ultralytics.engine.model.load_checkpoint",
-        lambda path: (original_model, {"checkpoint": True}),
-    )
-
-    model.train(data="coco8.yaml", epochs=1, **kwargs)
-
-    assert captured["trainer"].model is original_model, "Trainer model does not match original"
-    assert captured["cfg"] == original_model.yaml, f"Config mismatch: {captured['cfg']} != {original_model.yaml}"
-    assert captured["weights"] is (original_model if uses_weights else None), "Unexpected weights loaded"
-
-
 def test_train_multi_custom_trainer_metrics_and_failure_keys(monkeypatch, tmp_path):
     """Test custom multi-dataset runs keep memory metrics and unique failure keys."""
     model = YOLO(MODEL)

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -846,7 +846,7 @@ class Model(torch.nn.Module):
             )
             self.metrics = self.trainer.train()
             return self.metrics
-        pretrained = args.get("pretrained", True)
+        pretrained = args.get("pretrained", self.overrides.get("pretrained", True))
         if args.get("resume") is True:  # resume=True (boolean) uses current model as checkpoint
             if self.ckpt and self.ckpt.get("epoch", -1) >= 0 and self.ckpt.get("optimizer") is not None:
                 args["resume"] = self.ckpt_path

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -834,6 +834,7 @@ class Model(torch.nn.Module):
             "task": self.task,
         }  # method defaults
         args = {**overrides, **custom, **kwargs, "mode": "train"}  # prioritizes rightmost args
+        pretrained = args.setdefault("pretrained", self.overrides.get("pretrained", True))
         if isinstance(args.get("data"), (list, tuple)):  # fine-tune a single base model across multiple datasets
             from ultralytics.engine.trainer import MultiTrainer
 
@@ -846,7 +847,6 @@ class Model(torch.nn.Module):
             )
             self.metrics = self.trainer.train()
             return self.metrics
-        pretrained = args.get("pretrained", self.overrides.get("pretrained", True))
         if args.get("resume") is True:  # resume=True (boolean) uses current model as checkpoint
             if self.ckpt and self.ckpt.get("epoch", -1) >= 0 and self.ckpt.get("optimizer") is not None:
                 args["resume"] = self.ckpt_path

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -309,6 +309,7 @@ class Model(torch.nn.Module):
                 m.reset_parameters()
         for p in self.model.parameters():
             p.requires_grad = True
+        self.overrides["pretrained"] = False  # train() builds the seeded model from the architecture
         self.predictor = None
         return self
 
@@ -334,12 +335,11 @@ class Model(torch.nn.Module):
         """
         self._check_is_pytorch_model()
         if isinstance(weights, (str, Path)):
-            self.overrides["pretrained"] = weights  # remember the weights for DDP training
             weights, ckpt = load_checkpoint(weights)
             ckpt_path = weights.pt_path
         else:
-            self.overrides.pop("pretrained", None)
             ckpt, ckpt_path = {"model": self.model}, None  # an object load has no file to resume from
+        self.overrides.pop("pretrained", None)
         self.model.load(weights)
         self.ckpt, self.ckpt_path = ckpt, ckpt_path  # train() seeds from self.model while ckpt is set
         self.predictor = None
@@ -846,7 +846,7 @@ class Model(torch.nn.Module):
             )
             self.metrics = self.trainer.train()
             return self.metrics
-        pretrained = kwargs.get("pretrained", overrides.get("pretrained", True) if kwargs.get("cfg") else True)
+        pretrained = args.get("pretrained", True)
         if args.get("resume") is True:  # resume=True (boolean) uses current model as checkpoint
             if self.ckpt and self.ckpt.get("epoch", -1) >= 0 and self.ckpt.get("optimizer") is not None:
                 args["resume"] = self.ckpt_path

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1276,6 +1276,7 @@ class MultiTrainer:
                     overrides["save_dir"] = str(save_dir)
                     if self.trainer is None:
                         overrides["model"] = str(base_model)
+                        overrides.pop("cfg", None)  # already merged here; the CLI would re-apply the file
                         subprocess.run(
                             [
                                 *_YOLO_CLI_COMMAND,

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1276,7 +1276,6 @@ class MultiTrainer:
                     overrides["save_dir"] = str(save_dir)
                     if self.trainer is None:
                         overrides["model"] = str(base_model)
-                        overrides["pretrained"] = True
                         subprocess.run(
                             [
                                 *_YOLO_CLI_COMMAND,
@@ -1287,7 +1286,11 @@ class MultiTrainer:
                         )
                     else:
                         trainer = self.trainer(overrides=overrides, _callbacks=self.callbacks)
-                        trainer.model = trainer.get_model(weights=self.model, cfg=self.model.yaml)
+                        pretrained = overrides.get("pretrained", True)
+                        weights = None if pretrained is False else self.model
+                        if isinstance(pretrained, (str, Path)):
+                            weights, _ = load_checkpoint(pretrained)
+                        trainer.model = trainer.get_model(weights=weights, cfg=self.model.yaml)
                         trainer.train()
                     best, last = save_dir / "weights" / "best.pt", save_dir / "weights" / "last.pt"
                     ckpt = best if best.exists() else last

--- a/ultralytics/models/yolo/classify/train.py
+++ b/ultralytics/models/yolo/classify/train.py
@@ -83,7 +83,7 @@ class ClassificationTrainer(BaseTrainer):
             model.load(weights)
 
         for m in model.modules():
-            if self.args.pretrained is False and hasattr(m, "reset_parameters"):
+            if self.args.pretrained is False and not self.resume and hasattr(m, "reset_parameters"):
                 m.reset_parameters()
             if isinstance(m, torch.nn.Dropout) and self.args.dropout:
                 m.p = self.args.dropout  # set dropout

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -354,7 +354,7 @@ class YOLOE(Model):
 
     def _prompt_embedding_model(self) -> str:
         """Return the checkpoint identifier used to bind prompt embeddings to this model."""
-        source = self.overrides.get("pretrained") or getattr(self.model, "pt_path", None) or self.ckpt_path
+        source = getattr(self.model, "pt_path", None) or self.ckpt_path
         source = source if isinstance(source, (str, Path)) else self.model.yaml["yaml_file"]
         model = Path(source).stem
         return model[:-4] if model.endswith("-seg") else model


### PR DESCRIPTION
## summary

- `reset_weights()` records `pretrained=False` and `train()` resolves `pretrained` from the merged args before the multi-dataset branch, so the trainer builds after `init_seeds` instead of taking the unseeded reset module as the donor
- `load(<path>)` no longer stores the path in `overrides["pretrained"]`: the DDP launcher ships the parent's module since #26050, and that stored path is why `train()` ignored the override
- `MultiTrainer` no longer forces `pretrained=True` or forwards `cfg=` to its CLI children, and resolves the donor like `Model.train()` in the Python arm
- the classify trainer skips its `pretrained=False` reset on resume, as the base trainer does
- one commit per fix

## measured

cpu, coco8, yolo26n; w0 is the absolute sum of `model.0.conv.weight` in `last.pt` (90.58 = `yolo26n.pt`, 41-42 = fresh init)

| sequence | before | after |
| -- | -- | -- |
| `YOLO(pt).reset_weights().train(seed=0, deterministic=True)` twice, also with `data=[...]` or `cfg=<yaml without pretrained>` | differ | identical |
| `YOLO(yaml).train(data=[...], pretrained=pt)` / `.tune(pretrained=pt)` | 41.0 / 42.8 | 90.58 / 90.58 |
| `YOLO(pt).train(data=[...], pretrained=False)` | 90.58 | fresh init |
| `YOLO(pt).train(cfg=<copy of default.yaml>, data=[...])` per-dataset metrics | `None` | metrics |
| `YOLO(cls.pt).train(pretrained=False)`, interrupted, `train(resume=True)`: weights equal `last.pt` | no | yes |
| `YOLO(yaml).train(seed=0)` twice; `YOLO(pt).train()`; `YOLO("yolo11-cls-resnet18.yaml").train(pretrained=False)` scratch; YOLOE prompt-embedding id | unchanged | unchanged |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Training now consistently honors the resolved `pretrained` setting after weight resets, checkpoint loads, and multi-dataset setup.

### 📊 Key Changes
- `reset_weights()` records `pretrained=False`, while `Model.train()` resolves `pretrained` from the merged training arguments before entering the multi-dataset path.
- `load()` no longer stores a checkpoint path in `overrides["pretrained"]`, preventing that path from overriding explicit training arguments.
- `MultiTrainer` now removes the already-merged `cfg` before launching CLI children and selects donor weights according to `pretrained` in Python-based training.
- Classification training no longer resets model parameters when resuming with `pretrained=False`.
- YOLO prompt-embedding model identification now uses the model checkpoint path or YAML source instead of `overrides["pretrained"]`.

### 🎯 Purpose & Impact
- `reset_weights().train()` can build the model after seed initialization rather than reusing the unseeded reset module.
- Explicit `pretrained=False` starts from fresh parameters, while a checkpoint path can be used as the donor in standard and multi-dataset training.
- Classification resume runs preserve the resumed weights instead of resetting them.