### PR TITLE
Write EMA test poison by index so it lands on channels_last CUDA weights

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -249,13 +249,18 @@ def test_nan_recovery():
     assert nan_injected[0], "NaN injection failed"
 
 
+def set_first(param, value):
+    """Write a value into a parameter's first element, which flatten() cannot do for channels_last CUDA weights."""
+    param.data[(0,) * param.ndim] = value
+
+
 def test_checkpoint_fp16_overflow():
     """Test a finite model whose weights overflow fp16 is still checkpointed (clamped) instead of skipped."""
 
     def inflate_ema(trainer):
         """Push an EMA weight above the fp16 max (65504) so its fp16 snapshot would otherwise become Inf."""
         if trainer.ema is not None:
-            next(iter(trainer.ema.ema.parameters())).data.flatten()[0] = 1.0e5
+            set_first(next(iter(trainer.ema.ema.parameters())), 1.0e5)
 
     overrides = {"data": "coco8.yaml", "model": "yolo26n.yaml", "imgsz": 32, "epochs": 2}
     trainer = detect.DetectionTrainer(overrides=overrides)
@@ -268,9 +273,11 @@ def test_checkpoint_fp16_overflow():
     )
     # Validation must leave the live EMA fp32 and unchanged; checkpoint serialization may clamp its fp16 copy.
     ema_param = next(iter(trainer.ema.ema.parameters()))
-    assert ema_param.dtype == torch.float32 and torch.isfinite(ema_param).all() and ema_param.flatten()[0] == 1.0e5, (
-        "validation corrupted the live EMA"
-    )
+    assert (
+        ema_param.dtype == torch.float32
+        and torch.isfinite(ema_param).all()
+        and ema_param[(0,) * ema_param.ndim] == 1.0e5
+    ), "validation corrupted the live EMA"
 
 
 def test_checkpoint_nonfinite_ema_resync():
@@ -279,7 +286,7 @@ def test_checkpoint_nonfinite_ema_resync():
     def poison_ema(trainer):
         """Make the live fp32 EMA genuinely non-finite while the model stays finite (sticky-NaN on a finite-loss run)."""
         if trainer.ema is not None:
-            next(iter(trainer.ema.ema.parameters())).data.flatten()[0] = float("inf")
+            set_first(next(iter(trainer.ema.ema.parameters())), float("inf"))
 
     overrides = {"data": "coco8.yaml", "model": "yolo26n.yaml", "imgsz": 32, "epochs": 2}
     trainer = detect.DetectionTrainer(overrides=overrides)
@@ -298,8 +305,8 @@ def test_checkpoint_nonfinite_ema_and_model_sanitized():
     def poison_ema_and_model(trainer):
         """Force the first parameter non-finite in both the live EMA and the model (finite-loss sticky-NaN)."""
         if trainer.ema is not None:
-            next(iter(trainer.ema.ema.parameters())).data.flatten()[0] = float("inf")
-            next(iter(unwrap_model(trainer.model).parameters())).data.flatten()[0] = float("nan")
+            set_first(next(iter(trainer.ema.ema.parameters())), float("inf"))
+            set_first(next(iter(unwrap_model(trainer.model).parameters())), float("nan"))
 
     overrides = {"data": "coco8.yaml", "model": "yolo26n.yaml", "imgsz": 32, "epochs": 1}
     trainer = detect.DetectionTrainer(overrides=overrides)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -249,18 +249,13 @@ def test_nan_recovery():
     assert nan_injected[0], "NaN injection failed"
 
 
-def set_first(param, value):
-    """Write a value into a parameter's first element, which flatten() cannot do for channels_last CUDA weights."""
-    param.data[(0,) * param.ndim] = value
-
-
 def test_checkpoint_fp16_overflow():
     """Test a finite model whose weights overflow fp16 is still checkpointed (clamped) instead of skipped."""
 
     def inflate_ema(trainer):
         """Push an EMA weight above the fp16 max (65504) so its fp16 snapshot would otherwise become Inf."""
         if trainer.ema is not None:
-            set_first(next(iter(trainer.ema.ema.parameters())), 1.0e5)
+            next(iter(trainer.ema.ema.parameters())).data[0] = 1.0e5
 
     overrides = {"data": "coco8.yaml", "model": "yolo26n.yaml", "imgsz": 32, "epochs": 2}
     trainer = detect.DetectionTrainer(overrides=overrides)
@@ -273,11 +268,9 @@ def test_checkpoint_fp16_overflow():
     )
     # Validation must leave the live EMA fp32 and unchanged; checkpoint serialization may clamp its fp16 copy.
     ema_param = next(iter(trainer.ema.ema.parameters()))
-    assert (
-        ema_param.dtype == torch.float32
-        and torch.isfinite(ema_param).all()
-        and ema_param[(0,) * ema_param.ndim] == 1.0e5
-    ), "validation corrupted the live EMA"
+    assert ema_param.dtype == torch.float32 and torch.isfinite(ema_param).all() and ema_param.flatten()[0] == 1.0e5, (
+        "validation corrupted the live EMA"
+    )
 
 
 def test_checkpoint_nonfinite_ema_resync():
@@ -286,7 +279,7 @@ def test_checkpoint_nonfinite_ema_resync():
     def poison_ema(trainer):
         """Make the live fp32 EMA genuinely non-finite while the model stays finite (sticky-NaN on a finite-loss run)."""
         if trainer.ema is not None:
-            set_first(next(iter(trainer.ema.ema.parameters())), float("inf"))
+            next(iter(trainer.ema.ema.parameters())).data[0] = float("inf")
 
     overrides = {"data": "coco8.yaml", "model": "yolo26n.yaml", "imgsz": 32, "epochs": 2}
     trainer = detect.DetectionTrainer(overrides=overrides)
@@ -305,8 +298,8 @@ def test_checkpoint_nonfinite_ema_and_model_sanitized():
     def poison_ema_and_model(trainer):
         """Force the first parameter non-finite in both the live EMA and the model (finite-loss sticky-NaN)."""
         if trainer.ema is not None:
-            set_first(next(iter(trainer.ema.ema.parameters())), float("inf"))
-            set_first(next(iter(unwrap_model(trainer.model).parameters())), float("nan"))
+            next(iter(trainer.ema.ema.parameters())).data[0] = float("inf")
+            next(iter(unwrap_model(trainer.model).parameters())).data[0] = float("nan")
 
     overrides = {"data": "coco8.yaml", "model": "yolo26n.yaml", "imgsz": 32, "epochs": 1}
     trainer = detect.DetectionTrainer(overrides=overrides)


### PR DESCRIPTION
The existing checkpoint tests write poison values through flatten()[0]. For channels-last weights, flatten() creates a copy, so the writes do not reach the EMA/model and the tests can pass without exercising corruption recovery.

Replace the four writes with direct indexed assignments to the first channel. This mutates the original tensor for either layout and requires no helper or new test.

Validation: all three existing checkpoint tests pass locally; a direct channels-last tensor check reproduces the old dropped write and confirms the indexed write. The full cross-platform and GPU CI runs on the final branch head.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated checkpoint tests to write corruption values directly into parameter tensors so EMA and model poisoning works with channels-last CUDA weights.

### 📊 Key Changes

- Replaced four `flatten()[0]` assignments in `tests/test_engine.py` with direct `[0]` assignments.
- Updated tests covering EMA fp16 overflow, non-finite EMA resynchronization, and simultaneous non-finite EMA/model sanitization.
- Direct indexing mutates the original tensor, while `flatten()` can create a copy for channels-last tensors.

### 🎯 Purpose & Impact

- Ensures the checkpoint tests genuinely inject overflow, infinity, and NaN values into the live parameters across supported tensor layouts.
- No user-facing change; this improves test coverage of checkpoint corruption recovery.