### PR TITLE
Apply Albumentations to grayscale images

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.146"
+__version__ = "8.4.147"
 
 import importlib
 import os

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -2180,7 +2180,7 @@ class Albumentations(BaseTransform):
             return labels
 
         im = labels["img"]
-        if im.shape[2] != 3:  # Only apply Albumentation on 3-channel images
+        if im.shape[2] not in {1, 3}:  # Albumentations supports grayscale and color images only
             return labels
 
         if self.contains_spatial:


### PR DESCRIPTION
Fixes #26130

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated Albumentations preprocessing to run on both grayscale and three-channel images instead of only color images.

### 📊 Key Changes

- Changed the channel check in `ultralytics/data/augment.py` to allow images with 1 or 3 channels.
- Albumentations continues to skip images with other channel counts.
- Incremented the Ultralytics version from `8.4.146` to `8.4.147`.

### 🎯 Purpose & Impact

- Grayscale images can now receive configured Albumentations transforms during preprocessing.
- Images with unsupported channel counts retain the existing skip behavior.