### PR TITLE
Retry apt installs in the isolated export job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,7 +373,12 @@ jobs:
         with:
           python-version: "3.13"
       - name: Install export system dependencies
-        run: sudo apt-get update && sudo apt-get install -y openjdk-21-jre flatbuffers-compiler
+        uses: ultralytics/actions/retry@main
+        with:
+          retries: 3
+          retry_delay_seconds: 60
+          timeout_minutes: 10
+          run: sudo apt-get update && sudo apt-get install -y openjdk-21-jre flatbuffers-compiler
       - name: Cache uv wheels
         uses: actions/cache@v6
         with:


### PR DESCRIPTION
## summary
- wrap the `apt-get update && apt-get install` step of the IsolatedExports job in `ultralytics/actions/retry@main`, the same wrapper every other network-bound install step in this workflow already uses
- the step failed once on main with an apt index `Hash Sum mismatch` from a third-party repository preinstalled on the runner image, which a re-run resolved; retries make the job tolerate that without hiding a real install failure

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

The IsolatedExports job now retries its APT dependency installation to tolerate transient package-index failures.

### 📊 Key Changes

- Wrapped the `apt-get update && apt-get install` command in `ultralytics/actions/retry@main`.
- Configured up to 3 attempts, with a 60-second delay between retries.
- Set a 10-minute timeout for each retry-wrapped installation step.
- The command still installs `openjdk-21-jre` and `flatbuffers-compiler`.

### 🎯 Purpose & Impact

- The isolated export workflow can recover from transient APT errors, such as an index `Hash Sum mismatch`, without changing the dependencies installed or suppressing persistent installation failures.