### PR TITLE
Serve the buffered mosaic tile's semantic mask from ram instead of re-decoding it

### DIFF
--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -888,6 +888,7 @@ class SemanticDataset(YOLODataset):
         data (dict): Dataset configuration from YAML.
         mask_files (list[str]): List of mask file paths corresponding to images.
         include_class (np.ndarray | None): Class ids to keep per pixel (None keeps all).
+        masks (dict[int, np.ndarray]): Resized masks of the images in the mosaic buffer, evicted with them.
     """
 
     format_class = SemanticFormat
@@ -905,6 +906,7 @@ class SemanticDataset(YOLODataset):
         self.label_lut, self.inverse_lut = self._build_label_luts()
         self.mask_files = []
         self.include_class = None
+        self.masks = {}  # masks of the buffered images, evicted with the image buffer
         super().__init__(*args, data=data, **kwargs)
 
     def update_labels(self, include_class: list[int] | None) -> None:
@@ -1053,8 +1055,7 @@ class SemanticDataset(YOLODataset):
     def get_image_and_label(self, index):
         """Get image, label and semantic mask for the given index.
 
-        Overrides parent to include semantic mask so that Mosaic/CopyPaste mix images
-        also have their masks loaded.
+        Overrides parent to include the semantic mask, served from RAM for the images Mosaic draws from the buffer.
 
         Args:
             index (int): Dataset index.
@@ -1064,12 +1065,17 @@ class SemanticDataset(YOLODataset):
         """
         label = super().get_image_and_label(index)
         h, w = label["img"].shape[:2]
-        mask = self.load_mask(index, image_shape=(h, w))
-        if self.include_class is not None:  # keep only selected classes; remap the rest to the ignore label
-            mask[~np.isin(mask, self.include_class)] = 255
-        # Resize mask to match the resized image dimensions
-        if mask.shape[:2] != (h, w):
-            mask = cv2.resize(mask, (w, h), interpolation=cv2.INTER_NEAREST)
+        mask = self.masks.get(index)
+        if mask is None:
+            mask = self.load_mask(index, image_shape=(h, w))
+            if self.include_class is not None:  # keep only selected classes; remap the rest to the ignore label
+                mask[~np.isin(mask, self.include_class)] = 255
+            if mask.shape[:2] != (h, w):
+                mask = cv2.resize(mask, (w, h), interpolation=cv2.INTER_NEAREST)
+            if index in self.buffer:  # image is RAM-resident for mosaic reuse, keep its mask with it
+                self.masks[index] = mask
+                if len(self.masks) > len(self.buffer):
+                    self.masks = {i: self.masks[i] for i in self.buffer if i in self.masks}
         label["semantic_mask"] = mask
         return label
 


### PR DESCRIPTION
## summary

- keep the resized semantic mask of every image in the mosaic buffer next to the image, so a mosaic tile drawn from the buffer no longer re-decodes its mask PNG (or re-rasterizes its polygons) on every draw
- the dict is bounded by the buffer: entries are added only for buffered indices and pruned to the buffer whenever it outgrows it, so val, `cache='ram'` and non-buffered MixUp/CutMix partners keep loading masks exactly as before

## measured

Paired ABBA blocks, ratio inside each block, outputs fingerprinted (`img` + `semantic_mask`, 200 seeded samples) identical across arms.

| dataset, loader                                    | before    | after     | ratio              |
| -------------------------------------------------- | --------- | --------- | ------------------ |
| ADE20K, workers=0, ms/sample                       | 8.66–9.18 | 6.24–6.76 | 1.37 / 1.77 / 1.38 |
| ADE20K, workers=8, samples/s                       | 536       | 678       | 1.26               |
| cityscapes (1024x2048 masks), workers=0, ms/sample | 54.9      | 37.1–39.4 | 1.44               |
| dacl10k (polygon labels), workers=0, ms/sample     | 21.4–22.6 | 16.1–17.5 | 1.31               |
| dacl10k, workers=8, samples/s                      | 133–141   | 182–242   | 1.36 / 1.72        |
| mosaic=0 (no tile draws), workers=0                | 5.4–5.8   | 5.4–5.9   | 0.96 / 1.05        |

`load_mask` calls per sample 4.00 → 1.00 under mosaic, 1.00 → 1.00 without. Mask RAM per worker: +74 MB beside the 223 MB image buffer on ADE20K at batch 16 (+105 MB on cityscapes). On Ultralytics Platform the released package trains dacl10k at 11.7 img/s (H100 SXM) and 24.5 img/s (RTX PRO 6000) with `workers=8`, so the epoch there is set by this loader cost.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Semantic masks for images in the Mosaic buffer are now cached in RAM and reused, avoiding repeated mask decoding or polygon rasterization during Mosaic draws.

### 📊 Key Changes

- Added `SemanticDataset.masks` to store resized semantic masks keyed by buffered image index.
- `get_image_and_label()` now checks the mask cache before calling `load_mask()`.
- Cached masks are created only for images already in the Mosaic buffer and pruned to match the current buffer contents.
- Non-buffered images continue loading and processing masks through the existing path.

### 🎯 Purpose & Impact

- Mosaic sampling reuses cached semantic masks, reducing repeated mask-loading work while preserving the existing behavior for validation, `cache='ram'`, and non-buffered MixUp/CutMix partners.