### PR TITLE
Update license banner image to CDN asset

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -170,7 +170,7 @@ Beyond the Python package, two more surfaces run on the same models: the [Ultral
 ## YOLO Licenses: How is Ultralytics YOLO licensed?
 
 <a href="https://www.ultralytics.com/license?utm_source=docs.ultralytics.com&utm_medium=referral&utm_content=license_banner" target="_blank" rel="noopener noreferrer">
-<img width="100%" style="border-radius:.4rem" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-license.avif" alt="Ultralytics Enterprise License banner"></a>
+<img width="100%" style="border-radius:.4rem" src="https://cdn.ul.run/i/f349bcf492eb2982b9a5e7711c984585.avif" alt="Ultralytics Enterprise License banner"></a>
 
 Ultralytics offers two licensing options to accommodate diverse use cases:
 


### PR DESCRIPTION
## summary

- point the license banner on the docs homepage at the cdn-hosted asset instead of the raw github assets file
- the new image reads "no open-source restrictions" in place of "no agpl restrictions"

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the documentation homepage license banner to load a new CDN-hosted image that uses “no open-source restrictions” wording instead of “no agpl restrictions.”

### 📊 Key Changes
- Changed the license banner image source in `docs/en/index.md`.
- Replaced the raw GitHub asset URL with `https://cdn.ul.run/i/f349bcf492eb2982b9a5e7711c984585.avif`.
- Kept the existing license link, image dimensions, styling, and alt text unchanged.

### 🎯 Purpose & Impact
- The docs homepage now displays the updated CDN-hosted license banner with revised wording.
- No other documentation behavior or licensing links were changed.