### PR TITLE
Use Platform SDK for login and training resource downloads

### DIFF
--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -383,7 +383,7 @@ You can train models on your own hardware and stream real-time metrics to Ultral
 
 !!! warning "Package Version Requirement"
 
-    Platform integration requires **ultralytics>=8.4.120**. Lower versions will NOT work with Platform.
+    Platform integration requires **Python>=3.11** and **ultralytics>=8.4.120**. Lower versions will NOT work with Platform.
 
     ```bash
     pip install "ultralytics>=8.4.120"

--- a/docs/en/platform/quickstart.md
+++ b/docs/en/platform/quickstart.md
@@ -417,7 +417,7 @@ yolo train model=yolo26n.pt data=coco.yaml epochs=100 project=username/my-projec
 
 !!! note "Requirements"
 
-    Local training with metric streaming requires **ultralytics>=8.4.120**. API keys start with `ul_` followed by 40 hex characters (43 characters total) and are full-access tokens scoped to your workspace.
+    Local training with metric streaming requires **Python>=3.11** and **ultralytics>=8.4.120**. API keys start with `ul_` followed by 40 hex characters (43 characters total) and are full-access tokens scoped to your workspace.
 
 Read more about [API keys](account/api-keys.md), [dataset URIs](data/datasets.md#dataset-uri), and [remote training](train/cloud-training.md#remote-training).
 

--- a/docs/en/platform/train/cloud-training.md
+++ b/docs/en/platform/train/cloud-training.md
@@ -248,7 +248,7 @@ Train on your own hardware while streaming metrics to the platform.
 
 !!! warning "Package Version Requirement"
 
-    Platform integration requires **ultralytics>=8.4.120**. Lower versions will not work with Platform.
+    Platform integration requires **Python>=3.11** and **ultralytics>=8.4.120**. Lower versions will not work with Platform.
 
     ```bash
     pip install -U ultralytics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dependencies = [
     "polars>=0.20.0",
     "nvidia-ml-py>=12.0.0", # NVIDIA GPU monitoring https://pypi.org/project/nvidia-ml-py
     "ultralytics-thop>=2.1.6", # FLOPs computation https://github.com/ultralytics/thop
-    "ultralytics-platform>=0.1.3; python_version >= '3.11'",
+    "ultralytics-platform>=0.1.21; python_version >= '3.11'",
 ]
 
 # Optional dependencies ------------------------------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,25 +55,6 @@ def test_settings_migration(tmp_path: Path, api_key: str) -> None:
     assert "neptune" not in settings
 
 
-def test_platform_login(monkeypatch) -> None:
-    """Verify Platform login saves valid keys and logout removes them."""
-    import requests
-
-    from ultralytics import cfg
-
-    class Response:
-        status_code = 200
-
-    settings = {"api_key": ""}
-    monkeypatch.setattr(cfg, "SETTINGS", settings)
-    monkeypatch.setattr(requests, "get", lambda *args, **kwargs: Response())
-
-    cfg.handle_yolo_login(["login", "ul_valid"])
-    assert settings["api_key"] == "ul_valid"
-    cfg.handle_yolo_login(["logout"])
-    assert settings["api_key"] == ""
-
-
 def test_cli_imports_defer_torchvision() -> None:
     """Verify startup imports do not load torchvision or SAM3 geometry."""
     code = (

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -734,23 +734,19 @@ def handle_yolo_login(args: list[str]) -> None:
         LOGGER.info(f"Get an API key from {api_key_url} and then run 'yolo login API_KEY'.")
         return
 
-    import requests  # scoped as slow import
+    from ultralytics import APIConnectionError, APIError, Platform
 
     try:
-        response = requests.get(
-            f"{PLATFORM_URL}/api/settings",
-            headers={"Authorization": f"Bearer {args[1]}"},
-            timeout=30,
+        with Platform(api_key=args[1], base_url=PLATFORM_URL, timeout=30) as client:
+            client.account.summary()
+        SETTINGS["api_key"] = args[1]
+        LOGGER.info("New authentication successful ✅")
+    except APIError as error:
+        LOGGER.warning(
+            "Invalid API key" if error.status_code == 401 else f"Authentication failed (HTTP {error.status_code})"
         )
-        if response.status_code == 200:
-            SETTINGS["api_key"] = args[1]
-            LOGGER.info("New authentication successful ✅")
-        elif response.status_code == 401:
-            LOGGER.warning("Invalid API key")
-        else:
-            response.raise_for_status()
-    except requests.exceptions.RequestException as e:
-        LOGGER.warning(f"Authentication request failed, check your connection: {e}")
+    except APIConnectionError as error:
+        LOGGER.warning(f"Authentication request failed, check your connection: {error}")
 
 
 def handle_yolo_settings(args: list[str]) -> None:

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -241,6 +241,7 @@ class Model(torch.nn.Module):
             >>> model._load("yolo26n.pt")
             >>> model._load("path/to/weights.pth", task="detect")
         """
+        model_uri = checks.normalize_platform_uri(weights)
         if weights.lower().startswith(checks.REMOTE_FILE_PREFIXES):
             weights = checks.check_file(weights, download_dir=SETTINGS["weights_dir"])  # download and return local file
         weights = checks.check_model_file_from_stem(weights)  # add suffix, i.e. yolo26n -> yolo26n.pt
@@ -255,7 +256,7 @@ class Model(torch.nn.Module):
             self.model, self.ckpt = weights, None
             self.task = task or guess_model_task(weights)
             self.ckpt_path = weights
-        self.overrides["model"] = weights
+        self.overrides["model"] = model_uri if str(model_uri).startswith("ul://") else weights
         self.overrides["task"] = self.task
         self.model_name = weights
 

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -284,6 +284,11 @@ def on_pretrain_routine_start(trainer):
     _api_key = os.getenv("ULTRALYTICS_API_KEY") or SETTINGS.get("api_key")
     if not _api_key:
         return
+    if sys.version_info < (3, 11):
+        LOGGER.warning(
+            f"{PREFIX}Platform integration requires Python 3.11 or newer. Training will continue without tracking."
+        )
+        return
 
     project, name = _get_project_name(trainer)
     LOGGER.info(f"{PREFIX}Streaming training metrics to Platform")

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -38,7 +38,6 @@ from ultralytics.utils import (
     LOGGER,
     MACOS,
     ONLINE,
-    PLATFORM_API_URL,
     PLATFORM_URL,
     PYTHON_VERSION,
     RKNN_CHIPS,
@@ -95,76 +94,56 @@ def resolve_platform_uri(uri, hard=True):
         FileNotFoundError: If the resource is not found and hard=True.
         ConnectionError: If the request fails and hard=True.
     """
-    import requests  # scoped as slow import
-
-    # Scoped: SettingsManager imports torch_utils, which imports checks before SETTINGS is assigned.
+    from ultralytics import APIConnectionError, APIError, Platform
     from ultralytics.utils import SETTINGS
 
-    path = str(uri)[5:]
-    parts = path.split("/")
+    parts = str(uri)[5:].split("/")
+    if len(parts) != 3 or not all(parts):
+        raise ValueError(f"Invalid Platform URI: {uri}. Use ul://user/datasets/name or ul://user/project/model")
     api_key = os.getenv("ULTRALYTICS_API_KEY") or SETTINGS.get("api_key")
     if not api_key:
         raise ValueError(f"ULTRALYTICS_API_KEY required for '{uri}'. Get a key at {PLATFORM_URL}/settings")
 
-    if len(parts) == 3 and parts[1] == "datasets":
-        username, _, slug = parts
-        endpoint = f"datasets/{username}/{slug}/export"
-    elif len(parts) == 3:
-        username, project, model = parts
-        endpoint = f"models/{username}/{project}/{model}/download"
-    else:
-        raise ValueError(f"Invalid Platform URI: {uri}. Use ul://user/datasets/name or ul://user/project/model")
+    import httpx
 
-    url = f"{PLATFORM_API_URL}/{endpoint}"
-    # Short connect so retries are fast; long read for server-side generation.
-    timeout = (10, 3600) if "/datasets/" in url else (10, 90)
-    headers = {"Authorization": f"Bearer {api_key}"}
-
+    dataset = parts[1] == "datasets"
     try:
-        for attempt in range(5):
-            try:
-                # GET preserves Platform error bodies, unlike HEAD.
-                response = requests.get(url, headers=headers, allow_redirects=False, timeout=timeout)
-                if response.status_code in {408, 429} or response.status_code >= 500:
-                    raise requests.exceptions.HTTPError(f"HTTP {response.status_code}", response=response)
-                break
-            except (
-                requests.exceptions.ConnectionError,
-                requests.exceptions.ReadTimeout,
-                requests.exceptions.HTTPError,
-            ) as error:
-                if attempt >= 4:
-                    raise
-                delay = 2 * (2**attempt)  # 2s, 4s, 8s, 16s backoff
-                LOGGER.warning(f"Retry {attempt + 1}/5 for {uri} in {delay}s: {error}")
-                time.sleep(delay)
-    except Exception as error:
+        with Platform(
+            api_key=api_key,
+            base_url=PLATFORM_URL,
+            timeout=httpx.Timeout(3600 if dataset else 90, connect=10),
+            max_retries=4,
+        ) as client:
+            if dataset:
+                return client.datasets.export(parts[0], parts[2])["downloadUrl"]
+            files = client.models.files(*parts)["files"]
+            if files:
+                return files[0]["downloadUrl"]
+    except APIConnectionError as error:
         if hard:
             raise ConnectionError(f"Failed to resolve {uri}: {error}") from error
         LOGGER.warning(f"Failed to resolve {uri}: {error}")
         return None
+    except APIError as error:
+        # APIError.body may contain a proxy page echoing credentials; show only bounded JSON errors.
+        detail = str(error.json.get("error", "")).strip()[:500] if isinstance(error.json, dict) else ""
+        if error.status_code == 401:
+            raise ValueError(f"Invalid ULTRALYTICS_API_KEY for '{uri}'. {detail}") from None
+        if error.status_code == 403:
+            raise PermissionError(f"Access denied for '{uri}'. {detail}") from None
+        if error.status_code in {408, 429} or error.status_code >= 500:
+            message = f"Failed to resolve {uri} (HTTP {error.status_code}). {detail}"
+            if hard:
+                raise ConnectionError(message) from None
+            LOGGER.warning(message)
+            return None
+        if error.status_code != 404:
+            raise RuntimeError(f"Platform error for '{uri}' (HTTP {error.status_code}). {detail}") from None
 
-    if 300 <= response.status_code < 400 and "location" in response.headers:
-        return response.headers["location"]
-
-    # Echo only Platform's bounded JSON error: proxy/WAF pages may quote the Authorization header.
-    try:
-        detail = str(response.json().get("error", "")).strip()
-    except (AttributeError, TypeError, ValueError):
-        detail = ""
-    detail = f" {detail[:500]}" if detail else ""
-    if response.status_code == 401:
-        raise ValueError(f"Invalid ULTRALYTICS_API_KEY for '{uri}'.{detail}")
-    if response.status_code == 403:
-        raise PermissionError(f"Access denied for '{uri}'. Check dataset/model visibility settings.{detail}")
-    if response.status_code == 404:
-        if hard:
-            raise FileNotFoundError(f"Not found on Platform: {uri}.{detail}")
-        LOGGER.warning(f"Not found on Platform: {uri}.{detail}")
-        return None
-    if response.status_code == 409:
-        raise RuntimeError(f"Resource not ready: {uri}. Dataset may still be processing.{detail}")
-    raise RuntimeError(f"Platform error for '{uri}' (HTTP {response.status_code}).{detail or f' {response.reason}'}")
+    if hard:
+        raise FileNotFoundError(f"No dataset or model weights found on Platform: {uri}")
+    LOGGER.warning(f"No dataset or model weights found on Platform: {uri}")
+    return None
 
 
 def parse_requirements(file_path=ROOT.parent / "requirements.txt", package=""):


### PR DESCRIPTION
Use the required `ultralytics-platform` package for `yolo login`, Platform model files, and dataset export URLs. This deletes the separate authentication request and resource-download retry loop while retaining environment-key precedence, saved login settings, long dataset read timeouts, five read attempts, and bounded credential-free error reporting.

Platform integration now requires Python >=3.11 and `ultralytics-platform>=0.1.21`. Python 3.8–3.10 continue to support local YOLO workflows: Platform login/URIs report the Python requirement, and local training with a configured key warns and proceeds without Platform tracking. The documentation states this boundary.

Also preserve the original Platform model URI when `YOLO("ul://owner/project/model").train(...)` registers its training arguments. Previously `_load()` replaced that identity with the downloaded cache path, losing the source-model link in Python training. Checkpoint loading still uses the local file.

Training registration, metrics, logs, cancellation, and run-bound checkpoint publication retain their existing callbacks. `PLATFORM_API_URL` still owns worker event/checkpoint transport; `ULTRALYTICS_PLATFORM_URL` configures the SDK's public API origin. The published SDK's cloud job API cannot replace these training events. Resource failures now follow the public read API, including an empty files list becoming `FileNotFoundError`.

Validation:

- Five existing focused tests passed (URI normalization, worker transport, settings migration, lazy CLI imports).
- Published SDK 0.1.21 exercised through real local HTTP connections on Python 3.11 and 3.13: successful/invalid login, saved credentials, model/dataset reads, 401/403/404/409/422/503 handling, retries, soft failures, and proxy-response credential suppression.
- Real one-epoch CPU training on COCO8/COCO8-pose with local inputs, a downloaded `ul://` model, and a `ul://` NDJSON dataset; registration, console events, epoch metrics, completion, and local worker checkpoint handoff verified against a local HTTP receiver. Original model and dataset URIs verified in registration payloads.
- `yolo train model=ul://... data=coco8-pose.yaml` completed through the actual CLI entrypoint with registration, metrics, completion, and original model identity verified.
- Python 3.10 installed without the SDK, rejected Platform imports/URIs with the Python requirement, and completed a real local pose training run without tracking.
- Ruff formatting and pinned documentation formatting passed; no new Ruff findings relative to main (22 existing findings in the touched Python files). Removed the obsolete login test that only mocked `requests.get` success.

Companion: https://github.com/ultralytics/portal/pull/3970. Both PRs use existing deployed APIs and can ship independently; no unpublished SDK dependency is introduced. CLI design remains tracked in https://github.com/ultralytics/portal/issues/3969.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Platform login, model downloads, and dataset export resolution now use `ultralytics-platform>=0.1.21`, while training event transport and original `ul://` model identity are preserved.

### 📊 Key Changes

- Replaced direct HTTP authentication in `yolo login` with `Platform.account.summary()`, saving the API key only after successful authentication and reporting SDK authentication or connection errors.
- Reworked `resolve_platform_uri()` to use the SDK for dataset exports and model file retrieval, including SDK retries, long dataset read timeouts, API error handling, and `FileNotFoundError` when no model files are returned.
- Preserved the original `ul://owner/project/model` value in `model.overrides["model"]` after the model is downloaded, while checkpoint loading continues to use the local file.
- Raised the Python 3.11 dependency boundary for Platform integration and updated `ultralytics-platform` to `>=0.1.21`; Python 3.8–3.10 local training continues without Platform tracking and reports the requirement when Platform features are used.
- Kept `PLATFORM_API_URL` for worker events and checkpoint transport, while the SDK uses `ULTRALYTICS_PLATFORM_URL` for public API requests.

### 🎯 Purpose & Impact

- `yolo login`, `ul://` model loading, and `ul://` dataset loading now follow the published Platform SDK’s authentication, retry, and API error behavior.
- Python training with a downloaded `ul://` model retains the source URI in registration payloads, preventing the cache path from replacing the original model identity.
- Platform-integrated workflows require Python 3.11 or newer; local YOLO workflows on Python 3.8–3.10 remain available without Platform tracking.