### PR TITLE
Honor CLI arguments placed before cfg=<file> and a blank data in the cfg file

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -1043,7 +1043,7 @@ def entrypoint(debug: str = "") -> None:
                 k, v = parse_key_value_pair(a)
                 if k == "cfg" and v is not None:  # custom.yaml passed
                     LOGGER.info(f"Overriding {DEFAULT_CFG_PATH} with {v}")
-                    overrides = {k: val for k, val in YAML.load(checks.check_yaml(v)).items() if k != "cfg"}
+                    overrides = {**{k: val for k, val in YAML.load(checks.check_yaml(v)).items() if k != "cfg"}, **overrides}
                 else:
                     overrides[k] = v
             except (NameError, SyntaxError, ValueError, AssertionError) as e:

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -1043,7 +1043,10 @@ def entrypoint(debug: str = "") -> None:
                 k, v = parse_key_value_pair(a)
                 if k == "cfg" and v is not None:  # custom.yaml passed
                     LOGGER.info(f"Overriding {DEFAULT_CFG_PATH} with {v}")
-                    overrides = {**{k: val for k, val in YAML.load(checks.check_yaml(v)).items() if k != "cfg"}, **overrides}
+                    overrides = {
+                        **{k: val for k, val in YAML.load(checks.check_yaml(v)).items() if k != "cfg"},
+                        **overrides,
+                    }
                 else:
                     overrides[k] = v
             except (NameError, SyntaxError, ValueError, AssertionError) as e:

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -1136,7 +1136,7 @@ def entrypoint(debug: str = "") -> None:
         )
         LOGGER.warning(f"'source' argument is missing. Using default 'source={overrides['source']}'.")
     elif mode in {"train", "val"}:
-        if "data" not in overrides and "resume" not in overrides:
+        if overrides.get("data") is None and not overrides.get("resume"):
             overrides["data"] = DEFAULT_CFG.data or TASK2DATA.get(task or DEFAULT_CFG.task, DEFAULT_CFG.data)
             LOGGER.warning(f"'data' argument is missing. Using default 'data={overrides['data']}'.")
     elif mode == "export":


### PR DESCRIPTION
## summary
- `yolo ... cfg=<file>` merges the file under the arguments parsed before it instead of replacing them, so `yolo train data=coco8.yaml model=yolo26n.yaml cfg=custom.yaml` and the `cfg=`-first form name the same run, as the precedence documented in `docs/en/usage/cfg.md` and implemented by `get_cfg` already states
- a cfg file that leaves `data:` blank, which is what `yolo copy-cfg` writes, falls back to the task dataset for train and val instead of failing on `'None' does not exist`, so the documented `yolo cfg=default_copy.yaml imgsz=320` runs
- one commit per fix

## measured
cpu, coco8, yolo26n, `epochs=1 imgsz=32 batch=4 workers=0 plots=False`; `custom.yaml` is `default.yaml` without `pretrained`, `default_copy.yaml` is a fresh `yolo copy-cfg`

| command | before | after |
| -- | -- | -- |
| `yolo train data=coco8.yaml model=yolo26n.yaml cfg=custom.yaml` | `FileNotFoundError: 'None' does not exist` | 1 epoch on coco8 |
| `yolo detect train model=yolo26n.yaml cfg=train_custom.yaml` (the data-augmentation guide's CLI example with `model` given on the command line only) | trains `yolo26n.pt` after `'model' argument is missing` | trains `yolo26n.yaml` |
| `yolo cfg=default_copy.yaml imgsz=32` | `FileNotFoundError: 'None' does not exist` | `'data' argument is missing. Using default 'data=coco8.yaml'`, 1 epoch |
| `yolo val cfg=default_copy.yaml model=yolo26n.pt` | `FileNotFoundError: 'None' does not exist` | validates on coco8 |
| `yolo train cfg=custom.yaml data=coco8.yaml model=yolo26n.yaml` | 1 epoch | 1 epoch |
| `yolo train resume=True model=<ckpt>` without `data` | no dataset injected | no dataset injected |
| `yolo predict cfg=default_copy.yaml model=yolo26n.pt` (`source:` blank) | runs the file's `mode: train` | 2 images from `ASSETS` |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated CLI configuration handling so arguments take precedence over values loaded from `cfg=<file>` and blank dataset settings fall back to the task dataset for training and validation.

### 📊 Key Changes

- Merged values from the cfg file beneath already parsed CLI overrides, allowing commands such as `data=coco8.yaml model=yolo26n.yaml cfg=custom.yaml` to retain their explicit arguments.
- Treated `data: null` or blank `data` values as missing in train and val modes, injecting the task’s default dataset instead of attempting to load `None`.
- Changed resume detection to check whether `resume` is enabled, so dataset injection remains disabled for `resume=True` without affecting other cases.
- Preserved the cfg file’s mode and other settings while allowing command-line arguments to override them.

### 🎯 Purpose & Impact

- `cfg=`-based training and validation now use explicitly supplied CLI model and dataset values, regardless of whether those arguments appear before or after `cfg=`.
- Configurations generated by `yolo copy-cfg` can run training and validation without manually filling in `data`.
- Resume workflows without an explicit dataset continue to avoid automatic dataset injection.