### PR TITLE
Keep the cached predictor when .to() does not move the model

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -948,8 +948,8 @@ class Model(torch.nn.Module):
         """Apply a function to model parameters, buffers, and tensors.
 
         This method extends the functionality of the parent class's _apply method by additionally updating the device
-        in the model's overrides and dropping the cached predictor, which wraps its own copy of the module, when the
-        call actually replaced the parameter storage it was built from.
+        in the model's overrides and dropping the cached predictor when a model tensor is converted. No-op tensor
+        conversions preserve the predictor.
 
         Args:
             fn (Callable): A function to be applied to the model's tensors. This is typically a method like to(), cpu(),
@@ -966,10 +966,14 @@ class Model(torch.nn.Module):
             >>> model = model._apply(lambda t: t.cuda())  # Move model to GPU
         """
         self._check_is_pytorch_model()
-        state = [(t.device, t.data_ptr()) for t in self.model.parameters()]
-        super()._apply(fn)
-        if state != [(t.device, t.data_ptr()) for t in self.model.parameters()]:
-            self.predictor = None  # the cached predictor holds a copy of the storage this call replaced
+
+        def apply(t):
+            converted = fn(t)
+            if converted is not t:
+                self.predictor = None  # predictor owns a copy, including buffers and detection-head tensors
+            return converted
+
+        super()._apply(apply)
         self.overrides["device"] = self.device  # was str(self.device) i.e. device(type='cuda', index=0) -> 'cuda:0'
         return self
 

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -949,7 +949,7 @@ class Model(torch.nn.Module):
 
         This method extends the functionality of the parent class's _apply method by additionally updating the device
         in the model's overrides and dropping the cached predictor, which wraps its own copy of the module, when the
-        call actually moved the model or changed its precision.
+        call actually replaced the parameter storage it was built from.
 
         Args:
             fn (Callable): A function to be applied to the model's tensors. This is typically a method like to(), cpu(),
@@ -966,10 +966,10 @@ class Model(torch.nn.Module):
             >>> model = model._apply(lambda t: t.cuda())  # Move model to GPU
         """
         self._check_is_pytorch_model()
-        state = [(t.device, t.dtype) for t in self.model.parameters()]
+        state = [(t.device, t.data_ptr()) for t in self.model.parameters()]
         super()._apply(fn)
-        if state != [(t.device, t.dtype) for t in self.model.parameters()]:
-            self.predictor = None  # the cached predictor holds a copy of the module this call changed
+        if state != [(t.device, t.data_ptr()) for t in self.model.parameters()]:
+            self.predictor = None  # the cached predictor holds a copy of the storage this call replaced
         self.overrides["device"] = self.device  # was str(self.device) i.e. device(type='cuda', index=0) -> 'cuda:0'
         return self
 

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -947,9 +947,9 @@ class Model(torch.nn.Module):
     def _apply(self, fn) -> Model:
         """Apply a function to model parameters, buffers, and tensors.
 
-        This method extends the functionality of the parent class's _apply method by additionally resetting the
-        predictor and updating the device in the model's overrides. It's typically used for operations like moving the
-        model to a different device or changing its precision.
+        This method extends the functionality of the parent class's _apply method by additionally updating the device
+        in the model's overrides and dropping the cached predictor, which wraps its own copy of the module, when the
+        call actually moved the model or changed its precision.
 
         Args:
             fn (Callable): A function to be applied to the model's tensors. This is typically a method like to(), cpu(),
@@ -966,8 +966,10 @@ class Model(torch.nn.Module):
             >>> model = model._apply(lambda t: t.cuda())  # Move model to GPU
         """
         self._check_is_pytorch_model()
+        state = [(t.device, t.dtype) for t in self.model.parameters()]
         super()._apply(fn)
-        self.predictor = None  # reset predictor as device may have changed
+        if state != [(t.device, t.dtype) for t in self.model.parameters()]:
+            self.predictor = None  # the cached predictor holds a copy of the module this call changed
         self.overrides["device"] = self.device  # was str(self.device) i.e. device(type='cuda', index=0) -> 'cuda:0'
         return self
 


### PR DESCRIPTION
Fixes #26094. Repeated no-op model.to(device) calls discarded the cached predictor and rebuilt its deep-copied, fused model, increasing latency and memory use.

Observe tensor conversions in Model._apply: retain the predictor when the conversion returns the same tensor, and invalidate it when a tensor is replaced. This covers parameters, registered buffers, and detection-head tensors at their conversion owner without before/after state snapshots. Device overrides continue to update.

Validation: 10 existing prediction/model-method tests pass locally across detection, segmentation, semantic segmentation, depth, classification, pose, OBB, and grayscale models. Focused real-model checks cover no-op CPU/float conversions, buffer-only conversion, FP16 conversion, and channels-last conversion. No new arguments or mock tests.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated `Model._apply` to preserve the cached predictor for no-op tensor conversions while invalidating it when model tensors are replaced.

### 📊 Key Changes
- Wrapped tensor conversion in `Model._apply` to compare each converted tensor with its original object.
- Retained `self.predictor` when conversions return the same tensor.
- Cleared `self.predictor` when parameters, buffers, or detection-head tensors are replaced.
- Continued updating `self.overrides["device"]` after applying conversions.

### 🎯 Purpose & Impact
- Repeated no-op calls such as `.to()` no longer discard and rebuild the cached predictor, avoiding the associated deep-copy work.
- Actual tensor conversions still invalidate the predictor so it does not retain stale model state.