### PR TITLE
Return failure status from Platform login

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -742,11 +742,11 @@ def handle_yolo_login(args: list[str]) -> None:
         SETTINGS["api_key"] = args[1]
         LOGGER.info("New authentication successful ✅")
     except APIError as error:
-        LOGGER.warning(
+        raise SystemExit(
             "Invalid API key" if error.status_code == 401 else f"Authentication failed (HTTP {error.status_code})"
-        )
+        ) from None
     except APIConnectionError as error:
-        LOGGER.warning(f"Authentication request failed, check your connection: {error}")
+        raise SystemExit(f"Authentication request failed, check your connection: {error}") from None
 
 
 def handle_yolo_settings(args: list[str]) -> None:


### PR DESCRIPTION
Platform login currently prints a warning and exits successfully when the API rejects the key or the connection fails. Exit with status 1 and the existing error message at the shared login handler so both `yolo login` and the delegated `ul login` in https://github.com/ultralytics/sdk/pull/59 report failure correctly. Successful login and logout retain status 0.

Validation: exercised both entrypoints against loopback HTTP 200, 401, 403, and 503 responses and a refused connection; verified failed attempts preserve the saved credential, successful login saves it, and logout clears it. Ruff formatting passes; Ruff lint reports only the same two existing BLE001 findings as main.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the shared Platform login handler to exit with status 1 on authentication or connection failures while preserving successful login and logout behavior.

### 📊 Key Changes

- Replaced warning-only handling of `APIError` with `SystemExit`, returning failure for invalid keys and other HTTP errors.
- Replaced warning-only handling of `APIConnectionError` with `SystemExit`, returning failure when the authentication request cannot connect.
- Preserved the existing error messages for HTTP 401, other HTTP failures, and connection errors.
- Applied the behavior to both `yolo login` and delegated `ul login` entrypoints through the shared handler.

### 🎯 Purpose & Impact

- Failed Platform login attempts now correctly report a nonzero exit status to shells and calling processes, while successful login and logout continue to return status 0.