### PR TITLE
Bump to 8.4.145 for login failure exit status

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.144"
+__version__ = "8.4.145"
 
 import importlib
 import os


### PR DESCRIPTION
Bump `ultralytics` from `8.4.144` to `8.4.145` so the merged login failure exit-status fix in #26116 reaches PyPI. The published `8.4.144` predates that fix. This completes the release dependency for https://github.com/ultralytics/sdk/pull/59.

Validation: built the wheel and verified its metadata version and packaged login handler match the reviewed source. The diff changes only the existing version constant.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the `ultralytics` package version from `8.4.144` to `8.4.145` so the release containing the login failure exit-status fix can be published.

### 📊 Key Changes
- Changes `__version__` in `ultralytics/__init__.py` from `8.4.144` to `8.4.145`.
- Makes the package version align with the release dependency for the previously merged login failure fix.

### 🎯 Purpose & Impact
- Enables PyPI packaging of version `8.4.145`, which includes the reviewed login failure exit-status behavior.
- No other source files or runtime behavior are changed by this PR.