### PR TITLE
Fail curl downloads on HTTP errors instead of saving the error body

### DIFF
--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -364,7 +364,8 @@ def safe_download(
                         # cannot block interpreter shutdown while a non-daemon plot thread waits on a font download
                         args = ["--connect-timeout", "30", "--speed-limit", "1", "--speed-time", "300"]
                         r = subprocess.run(
-                            ["curl", "-#", f"-{s}fL", url, "-o", f, "--retry", "3", "-C", "-", *args], check=False
+                            ["curl", "-#", f"-{s}fL", "--http1.1", url, "-o", f, "--retry", "3", "-C", "-", *args],
+                            check=False,
                         ).returncode
                         assert r == 0, f"Curl return value {r}"
                     else:  # requests download; timeout bounds connect and per-chunk read gaps, not total transfer

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -364,7 +364,7 @@ def safe_download(
                         # cannot block interpreter shutdown while a non-daemon plot thread waits on a font download
                         args = ["--connect-timeout", "30", "--speed-limit", "1", "--speed-time", "300"]
                         r = subprocess.run(
-                            ["curl", "-#", f"-{s}L", url, "-o", f, "--retry", "3", "-C", "-", *args], check=False
+                            ["curl", "-#", f"-{s}fL", url, "-o", f, "--retry", "3", "-C", "-", *args], check=False
                         ).returncode
                         assert r == 0, f"Curl return value {r}"
                     else:  # requests download; timeout bounds connect and per-chunk read gaps, not total transfer


### PR DESCRIPTION
## summary
- add `-f` to the curl invocation in `safe_download` so an http 4xx/5xx response fails the attempt instead of writing the error body to the output file; the existing retry, cleanup and size validation handle the rest. without it a persistent http error published the error page as the asset and every later call served it as a cache hit; two docker ci runs on main failed this way on 2026-09-09 (`solution_ci_parking_areas.json` and `instances_val2017.json` answered 500, tests then read html as json)
- pin the curl fallback to `--http1.1`: on curl 8.7.x (the system curl of macos 14, 15 and 26 and of the macos github runners) `-f` over http/2 reports every status ≥ 400 as exit 56 instead of 22, so curl's own transient retries never run; over http/1.1 the same curl reports 22 and keeps its 3 retries. measured on 14 curl versions from 7.68 to 8.22, only the 8.7.x line differs, and only over http/2. `--http1.1` exists since curl 7.33.0 (2013); the newest requirement in this command before was `--retry` (7.12.3), and the only current distro below 7.33 is rhel/centos 7 with 7.29 (eol june 2024), where the curl fallback now exits 2 on the unknown option and the loop raises, after `requests` has already failed
- `-f` does not change which responses curl `--retry` retries: 404/401/403 stay one request with no backoff and 408/429/500/502/503/504 keep the three transient retries on every version measured; the manual's "combine with --fail to retry 4xx" sentence belongs to `--retry-all-errors`, which this call does not pass. what changes is that a failing curl attempt now reaches the outer loop instead of publishing the error body, so a persistent 404 costs 4 requests instead of 2 and a persistent 500 costs 13 requests and ~21 s instead of 5 and ~7 s (16 / 28 s with `curl=True`); dropping curl's retries instead would leave four attempts with no backoff at all

## measured
| scenario (real `safe_download`) | before | after |
|---|---|---|
| persistent 500 with html body | 5 requests, 7 s, html published | 13 requests, 21 s, ConnectionError, no file |
| 404 with html body | 2 requests, html published | 4 requests, 0 s, ConnectionError, no file |
| 500 then 200; 500 x2 then 200 (curl `--retry`) | ok, identical | ok, identical |
| drop at 1000 B, resume via `-C -` (206) | ok, identical | ok, identical |
| partial `.part`, server answers 500 on the resume | curl exit 33 after 1 request, part kept, loop continues | curl exit 22 after 4 requests / 7 s, part kept, loop continues |
| github release asset through the curl path, progress on and off | sha256 equal to requests path | sha256 equal to requests path |
| macos curl 8.7.1, http/2 tls server answering 500 for 3 s then 200 | ok at 3.1 s | ok at 3.1 s (`-f` alone: ConnectionError at 0.1 s) |
| same server, 500 for 10 s then 200 | html published at 7.1 s | ok at 10.1 s (`-f` alone: ConnectionError at 0.1 s) |

two curl boundaries, both measured: curl below 8.5 exits 22 on a 416 answered to a `-C -` resume of an already complete `.part` (curl/curl#10521); the loop reaches that state only if an attempt raised after writing the last byte, and the outcome is a ConnectionError with no file. curl 8.14.x returns exit 0 when `--retry` is given and the failure was not retried (404 under `-f`, fixed in 8.15.0); the body is not written, so the loop finds no file, moves to the next attempt and raises at the end

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated `safe_download`’s curl fallback to reject HTTP error responses and force HTTP/1.1, preventing error pages from being saved as downloaded assets while preserving the existing retry and cleanup flow.

### 📊 Key Changes
- Added curl’s `--fail` behavior so HTTP 4xx/5xx responses return a failure instead of writing the response body to the destination file.
- Added `--http1.1` to ensure curl 8.7.x preserves the expected retry behavior when handling HTTP errors.
- Kept the existing three curl retries, resume support via `-C -`, timeout settings, and outer download-attempt handling unchanged.
- Affected curl failures now reach the existing assertion/retry path rather than being treated as successful downloads.

### 🎯 Purpose & Impact
- Persistent HTTP errors no longer become cached HTML or other error-body files; `safe_download` continues retrying and ultimately raises instead of leaving the invalid asset in place.
- Successful downloads, resumable transfers, and transient HTTP failures continue through the existing curl workflow.