### PR TITLE
Remove general NNCF upper version bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ export-base = [
     "onnxruntime>=1.20.0; python_version >= '3.11'",
 ]
 export-openvino = [
-    "nncf>=2.14.0,<4.0.0; python_version >= '3.9'",  # OpenVINO INT8 export
+    "nncf>=2.14.0; python_version >= '3.9'",  # OpenVINO INT8 export
     "openvino>=2024.0.0",  # OpenVINO export
     "packaging>=26.0; platform_machine == 'aarch64' and platform_system == 'Linux' and python_version >= '3.9'", # NNCF on Linux ARM64
 ]


### PR DESCRIPTION
Remove the general `nncf<4.0.0` ceiling from the OpenVINO extra, matching the existing `nncf>=2.14.0` runtime requirement on PyTorch >=2.3. The upgrade to allow NNCF 3.x already shipped in #25825.

Keep the `nncf<3.0.0` constraints in `export-legacy-torch` and the exporter for PyTorch <2.3, which lacks `torch.uint16`. This is a one-line dependency change with no export implementation changes.

Validation on macOS ARM64 with Python 3.13.9, PyTorch 2.14.0, NNCF 3.3.0 and OpenVINO 2026.3.1: **9 passed** (36.37s), covering two standard OpenVINO export/inference cases plus static batch-1 INT8 export/inference for detect, segment, semantic, depth, classify, pose and obb. Auto-install was disabled.

```bash
YOLO_AUTOINSTALL=false python -m pytest tests/test_exports.py --slow -k 'test_export_openvino and (not matrix or False-8-1-False)' -q -rs
```

Legacy compatibility was checked separately on Python 3.10.19 with real PyTorch 2.2.2: importing NNCF 3.3.0 fails with `AttributeError: module 'torch' has no attribute 'uint16'`; selecting `nncf>=2.14.0,<3.0.0` installs NNCF 2.19.0 and imports successfully.

`git diff --check` passes. Future NNCF major releases remain untested.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Removed the `<4.0.0` upper bound from the OpenVINO extra so supported environments can resolve NNCF versions newer than 3.x.

### 📊 Key Changes
- Changed `pyproject.toml`’s `export-openvino` requirement from `nncf>=2.14.0,<4.0.0` to `nncf>=2.14.0`.
- Kept the `nncf<3.0.0` constraints for `export-legacy-torch` and PyTorch versions below 2.3.
- Made no changes to OpenVINO export implementation code.

### 🎯 Purpose & Impact
- OpenVINO INT8 export environments using the current runtime requirements are no longer capped at NNCF 3.x.
- Legacy environments using PyTorch below 2.3 continue to select NNCF versions below 3.0. Future NNCF major versions remain untested.