### PR TITLE
Document Platform Autotraining with Ask AI

### DIFF
--- a/docs/en/platform/autotraining.md
+++ b/docs/en/platform/autotraining.md
@@ -11,7 +11,9 @@ keywords: Ultralytics Platform, autotraining, Ask AI, Platform CLI, ul cloud, ag
 
 Sign in to [Ultralytics Platform](https://platform.ultralytics.com) and click **Ask AI**. The AI agent works directly with your datasets and models, automating tasks such as annotation, training, export, and deployment.
 
-<!-- Image placeholder: ![Ultralytics Platform dataset page with the Ask AI panel open beside the images](IMAGE_URL) -->
+To use Platform actions, first create an [Ultralytics API key](account/api-keys.md) in your personal workspace's **Settings > API Keys**. Ask AI uses your existing personal key automatically; you do not need to paste it into the conversation. Include the project or dataset link when working with a team workspace.
+
+![Ultralytics Platform PPE detection dataset with Ask AI reviewing classes, annotations, and training readiness](https://cdn.ul.run/i/94b13a80c2fb15e32ca6044d0ebe1d37.avif)
 
 ## Prompts to Try
 
@@ -29,7 +31,7 @@ Open the relevant dataset or project and ask:
 | Review classification | Which model has the best classification accuracy? Which breeds remain confusing, and what should we try next?                      |
 | Export a model        | Export this model to ONNX and give me the download link when it's ready.                                                           |
 
-<!-- Image placeholder: ![Ultralytics Platform project showing three completed resolution experiments beside an Ask AI comparison of their results](IMAGE_URL) -->
+![Ultralytics Platform logistics project with Ask AI comparing completed detection models and explaining validation differences](https://cdn.ul.run/i/33d99ff9fa815aa7ac82af74cdef637f.avif)
 
 ## Use Your Own Coding Agent
 
@@ -37,7 +39,7 @@ Ask AI uses the [Platform CLI](https://github.com/ultralytics/sdk), `ul cloud`, 
 
 ### Install and Connect
 
-Ask AI is ready to use in Platform. Follow the setup below to use the Platform CLI with your own coding agent.
+The setup below is for using the Platform CLI with your own coding agent outside Platform.
 
 The `ul` CLI comes with the Ultralytics package on **Python 3.11+**. Install or update it:
 

--- a/docs/en/platform/autotraining.md
+++ b/docs/en/platform/autotraining.md
@@ -1,0 +1,76 @@
+---
+plans: [free, pro, enterprise]
+comments: true
+description: Use Ask AI to manage datasets, train and compare models, annotate images, export, and deploy on Ultralytics Platform.
+keywords: Ultralytics Platform, autotraining, Ask AI, Platform CLI, ul cloud, agent skills, Claude Code, Codex
+---
+
+# Autotraining with Ask AI
+
+**Ask AI turns your requests into actions across Ultralytics Platform.** Find datasets, train and compare models, annotate images, export, and deploy through a conversation.
+
+Sign in to [Ultralytics Platform](https://platform.ultralytics.com) and click **Ask AI**. The AI agent works directly with your datasets and models, automating tasks such as annotation, training, export, and deployment.
+
+<!-- Image placeholder: ![Ultralytics Platform dataset page with the Ask AI panel open beside the images](IMAGE_URL) -->
+
+## Prompts to Try
+
+Open the relevant dataset or project and ask:
+
+| Goal                  | Example prompt                                                                                                                     |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Start a project       | Create a private project called "Wildlife Lab". Find and clone a wildlife detection dataset, then prepare a baseline training run. |
+| Compare resolutions   | Train three models on this dataset at image sizes 640, 800, and 960. Keep all other settings and dataset splits fixed.             |
+| Explore a dataset     | Find container ships, shipping containers, and cranes in xView. Is it a good starting point for port logistics?                    |
+| Create a baseline     | Train YOLO26n on this dataset and name the run "xview-baseline".                                                                   |
+| Compare models        | Compare the completed models. Which performed best, and why?                                                                       |
+| Deploy a model        | Deploy the completed model with the best validation mAP in this project. Give me its endpoint URL and status.                      |
+| Auto-annotate         | Use my best compatible model to annotate unlabeled images in this dataset. Preserve existing annotations.                          |
+| Review classification | Which model has the best classification accuracy? Which breeds remain confusing, and what should we try next?                      |
+| Export a model        | Export this model to ONNX and give me the download link when it's ready.                                                           |
+
+<!-- Image placeholder: ![Ultralytics Platform project showing three completed resolution experiments beside an Ask AI comparison of their results](IMAGE_URL) -->
+
+## Use Your Own Coding Agent
+
+Ask AI uses the [Platform CLI](https://github.com/ultralytics/sdk), `ul cloud`, and its companion [platform-cli skill](https://github.com/ultralytics/skills). You can use the same commands from Claude Code, Codex, or another compatible coding agent.
+
+### Install and Connect
+
+Ask AI is ready to use in Platform. Follow the setup below to use the Platform CLI with your own coding agent.
+
+The `ul` CLI comes with the Ultralytics package on **Python 3.11+**. Install or update it:
+
+```bash
+pip install -U ultralytics
+```
+
+Create a [Platform API key](account/api-keys.md) and set it in the terminal used by your agent. Check the connection with:
+
+```bash
+export ULTRALYTICS_API_KEY="YOUR_API_KEY"
+ul cloud account summary
+```
+
+### Add the Skill
+
+Follow the [Agent Skills installation guide](../integrations/agent-skills.md#installation) for Claude Code and Codex plugins. For agents supported by the skills CLI, install the Platform skill with:
+
+```bash
+npx skills add ultralytics/skills --skill platform-cli
+```
+
+Then use prompts like the examples above, including the project or dataset link for context.
+
+### Run Commands Directly
+
+Use your project and model URL slugs in commands:
+
+```bash
+ul cloud datasets list
+ul cloud models list project=license-plate
+ul cloud models training project=license-plate model=baseline
+ul cloud training start --help
+```
+
+Use `ul cloud --help` to discover commands and `ul cloud <resource> <operation> --help` for their arguments. See the [Platform API reference](api/index.md) for more details.

--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -251,6 +251,7 @@ Once deployed, call your endpoint from any language. `conf`, `iou`, and `imgsz` 
 Get started with these resources:
 
 - [**Quickstart**](quickstart.md): Create your first project and train a model in minutes
+- [**Autotraining**](autotraining.md): Use Ask AI to manage datasets, run experiments, compare models, and deploy
 - [**Explore**](explore.md): Browse and clone public datasets and projects
 - [**Data**](data/index.md): Dataset preparation overview
 - [**Datasets**](data/datasets.md): Upload and manage your training data

--- a/docs/en/platform/quickstart.md
+++ b/docs/en/platform/quickstart.md
@@ -150,7 +150,7 @@ Press `Cmd+K` (Mac) or `Ctrl+K` (Windows/Linux) to open the search bar. Search a
 
 ### AI Chat Assistant
 
-A floating chat widget is available on every page. Click it to ask questions about YOLO training, annotation, deployment, or any Platform feature. The assistant provides context-aware help based on the current page.
+Click **Ask AI** to work with an AI agent that automates tasks across Ultralytics Platform. It works directly with your datasets and models to annotate images, run training experiments, compare results, and export or deploy models. See [Autotraining with Ask AI](autotraining.md) for example prompts and setup for your own coding agent.
 
 ### Onboarding Tours
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -601,6 +601,7 @@ nav:
   - Platform:
       - Platform: platform/index.md
       - Quickstart: platform/quickstart.md
+      - Autotraining: platform/autotraining.md
       - Data:
           - platform/data/index.md
           - Datasets: platform/data/datasets.md


### PR DESCRIPTION
Documents Autotraining with Ask AI, with example prompts, Platform navigation, a Quickstart link, and setup for using the Platform CLI with a local coding agent. Clarifies the personal Platform API key required for Ask AI actions.

Includes two manually captured 1920×1080 screenshots from the Jane example account: a dataset-readiness review and comparison of existing model results. Both conversations used read-only requests; no training or deployments were started. Assets are hosted through Portal Content Assets, and old assets are retained.

Validation: verified CLI help and current skill/package sources, rendered changed Markdown and checked relative links and anchors, confirmed both CDN images return HTTP 200 at 1920×1080, and passed pinned Prettier and `git diff --check`. Full docs validation runs in CI.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Added documentation for using Ask AI and the Platform CLI to manage datasets, train and compare models, annotate images, export models, and deploy them.

### 📊 Key Changes
- Added `docs/en/platform/autotraining.md` with Ask AI workflows, example prompts, two screenshots, API key setup, Platform CLI installation, agent skill setup, and direct `ul cloud` commands.
- Documented that Ask AI actions use a personal Ultralytics Platform API key configured in the user’s workspace, while CLI use requires `ULTRALYTICS_API_KEY`.
- Added the Autotraining page to the Platform navigation and linked it from the Platform index and Quickstart AI Chat Assistant section.
- Included examples covering YOLO26 baseline training, experiment comparisons, dataset exploration, auto-annotation, ONNX export, and deployment.

### 🎯 Purpose & Impact
Users can now find a dedicated workflow for operating Ultralytics Platform through Ask AI, compatible coding agents, and the Platform CLI, including setup instructions and example requests.