### PR TITLE
Share RAM image caches across DataLoader workers

### DIFF
--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -7,6 +7,7 @@ import math
 import os
 import random
 from copy import deepcopy
+from multiprocessing import RawArray
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from typing import Any
@@ -70,22 +71,28 @@ class BaseDataset(Dataset):
     """
 
     class _ImageCache:
-        """Store images in one contiguous array to preserve copy-on-write sharing between workers."""
+        """Store images in one shared buffer across fork, spawn, and forkserver workers."""
 
         def __init__(self, images: list[np.ndarray]):
             """Pack images and their layouts into contiguous NumPy arrays."""
             self.shapes = np.array([im.shape for im in images])
             self.dtypes = np.array([im.dtype.str for im in images])
             self.offsets = np.concatenate(([0], np.cumsum([im.nbytes for im in images])))
-            self.buffer = np.empty(self.offsets[-1], dtype=np.uint8)
+            self.buffer = RawArray("B", int(self.offsets[-1]))
+            buffer = np.frombuffer(self.buffer, dtype=np.uint8)
             for i, im in enumerate(images):
-                self.buffer[self.offsets[i] : self.offsets[i + 1]] = im.reshape(-1).view(np.uint8)
+                buffer[self.offsets[i] : self.offsets[i + 1]] = im.reshape(-1).view(np.uint8)
                 images[i] = None
 
         def __getitem__(self, i: int) -> np.ndarray:
-            """Return an image view by index."""
+            """Return a private image copy so transforms cannot modify the shared cache."""
             i = range(len(self.shapes))[i]
-            return self.buffer[self.offsets[i] : self.offsets[i + 1]].view(self.dtypes[i]).reshape(self.shapes[i])
+            return (
+                np.frombuffer(self.buffer, dtype=np.uint8)[self.offsets[i] : self.offsets[i + 1]]
+                .view(self.dtypes[i])
+                .reshape(self.shapes[i])
+                .copy()
+            )
 
     def __init__(
         self,
@@ -293,7 +300,7 @@ class BaseDataset(Dataset):
 
             return im, (h0, w0), im.shape[:2]
 
-        return self.ims[i], self.im_hw0[i], self.im_hw[i]
+        return im, self.im_hw0[i], self.im_hw[i]
 
     def cache_images(self) -> None:
         """Cache images to memory or disk for faster training."""

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -1238,11 +1238,11 @@ class ClassificationDataset:
         return len(self.samples)
 
     def cache_images(self) -> None:
-        """Decode all images once into a single contiguous uint8 buffer before DataLoader workers fork.
+        """Decode all images once into a single shared uint8 buffer before DataLoader workers start.
 
         A Python list of per-image arrays is duplicated into every forked worker by copy-on-write refcounting
-        (https://github.com/ultralytics/ultralytics/issues/9824); one shared numpy buffer is read-only across
-        workers instead, so RAM stays flat. Original image sizes are preserved for the transforms.
+        (https://github.com/ultralytics/ultralytics/issues/9824); a shared buffer avoids copying the full cache
+        for every worker regardless of start method. Original image sizes are preserved for the transforms.
         """
         with ThreadPool(NUM_THREADS) as pool:
             ims = list(


### PR DESCRIPTION
## Summary

Share the RAM image cache across DataLoader workers under `spawn` and `forkserver` instead of copying it into every worker. `BaseDataset._ImageCache` stores its packed buffer in a CPU `torch.uint8` tensor rather than a NumPy array (`ultralytics/data/base.py`, shared by detection-family and classification datasets). This replaces the earlier `multiprocessing.RawArray` implementation.

- `fork` and zero-worker loaders are unchanged: ordinary anonymous memory shared copy-on-write, with no shared-memory backing.
- `spawn`/`forkserver` workers receive the buffer through torch's existing multiprocessing reducers, which move the storage to shared memory once when the dataset is pickled for the first worker.
- Images are still returned as views. The per-image `.copy()` from the RawArray version is gone.

`spawn` is the default on macOS and Windows, and `forkserver` is the Linux default from Python 3.14, so `cache="ram"` currently costs `(1 + workers)x` the cache size there.

## Results

Real `build_yolo_dataset`/`ClassificationDataset` + `build_dataloader`, 8 workers, 3 epochs with augmentation, Linux, PSS summed over the parent and workers from `/proc/<pid>/smaps`.

| Task, env | Start method | Buffer PSS main → PR | Total PSS main → PR | First batch main → PR |
| --- | --- | --- | --- | --- |
| detect 0.87 GB, py3.12 / torch 2.7 | fork | 0.87 → 0.87 GB | 2.10 → 2.26 GB | 0.12 → 0.30 s |
| | spawn | 7.85 → 0.87 GB | 11.10 → 3.98 GB | 11.95 → 6.20 s |
| | forkserver | 7.85 → 0.87 GB | 11.11 → 4.12 GB | 11.82 → 5.97 s |
| detect 0.87 GB, py3.14 / torch 2.14 | fork | 0.87 → 0.88 GB | 2.06 → 2.44 GB | 0.14 → 0.27 s |
| | spawn | 7.86 → 0.87 GB | 11.44 → 4.70 GB | 11.46 → 6.74 s |
| | forkserver | 7.86 → 0.87 GB | 9.31 → 2.46 GB | 6.38 → 1.66 s |
| classify 1.00 GB, py3.12 / torch 2.7 | fork | 1.00 → 1.06 GB | 2.53 → 2.45 GB | 0.18 → 0.26 s |
| | spawn | 9.26 → 1.00 GB | 12.79 → 4.76 GB | 18.14 → 10.77 s |
| | forkserver | 9.26 → 1.00 GB | 12.68 → 4.64 GB | 18.46 → 11.38 s |

- Steady-state throughput is within noise in every cell (detect 2350-2600 img/s, classify 7900-8300 img/s).
- Under `fork` the tensor reports `is_shared() == False` and maps as `[anon]`. Under spawn/forkserver it maps as one `/dev/shm/torch_*` object with zero private-dirty bytes.
- The SHA-1 of the whole cache is unchanged after 3 augmented epochs in all 18 runs, including the spawn/forkserver runs where a worker write would reach the parent's buffer. `main` already returns views into the cache, so the no-in-place-writes contract is not new.
- macOS, Python 3.14 / torch 2.9.1, spawn, 8 workers: `is_shared() == True`, hash unchanged, first batch 5.82 → 4.21 s.

## Constrained shared memory

Tested in disposable mount namespaces with a size-limited tmpfs over `/dev/shm`, GPU training with 8 workers under `forkserver`.

- Moving a tensor to shared memory larger than `/dev/shm` kills the parent with SIGBUS on torch 2.7, 2.8, and 2.9, and raises `RuntimeError: unable to allocate shared memory(shm)` from torch 2.10. SIGBUS cannot be caught, so `_ImageCache.__getstate__` checks free space first and otherwise pickles the buffer by value, which is what `main` does today, with a warning.
- The check requires 2x the cache size, the same margin as `check_cache_ram()`, because worker batches travel through `/dev/shm` too:

| `/dev/shm` | main | this PR (2x margin) | 1x margin variant |
| --- | --- | --- | --- |
| 1500 MB | pass | pass, falls back with warning | pass |
| 1000 MB | pass | pass, falls back with warning | worker bus errors |
| 64 MB | worker bus errors with or without caching | same | same |

A 64 MB `/dev/shm` (the Docker default) already breaks multi-worker training on `main` with no cache at all, so that row is unchanged by this PR.

## Scope

- Does not change worker start methods, pinning, or loader lifecycle.
- Does not share caches between independent DDP ranks ([#22307](https://github.com/ultralytics/ultralytics/issues/22307)).
- The warning repeats once per worker when the fallback triggers.
- Not run on Windows locally. The existing `cache="ram"` tests train on single-batch datasets where `build_dataloader` uses zero workers, so they never pickle the cache; `test_image_cache_shared_with_spawned_workers` (added in `b882f749a`) sends an `_ImageCache` through two spawned workers and asserts intact contents and `is_shared()`, which CI runs on Windows, macOS, ARM, and the Python 3.8 / torch 1.8 floor. It fails on `main`.

Related: [#9824](https://github.com/ultralytics/ultralytics/issues/9824), #24670, #24673 (existing contiguous cache), #24364 (earlier shared-tensor exploration), [pytorch/pytorch#13246](https://github.com/pytorch/pytorch/issues/13246). #26085 fixes the fork deadlock separately.

## Related issues

Plain references, not closing keywords.

| Issue | State | Relation |
| --- | --- | --- |
| #9824 High RAM using when add (cache=True) in Classification Training | closed | Origin of the contiguous cache owner this PR modifies (fixed for fork by #24670/#24673). This PR extends the same flat-memory behavior to spawn/forkserver. |
| #25832 RAM caching consumption during training | open | Related symptom; the reported runs used `cache=False`/`disk`, so this PR does not resolve it. |
| #22307 Multi-GPU training with cache=True loads 'n' copies of dataset in RAM | closed | Out of scope: independent DDP ranks each build their own cache. This PR shares within one rank's workers only. |
| #22944 Ultralytics YOLO DDP on GPU, causing SIGKILL (-9) OOM | closed | Same as #22307: `cache=True` under DDP. Out of scope. |
| #9500, #19947, #24364 | closed PRs | Earlier attempts; #24364's review asked for the worker-memory and constrained-storage evidence provided here. |
| #26085 | PR | Companion fork-deadlock fix. |
| [pytorch/pytorch#13246](https://github.com/pytorch/pytorch/issues/13246) | open upstream | Worker memory replication; its NumPy workaround is fork-only, which is the gap closed here. |

Checked and excluded: #24065, #24036, #22621 (macOS memory growth with `cache=False`), #19671 (`cache='disk'`).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

RAM image caches now use a contiguous CPU `torch.uint8` tensor so `spawn` and `forkserver` DataLoader workers can share the cache instead of receiving separate copies.

### 📊 Key Changes

- Replaced `_ImageCache`’s contiguous NumPy buffer with a CPU `torch.uint8` tensor while preserving image shapes, dtypes, offsets, and view-based image access.
- Added pickle state handling that uses PyTorch shared memory for workers and falls back to copying the buffer when `/dev/shm` lacks twice the cache size, with a warning.
- Kept `fork` and zero-worker behavior unchanged, including anonymous copy-on-write storage rather than explicit shared-memory backing.
- Added a spawned-worker test that verifies cached image contents and confirms the cache buffer is shared.
- Updated the image-cache documentation to describe the storage as a shared contiguous buffer.

### 🎯 Purpose & Impact

- Reduces per-worker RAM duplication for `cache="ram"` with `spawn` and `forkserver`, including the defaults commonly used on macOS, Windows, and newer Python versions.
- Preserves image views and existing cache layout while removing the previous per-image copy required by the `RawArray` implementation.
- When shared-memory capacity is insufficient, workers receive a copied cache instead; independent DDP ranks are not shared by this change.