### PR TITLE
Fix model loading, numerical edge cases, and CI setup

### DIFF
--- a/.github/scripts/create-export-env.py
+++ b/.github/scripts/create-export-env.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import psutil
+
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO))
 
@@ -78,6 +80,10 @@ def main():
     parser.add_argument("--list", action="store_true", help="Print isolated export environment ids and exit.")
     args = parser.parse_args()
     envs = args.env or isolated_env_ids()
+
+    if "isolated-deepx" in envs and psutil.virtual_memory().total < 15 * (1 << 30):
+        print("Skipping DEEPX: at least 15 GiB of RAM is required.", file=sys.stderr)
+        envs = [env for env in envs if env != "isolated-deepx"]
 
     if args.list:
         print("\n".join(envs))

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -15,6 +15,7 @@ on:
       - synchronize
 
 permissions:
+  contents: read
   actions: write
   pull-requests: write
 

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.143"
+__version__ = "8.4.144"
 
 import importlib
 import os

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -2218,7 +2218,7 @@ def yaml_model_load(path):
         path = path.with_name(new_stem + path.suffix)
 
     unified_path = re.sub(r"(\d+)([nslmx])(.+)?$", r"\1\3", str(path))  # i.e. yolov8x.yaml -> yolov8.yaml
-    yaml_file = check_yaml(unified_path, hard=False) or check_yaml(path)
+    yaml_file = check_yaml(path, hard=False) or check_yaml(unified_path)
     d = YAML.load(yaml_file)  # model dict
     d["scale"] = guess_model_scale(path)
     d["yaml_file"] = str(path)

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -163,7 +163,7 @@ def bbox_iou(
             if CIoU:  # https://github.com/Zzh-tju/DIoU-SSD-pytorch/blob/master/utils/box/box_utils.py#L47
                 v = (4 / math.pi**2) * ((w2 / h2).atan() - (w1 / h1).atan()).pow(2)
                 with torch.no_grad():
-                    alpha = v / (v - iou + (1 + eps)).clamp_(min=eps)
+                    alpha = v / (1 - iou + v + eps)
                 return iou - (rho2 / c2 + v * alpha)  # CIoU
             return iou - rho2 / c2  # DIoU
         c_area = cw * ch + eps  # convex area

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -163,7 +163,7 @@ def bbox_iou(
             if CIoU:  # https://github.com/Zzh-tju/DIoU-SSD-pytorch/blob/master/utils/box/box_utils.py#L47
                 v = (4 / math.pi**2) * ((w2 / h2).atan() - (w1 / h1).atan()).pow(2)
                 with torch.no_grad():
-                    alpha = v / (v - iou + (1 + eps))
+                    alpha = v / (v - iou + (1 + eps)).clamp_(min=eps)
                 return iou - (rho2 / c2 + v * alpha)  # CIoU
             return iou - rho2 / c2  # DIoU
         c_area = cw * ch + eps  # convex area

--- a/ultralytics/utils/tal.py
+++ b/ultralytics/utils/tal.py
@@ -89,7 +89,7 @@ class TaskAlignedAssigner(nn.Module):
                 torch.full_like(pd_scores[..., 0], self.num_classes),
                 torch.zeros_like(pd_bboxes),
                 torch.zeros_like(pd_scores),
-                torch.zeros_like(pd_scores[..., 0]),
+                torch.zeros_like(pd_scores[..., 0], dtype=torch.bool),
                 torch.zeros_like(pd_scores[..., 0]),
             )
 


### PR DESCRIPTION
Fix five issues in model loading, assignment, overlap calculation, and CI:

- Prefer an explicitly requested model YAML before trying its scale-unified fallback. If `custom26n.yaml` and `custom26.yaml` both exist, requesting the former must load its contents.
- Return a boolean foreground mask for empty-label batches, matching the normal return contract of both task-aligned assigners.
- Add epsilon last in the CIoU alpha denominator so identical FP16/BF16 boxes do not produce NaN values and gradients when rounding removes epsilon from `1 + eps`.
- Grant the CLA workflow `contents: read`, which the commit-comparison API requires.
- Skip the DEEPX environment before installation and smoke export on machines with less than 15 GiB total RAM. Apply the filter to both `--list` and explicit environment selection, and report the skip on stderr.

Validation: explicit-file and fallback loading checks, empty-mask checks across FP16/BF16/FP32, finite CIoU and gradient checks, and focused PyTorch 1.8 CPU validation pass. The existing all-model-YAML test passes on PyTorch 2.13. The full Docs Ruff command, Ruff formatting checks for changed Python files, Actionlint for CLA, and `git diff --check` pass.

Export environment listing and the existing environment-registry tests pass. The RAM filter was reviewed; validation on this machine exercises the sufficient-memory path.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Fixed model YAML selection, empty-batch mask typing, CIoU numerical stability, CLA permissions, and low-memory DEEPX environment handling.

### 📊 Key Changes

- `yaml_model_load()` now checks the explicitly requested YAML before its scale-unified fallback, preserving files such as `custom26n.yaml` when present.
- Empty-label batches in the task-aligned assigner now return a boolean foreground mask, matching the normal return contract.
- CIoU alpha computation places epsilon after the denominator terms, preventing NaN values for identical FP16 and BF16 boxes when rounding removes earlier epsilon contributions.
- The CLA workflow now has `contents: read` permission, and export environment creation skips `isolated-deepx` below 15 GiB of RAM for both listed and explicitly selected environments, reporting the skip on stderr.
- The package version was incremented from `8.4.143` to `8.4.144`.

### 🎯 Purpose & Impact

- Explicit model files take precedence over unified fallback files during loading.
- Empty-label assignment returns the expected boolean mask type, and CIoU remains finite for the covered low-precision edge cases.
- CLA commit comparisons have the required repository-read permission.
- DEEPX setup and smoke export are avoided on machines with insufficient memory; other export environments remain selectable.