### PR TITLE
Install GitHub CLI in CPU and GPU runner images

### DIFF
--- a/docker/Dockerfile-runner
+++ b/docker/Dockerfile-runner
@@ -25,7 +25,7 @@ RUN FILENAME=actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz && \
     rm "$FILENAME" && \
     uv pip install --system --no-cache pytest-cov tensorrt-cu13 && \
     ./bin/installdependencies.sh && \
-    apt-get install -y --no-install-recommends g++ libicu-dev sudo && \
+    apt-get install -y --no-install-recommends g++ gh libicu-dev sudo && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile-runner-cpu
+++ b/docker/Dockerfile-runner-cpu
@@ -26,7 +26,7 @@ RUN FILENAME=actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz && \
     # Install runner dependencies \
     uv pip install --system pytest-cov && \
     ./bin/installdependencies.sh && \
-    apt-get install -y --no-install-recommends gpg libicu-dev sudo && \
+    apt-get install -y --no-install-recommends gh gpg libicu-dev sudo && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
CPU runner jobs that call `gh` fail with `gh: command not found`, including Portal's Playwright preview resolver after moving to `cpu-latest`.

Install GitHub CLI in the existing apt dependency lists for both CPU and GPU runner images. This makes the CLI available by default across repositories without duplicating setup in individual workflows. The existing image publishing and runner refresh processes own rollout.

Validation: full two-line diff reviewed and `git diff --check` passed. Installing the distro package and running `gh --version` succeeded in Debian Trixie and Ubuntu 24.04 containers. These were package-install smoke checks, not full CPU/GPU runner image builds.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Added the GitHub CLI package to the CPU and GPU runner image definitions so workflows using `gh` can run without installing it separately.

### 📊 Key Changes
- Added `gh` to the apt dependency list in `docker/Dockerfile-runner`.
- Added `gh` to the apt dependency list in `docker/Dockerfile-runner-cpu`.
- Kept the existing cleanup of apt package lists after installation.

### 🎯 Purpose & Impact
- Newly published and refreshed CPU and GPU runner images will provide the `gh` command by default, supporting workflows such as Portal’s Playwright preview resolver.
- Existing image publishing and runner refresh processes determine when this change becomes available; the PR did not include full image builds.