### PR TITLE
Enable GPU CI on CUDA 13 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,7 +419,7 @@ jobs:
         run: uv cache prune --ci
 
   GPU:
-    if: github.repository == 'ultralytics/ultralytics' && (github.event_name != 'workflow_dispatch' || github.event.inputs.gpu == 'true')
+    if: github.repository == 'ultralytics/ultralytics' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'workflow_dispatch' || github.event.inputs.gpu == 'true')
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,7 +435,7 @@ jobs:
       - name: Install requirements
         run: |
           # Install TensorRT into the job venv so uv can reuse the runner image cache.
-          uv pip install -e ".[export-base]" pytest-cov onnxruntime-gpu tensorrt-cu13 "nvidia-modelopt[onnx]>=0.44" lap
+          uv pip install -e ".[export-base]" pytest-cov onnxruntime-gpu tensorrt-cu13 "nvidia-modelopt[onnx]>=0.44" lap --torch-backend cu132
         env:
           PIP_BREAK_SYSTEM_PACKAGES: 1
       - name: Check environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,8 +419,7 @@ jobs:
         run: uv cache prune --ci
 
   GPU:
-    # Temporarily disabled; remove "false &&" to re-enable.
-    if: false && github.repository == 'ultralytics/ultralytics' && (github.event_name != 'workflow_dispatch' || github.event.inputs.gpu == 'true')
+    if: github.repository == 'ultralytics/ultralytics' && (github.event_name != 'workflow_dispatch' || github.event.inputs.gpu == 'true')
     permissions:
       contents: read
       id-token: write
@@ -436,7 +435,7 @@ jobs:
       - name: Install requirements
         run: |
           # Install TensorRT into the job venv so uv can reuse the runner image cache.
-          uv pip install -e ".[export-base]" pytest-cov onnxruntime-gpu "torch<2.11" "tensorrt-cu12>=7.0.0,!=10.2.0" "nvidia-modelopt[onnx]>=0.44" lap  # TODO: remove torch pin after GPU runner driver update to CUDA 13.0
+          uv pip install -e ".[export-base]" pytest-cov onnxruntime-gpu tensorrt-cu13 "nvidia-modelopt[onnx]>=0.44" lap
         env:
           PIP_BREAK_SYSTEM_PACKAGES: 1
       - name: Check environment


### PR DESCRIPTION
Restores GPU CI for trusted same-repository pull requests, main pushes, nightly runs, and manual dispatch. The job installs PyTorch with the CUDA 13.2 backend and TensorRT CUDA 13, removing the obsolete PyTorch upper bound and CUDA 12 dependency.

Validation on ultra5: all 8 regular CUDA tests passed, including multi-GPU training; the full scheduled GPU suite passed all 186 tests on PyTorch 2.14.0+cu132. All applicable PR checks passed.

Full GPU run: https://github.com/ultralytics/ultralytics/actions/runs/34453871129

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Re-enabled the GPU CI job for trusted pull requests and selected workflow triggers, updating its dependencies from CUDA 12 to CUDA 13.2.

### 📊 Key Changes
- Removed the condition that disabled the `GPU` job.
- Restricted pull-request GPU runs to trusted pull requests from the same repository.
- Kept GPU runs available for main pushes, nightly workflows, and manual dispatches when the `gpu` input is enabled.
- Replaced the `torch<2.11` and `tensorrt-cu12` dependencies with the CUDA 13 stack: `--torch-backend cu132` and `tensorrt-cu13`.
- Removed the obsolete PyTorch version upper bound and CUDA 12 driver-update comment.

### 🎯 Purpose & Impact
- GPU CI now executes for the configured trusted workflows using PyTorch with CUDA 13.2 and TensorRT CUDA 13; no other application behavior is changed.