### PR TITLE
Install jq in CPU and GPU runner images

### DIFF
--- a/docker/Dockerfile-runner
+++ b/docker/Dockerfile-runner
@@ -25,7 +25,7 @@ RUN FILENAME=actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz && \
     rm "$FILENAME" && \
     uv pip install --system --no-cache pytest-cov tensorrt-cu13 && \
     ./bin/installdependencies.sh && \
-    apt-get install -y --no-install-recommends g++ gh libicu-dev sudo && \
+    apt-get install -y --no-install-recommends g++ gh jq libicu-dev sudo && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile-runner-cpu
+++ b/docker/Dockerfile-runner-cpu
@@ -26,7 +26,7 @@ RUN FILENAME=actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz && \
     # Install runner dependencies \
     uv pip install --system pytest-cov && \
     ./bin/installdependencies.sh && \
-    apt-get install -y --no-install-recommends gh gpg libicu-dev sudo && \
+    apt-get install -y --no-install-recommends gh gpg jq libicu-dev sudo && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Runner jobs fail with `jq: command not found` because neither runner image installs the CLI. Add `jq` to the existing apt dependency lists for CPU and GPU runner images.

Validation: `git diff --check` passes. Runner images must be rebuilt and running containers recreated to pick up the dependency.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Added the `jq` command-line tool to both CPU and GPU runner images to prevent runner jobs from failing when invoking `jq`.

### 📊 Key Changes
- Updated `docker/Dockerfile-runner` to install `jq` with the existing APT dependencies.
- Updated `docker/Dockerfile-runner-cpu` to install `jq` with the existing APT dependencies.
- Retained the existing APT cleanup steps after installation.

### 🎯 Purpose & Impact
- Newly built CPU and GPU runner images provide the `jq` CLI for runner jobs.
- Existing images must be rebuilt and running containers recreated before the dependency is available.