### PR TITLE
Quote the measured INT8 accuracy of QAT against calibration

### DIFF
--- a/docs/en/modes/export.md
+++ b/docs/en/modes/export.md
@@ -163,7 +163,7 @@ The INT8 exports above are post-training quantization: ranges are observed in a 
 
 Use a small learning rate when fine-tuning a pretrained checkpoint. QAT can initially reduce accuracy, and its benefit over post-training quantization depends on the model, dataset, and training budget. Validate the exported model against both the original checkpoint and a post-training quantized export; fake-quantization scores during training do not establish deployment accuracy.
 
-How much QAT is worth depends on how well the export backend's own calibration handles the model. Measured on COCO val2017 with TensorRT engines exported from QAT runs stopped by `patience`, at `imgsz=640` and batch 1:
+How much QAT is worth depends on how well the export backend's own calibration handles the model. mAP50-95 measured on COCO val2017 with TensorRT 10.16 engines exported from QAT runs stopped by `patience`, at `imgsz=640` and batch 1:
 
 | Model     | FP32 engine | PTQ INT8 engine | QAT INT8 engine |
 | --------- | ----------- | --------------- | --------------- |
@@ -173,7 +173,7 @@ How much QAT is worth depends on how well the export backend's own calibration h
 | `yolo26l` | 0.5440      | 0.4889          | 0.5307          |
 | `yolo26x` | 0.5701      | 0.5138          | 0.5527          |
 
-QAT costs 0.8 to 1.7 mAP50-95 against FP32 across the range, while post-training quantization costs 1.0 on `yolo26n` and 5.5 to 5.7 on the larger models. So QAT buys almost nothing on the smallest model, where calibration already works well, and 3 to 4 points on the rest. Expect different figures on another dataset, export format, or TensorRT version, and measure your own.
+QAT costs 0.8 to 1.7 mAP50-95 against FP32 across the range, while post-training quantization costs 1.0 on `yolo26n` and 3.8 to 5.7 on the larger models. So QAT buys almost nothing on the smallest model, where calibration already works well, and 3.0 to 4.4 points on the rest. Expect different figures on another dataset, export format, or TensorRT version, and measure your own.
 
 QAT models require `compile=False`; ModelOpt's quantized modules do not support `torch.compile`.
 

--- a/docs/en/modes/export.md
+++ b/docs/en/modes/export.md
@@ -173,7 +173,7 @@ How much QAT is worth depends on how well the export backend's own calibration h
 | `yolo26l` | 0.5440      | 0.4889          | 0.5307          |
 | `yolo26x` | 0.5701      | 0.5138          | 0.5527          |
 
-QAT costs 0.8 to 1.7 mAP50-95 against FP32 across the range, while post-training quantization costs 1.0 on `yolo26n` and 3.8 to 5.7 on the larger models. So QAT buys almost nothing on the smallest model, where calibration already works well, and 3.0 to 4.4 points on the rest. Expect different figures on another dataset, export format, or TensorRT version, and measure your own.
+QAT costs 0.008 to 0.017 mAP50-95 against FP32 across the range, while post-training quantization costs 0.010 on `yolo26n` and 0.038 to 0.057 on the larger models. So QAT buys almost nothing on the smallest model, where calibration already works well, and 0.030 to 0.044 on the rest. Expect different figures on another dataset, export format, or TensorRT version, and measure your own.
 
 QAT models require `compile=False`; ModelOpt's quantized modules do not support `torch.compile`.
 

--- a/docs/en/modes/export.md
+++ b/docs/en/modes/export.md
@@ -163,6 +163,18 @@ The INT8 exports above are post-training quantization: ranges are observed in a 
 
 Use a small learning rate when fine-tuning a pretrained checkpoint. QAT can initially reduce accuracy, and its benefit over post-training quantization depends on the model, dataset, and training budget. Validate the exported model against both the original checkpoint and a post-training quantized export; fake-quantization scores during training do not establish deployment accuracy.
 
+How much QAT is worth depends on how well the export backend's own calibration handles the model. Measured on COCO val2017 with TensorRT engines exported from QAT runs stopped by `patience`, at `imgsz=640` and batch 1:
+
+| Model     | FP32 engine | PTQ INT8 engine | QAT INT8 engine |
+| --------- | ----------- | --------------- | --------------- |
+| `yolo26n` | 0.4032      | 0.3934          | 0.3935          |
+| `yolo26s` | 0.4794      | 0.4412          | 0.4711          |
+| `yolo26m` | 0.5269      | 0.4696          | 0.5137          |
+| `yolo26l` | 0.5440      | 0.4889          | 0.5307          |
+| `yolo26x` | 0.5701      | 0.5138          | 0.5527          |
+
+QAT costs 0.8 to 1.7 mAP50-95 against FP32 across the range, while post-training quantization costs 1.0 on `yolo26n` and 5.5 to 5.7 on the larger models. So QAT buys almost nothing on the smallest model, where calibration already works well, and 3 to 4 points on the rest. Expect different figures on another dataset, export format, or TensorRT version, and measure your own.
+
 QAT models require `compile=False`; ModelOpt's quantized modules do not support `torch.compile`.
 
 The output head is deliberately left in float to limit INT8 accuracy loss. QAT runs through [NVIDIA TensorRT Model Optimizer](https://github.com/NVIDIA/TensorRT-Model-Optimizer), installed automatically on first use, and the resulting checkpoint needs it installed to load. Those ranges travel with the checkpoint and `onnx` and `engine` exports emit them as Q/DQ nodes; other formats read calibration instead and reject a QAT checkpoint.

--- a/docs/en/modes/export.md
+++ b/docs/en/modes/export.md
@@ -129,7 +129,7 @@ For INT8 and W8A16 exports, provide representative calibration data with `data`,
 
 ### Quantization-Aware Training
 
-The INT8 exports above are post-training quantization: ranges are observed in a single calibration pass over `data`. Quantization-aware training (QAT) instead learns weights that tolerate INT8 by fine-tuning with fake-quantization in the loop, which recovers accuracy that calibration alone loses. Pass `quantize=8` to `train` to fine-tune a pretrained checkpoint, then export it as usual:
+The INT8 exports above are post-training quantization (PTQ): ranges are observed in a single calibration pass over `data`. Quantization-aware training (QAT) instead learns weights that tolerate INT8 by fine-tuning with fake-quantization in the loop, which recovers accuracy that calibration alone loses. Pass `quantize=8` to `train` to fine-tune a pretrained checkpoint, then export it as usual:
 
 !!! example
 
@@ -163,7 +163,7 @@ The INT8 exports above are post-training quantization: ranges are observed in a 
 
 Use a small learning rate when fine-tuning a pretrained checkpoint. QAT can initially reduce accuracy, and its benefit over post-training quantization depends on the model, dataset, and training budget. Validate the exported model against both the original checkpoint and a post-training quantized export; fake-quantization scores during training do not establish deployment accuracy.
 
-How much QAT is worth depends on how well the export backend's own calibration handles the model. mAP50-95 measured on COCO val2017 with TensorRT 10.16 engines exported from QAT runs stopped by `patience`, at `imgsz=640` and batch 1:
+How much QAT is worth depends on how well the export backend's own calibration handles the model. The values below are mAP50-95 on COCO val2017, measured with TensorRT 10.16 engines at `imgsz=640` and batch 1, where each QAT checkpoint was trained with `epochs=20 patience=3`:
 
 | Model     | FP32 engine | PTQ INT8 engine | QAT INT8 engine |
 | --------- | ----------- | --------------- | --------------- |


### PR DESCRIPTION
Follow-up to #26083, docs only.

That PR's guidance says QAT's benefit "depends on the model, dataset, and training budget" and tells the reader to validate on the exported artifact — both correct, but a reader still cannot tell whether the training time is worth spending. This adds the figures behind that sentence.

Measured on COCO val2017 through `YOLO(engine).val()`, TensorRT 10.16, `imgsz=640`, batch 1, one RTX PRO 6000 per arm. Every QAT checkpoint was trained with `epochs=20 patience=3` so the schedule chose its own stopping point (`n` 7, `x` 9, `m` 11, `s` 13, `l` 16 epochs), and every engine came from the ordinary one-call `model.export(format="engine", quantize=8)`:

| Model | FP32 engine | PTQ INT8 | QAT INT8 | PTQ gap | QAT gap |
| --- | --- | --- | --- | --- | --- |
| `yolo26n` | 0.4032 | 0.3934 | 0.3935 | −0.98 | −0.97 |
| `yolo26s` | 0.4794 | 0.4412 | 0.4711 | −3.82 | −0.84 |
| `yolo26m` | 0.5269 | 0.4696 | 0.5137 | −5.73 | −1.32 |
| `yolo26l` | 0.5440 | 0.4889 | 0.5307 | −5.51 | −1.33 |
| `yolo26x` | 0.5701 | 0.5138 | 0.5527 | −5.63 | −1.74 |

The pattern is that QAT holds a stable INT8 floor while the built-in calibrator degrades with model size, so `yolo26n` is the one size where QAT is not worth running.

Worth recording why this is a separate PR rather than something I should have got right the first time: my original description compared QAT against **torch fake-quant** PTQ, which measures a quantizer placement nobody deploys. On `yolo26m` that comparison put PTQ at −1.15 where the exported engine loses −5.73, which inverted the ranking and is exactly the mistake your "fake-quantization scores during training do not establish deployment accuracy" sentence warns against. These numbers are all exported-artifact measurements.

The paragraph closes by telling the reader to expect different figures on another dataset, format or TensorRT version and to measure their own, so the table is calibration for expectations rather than a promise. Raw results and the harness are on ultra7 under `~/qat/exp` if you want to reproduce a row.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the export documentation to quantify how YOLO26 QAT compares with PTQ INT8 and FP32 TensorRT engines on COCO, helping users assess when QAT training may be worthwhile.

### 📊 Key Changes
- Clarified that the documented INT8 export workflow uses post-training quantization (PTQ).
- Added TensorRT 10.16 mAP50-95 results for `yolo26n`, `yolo26s`, `yolo26m`, `yolo26l`, and `yolo26x` using FP32, PTQ INT8, and QAT INT8 engines.
- Documented that QAT provides little improvement for `yolo26n`, while retaining more accuracy than PTQ on the larger models.
- Added the measured accuracy ranges, test conditions, and a warning that results vary by dataset, export format, and TensorRT version.

### 🎯 Purpose & Impact
- Documentation now provides concrete exported-engine measurements for comparing QAT with PTQ instead of relying only on training-time fake-quantization scores.
- Users are directed to measure their own exported models because the reported accuracy results are environment- and dataset-specific.