### PR TITLE
Limit isolated export APT updates to Ubuntu sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,7 +373,9 @@ jobs:
         with:
           python-version: "3.13"
       - name: Install export system dependencies
-        run: sudo apt-get update && sudo apt-get install -y openjdk-21-jre flatbuffers-compiler
+        run: |
+          sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/ubuntu.sources" -o Dir::Etc::sourceparts="-"
+          sudo apt-get install -y openjdk-21-jre flatbuffers-compiler
       - name: Cache uv wheels
         uses: actions/cache@v6
         with:


### PR DESCRIPTION
The [IsolatedExports job](https://github.com/ultralytics/ultralytics/actions/runs/34383987869/job/102575524400) failed before tests because Google Chrome’s APT repository served mismatched package hashes. This job only needs Ubuntu’s Java and FlatBuffers packages.

Limit its APT update to the runner’s existing `ubuntu.sources` file and disable discovery of additional source files for that command. Preserve the existing package installation and Ubuntu mirror configuration.

Validation: verified the source path against GitHub’s runner-image configuration; the scoped update passes in Ubuntu 24.04 AMD64 Docker, with package installation validation in progress. `git diff --check` and actionlint pass when excluding existing custom-runner-label warnings.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
The IsolatedExports workflow now limits APT index updates to Ubuntu’s existing `ubuntu.sources` file while preserving installation of Java and FlatBuffers dependencies.

### 📊 Key Changes
- Scoped `apt-get update` to `sources.list.d/ubuntu.sources`.
- Disabled discovery of additional APT source files for the update.
- Kept installation of `openjdk-21-jre` and `flatbuffers-compiler` unchanged.
- Preserved the workflow’s existing Ubuntu mirror configuration.

### 🎯 Purpose & Impact
- Prevents unrelated APT repositories, such as Google Chrome’s source, from affecting dependency setup in the IsolatedExports job.
- No user-facing change.