### PR TITLE
Add https://youtu.be/ZsxHIN2PoiY to docs

### DIFF
--- a/docs/en/modes/track.md
+++ b/docs/en/modes/track.md
@@ -291,6 +291,17 @@ Once exported, point to the TensorRT model path in your tracker config.
 
 The sections below describe each tracker's design, specific parameters, and tuning tips.
 
+<p align="center">
+  <br>
+  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/ZsxHIN2PoiY"
+    title="YouTube video player" frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen>
+  </iframe>
+  <br>
+  <strong>Watch:</strong> Which Object Tracker Performs Better? | Speed, FPS & ID Stability | Ultralytics YOLO26 📊
+</p>
+
 ### BoT-SORT
 
 [BoT-SORT](https://github.com/NirAharon/BoT-SORT) (Aharon et al., 2022) extends ByteTrack with camera-motion compensation and optional ReID:


### PR DESCRIPTION
@glenn-jocher @Laughing-q FYI. Thanks

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Added an embedded YouTube video to the object tracking documentation to introduce a comparison of tracker speed, FPS, and ID stability.

### 📊 Key Changes
- Updated `docs/en/modes/track.md` with a centered, lazy-loaded YouTube iframe.
- Added the video title and playback permissions for the Ultralytics YOLO26 tracker comparison.
- Positioned the video before the BoT-SORT and other tracker-specific sections.

### 🎯 Purpose & Impact
Improves the object tracking documentation by providing users with direct access to a relevant tracker comparison video. No package behavior or tracking functionality changes.