### PR TITLE
Rewrite quickstart around installation and a first prediction

### DIFF
--- a/docs/en/help/contributing.md
+++ b/docs/en/help/contributing.md
@@ -37,6 +37,22 @@ We greatly appreciate contributions in the form of [pull requests (PRs)](https:/
 5. **[Commit your changes](https://docs.github.com/en/desktop/making-changes-in-a-branch/committing-and-reviewing-changes-to-your-project-in-github-desktop):** Commit your changes with concise and descriptive commit messages. If your changes address a specific issue, include the issue number (e.g., `Fix #123: Corrected calculation error.`).
 6. **[Create a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request):** Submit a pull request from your branch to the `main` branch of the original Ultralytics repository. Provide a clear title and a detailed description explaining the purpose and scope of your changes.
 
+### Development Installation
+
+Clone your fork (or the main repository) and install it in editable mode (`-e`) so Python runs your local files and picks up every change without reinstalling:
+
+```bash
+git clone https://github.com/YOUR_USERNAME/ultralytics.git
+cd ultralytics
+pip install -e .
+```
+
+To make another project depend on a fork instead of the PyPI package, point pip or `requirements.txt` at the fork's branch:
+
+```text title="requirements.txt"
+git+https://github.com/YOUR_USERNAME/ultralytics.git@my-custom-branch
+```
+
 ### 📚 Documentation Changes
 
 Documentation source lives under `docs/en/`. From the repository root, install the development dependencies and run the complete strict validation before opening a PR:

--- a/docs/en/help/contributing.md
+++ b/docs/en/help/contributing.md
@@ -22,11 +22,11 @@ Welcome! We're thrilled that you're considering contributing to our [Ultralytics
   <strong>Watch:</strong> How to Contribute to Ultralytics Repository | Ultralytics Models, Datasets and Documentation 🚀
 </p>
 
-## 🤝 Code of Conduct
+## Code of Conduct
 
 To ensure a welcoming and inclusive environment for everyone, all contributors must adhere to our [Code of Conduct](code-of-conduct.md). **Respect**, **kindness**, and **professionalism** are at the heart of our community.
 
-## 🚀 Contributing via Pull Requests
+## Contributing via Pull Requests
 
 We greatly appreciate contributions in the form of [pull requests (PRs)](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests). To make the review process as smooth as possible, please follow these steps:
 
@@ -53,7 +53,7 @@ To make another project depend on a fork instead of the PyPI package, point pip 
 git+https://github.com/YOUR_USERNAME/ultralytics.git@my-custom-branch
 ```
 
-### 📚 Documentation Changes
+### Documentation Changes
 
 Documentation source lives under `docs/en/`. From the repository root, install the development dependencies and run the complete strict validation before opening a PR:
 
@@ -64,7 +64,7 @@ python docs/build_docs.py
 
 The validation prepares generated references, macros, and comparison pages before running `zensical build --strict`. For a faster live preview of pages that do not use macros, run `zensical serve`.
 
-### 📝 CLA Signing
+### CLA Signing
 
 Before we can merge your pull request, you must sign our [Contributor License Agreement (CLA)](CLA.md). This legal agreement ensures that your contributions are properly licensed, allowing the project to continue being distributed under the [AGPL-3.0 license](https://www.ultralytics.com/legal/agpl-3-0-software-license).
 
@@ -74,7 +74,7 @@ After submitting your pull request, the CLA bot will guide you through the signi
 I have read the CLA Document and I sign the CLA
 ```
 
-### ✍️ Google-Style Docstrings
+### Google-Style Docstrings
 
 When adding new functions or classes, include [Google-style docstrings](https://google.github.io/styleguide/pyguide.html) for clear, standardized documentation. Always enclose both input and output `types` in parentheses (e.g., `(bool)`, `(np.ndarray)`).
 
@@ -196,11 +196,11 @@ When adding new functions or classes, include [Google-style docstrings](https://
             return arg1 == arg2
         ```
 
-### ✅ GitHub Actions CI Tests
+### GitHub Actions CI Tests
 
 All pull requests must pass the [GitHub Actions](https://github.com/features/actions) [Continuous Integration](CI.md) (CI) tests before they can be merged. These tests include linting, unit tests, and other checks to ensure that your changes meet the project's quality standards. Review the CI output and address any issues that arise.
 
-## ✨ Best Practices for Code Contributions
+## Best Practices for Code Contributions
 
 When contributing code to Ultralytics projects, keep these best practices in mind:
 
@@ -211,7 +211,7 @@ When contributing code to Ultralytics projects, keep these best practices in min
 - **Use consistent formatting:** Tools like [Ruff Formatter](https://github.com/astral-sh/ruff) can help maintain stylistic consistency.
 - **Add appropriate tests:** Include [tests](../guides/model-testing.md) for new features to ensure they work as expected.
 
-## 👀 Reviewing Pull Requests
+## Reviewing Pull Requests
 
 Reviewing pull requests is another valuable way to contribute. When reviewing PRs:
 
@@ -222,7 +222,7 @@ Reviewing pull requests is another valuable way to contribute. When reviewing PR
 - **Provide constructive feedback:** Offer specific, clear feedback about any issues or concerns.
 - **Recognize effort:** Acknowledge the author's work to maintain a positive collaborative atmosphere.
 
-## 🐞 Reporting Bugs
+## Reporting Bugs
 
 We highly value bug reports as they help us improve the quality and reliability of our projects. When reporting a bug via [GitHub Issues](https://github.com/ultralytics/ultralytics/issues):
 
@@ -231,13 +231,13 @@ We highly value bug reports as they help us improve the quality and reliability 
 - **Describe the environment:** Specify your operating system, Python version, relevant library versions (e.g., [`torch`](https://pytorch.org/), [`ultralytics`](https://github.com/ultralytics/ultralytics)), and hardware ([CPU](https://en.wikipedia.org/wiki/Central_processing_unit)/[GPU](https://www.ultralytics.com/glossary/gpu-graphics-processing-unit)).
 - **Explain expected vs. actual behavior:** Clearly state what you expected to happen and what actually occurred. Include any error messages or tracebacks.
 
-## 📜 License
+## License
 
 Ultralytics uses the [GNU Affero General Public License v3.0 (AGPL-3.0)](https://www.ultralytics.com/legal/agpl-3-0-software-license) for its repositories. This license promotes [openness](https://en.wikipedia.org/wiki/Openness), [transparency](https://www.ultralytics.com/glossary/transparency-in-ai), and [collaborative improvement](https://en.wikipedia.org/wiki/Collaborative_software) in software development. It ensures that all users have the freedom to use, modify, and share the software, fostering a strong community of collaboration and innovation.
 
 We encourage all contributors to familiarize themselves with the terms of the [AGPL-3.0 license](https://opensource.org/license/agpl-3.0) to contribute effectively and ethically to the Ultralytics open-source community.
 
-## 🌍 Open-Sourcing Your YOLO Project Under AGPL-3.0
+## Open-Sourcing Your YOLO Project Under AGPL-3.0
 
 Using Ultralytics YOLO models or code in your project? The [AGPL-3.0 license](https://opensource.org/license/agpl-3.0) requires that your entire derivative work also be open-sourced under AGPL-3.0. This ensures modifications and larger projects built upon open-source foundations remain open.
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -64,9 +64,9 @@ pip install ultralytics
 yolo predict model=yolo26n.pt source='https://github.com/ultralytics/assets/releases/download/v0.0.0/bus.jpg'
 ```
 
-The model weights and the example image download automatically, and the annotated result is saved to `runs/detect/predict`.
+The model weights and the example image download automatically, and the annotated result is saved to the directory the command prints, `runs/detect/predict` on a first run.
 
-See the [Quickstart](quickstart.md) guide for the full installation and usage reference.
+See the [Quickstart](quickstart.md) guide for every installation method and your first prediction.
 
 ## What Do You Want to Do?
 

--- a/docs/en/integrations/mlflow.md
+++ b/docs/en/integrations/mlflow.md
@@ -32,7 +32,7 @@ Ensure MLflow is installed. If not, install it using pip:
 pip install mlflow
 ```
 
-Make sure that MLflow logging is enabled in Ultralytics settings. Usually, this is controlled by the settings `mlflow` key. See the [settings](../quickstart.md#ultralytics-settings) page for more info.
+Make sure that MLflow logging is enabled in Ultralytics settings. Usually, this is controlled by the settings `mlflow` key. See the [settings](../usage/settings.md) page for more info.
 
 !!! example "Update Ultralytics MLflow Settings"
 
@@ -136,7 +136,7 @@ To set up MLflow logging with Ultralytics YOLO, you first need to ensure MLflow 
 pip install mlflow
 ```
 
-Next, enable MLflow logging in Ultralytics settings. This can be controlled using the `mlflow` key. For more information, see the [settings guide](../quickstart.md#ultralytics-settings).
+Next, enable MLflow logging in Ultralytics settings. This can be controlled using the `mlflow` key. For more information, see the [settings guide](../usage/settings.md).
 
 !!! example "Update Ultralytics MLflow Settings"
 
@@ -186,7 +186,7 @@ Yes, you can disable MLflow logging for Ultralytics YOLO by updating the setting
 yolo settings mlflow=False
 ```
 
-For further customization and resetting settings, refer to the [settings guide](../quickstart.md#ultralytics-settings).
+For further customization and resetting settings, refer to the [settings guide](../usage/settings.md).
 
 ### How can I start and stop an MLflow server for Ultralytics YOLO tracking?
 

--- a/docs/en/integrations/vscode.md
+++ b/docs/en/integrations/vscode.md
@@ -240,7 +240,7 @@ If you use VS Code and have started to see a message prompting you to install th
 
 1. Install Ultralytics-snippets and the message will no longer be shown 😆!
 
-2. You can use `yolo settings vscode_msg=False` to disable the message from showing without having to install the extension. You can learn more about the [Ultralytics Settings](../quickstart.md#ultralytics-settings) on the [quickstart](../quickstart.md) page if you're unfamiliar.
+2. You can use `yolo settings vscode_msg=False` to disable the message from showing without having to install the extension. You can learn more on the [Ultralytics Settings](../usage/settings.md) page if you're unfamiliar.
 
 ### I have an idea for a new Ultralytics code snippet, how can I get one added?
 

--- a/docs/en/modes/train.md
+++ b/docs/en/modes/train.md
@@ -327,7 +327,7 @@ These settings can be adjusted to meet the specific requirements of the dataset 
 
 ## Logging
 
-Training metrics, plots, and checkpoints are always written to the run directory, and Ultralytics also streams them to any experiment tracker you have installed and enabled: [Comet](../integrations/comet.md), [ClearML](../integrations/clearml.md), [TensorBoard](../integrations/tensorboard.md), [MLflow](../integrations/mlflow.md), [Weights & Biases](../integrations/weights-biases.md), and [DVCLive](../integrations/dvc.md). Each logger is toggled through the [Ultralytics settings](../quickstart.md#ultralytics-settings), for example `yolo settings tensorboard=True`. The three most common setups are shown below.
+Training metrics, plots, and checkpoints are always written to the run directory, and Ultralytics also streams them to any experiment tracker you have installed and enabled: [Comet](../integrations/comet.md), [ClearML](../integrations/clearml.md), [TensorBoard](../integrations/tensorboard.md), [MLflow](../integrations/mlflow.md), [Weights & Biases](../integrations/weights-biases.md), and [DVCLive](../integrations/dvc.md). Each logger is toggled through the [Ultralytics settings](../usage/settings.md), for example `yolo settings tensorboard=True`. The three most common setups are shown below.
 
 ### Comet
 

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -1,12 +1,111 @@
 ---
 comments: true
-description: Learn how to install Ultralytics using pip, conda, or Docker. Follow our step-by-step guide for a seamless setup of Ultralytics YOLO.
-keywords: Ultralytics, YOLO26, YOLO11, Install Ultralytics, pip, conda, Docker, GitHub, machine learning, object detection
+description: Install Ultralytics YOLO with pip, conda, Docker, or from source, then run your first prediction with a pretrained YOLO26 model from the CLI or Python.
+keywords: Install Ultralytics, Ultralytics, YOLO26, YOLO11, pip install ultralytics, conda, Docker, quickstart, yolo predict, object detection
 ---
 
 # Install Ultralytics
 
-Ultralytics offers a variety of installation methods, including pip, conda, and Docker. You can install YOLO via the `ultralytics` pip package for the latest stable release, or by cloning the [Ultralytics GitHub repository](https://github.com/ultralytics/ultralytics) for the most current version. Docker is also an option to run the package in an isolated container, which avoids local installation.
+Install the `ultralytics` package with pip, conda, or Docker, or from source, then run your first prediction with a pretrained [YOLO26](models/yolo26.md) model. Every method installs all required dependencies listed in [pyproject.toml](https://github.com/ultralytics/ultralytics/blob/main/pyproject.toml).
+
+!!! example "Install"
+
+    === "Pip (recommended)"
+
+        Install or update the [ultralytics](https://pypi.org/project/ultralytics/) package in a Python>=3.8 environment with PyTorch>=1.8:
+
+        ```bash
+        pip install -U ultralytics
+        ```
+
+        For the latest development version, install directly from the [Ultralytics GitHub repository](https://github.com/ultralytics/ultralytics):
+
+        ```bash
+        pip install git+https://github.com/ultralytics/ultralytics.git@main
+        ```
+
+    === "Conda"
+
+        Install from [conda-forge](https://anaconda.org/conda-forge/ultralytics):
+
+        ```bash
+        conda install -c conda-forge ultralytics
+        ```
+
+        In a CUDA environment, install `ultralytics` together with the `pytorch-gpu` metapackage in the same command so conda resolves a CUDA-enabled PyTorch build. PyTorch no longer publishes new releases to the `pytorch` conda channel, so install everything from conda-forge:
+
+        ```bash
+        conda install -c conda-forge ultralytics pytorch-gpu
+        ```
+
+        See the [Conda Quickstart Guide](guides/conda-quickstart.md) for environment setup, the libmamba solver, and the Conda Docker image.
+
+    === "Docker"
+
+        Run the package in an isolated container with the official images on [Docker Hub](https://hub.docker.com/r/ultralytics/ultralytics):
+
+        ```bash
+        # Pull the latest ultralytics image and run it with GPU support
+        sudo docker pull ultralytics/ultralytics:latest
+        sudo docker run -it --ipc=host --device nvidia.com/gpu=all ultralytics/ultralytics:latest
+        ```
+
+        The default AMD64 GPU image uses PyTorch 2.14 and CUDA 13.2. On Linux, CDI device requests require Docker >= 28.2.0 and NVIDIA Container Toolkit >= 1.18; the legacy `--gpus all` flag can lose GPU access after host daemon reloads, so use `--device` instead. See the [Docker Quickstart Guide](guides/docker-quickstart.md) for the [full image table](guides/docker-quickstart.md#installing-ultralytics-docker-images) (CPU, export, ARM64, and JetPack variants), host driver requirements, and volume mounts.
+
+    === "Git clone"
+
+        Clone the repository and install it in editable mode (`-e`) to run the latest source or develop locally:
+
+        ```bash
+        git clone https://github.com/ultralytics/ultralytics
+        cd ultralytics
+        pip install -e .
+        ```
+
+        To work from a fork or pin a custom branch in another project, see [Development Installation](help/contributing.md#development-installation).
+
+    === "Headless"
+
+        On servers without a display (cloud VMs, containers, CI pipelines), install the variant that depends on `opencv-python-headless` to avoid `libGL` errors:
+
+        ```bash
+        pip install ultralytics-opencv-headless
+        ```
+
+        It provides the same functionality and API as `ultralytics`, minus OpenCV's GUI components.
+
+!!! tip
+
+    [PyTorch](https://www.ultralytics.com/glossary/pytorch) requirements vary by operating system and CUDA version. To use a specific build, install PyTorch first by following the [PyTorch installation instructions](https://pytorch.org/get-started/locally/), then install `ultralytics`.
+
+## Use Ultralytics with CLI
+
+Run your first prediction from the terminal with the `yolo` command:
+
+```bash
+yolo predict model=yolo26n.pt
+```
+
+The pretrained `yolo26n.pt` weights download automatically, the model runs on two bundled sample images, and the command prints where it saved the annotated results, `runs/detect/predict` on a first run. Point `source` at your own image, video, directory, URL, or stream, or at a webcam with `source=0`:
+
+```bash
+yolo predict model=yolo26n.pt source=0 show=True
+```
+
+`predict` is the **mode**, what to do with the model: `train`, `val`, `predict`, `export`, `track`, or `benchmark`. The **task** (`detect`, `segment`, `semantic`, `depth`, `classify`, `pose`, or `obb`) is read from the model file, so the `yolo TASK MODE ARGS` syntax usually needs only the mode plus `arg=value` pairs such as `imgsz=640`. See the [CLI Guide](usage/cli.md) for every mode and the [Configuration](usage/cfg.md) page for all arguments.
+
+## Use Ultralytics with Python
+
+The same prediction in Python:
+
+```python
+from ultralytics import YOLO
+
+model = YOLO("yolo26n.pt")  # load a pretrained YOLO26n detection model
+results = model("https://ultralytics.com/images/bus.jpg", save=True)  # predict and save the annotated image
+```
+
+`results` is a list of [Results](modes/predict.md#working-with-results) objects, one per image, carrying boxes, masks, keypoints, or class probabilities depending on the task. The [Python Guide](usage/python.md) covers training, validation, export, and tracking with the same `YOLO` class.
 
 <p align="center">
   <br>
@@ -19,430 +118,13 @@ Ultralytics offers a variety of installation methods, including pip, conda, and 
   <strong>Watch:</strong> Ultralytics YOLO Quick Start Guide
 </p>
 
-!!! example "Install"
-
-    ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ultralytics?logo=python&logoColor=gold)
-
-    === "Pip install (recommended)"
-
-        Install or update the `ultralytics` package using pip by running `pip install -U ultralytics`. For more details on the `ultralytics` package, visit the [Python Package Index (PyPI)](https://pypi.org/project/ultralytics/).
-
-        [![PyPI - Version](https://img.shields.io/pypi/v/ultralytics?logo=pypi&logoColor=white)](https://pypi.org/project/ultralytics/) [![Downloads](https://static.pepy.tech/badge/ultralytics)](https://clickpy.clickhouse.com/dashboard/ultralytics)
-
-        ```bash
-        # Install or upgrade the ultralytics package from PyPI
-        pip install -U ultralytics
-        ```
-
-        You can also install `ultralytics` directly from the [Ultralytics GitHub repository](https://github.com/ultralytics/ultralytics). This can be useful if you want the latest development version. Ensure you have the Git command-line tool installed, and then run:
-
-        ```bash
-        # Install the ultralytics package from GitHub
-        pip install git+https://github.com/ultralytics/ultralytics.git@main
-        ```
-
-    === "Conda install"
-
-        Conda can be used as an alternative package manager to pip. For more details, visit [Anaconda](https://anaconda.org/conda-forge/ultralytics). The Ultralytics feedstock repository for updating the conda package is available at [GitHub](https://github.com/conda-forge/ultralytics-feedstock/).
-
-        [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ultralytics?logo=condaforge)](https://anaconda.org/conda-forge/ultralytics) [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ultralytics.svg)](https://anaconda.org/conda-forge/ultralytics) [![Conda Recipe](https://img.shields.io/badge/recipe-ultralytics-green.svg)](https://anaconda.org/conda-forge/ultralytics) [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ultralytics.svg)](https://anaconda.org/conda-forge/ultralytics)
-
-        ```bash
-        # Install the ultralytics package using conda
-        conda install -c conda-forge ultralytics
-        ```
-
-        !!! note
-
-            If you are installing in a CUDA environment, install `ultralytics` together with the `pytorch-gpu` metapackage in the same command so conda resolves a CUDA-enabled PyTorch build. PyTorch no longer publishes new releases to the `pytorch` conda channel, so install everything from conda-forge.
-            ```bash
-            # Install all packages together using conda
-            conda install -c conda-forge ultralytics pytorch-gpu
-            ```
-
-        ### Conda Docker Image
-
-        Build the current Conda image locally using the [Conda Docker instructions](guides/conda-quickstart.md#ultralytics-conda-docker-image). Automated publishing of `latest-conda` is disabled; pulling that tag does not provide the current Dockerfile's PyTorch 2.13 / CUDA 13.0 environment.
-
-    === "Git clone"
-
-        Clone the [Ultralytics GitHub repository](https://github.com/ultralytics/ultralytics) if you are interested in contributing to development or wish to experiment with the latest source code. After cloning, navigate into the directory and install the package in editable mode `-e` using pip.
-
-        [![GitHub last commit](https://img.shields.io/github/last-commit/ultralytics/ultralytics?logo=github)](https://github.com/ultralytics/ultralytics) [![GitHub commit activity](https://img.shields.io/github/commit-activity/t/ultralytics/ultralytics)](https://github.com/ultralytics/ultralytics)
-
-        ```bash
-        # Clone the ultralytics repository
-        git clone https://github.com/ultralytics/ultralytics
-
-        # Navigate to the cloned directory
-        cd ultralytics
-
-        # Install the package in editable mode for development
-        pip install -e .
-        ```
-
-    === "Docker"
-
-        Use Docker to execute the `ultralytics` package in an isolated container, ensuring consistent performance across various environments. By selecting one of the official `ultralytics` images from [Docker Hub](https://hub.docker.com/r/ultralytics/ultralytics), you avoid the complexity of local installation and gain access to a verified working environment. Ultralytics publishes a set of official Docker images, each designed for high compatibility and efficiency:
-
-        [![Docker Image Version](https://img.shields.io/docker/v/ultralytics/ultralytics?sort=semver&logo=docker)](https://hub.docker.com/r/ultralytics/ultralytics) [![Docker Pulls](https://img.shields.io/docker/pulls/ultralytics/ultralytics)](https://hub.docker.com/r/ultralytics/ultralytics)
-
-        See the [Docker image table](guides/docker-quickstart.md#installing-ultralytics-docker-images) for the complete list of GPU, CPU, export, ARM64, and JetPack images. The default AMD64 GPU image uses PyTorch 2.14 and CUDA 13.2; check the [GPU and host driver requirements](guides/docker-quickstart.md#installing-ultralytics-docker-images) before running it.
-
-        Here are the commands to get the latest image and execute it:
-
-        ```bash
-        # Set image name as a variable
-        t=ultralytics/ultralytics:latest
-
-        # Pull the latest ultralytics image from Docker Hub
-        sudo docker pull $t
-
-        # Run the ultralytics image in a container with GPU support
-        sudo docker run -it --ipc=host --device nvidia.com/gpu=all $t                         # all GPUs
-        sudo docker run -it --ipc=host --device nvidia.com/gpu=2 --device nvidia.com/gpu=3 $t # specify GPUs
-        ```
-
-        On Linux, CDI device requests require Docker >= 28.2.0 and NVIDIA Container Toolkit >= 1.18. The legacy `--gpus all` flag can lose GPU access after host daemon reloads, so upgrade older Linux hosts and use `--device` instead. See the [Docker Quickstart Guide](guides/docker-quickstart.md) for details.
-
-        The above command initializes a Docker container with the latest `ultralytics` image. The `-it` flags assign a pseudo-TTY and keep stdin open, allowing interaction with the container. The `--ipc=host` flag sets the IPC (Inter-Process Communication) namespace to the host, which is essential for sharing memory between processes. The `--device nvidia.com/gpu=all` flag grants access to all available GPUs inside the container through [CDI](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html), crucial for tasks requiring GPU computation.
-
-        Note: To work with files on your local machine within the container, use Docker volumes to mount a local directory into the container:
-
-        ```bash
-        # Mount local directory to a directory inside the container
-        sudo docker run -it --ipc=host --device nvidia.com/gpu=all -v /path/on/host:/path/in/container $t
-        ```
-
-        Replace `/path/on/host` with the directory path on your local machine, and `/path/in/container` with the desired path inside the Docker container.
-
-        For advanced Docker usage, explore the [Ultralytics Docker Guide](guides/docker-quickstart.md).
-
-See the `ultralytics` [pyproject.toml](https://github.com/ultralytics/ultralytics/blob/main/pyproject.toml) file for a list of dependencies. Note that all examples above install all required dependencies.
-
-!!! tip
-
-    [PyTorch](https://www.ultralytics.com/glossary/pytorch) requirements vary by operating system and CUDA requirements, so install PyTorch first by following the instructions at [PyTorch](https://pytorch.org/get-started/locally/).
-
-    <a href="https://pytorch.org/get-started/locally/">
-        <img width="800" alt="PyTorch installation selector for different platforms" src="https://cdn.ul.run/i/afbbb2da0266468e5371291bbfed0ab3.avif">
-    </a>
-
-## Headless Server Installation
-
-For server environments without a display (e.g., cloud VMs, Docker containers, CI/CD pipelines), use the `ultralytics-opencv-headless` package. This is identical to the standard `ultralytics` package but depends on `opencv-python-headless` instead of `opencv-python`, avoiding unnecessary GUI dependencies and potential `libGL` errors.
-
-!!! example "Headless Install"
-
-    ```bash
-    pip install ultralytics-opencv-headless
-    ```
-
-Both packages provide the same functionality and API. The headless variant simply excludes OpenCV's GUI components that require display libraries.
-
-## Advanced Installation
-
-While the standard installation methods cover most use cases, you might need a more tailored setup for development or custom configurations.
-
-!!! example "Advanced Methods"
-
-    === "Install from Fork"
-
-        If you need persistent custom modifications, you can fork the Ultralytics repository, make changes to `pyproject.toml` or other code, and install from your fork.
-
-        1.  **Fork** the [Ultralytics GitHub repository](https://github.com/ultralytics/ultralytics) to your own GitHub account.
-        2.  **Clone** your fork locally:
-            ```bash
-            git clone https://github.com/YOUR_USERNAME/ultralytics.git
-            cd ultralytics
-            ```
-        3.  **Create a new branch** for your changes:
-            ```bash
-            git checkout -b my-custom-branch
-            ```
-        4.  **Make your modifications** to `pyproject.toml` or other files as needed.
-        5.  **Commit and push** your changes:
-            ```bash
-            git add .
-            git commit -m "My custom changes"
-            git push origin my-custom-branch
-            ```
-        6.  **Install** using pip with the `git+https` syntax, pointing to your branch:
-            ```bash
-            pip install git+https://github.com/YOUR_USERNAME/ultralytics.git@my-custom-branch
-            ```
-
-    === "Local Clone and Install"
-
-        Clone the repository locally, modify files as needed, and install in editable mode.
-
-        1.  **Clone** the Ultralytics repository:
-            ```bash
-            git clone https://github.com/ultralytics/ultralytics
-            cd ultralytics
-            ```
-        2.  **Make your modifications** to `pyproject.toml` or other files as needed.
-        3.  **Install** the package in editable mode (`-e`). Pip will use your modified `pyproject.toml` to resolve dependencies:
-            ```bash
-            pip install -e .
-            ```
-
-        This approach is useful for development or testing local changes before committing.
-
-    === "Use requirements.txt"
-
-        Specify a custom Ultralytics fork in your `requirements.txt` file to ensure consistent installations across your team.
-
-        ```text title="requirements.txt"
-        # Install ultralytics from a specific git branch
-        git+https://github.com/YOUR_USERNAME/ultralytics.git@my-custom-branch
-
-        # Other project dependencies
-        flask
-        ```
-
-        Install dependencies from the file:
-        ```bash
-        pip install -r requirements.txt
-        ```
-
-## Use Ultralytics with CLI
-
-The Ultralytics command-line interface (CLI) allows for simple single-line commands without needing a Python environment. CLI requires no customization or Python code; run all tasks from the terminal with the `yolo` command. For more on using YOLO from the command line, see the [CLI Guide](usage/cli.md).
-
-!!! example
-
-    === "Syntax"
-
-        Ultralytics `yolo` commands use the following syntax:
-        ```bash
-        yolo TASK MODE ARGS
-        ```
-        - `TASK` (optional) is one of ([detect](tasks/detect.md), [segment](tasks/segment.md), [semantic](tasks/semantic.md), [depth](tasks/depth.md), [classify](tasks/classify.md), [pose](tasks/pose.md), [obb](tasks/obb.md))
-        - `MODE` (required) is one of ([train](modes/train.md), [val](modes/val.md), [predict](modes/predict.md), [export](modes/export.md), [track](modes/track.md), [benchmark](modes/benchmark.md))
-        - `ARGS` (optional) are `arg=value` pairs like `imgsz=640` that override defaults.
-
-        See all `ARGS` in the full [Configuration Guide](usage/cfg.md) or with the `yolo cfg` CLI command.
-
-    === "Train"
-
-        Train a detection model for 10 [epochs](https://www.ultralytics.com/glossary/epoch) with an initial learning rate of 0.01:
-        ```bash
-        yolo train data=coco8.yaml model=yolo26n.pt epochs=10 lr0=0.01
-        ```
-
-    === "Predict"
-
-        Predict a YouTube video using a pretrained segmentation model at image size 320:
-        ```bash
-        yolo predict model=yolo26n-seg.pt source='https://youtu.be/LNwODJXcvt4' imgsz=320
-        ```
-
-    === "Val"
-
-        Validate a pretrained detection model with a batch size of 1 and image size of 640:
-        ```bash
-        yolo val model=yolo26n.pt data=coco8.yaml batch=1 imgsz=640
-        ```
-
-    === "Export"
-
-        Export a YOLO26n classification model to ONNX format with an image size of 224x128 (no TASK required):
-        ```bash
-        yolo export model=yolo26n-cls.pt format=onnx imgsz=224,128
-        ```
-
-    === "Count"
-
-        Count objects in a video or live stream using YOLO26:
-        ```bash
-        yolo solutions count show=True
-
-        yolo solutions count source="path/to/video.mp4" # specify video file path
-        ```
-
-    === "Workout"
-
-        Monitor workout exercises using a YOLO26 pose model:
-        ```bash
-        yolo solutions workout show=True
-
-        yolo solutions workout source="path/to/video.mp4" # specify video file path
-
-        # Use keypoints for ab-workouts
-        yolo solutions workout kpts="[5, 11, 13]" # left side
-        yolo solutions workout kpts="[6, 12, 14]" # right side
-        ```
-
-    === "Queue"
-
-        Use YOLO26 to count objects in a designated queue or region:
-        ```bash
-        yolo solutions queue show=True
-
-        yolo solutions queue source="path/to/video.mp4" # specify video file path
-
-        yolo solutions queue region="[(20, 400), (1080, 400), (1080, 360), (20, 360)]" # configure queue coordinates
-        ```
-
-    === "Inference with Streamlit"
-
-        Perform object detection, instance segmentation, or pose estimation in a web browser using [Streamlit](reference/solutions/streamlit_inference.md):
-        ```bash
-        yolo solutions inference
-
-        yolo solutions inference model="path/to/model.pt" # use model fine-tuned with Ultralytics Python package
-        ```
-
-    === "Special"
-
-        Run special commands to see the version, view settings, run checks, and more:
-        ```bash
-        yolo help
-        yolo checks
-        yolo version
-        yolo settings
-        yolo login API_KEY
-        yolo logout
-        yolo copy-cfg
-        yolo cfg
-        yolo solutions help
-        ```
-
-!!! warning
-
-    Arguments must be passed as `arg=value` pairs, split by an equals `=` sign and delimited by spaces. Do not use `--` argument prefixes or commas `,` between arguments.
-
-    - `yolo predict model=yolo26n.pt imgsz=640 conf=0.25`  ✅
-    - `yolo predict model yolo26n.pt imgsz 640 conf 0.25`  ❌ (missing `=`)
-    - `yolo predict model=yolo26n.pt, imgsz=640, conf=0.25`  ❌ (do not use `,`)
-    - `yolo predict --model yolo26n.pt --imgsz 640 --conf 0.25`  ❌ (do not use `--`)
-    - `yolo solution model=yolo26n.pt imgsz=640 conf=0.25` ❌ (use `solutions`, not `solution`)
-
-[CLI Guide](usage/cli.md){ .md-button }
-
-## Use Ultralytics with Python
-
-The Ultralytics YOLO Python interface offers seamless integration into Python projects, making it easy to load, run, and process model outputs. Designed for simplicity, the Python interface allows users to quickly implement [object detection](https://www.ultralytics.com/glossary/object-detection), [instance segmentation](tasks/segment.md), [semantic segmentation](tasks/semantic.md), [depth estimation](tasks/depth.md), and [classification](tasks/classify.md). This makes the YOLO Python interface an invaluable tool for incorporating these functionalities into Python projects.
-
-For instance, users can load a model, train it, evaluate its performance, and export it to ONNX format with just a few lines of code. Explore the [Python Guide](usage/python.md) to learn more about using YOLO within your Python projects.
-
-!!! example
-
-    ```python
-    from ultralytics import YOLO
-
-    # Create a new YOLO model from scratch
-    model = YOLO("yolo26n.yaml")
-
-    # Load a pretrained YOLO model (recommended for training)
-    model = YOLO("yolo26n.pt")
-
-    # Train the model using the 'coco8.yaml' dataset for 3 epochs
-    results = model.train(data="coco8.yaml", epochs=3)
-
-    # Evaluate the model's performance on the validation set
-    results = model.val()
-
-    # Perform object detection on an image using the model
-    results = model("https://ultralytics.com/images/bus.jpg")
-
-    # Export the model to ONNX format
-    success = model.export(format="onnx")
-    ```
-
-[Python Guide](usage/python.md){.md-button .md-button--primary}
-
 ## Ultralytics Settings
 
-The Ultralytics library includes a `SettingsManager` for fine-grained control over experiments, allowing users to access and modify settings easily. Stored in a JSON file within the environment's user configuration directory, these settings can be viewed or modified in the Python environment or via the Command-Line Interface (CLI).
+Persistent settings such as the datasets, weights, and runs directories, the [Ultralytics Platform](https://platform.ultralytics.com) API key, and experiment-logger toggles live in a JSON file managed with `yolo settings`. See the [Settings](usage/settings.md) page to view, change, or reset them.
 
-### Inspecting Settings
+## What's Next
 
-To view the current configuration of your settings:
-
-!!! example "View settings"
-
-    === "Python"
-
-        Use Python to view your settings by importing the `settings` object from the `ultralytics` module. Print and return settings with these commands:
-        ```python
-        from ultralytics import settings
-
-        # View all settings
-        print(settings)
-
-        # Return a specific setting
-        value = settings["runs_dir"]
-        ```
-
-    === "CLI"
-
-        The command-line interface allows you to check your settings with:
-        ```bash
-        yolo settings
-        ```
-
-### Modifying Settings
-
-Ultralytics makes it easy to modify settings in the following ways:
-
-!!! example "Update settings"
-
-    === "Python"
-
-        In Python, use the `update` method on the `settings` object:
-        ```python
-        from ultralytics import settings
-
-        # Update a setting
-        settings.update({"runs_dir": "/path/to/runs"})
-
-        # Update multiple settings
-        settings.update({"runs_dir": "/path/to/runs", "tensorboard": False})
-
-        # Reset settings to default values
-        settings.reset()
-        ```
-
-    === "CLI"
-
-        To modify settings using the command-line interface:
-        ```bash
-        # Update a setting
-        yolo settings runs_dir='/path/to/runs'
-
-        # Update multiple settings
-        yolo settings runs_dir='/path/to/runs' tensorboard=False
-
-        # Reset settings to default values
-        yolo settings reset
-        ```
-
-### Understanding Settings
-
-The table below overviews the adjustable settings within Ultralytics, including example values, data types, and descriptions.
-
-| Name               | Example Value         | Data Type | Description                                                                                                      |
-| ------------------ | --------------------- | --------- | ---------------------------------------------------------------------------------------------------------------- |
-| `settings_version` | `'0.0.7'`             | `str`     | Ultralytics _settings_ version (distinct from the Ultralytics [pip] version)                                     |
-| `datasets_dir`     | `'/path/to/datasets'` | `str`     | Directory where datasets are stored                                                                              |
-| `weights_dir`      | `'/path/to/weights'`  | `str`     | Directory where model weights are stored                                                                         |
-| `runs_dir`         | `'/path/to/runs'`     | `str`     | Directory where experiment runs are stored                                                                       |
-| `uuid`             | `'a1b2c3d4'`          | `str`     | Unique identifier for the current settings                                                                       |
-| `sync`             | `True`                | `bool`    | Option to sync analytics and crashes to [Ultralytics Platform]                                                   |
-| `api_key`          | `''`                  | `str`     | [Ultralytics Platform] API Key                                                                                   |
-| `clearml`          | `True`                | `bool`    | Option to use [ClearML] logging                                                                                  |
-| `comet`            | `True`                | `bool`    | Option to use [Comet ML] for experiment tracking and visualization                                               |
-| `dvc`              | `True`                | `bool`    | Option to use [DVC for experiment tracking] and version control                                                  |
-| `mlflow`           | `True`                | `bool`    | Option to use [MLFlow] for experiment tracking                                                                   |
-| `raytune`          | `True`                | `bool`    | Option to use [Ray Tune] for [hyperparameter tuning](https://www.ultralytics.com/glossary/hyperparameter-tuning) |
-| `tensorboard`      | `False`               | `bool`    | Option to use [TensorBoard] for visualization                                                                    |
-| `wandb`            | `False`               | `bool`    | Option to use [Weights & Biases] logging                                                                         |
-| `vscode_msg`       | `True`                | `bool`    | When a VS Code terminal is detected, enables a prompt to download the [Ultralytics-Snippets] extension.          |
-| `openvino_msg`     | `True`                | `bool`    | On Intel CPUs, enables a prompt suggesting [OpenVINO](./integrations/openvino.md) export for faster inference.   |
-
-Revisit these settings as you progress through projects or experiments to ensure optimal configuration.
+Browse the [modes](modes/index.md) YOLO runs in and the [YOLO26](models/yolo26.md) model sizes, then [train on your own data](modes/train.md) after formatting it with the [Datasets guide](datasets/index.md).
 
 ## FAQ
 
@@ -507,7 +189,7 @@ cd ultralytics
 pip install -e .
 ```
 
-This allows contributions to the project or experimentation with the latest source code. For details, visit the [Ultralytics GitHub repository](https://github.com/ultralytics/ultralytics).
+This allows contributions to the project or experimentation with the latest source code. For forks and pinning a custom branch, see [Development Installation](help/contributing.md#development-installation).
 
 ### Why should I use Ultralytics YOLO CLI?
 
@@ -524,16 +206,3 @@ yolo train data=coco8.yaml model=yolo26n.pt epochs=10 lr0=0.01
 ```
 
 Explore more commands and usage examples in the full [CLI Guide](usage/cli.md).
-
-<!-- Article Links -->
-
-[Ultralytics Platform]: https://platform.ultralytics.com
-[pip]: https://pypi.org/project/ultralytics/
-[DVC for experiment tracking]: https://dvc.org/doc/dvclive/ml-frameworks/yolo
-[Comet ML]: ./integrations/comet.md
-[ClearML]: ./integrations/clearml.md
-[MLFlow]: ./integrations/mlflow.md
-[Tensorboard]: ./integrations/tensorboard.md
-[Ray Tune]: ./integrations/ray-tune.md
-[Weights & Biases]: ./integrations/weights-biases.md
-[Ultralytics-Snippets]: ./integrations/vscode.md

--- a/docs/en/usage/settings.md
+++ b/docs/en/usage/settings.md
@@ -24,9 +24,9 @@ Ultralytics stores persistent, per-machine settings in a JSON file in the user c
     === "CLI"
 
         ```bash
-        yolo settings  # view all settings
-        yolo settings runs_dir='/path/to/runs' tensorboard=False  # update one or more settings
-        yolo settings reset  # restore defaults
+        yolo settings                                            # view all settings
+        yolo settings runs_dir='/path/to/runs' tensorboard=False # update one or more settings
+        yolo settings reset                                      # restore defaults
         ```
 
 ## Settings Reference

--- a/docs/en/usage/settings.md
+++ b/docs/en/usage/settings.md
@@ -40,7 +40,7 @@ Ultralytics stores persistent, per-machine settings in a JSON file in the user c
 | `uuid`             | `'a1b2c3d4'`          | `str`     | Anonymized machine identifier (SHA-256 hash) used for analytics                                                                              |
 | `sync`             | `True`                | `bool`    | Send anonymized analytics and crash reports to Ultralytics, see [Privacy](../help/privacy.md)                                                |
 | `api_key`          | `''`                  | `str`     | [Ultralytics Platform](https://platform.ultralytics.com) API key                                                                             |
-| `openai_api_key`   | `''`                  | `str`     | OpenAI API key (currently unused)                                                                                                            |
+| `openai_api_key`   | `''`                  | `str`     | OpenAI API key for the [Explorer](../datasets/explorer/index.md) Ask AI feature, available up to `ultralytics==8.3.11`                       |
 | `clearml`          | `True`                | `bool`    | Enable [ClearML](../integrations/clearml.md) logging                                                                                         |
 | `comet`            | `True`                | `bool`    | Enable [Comet ML](../integrations/comet.md) experiment tracking                                                                              |
 | `dvc`              | `True`                | `bool`    | Enable [DVC](../integrations/dvc.md) experiment tracking                                                                                     |

--- a/docs/en/usage/settings.md
+++ b/docs/en/usage/settings.md
@@ -1,0 +1,52 @@
+---
+comments: true
+description: View, change, and reset persistent Ultralytics settings such as the datasets, weights, and runs directories, the Platform API key, and experiment-logger toggles.
+keywords: Ultralytics settings, SettingsManager, yolo settings, runs_dir, datasets_dir, weights_dir, experiment tracking, YOLO configuration
+---
+
+# Ultralytics Settings
+
+Ultralytics stores persistent, per-machine settings in a JSON file in the user configuration directory and exposes them through the `settings` object in Python and the `yolo settings` command. They control where datasets, weights, and runs are stored, the [Ultralytics Platform](https://platform.ultralytics.com) API key, and which experiment trackers are enabled. Per-run arguments such as `imgsz` and `epochs` are documented on the [Configuration](cfg.md) page instead.
+
+!!! example "View, update, and reset settings"
+
+    === "Python"
+
+        ```python
+        from ultralytics import settings
+
+        print(settings)  # view all settings
+        value = settings["runs_dir"]  # read one setting
+        settings.update({"runs_dir": "/path/to/runs", "tensorboard": False})  # update one or more settings
+        settings.reset()  # restore defaults
+        ```
+
+    === "CLI"
+
+        ```bash
+        yolo settings  # view all settings
+        yolo settings runs_dir='/path/to/runs' tensorboard=False  # update one or more settings
+        yolo settings reset  # restore defaults
+        ```
+
+## Settings Reference
+
+| Name               | Example Value         | Data Type | Description                                                                                                                                  |
+| ------------------ | --------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `settings_version` | `'0.0.8'`             | `str`     | Settings schema version, distinct from the `ultralytics` package version                                                                     |
+| `datasets_dir`     | `'/path/to/datasets'` | `str`     | Directory where datasets are stored                                                                                                          |
+| `weights_dir`      | `'/path/to/weights'`  | `str`     | Directory where model weights are stored                                                                                                     |
+| `runs_dir`         | `'/path/to/runs'`     | `str`     | Directory where experiment runs are stored                                                                                                   |
+| `uuid`             | `'a1b2c3d4'`          | `str`     | Anonymized machine identifier (SHA-256 hash) used for analytics                                                                              |
+| `sync`             | `True`                | `bool`    | Send anonymized analytics and crash reports to Ultralytics, see [Privacy](../help/privacy.md)                                                |
+| `api_key`          | `''`                  | `str`     | [Ultralytics Platform](https://platform.ultralytics.com) API key                                                                             |
+| `openai_api_key`   | `''`                  | `str`     | OpenAI API key (currently unused)                                                                                                            |
+| `clearml`          | `True`                | `bool`    | Enable [ClearML](../integrations/clearml.md) logging                                                                                         |
+| `comet`            | `True`                | `bool`    | Enable [Comet ML](../integrations/comet.md) experiment tracking                                                                              |
+| `dvc`              | `True`                | `bool`    | Enable [DVC](../integrations/dvc.md) experiment tracking                                                                                     |
+| `mlflow`           | `True`                | `bool`    | Enable [MLflow](../integrations/mlflow.md) experiment tracking                                                                               |
+| `raytune`          | `True`                | `bool`    | Enable [Ray Tune](../integrations/ray-tune.md) [hyperparameter tuning](https://www.ultralytics.com/glossary/hyperparameter-tuning) reporting |
+| `tensorboard`      | `False`               | `bool`    | Enable [TensorBoard](../integrations/tensorboard.md) logging                                                                                 |
+| `wandb`            | `False`               | `bool`    | Enable [Weights & Biases](../integrations/weights-biases.md) logging                                                                         |
+| `vscode_msg`       | `True`                | `bool`    | Show a prompt to install the [Ultralytics-Snippets](../integrations/vscode.md) extension when a VS Code terminal is detected                 |
+| `openvino_msg`     | `True`                | `bool`    | On Intel CPUs, show a tip suggesting [OpenVINO](../integrations/openvino.md) export for faster inference                                     |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,6 +139,7 @@ nav:
           - Python: usage/python.md
           - Callbacks: usage/callbacks.md
           - Configuration: usage/cfg.md
+          - Settings: usage/settings.md
           - Simple Utilities: usage/simple-utilities.md
           - Advanced Customization: usage/engine.md
       - YOLO26 🚀: models/yolo26.md

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -769,9 +769,9 @@ def handle_yolo_settings(args: list[str]) -> None:
         - The function will check for alignment between the provided settings and the existing ones.
         - After processing, the updated settings will be displayed.
         - For more information on handling YOLO settings, visit:
-          https://docs.ultralytics.com/quickstart#ultralytics-settings
+          https://docs.ultralytics.com/usage/settings
     """
-    url = "https://docs.ultralytics.com/quickstart#ultralytics-settings"  # help URL
+    url = "https://docs.ultralytics.com/usage/settings"  # help URL
     try:
         if any(args):
             if args[0] == "reset":

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -1424,7 +1424,7 @@ class SettingsManager(JSONDict):
         self.help_msg = (
             f"\nView Ultralytics Settings with 'yolo settings' or at '{self.file}'"
             "\nUpdate Settings with 'yolo settings key=value', i.e. 'yolo settings runs_dir=path/to/dir'. "
-            "For help see https://docs.ultralytics.com/quickstart#ultralytics-settings."
+            "For help see https://docs.ultralytics.com/usage/settings."
         )
 
         with torch_distributed_zero_first(LOCAL_RANK):


### PR DESCRIPTION
## summary

- rewrite `docs/en/quickstart.md` as installation followed by a first prediction: the five install methods stay visible as tabs under the same `Install Ultralytics` heading, the first runnable command is `yolo predict model=yolo26n.pt` with a webcam variant, and the first python example predicts with a pretrained `.pt` and saves its output instead of building an untrained model from yaml
- move the persistent settings section and its table to a new `usage/settings.md` page (nav entry under usage), re-verified against `SettingsManager.defaults`, and repoint the settings links in mlflow, vscode, train, and the two package help urls
- move fork and editable installs to a `Development Installation` section in `help/contributing.md`, and drop the emoji prefixes from that page's headings so its six same-page anchor links resolve on the live site
- delete the cli and python reference tabs, the advanced-installation block, and the badges from quickstart, which `usage/cli.md`, `usage/python.md`, and the contributing guide already own; existing inbound anchors (`#use-ultralytics-with-cli`, `#use-ultralytics-with-python`, the clone faq) are preserved

## measured

| item | before | after |
| --- | --- | --- |
| `quickstart.md` lines | 539 | 208 |
| first runnable prediction command | line 238 | line 86 |
| first python example model | `YOLO("yolo26n.yaml")` (untrained) | `YOLO("yolo26n.pt")` |
| settings table rows vs `SettingsManager.defaults` keys | 16 / 17, `settings_version` `0.0.7` vs code `0.0.8` | 17 / 17, `0.0.8` |
| `help/contributing.md` same-page links resolving on the live site | 0 of 6 | 6 of 6 |
| relative links + anchors across the changed pages and their consumers | – | 0 broken |

every command on the new pages was run as written on the branch: `yolo predict model=yolo26n.pt`, the python predict with `save=True`, `yolo settings ...` update and reset, and the python `settings.update`/`settings.reset`.

replaces #25225, whose branch had drifted and conflicted with main.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Reworked the quickstart into an installation-to-first-prediction guide, moved persistent settings into a dedicated page, and relocated development-installation instructions to the contributing guide.

### 📊 Key Changes

- Reorganized `quickstart.md` around five installation tabs—Pip, Conda, Docker, Git clone, and Headless—followed by CLI and Python predictions using pretrained `yolo26n.pt`.
- Added `usage/settings.md` with Python and CLI examples plus a reference table matching the current 17 `SettingsManager` defaults, and added it to the documentation navigation.
- Moved fork and editable-install instructions to a new `Development Installation` section in `help/contributing.md`.
- Removed duplicated CLI, Python, advanced-installation, settings, and badge content from the quickstart while preserving relevant links and FAQ anchors.
- Updated settings references in MLflow, VS Code, training documentation, and CLI/Python help messages to point to `usage/settings.md`.

### 🎯 Purpose & Impact

- New users can install Ultralytics and run a first CLI or Python prediction earlier in the quickstart, with the Python example loading pretrained weights and saving its output.
- Persistent settings, including directories, API keys, and experiment-logger options, now have a dedicated reference and workflow page.
- Contributors find fork and editable-install instructions in the contributing guide, whose heading anchors were changed to resolve correctly.
- Existing documentation links now target the new settings page instead of the removed quickstart settings section.