### PR TITLE
Require Platform SDK >=0.1.32 for shared login

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,6 @@ Ultralytics (`ultralytics` on PyPI, AGPL-3.0) is the official Python package for
 
 ## Core Principles (CRITICAL)
 
-**PyPI releases:** Ultralytics-owned packages must use three-number `MAJOR.MINOR.PATCH` versions only; increment the patch number, never add suffixes or bypass version guards.
-
 **Less is more. The simplest solution is the best solution.** The action hierarchy for every change: **Delete > Replace > Add**.
 
 1. **Solve at the owner**: Put behavior in the code path that owns or observes it. For fixes, never guard a symptom with a staleness check, initialization flag, skip-first-call branch, or `try/except` around broken logic; relocate the trigger and delete the wrong path. For features, extend the existing owner rather than creating a parallel abstraction.
@@ -92,6 +90,7 @@ Adding a task or family means a Trainer/Validator/Predictor triplet wired into `
 
 ## Conventions
 
+- Ultralytics-owned PyPI packages use `MAJOR.MINOR.PATCH` versions only; no suffixes.
 - Every Python file starts with `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license` — Ultralytics Actions adds headers automatically; don't add or revert them manually.
 - Google-style docstrings with types in parentheses (`arg1 (int): ...`); Ruff enforces `convention = "google"` and formats docstring code blocks; the Actions bot also runs docformatter, prettier (YAML/JSON/Markdown), and codespell — expect bot commits on PR branches. Format markdown exactly as the bot does, never with unpinned defaults: `npx prettier@3.8.5 --tab-width 4 --print-width 120 --write` for `docs/**/*.md` (the documentation dialect requires 4-space list continuation; prettier's default tab width 2 breaks rendering) and the same command without `--tab-width` for markdown outside `docs/`.
 - Tests hit the live network: weights (e.g. `yolo26n.pt`) and assets auto-download from GitHub releases; shared constants (`MODEL`, `CFG`, `SOURCE`) live in `tests/__init__.py`, with `MODEL` deliberately under a "path with spaces" directory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Ultralytics (`ultralytics` on PyPI, AGPL-3.0) is the official Python package for
 
 ## Core Principles (CRITICAL)
 
-**PyPI release policy (CRITICAL):** Every Ultralytics-owned package published to PyPI must use exactly three numeric components, `MAJOR.MINOR.PATCH`. Never publish post-releases, prereleases, development releases, local versions, or other suffixes; increment the patch number and never weaken or bypass the publishing version guard.
+**PyPI releases:** Ultralytics-owned packages must use three-number `MAJOR.MINOR.PATCH` versions only; increment the patch number, never add suffixes or bypass version guards.
 
 **Less is more. The simplest solution is the best solution.** The action hierarchy for every change: **Delete > Replace > Add**.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ Ultralytics (`ultralytics` on PyPI, AGPL-3.0) is the official Python package for
 
 ## Core Principles (CRITICAL)
 
+**PyPI release policy (CRITICAL):** Every Ultralytics-owned package published to PyPI must use exactly three numeric components, `MAJOR.MINOR.PATCH`. Never publish post-releases, prereleases, development releases, local versions, or other suffixes; increment the patch number and never weaken or bypass the publishing version guard.
+
 **Less is more. The simplest solution is the best solution.** The action hierarchy for every change: **Delete > Replace > Add**.
 
 1. **Solve at the owner**: Put behavior in the code path that owns or observes it. For fixes, never guard a symptom with a staleness check, initialization flag, skip-first-call branch, or `try/except` around broken logic; relocate the trigger and delete the wrong path. For features, extend the existing owner rather than creating a parallel abstraction.

--- a/docs/en/platform/account/api-keys.md
+++ b/docs/en/platform/account/api-keys.md
@@ -103,7 +103,7 @@ curl -H "Authorization: Bearer YOUR_API_KEY" \
   https://platform.ultralytics.com/api/...
 ```
 
-Or pass it to the Python SDK (`pip install "ultralytics-platform>=0.1.5"`), which also reads `ULTRALYTICS_API_KEY`:
+Or pass it to the Python SDK (`pip install "ultralytics-platform>=0.1.32"`), which reads `ULTRALYTICS_API_KEY` or the key saved by `yolo login` when `api_key` is omitted:
 
 ```python
 from ultralytics_platform import Platform

--- a/docs/en/platform/api/index.md
+++ b/docs/en/platform/api/index.md
@@ -25,7 +25,7 @@ integrations_path: ../../integrations
     === "Python SDK"
 
         ```bash
-        pip install "ultralytics-platform>=0.1.5" # Python 3.11+
+        pip install "ultralytics-platform>=0.1.32" # Python 3.11+
         ```
 
         ```python
@@ -2384,13 +2384,13 @@ OpenAPI contract, with one method per endpoint (`client.datasets.list`, `client.
 and optional per-request `timeout` and `extra_headers`.
 
 ```bash
-pip install "ultralytics-platform>=0.1.5" # Python 3.11+
+pip install "ultralytics-platform>=0.1.32" # Python 3.11+
 ```
 
 ```python
 from ultralytics_platform import Platform
 
-with Platform() as client:  # reads ULTRALYTICS_API_KEY
+with Platform() as client:  # reads ULTRALYTICS_API_KEY or the key saved by yolo login
     dataset = client.datasets.retrieve("acme-vision", "warehouse")
     images = client.datasets.images("acme-vision", "warehouse", limit=10)
     export = client.exports.create("acme-vision", "inspection", "v3", format="onnx")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dependencies = [
     "polars>=0.20.0",
     "nvidia-ml-py>=12.0.0", # NVIDIA GPU monitoring https://pypi.org/project/nvidia-ml-py
     "ultralytics-thop>=2.1.6", # FLOPs computation https://github.com/ultralytics/thop
-    "ultralytics-platform>=0.1.21; python_version >= '3.11'",
+    "ultralytics-platform>=0.1.32; python_version >= '3.11'",
 ]
 
 # Optional dependencies ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Require `ultralytics-platform>=0.1.32` on Python 3.11+ so supported Ultralytics installations receive the SDK that reuses `yolo login` credentials. Update the documented SDK installation minimums and describe saved-login fallback.

The Python version marker is unchanged. Validation: parsed package metadata confirms the new floor applies on Python 3.11/3.14 and remains excluded on Python 3.8/3.10; documentation formatting and diff checks pass. SDK shared authentication was validated with actual published and current-main YOLO login/logout flows using isolated settings and local HTTP, and SDK CI covers Python 3.11/3.14.

`ultralytics-platform==0.1.32` is published on PyPI and its installed wheel passes both login/logout integration flows. Shared authentication landed in ultralytics/sdk#56 and the 0.1.32 contract update in ultralytics/sdk#57.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the Python 3.11+ Platform SDK requirement to `ultralytics-platform>=0.1.32` and documented its shared use of credentials saved by `yolo login`.

### 📊 Key Changes

- Raised the `ultralytics-platform` dependency minimum from `0.1.21` to `0.1.32` for Python 3.11 and newer; the existing Python version marker is unchanged.
- Updated Platform SDK installation examples in the API and API key documentation from `0.1.5` to `0.1.32`.
- Documented that the SDK reads `ULTRALYTICS_API_KEY` or the key saved by `yolo login` when `api_key` is omitted.
- Added the repository convention that Ultralytics-owned PyPI packages use three-part `MAJOR.MINOR.PATCH` versions without suffixes.

### 🎯 Purpose & Impact

- Python 3.11+ installations now require the SDK version that supports shared authentication with `yolo login`; Python 3.8–3.10 are unaffected by this dependency because the existing marker excludes them.
- SDK users can follow the updated documentation to use saved `yolo login` credentials when creating a `Platform` client without explicitly passing an API key.