### PR TITLE
Fix broken DL Streamer system requirements link

### DIFF
--- a/docs/en/guides/dlstreamer-intel.md
+++ b/docs/en/guides/dlstreamer-intel.md
@@ -27,7 +27,7 @@ DL Streamer enables analysis of audio and video streams to detect, classify, tra
 
 DL Streamer supports many AI models including the full Ultralytics YOLO family (YOLOv5 through YOLO26) all in OpenVINO™ format.
 
-DL Streamer is being regularly validated with systems provided on [System Requirements — Open Edge Platform Documentation](https://docs.openedgeplatform.intel.com/2026.1/edge-ai-libraries/dlstreamer/get_started/system_requirements.html)
+DL Streamer is being regularly validated with systems provided on [System Requirements — Open Edge Platform Documentation](https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dlstreamer/system_requirements.html)
 
 ## Prerequisites
 


### PR DESCRIPTION
The 2026.1 system requirements URL returns 404 after redirect. Switched to the dev path used by the other DL Streamer links on this page, which resolves directly with no redirect.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the DL Streamer system requirements link to the working Open Edge Platform development documentation path.

### 📊 Key Changes
- Replaced the broken `2026.1` system requirements URL in `docs/en/guides/dlstreamer-intel.md`.
- Linked to the `/dev/edge-ai-libraries/dlstreamer/system_requirements.html` page, matching the path used by other DL Streamer links.

### 🎯 Purpose & Impact
- The DL Streamer guide now points readers to a directly resolving system requirements page.
- No code or runtime behavior changed.