### PR TITLE
Document the Platform CLI agent skill

### DIFF
--- a/docs/en/integrations/agent-skills.md
+++ b/docs/en/integrations/agent-skills.md
@@ -1,26 +1,27 @@
 ---
 comments: true
-description: Install the official Ultralytics Agent Skills for YOLO model selection, datasets, training, tuning, inference, and export.
-keywords: Ultralytics, YOLO, agent skills, Claude Code, Codex, Cursor, Gemini CLI, SKILL.md, training, inference, export
+description: Install the official Ultralytics Agent Skills for YOLO model selection, datasets, training, tuning, inference, export, and Platform CLI automation.
+keywords: Ultralytics, YOLO, agent skills, Claude Code, Codex, Cursor, Gemini CLI, SKILL.md, training, inference, export, Platform CLI, ul cloud
 ---
 
 # Ultralytics Agent Skills
 
-[Ultralytics Agent Skills](https://github.com/ultralytics/skills) give compatible AI coding agents instructions and reference material for working with the `ultralytics` Python package, the `yolo` CLI, and [Ultralytics Platform](https://platform.ultralytics.com). They follow the open [Agent Skills](https://agentskills.io/) format and load when a relevant task is requested.
+[Ultralytics Agent Skills](https://github.com/ultralytics/skills) give compatible AI coding agents instructions and reference material for working with the `ultralytics` Python package, the `yolo` CLI, and [Ultralytics Platform](https://platform.ultralytics.com), including automation with `ul cloud`. They follow the open [Agent Skills](https://agentskills.io/) format and load when a relevant task is requested.
 
 ## Available Skills
 
-The repository contains one router and six lifecycle skills:
+The repository contains one router, six lifecycle skills, and one Platform CLI skill:
 
-| Skill            | Use for                                                                                                   |
-| ---------------- | --------------------------------------------------------------------------------------------------------- |
-| `yolo`           | Core Python and CLI usage, Platform workflows, and routing to the other skills                            |
-| `yolo-models`    | Selecting model families, sizes, tasks, and weights                                                       |
-| `yolo-datasets`  | Preparing, converting, validating, and troubleshooting [datasets](../datasets/index.md)                   |
-| `yolo-training`  | [Training](../modes/train.md), validation, resumes, multi-GPU use, and troubleshooting                    |
-| `yolo-tuning`    | [Hyperparameter tuning](../guides/hyperparameter-tuning.md) and experiment improvement                    |
-| `yolo-inference` | [Prediction](../modes/predict.md), results, [tracking](../modes/track.md), and Solutions                  |
-| `yolo-export`    | [Export](../modes/export.md), quantization, deployment formats, and [benchmarking](../modes/benchmark.md) |
+| Skill            | Use for                                                                                                                               |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `yolo`           | Core Python and CLI usage, Platform workflows, and routing to the other skills                                                        |
+| `yolo-models`    | Selecting model families, sizes, tasks, and weights                                                                                   |
+| `yolo-datasets`  | Preparing, converting, validating, and troubleshooting [datasets](../datasets/index.md)                                               |
+| `yolo-training`  | [Training](../modes/train.md), validation, resumes, multi-GPU use, and troubleshooting                                                |
+| `yolo-tuning`    | [Hyperparameter tuning](../guides/hyperparameter-tuning.md) and experiment improvement                                                |
+| `yolo-inference` | [Prediction](../modes/predict.md), results, [tracking](../modes/track.md), and Solutions                                              |
+| `yolo-export`    | [Export](../modes/export.md), quantization, deployment formats, and [benchmarking](../modes/benchmark.md)                             |
+| `platform-cli`   | Automating [Ultralytics Platform](../platform/index.md) with `ul cloud`: resources, uploads, cloud training, exports, and deployments |
 
 The skills include version-grounded catalogs where exact weights, arguments, or export formats matter, while deferring to the installed package when behavior differs.
 
@@ -44,7 +45,7 @@ The skills include version-grounded catalogs where exact weights, arguments, or 
 
 === "Other agents"
 
-    Install all seven skills with the [skills CLI](https://www.skills.sh/):
+    Install all eight skills with the [skills CLI](https://www.skills.sh/):
 
     ```bash
     npx skills add ultralytics/skills
@@ -54,13 +55,15 @@ The skills include version-grounded catalogs where exact weights, arguments, or 
 
 Once installed, ask the agent naturally, for example: "Export my trained YOLO model to TensorRT with INT8 quantization and benchmark it." The `yolo` router selects the relevant lifecycle guidance.
 
+The `platform-cli` skill uses the `ul` CLI, installed with `pip install ultralytics` or `pip install ultralytics-platform`. Try asking: "List my Platform datasets using `ul cloud`."
+
 See the [`ultralytics/skills` repository](https://github.com/ultralytics/skills) for current installation commands, source files, updates, and issue reporting.
 
 ## FAQ
 
 ### What are Ultralytics Agent Skills?
 
-They are reusable instructions and reference material that help AI coding agents work with Ultralytics Platform, the `ultralytics` Python package, and the `yolo` CLI.
+They are reusable instructions and reference material that help AI coding agents work with Ultralytics Platform, the `ultralytics` Python package, the `yolo` CLI, and the `ul` Platform CLI.
 
 ### Which agents can use these skills?
 
@@ -68,7 +71,7 @@ The repository provides plugins for Claude Code and Codex. Cursor, Gemini CLI, a
 
 ### Which skill should I install?
 
-Install the complete plugin for automatic routing across the computer vision lifecycle. To install one skill with the skills CLI, pass its name with `--skill`, such as `--skill yolo-training`.
+Install the complete plugin for automatic routing across the computer vision lifecycle and Platform CLI operations. To install one skill with the skills CLI, pass its name with `--skill`, such as `--skill yolo-training` or `--skill platform-cli`.
 
 ### Do the skills replace the Ultralytics documentation?
 

--- a/docs/en/integrations/agent-skills.md
+++ b/docs/en/integrations/agent-skills.md
@@ -55,7 +55,7 @@ The skills include version-grounded catalogs where exact weights, arguments, or 
 
 Once installed, ask the agent naturally, for example: "Export my trained YOLO model to TensorRT with INT8 quantization and benchmark it." The `yolo` router selects the relevant lifecycle guidance.
 
-For the `platform-cli` skill, try asking: "List my Platform datasets using `ul cloud`."
+The `platform-cli` skill uses the `ul` CLI (Python 3.11+), included with `pip install ultralytics` or the standalone SDK (`pip install ultralytics-platform`). Try asking: "List my Ultralytics Platform datasets."
 
 See the [`ultralytics/skills` repository](https://github.com/ultralytics/skills) for current installation commands, source files, updates, and issue reporting.
 

--- a/docs/en/integrations/agent-skills.md
+++ b/docs/en/integrations/agent-skills.md
@@ -55,7 +55,7 @@ The skills include version-grounded catalogs where exact weights, arguments, or 
 
 Once installed, ask the agent naturally, for example: "Export my trained YOLO model to TensorRT with INT8 quantization and benchmark it." The `yolo` router selects the relevant lifecycle guidance.
 
-The `platform-cli` skill uses the `ul` CLI, installed with `pip install ultralytics` or `pip install ultralytics-platform`. Try asking: "List my Platform datasets using `ul cloud`."
+For the `platform-cli` skill, try asking: "List my Platform datasets using `ul cloud`."
 
 See the [`ultralytics/skills` repository](https://github.com/ultralytics/skills) for current installation commands, source files, updates, and issue reporting.
 


### PR DESCRIPTION
The Agent Skills page omits the new `platform-cli` skill. Add its `ul cloud` workflows, update the skill count to eight, and document CLI installation, the Python requirement, an example prompt, and single-skill selection using the existing page format.

Validation: Prettier 3.8.5 with the repository's documentation settings, codespell, `git diff --check`, and targeted Markdown rendering and relative-link checks passed. The full documentation build was not run locally.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the Agent Skills documentation to include the `platform-cli` skill and explain its `ul cloud` workflows, installation requirements, and selection options.

### 📊 Key Changes

- Added `platform-cli` to the skills table for Platform resources, uploads, cloud training, exports, and deployments through `ul cloud`.
- Updated the documented skill count from seven to eight.
- Documented that the `ul` CLI requires Python 3.11+ and is available through `pip install ultralytics` or `pip install ultralytics-platform`.
- Added an example prompt for listing Ultralytics Platform datasets.
- Updated the FAQ to cover the `ul` CLI and selecting `platform-cli` with `--skill`.

### 🎯 Purpose & Impact

- Users can now discover and install the Platform CLI agent skill, understand its Python requirement, and request Platform workflows through compatible AI coding agents.
- No runtime or package behavior changed; this PR only updates documentation.