### PR TITLE
Tools/sh config defaults

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -155,9 +155,9 @@ python tools/predict.py --model "/absolute/path/to/runs/segment/train-2/weights/
 
 ```bash
 python tools/train.py --task detect --data coco8.yaml --epochs 100 --device 0 \
-    --optimizer AdamW --lr0 0.001 --lrf 0.01 --weight_decay 0.0005 \
-    --warmup_epochs 3 --cos_lr True --patience 30 --seed 42 \
-    --mosaic 1.0 --mixup 0.1 --close_mosaic 10 --amp True
+  --optimizer AdamW --lr0 0.001 --lrf 0.01 --weight_decay 0.0005 \
+  --warmup_epochs 3 --cos_lr True --patience 30 --seed 42 \
+  --mosaic 1.0 --mixup 0.1 --close_mosaic 10 --amp True
 ```
 
 希望手动控制学习率和动量时，应显式选择优化器；`--optimizer auto` 会由框架自动决定这些值。

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,6 +1,7 @@
 # 通用训练、验证与预测脚本
 
 三个独立 Python 脚本覆盖当前仓库支持的七类 YOLO 任务。通过 `--参数 值` 指定配置，无需修改脚本。
+同目录的 `train.sh`、`val.sh` 和 `detect.sh` 分别启动训练、验证和目标检测，并将收到的参数原样传给 Python 脚本。
 脚本直接调用仓库的 `YOLO` 接口，数据读取、任务识别、指标计算和可视化均由框架处理。
 
 ## 安装与运行
@@ -18,6 +19,18 @@ python tools/train.py --help
 python tools/val.py --help
 python tools/predict.py --help
 ```
+
+也可以通过 shell 脚本传入相同参数：
+
+```bash
+./tools/train.sh --task detect --epochs 1 --device cpu
+./tools/val.sh --task detect --device cpu
+./tools/detect.sh --source "ultralytics/assets/bus.jpg" --device cpu
+```
+
+`detect.sh` 调用 `predict.py` 并默认传入 `--task detect`；显式传入 `--task` 可覆盖该默认值。
+三个 shell 脚本可从任意目录运行，参数格式与对应 Python 脚本完全一致。若没有执行权限，也可使用
+`bash tools/train.sh ...`、`bash tools/val.sh ...` 或 `bash tools/detect.sh ...`。
 
 分别运行需要的步骤，例如使用示例数据进行一轮 CPU 训练：
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,7 +1,8 @@
 # 通用训练、验证与预测脚本
 
 三个独立 Python 脚本覆盖当前仓库支持的七类 YOLO 任务。通过 `--参数 值` 指定配置，无需修改脚本。
-同目录的 `train.sh`、`val.sh` 和 `detect.sh` 分别启动训练、验证和目标检测，并将收到的参数原样传给 Python 脚本。
+同目录的 `train.sh`、`val.sh` 和 `detect.sh` 分别启动训练、验证和目标检测：脚本顶部逐行列出默认配置，
+运行时与命令行参数合并透传给 Python 脚本，同名参数以命令行为准，其余参数继续使用配置值。
 脚本直接调用仓库的 `YOLO` 接口，数据读取、任务识别、指标计算和可视化均由框架处理。
 
 ## 安装与运行
@@ -20,17 +21,30 @@ python tools/val.py --help
 python tools/predict.py --help
 ```
 
-也可以通过 shell 脚本传入相同参数：
+也可以直接运行 shell 脚本，不带参数时完全使用脚本内的默认配置：
 
 ```bash
-./tools/train.sh --task detect --epochs 1 --device cpu
-./tools/val.sh --task detect --device cpu
-./tools/detect.sh --source "ultralytics/assets/bus.jpg" --device cpu
+./tools/train.sh
+./tools/val.sh
+./tools/detect.sh
 ```
 
-`detect.sh` 调用 `predict.py` 并默认传入 `--task detect`；显式传入 `--task` 可覆盖该默认值。
-三个 shell 脚本可从任意目录运行，参数格式与对应 Python 脚本完全一致。若没有执行权限，也可使用
-`bash tools/train.sh ...`、`bash tools/val.sh ...` 或 `bash tools/detect.sh ...`。
+命令行参数会追加在配置之后合并透传，同名参数以命令行为准，例如只改训练轮数或临时换输入：
+
+```bash
+./tools/train.sh --epochs 50
+./tools/val.sh --task segment --data "/absolute/path/to/dataset.yaml"
+./tools/detect.sh --source "/absolute/path/to/video.mp4"
+```
+
+长期使用的默认值直接编辑各 sh 脚本顶部的"默认配置"区，每行一个参数；三个脚本均含 `MODEL` 配置，留空 `""` 使用 `TASK`
+对应的内置预训练模型，填入 `.pt` 权重路径（如训练产出的 `best.pt`）即从该权重训练、验证或预测；均含 `PROJECT` 配置，
+留空 `""` 输出到框架默认 `runs/<任务>/`，相对名追加在任务目录后，绝对路径直接作为项目目录；`NAME` 留空 `""` 使用各脚本
+默认子目录名（`train`/`val`/`predict`），重名自动递增；`detect.sh` 的默认任务与输入源也在该区。
+`train.sh` 的配置区已按上文「训练超参数」表列出全部超参数，取值与 `ultralytics/cfg/default.yaml` 一致，
+修改后始终作为命令行覆盖项传入；设为 `None` 表示沿用框架可选默认，如 `TIME`、`FREEZE`、`CLASSES`。
+配置中的 `TASK` 与 `DATA` 需保持匹配。三个 shell 脚本可从任意目录运行，参数格式与对应 Python 脚本完全一致。
+若没有执行权限，也可使用 `bash tools/train.sh ...`、`bash tools/val.sh ...` 或 `bash tools/detect.sh ...`。
 
 分别运行需要的步骤，例如使用示例数据进行一轮 CPU 训练：
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -74,15 +74,16 @@ python tools/train.py --task segment --data "/absolute/path/to/dataset.yaml" --e
 
 - `--epochs`：训练轮数，整数，默认 `100`。
 - `--imgsz`：输入尺寸，整数，默认 `640`；分类可按需改为 `224`。
-- `--batch`：训练和验证批次大小，整数，默认 `8`；内存不足时调小。
+- `--batch`：训练和验证默认 `8`；训练还支持 `-1` 自动估算或 `0.7` 等显存比例，验证仍使用整数。
 - `--workers`：训练和验证的数据加载进程数，整数，默认 `0`，可按运行环境增加。
 - `--device`：省略时由框架选择；可填写 `cpu`、`0`（CUDA）或 `mps`（Apple Silicon）。
 - `--project`：省略时沿用框架的输出目录设置；相对项目名自动放在对应任务目录下，绝对路径直接作为项目目录。
 - `--name`：本次输出子目录名，三个脚本分别默认为 `train`、`val`、`predict`。
 - `--split`：验证数据划分，默认 `val`，可选 `train`、`val`、`test`；数据集必须提供相应划分。
 
-布尔开关不需要附加 `True` 或 `False`：预测时使用 `--show` 开启窗口显示，使用 `--no-save` 关闭保存。
-未知参数、缺失参数值、非法整数和无效任务会在加载模型前由参数解析器报错。
+预测的布尔开关不需要附加 `True` 或 `False`：使用 `--show` 开启窗口显示，使用 `--no-save` 关闭保存。
+训练的新增布尔参数需要显式值，例如 `--amp False`、`--cos_lr True`。
+未知参数、缺失参数值和无效任务由参数解析器报错；训练超参数的类型和取值范围复用框架校验，在加载模型前检查。
 
 默认输出通常位于 `runs/<任务>/<模式>/`，实际根目录取决于 Ultralytics 的 `runs_dir` 设置。
 已有目录会自动递增，例如 `train-2`；以运行日志打印的实际路径为准。
@@ -97,6 +98,52 @@ python tools/predict.py --model "/absolute/path/to/runs/segment/train-2/weights/
 
 验证时传入训练使用的 `--data`。路径可以包含空格，按上例使用引号包裹；其他相对路径相对于运行命令的工作目录。
 验证输出 `metrics.results_dict`，由任务决定指标，例如检测 mAP、语义分割 mIoU、深度 delta1、分类准确率。
+
+## 训练超参数
+
+`train.py --help` 列出全部支持的选项。新增参数与框架配置使用相同的下划线名称，按需传入即可：
+
+| 类别           | 参数                                                                                                                                |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| 优化器与学习率 | `--optimizer`、`--lr0`、`--lrf`、`--momentum`、`--weight_decay`、`--cos_lr`、`--nbs`                                                |
+| 预热           | `--warmup_epochs`、`--warmup_momentum`、`--warmup_bias_lr`                                                                          |
+| 训练控制       | `--patience`、`--time`、`--seed`、`--deterministic`、`--amp`、`--cache`、`--freeze`、`--resume`、`--pretrained`                     |
+| 数据与性能     | `--fraction`、`--rect`、`--single_cls`、`--classes`、`--multi_scale`、`--compile`、`--channels_last`、`--cls_remap`                 |
+| 色彩与几何增强 | `--hsv_h`、`--hsv_s`、`--hsv_v`、`--degrees`、`--translate`、`--scale`、`--shear`、`--perspective`、`--flipud`、`--fliplr`、`--bgr` |
+| 样本混合增强   | `--mosaic`、`--mixup`、`--cutmix`、`--copy_paste`、`--copy_paste_mode`、`--close_mosaic`                                            |
+| 分割与分类     | `--overlap_mask`、`--mask_ratio`、`--auto_augment`、`--erasing`、`--dropout`                                                        |
+| 损失权重       | `--box`、`--cls`、`--cls_pw`、`--dfl`、`--pose`、`--kobj`、`--rle`、`--angle`、`--dlog`、`--dgrad`、`--dlam`                        |
+| 蒸馏           | `--distill_model`、`--dis`                                                                                                          |
+| 保存与日志     | `--save`、`--save_period`、`--plots`、`--val`、`--verbose`、`--exist_ok`                                                            |
+
+数值支持小数和科学计数法；布尔值使用 `True` / `False`，大小写均可。
+列表和元组应使用引号，例如 `--freeze '[0,1,2]'`、`--classes '[0,2]'`、`--scale '(0.5,1.5)'`。
+混合类型参数沿用框架语义，例如 `--cache disk`、`--amp bf16`、`--pretrained False`。
+任务专属参数仅在对应任务中生效；设备相关功能也取决于框架和运行环境的支持。
+
+新增超参数未传入时不会作为命令行覆盖项传给模型；具体取值由框架默认配置、模型设置或续训检查点决定。
+帮助中的默认值来自 `ultralytics/cfg/default.yaml`；原有基础参数仍沿用脚本默认值。
+
+例如，手动指定优化器、学习率、增强和早停：
+
+```bash
+python tools/train.py --task detect --data coco8.yaml --epochs 100 --device 0 \
+    --optimizer AdamW --lr0 0.001 --lrf 0.01 --weight_decay 0.0005 \
+    --warmup_epochs 3 --cos_lr True --patience 30 --seed 42 \
+    --mosaic 1.0 --mixup 0.1 --close_mosaic 10 --amp True
+```
+
+希望手动控制学习率和动量时，应显式选择优化器；`--optimizer auto` 会由框架自动决定这些值。
+AutoBatch 依赖支持的训练设备；CPU、MPS 等环境可能回退到固定批次。
+
+对中断且仍保留优化器状态的训练，可使用原始 `last.pt` 续训：
+
+```bash
+python tools/train.py --model "/absolute/path/to/run/weights/last.pt" --resume True --device 0
+```
+
+续训由框架恢复原来的训练配置，部分命令行超参数不会覆盖检查点设置。
+训练已完成、被裁剪或没有优化器状态的权重不能按中断训练恢复；框架会提示并按其现有规则处理。
 
 ## 图片、视频与摄像头预测
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,6 +1,6 @@
 # 通用训练、验证与预测脚本
 
-三个独立 Python 脚本覆盖当前仓库支持的七类 YOLO 任务。在各脚本顶部修改配置后运行，无需命令行参数。
+三个独立 Python 脚本覆盖当前仓库支持的七类 YOLO 任务。通过 `--参数 值` 指定配置，无需修改脚本。
 脚本直接调用仓库的 `YOLO` 接口，数据读取、任务识别、指标计算和可视化均由框架处理。
 
 ## 安装与运行
@@ -11,23 +11,31 @@
 python -m pip install -e .
 ```
 
-分别运行需要的步骤：
+查看各脚本支持的参数：
 
 ```bash
-python tools/train.py
-python tools/val.py
-python tools/predict.py
+python tools/train.py --help
+python tools/val.py --help
+python tools/predict.py --help
 ```
 
-默认训练为 100 轮。首次检查流程时，先将 `train.py` 中 `ARGS` 的 `epochs` 改为 `1`。
+分别运行需要的步骤，例如使用示例数据进行一轮 CPU 训练：
+
+```bash
+python tools/train.py --task detect --epochs 1 --device cpu
+python tools/val.py --task detect --device cpu
+python tools/predict.py --task detect --device cpu
+```
+
+省略参数时沿用默认配置，训练默认 100 轮。以上验证和预测命令使用默认预训练模型；使用训练产物的方法见下文。
 默认模型和示例数据在本地缺失时会由框架下载，需要网络连接。
 
 ## 选择任务与数据
 
-每个脚本独立配置。保留 `MODEL = None`，修改 `TASK` 即可选择仓库内置模型。
-训练和验证的 `DATA = None` 使用加载后模型对应任务的示例数据：
+三个脚本均支持 `--task`，默认 `detect`。不传 `--model` 时，使用对应任务的仓库内置模型。
+训练和验证不传 `--data` 时，使用加载后模型对应任务的示例数据：
 
-| TASK       | 任务       | 默认模型           | 默认数据           |
+| --task     | 任务       | 默认模型           | 默认数据           |
 | ---------- | ---------- | ------------------ | ------------------ |
 | `detect`   | 目标检测   | `yolo26n.pt`       | `coco8.yaml`       |
 | `segment`  | 实例分割   | `yolo26n-seg.pt`   | `coco8-seg.yaml`   |
@@ -37,17 +45,15 @@ python tools/predict.py
 | `pose`     | 姿态估计   | `yolo26n-pose.pt`  | `coco8-pose.yaml`  |
 | `obb`      | 旋转框检测 | `yolo26n-obb.pt`   | `dota8.yaml`       |
 
-例如，训练实例分割只需修改 `train.py`：
+例如，使用自己的数据训练实例分割：
 
-```python
-TASK = "segment"
-MODEL = None
-DATA = "/absolute/path/to/dataset.yaml"
+```bash
+python tools/train.py --task segment --data "/absolute/path/to/dataset.yaml" --epochs 100 --batch 8 --device 0
 ```
 
-`MODEL` 也可以填写已有 `.pt` 权重；训练还支持模型 `.yaml`，从模型结构开始训练。
-指定模型后，任务由模型自身识别，`TASK` 仅在 `MODEL = None` 时选择默认模型。
-自定义数据必须匹配模型任务；使用自己的数据时，务必在训练和验证脚本中都填写 `DATA`。
+`--model` 可以指定已有 `.pt` 权重；训练还支持模型 `.yaml`，从模型结构开始训练。
+指定模型后，任务由模型自身识别，`--task` 仅在未指定模型时选择默认模型。
+自定义数据必须匹配模型任务；使用自己的数据时，务必在训练和验证命令中都传入 `--data`。
 
 数据格式按任务区分：
 
@@ -55,7 +61,7 @@ DATA = "/absolute/path/to/dataset.yaml"
 - `segment`：数据集 YAML 指向图片；对应 TXT 每行是类别及归一化多边形顶点。
 - `semantic`：数据集 YAML 指定图片与语义掩码配置；掩码像素值表示类别，格式参考 `cityscapes8.yaml`。
 - `depth`：数据集 YAML 指定 RGB 图片及深度配置；对应深度图为 16 位 PNG，`depth_scale` 指定米制换算比例，格式参考 `depth8.yaml`。
-- `classify`：`DATA` 是数据集目录，按 `train/类别名/图片` 和 `val/类别名/图片` 组织，无需数据集 YAML。
+- `classify`：`--data` 是数据集目录，按 `train/类别名/图片` 和 `val/类别名/图片` 组织，无需数据集 YAML。
 - `pose`：数据集 YAML 包含 `kpt_shape` 等配置；对应 TXT 包含类别、框及关键点，格式参考 `coco8-pose.yaml`。
 - `obb`：数据集 YAML 指向图片；对应 TXT 每行是类别及旋转框的四个归一化顶点。
 
@@ -64,43 +70,47 @@ DATA = "/absolute/path/to/dataset.yaml"
 
 ## 常用配置与输出
 
-直接修改脚本顶部的 `ARGS`：
+可通过命令行覆盖以下参数，`--help` 会列出当前脚本支持的选项：
 
-- `epochs`：训练轮数，默认 `100`。
-- `imgsz`：输入尺寸，默认 `640`；分类可按需改为 `224`。
-- `batch`：训练和验证批次大小，默认 `8`；内存不足时调小。
-- `workers`：数据加载进程数，默认 `0`，可按运行环境增加。
-- `device`：默认 `None`，由框架选择；可填写 `"cpu"`、`0`（CUDA）或 `"mps"`（Apple Silicon）。
-- `project`：默认 `None`，沿用框架的输出目录设置；相对项目名自动放在对应任务目录下，绝对路径直接作为项目目录。
-- `name`：本次输出子目录名，三个脚本分别默认为 `train`、`val`、`predict`。
-- `split`：验证数据划分，默认 `"val"`；仅在数据集提供相应划分时改用 `"test"`。
+- `--epochs`：训练轮数，整数，默认 `100`。
+- `--imgsz`：输入尺寸，整数，默认 `640`；分类可按需改为 `224`。
+- `--batch`：训练和验证批次大小，整数，默认 `8`；内存不足时调小。
+- `--workers`：训练和验证的数据加载进程数，整数，默认 `0`，可按运行环境增加。
+- `--device`：省略时由框架选择；可填写 `cpu`、`0`（CUDA）或 `mps`（Apple Silicon）。
+- `--project`：省略时沿用框架的输出目录设置；相对项目名自动放在对应任务目录下，绝对路径直接作为项目目录。
+- `--name`：本次输出子目录名，三个脚本分别默认为 `train`、`val`、`predict`。
+- `--split`：验证数据划分，默认 `val`，可选 `train`、`val`、`test`；数据集必须提供相应划分。
+
+布尔开关不需要附加 `True` 或 `False`：预测时使用 `--show` 开启窗口显示，使用 `--no-save` 关闭保存。
+未知参数、缺失参数值、非法整数和无效任务会在加载模型前由参数解析器报错。
 
 默认输出通常位于 `runs/<任务>/<模式>/`，实际根目录取决于 Ultralytics 的 `runs_dir` 设置。
 已有目录会自动递增，例如 `train-2`；以运行日志打印的实际路径为准。
-设置绝对 `project` 时，请在路径中自行区分任务，例如 `/absolute/path/to/runs/segment`。
+设置绝对 `--project` 时，请在路径中自行区分任务，例如 `/absolute/path/to/runs/segment`。
 
-训练结束会打印输出目录和最佳权重路径。将实际路径填入 `val.py` 和 `predict.py`：
+训练结束会打印输出目录和最佳权重路径。验证和预测时，将实际路径传给 `--model`：
 
-```python
-MODEL = "/absolute/path/to/runs/segment/train-2/weights/best.pt"
+```bash
+python tools/val.py --model "/absolute/path/to/runs/segment/train-2/weights/best.pt" --data "/absolute/path/to/dataset.yaml"
+python tools/predict.py --model "/absolute/path/to/runs/segment/train-2/weights/best.pt" --source "/absolute/path/to/image.jpg"
 ```
 
-同时在 `val.py` 中填写训练使用的 `DATA`，再运行验证和预测。路径可以包含空格。
+验证时传入训练使用的 `--data`。路径可以包含空格，按上例使用引号包裹；其他相对路径相对于运行命令的工作目录。
 验证输出 `metrics.results_dict`，由任务决定指标，例如检测 mAP、语义分割 mIoU、深度 delta1、分类准确率。
 
 ## 图片、视频与摄像头预测
 
-修改 `predict.py` 中的 `SOURCE`，例如：
+通过 `--source` 指定输入，例如：
 
-```python
-SOURCE = "/absolute/path/to/image.jpg"  # 单张图片
-SOURCE = "/absolute/path/to/images"  # 图片目录
-SOURCE = "/absolute/path/to/video.mp4"  # 视频
-SOURCE = 0  # 摄像头
+```bash
+python tools/predict.py --source "/absolute/path/to/image.jpg"
+python tools/predict.py --source "/absolute/path/to/images"
+python tools/predict.py --source "/absolute/path/to/video.mp4"
+python tools/predict.py --source 0 --show --no-save
 ```
 
-默认输入为仓库自带示例图片，`save=True` 保存可视化，`show=False` 不弹出窗口。
-需要实时查看时，将 `ARGS` 中的 `show` 改为 `True`；摄像头需要设备访问权限，按 Ctrl+C 停止。
+默认输入为仓库自带示例图片，保存可视化且不弹出窗口。
+需要实时查看时添加 `--show`；摄像头需要设备访问权限，按 Ctrl+C 停止。
 显示和视频保存使用框架及当前环境支持的后端。
 
 脚本逐个消费 `stream=True` 返回的 `Results`，避免将整段视频的预测结果保存在列表中。

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,109 @@
+# 通用训练、验证与预测脚本
+
+三个独立 Python 脚本覆盖当前仓库支持的七类 YOLO 任务。在各脚本顶部修改配置后运行，无需命令行参数。
+脚本直接调用仓库的 `YOLO` 接口，数据读取、任务识别、指标计算和可视化均由框架处理。
+
+## 安装与运行
+
+在当前仓库根目录激活 Python 环境，然后安装本地代码：
+
+```bash
+python -m pip install -e .
+```
+
+分别运行需要的步骤：
+
+```bash
+python tools/train.py
+python tools/val.py
+python tools/predict.py
+```
+
+默认训练为 100 轮。首次检查流程时，先将 `train.py` 中 `ARGS` 的 `epochs` 改为 `1`。
+默认模型和示例数据在本地缺失时会由框架下载，需要网络连接。
+
+## 选择任务与数据
+
+每个脚本独立配置。保留 `MODEL = None`，修改 `TASK` 即可选择仓库内置模型。
+训练和验证的 `DATA = None` 使用加载后模型对应任务的示例数据：
+
+| TASK       | 任务       | 默认模型           | 默认数据           |
+| ---------- | ---------- | ------------------ | ------------------ |
+| `detect`   | 目标检测   | `yolo26n.pt`       | `coco8.yaml`       |
+| `segment`  | 实例分割   | `yolo26n-seg.pt`   | `coco8-seg.yaml`   |
+| `semantic` | 语义分割   | `yolo26n-sem.pt`   | `cityscapes8.yaml` |
+| `depth`    | 深度估计   | `yolo26n-depth.pt` | `depth8.yaml`      |
+| `classify` | 图像分类   | `yolo26n-cls.pt`   | `imagenet10`       |
+| `pose`     | 姿态估计   | `yolo26n-pose.pt`  | `coco8-pose.yaml`  |
+| `obb`      | 旋转框检测 | `yolo26n-obb.pt`   | `dota8.yaml`       |
+
+例如，训练实例分割只需修改 `train.py`：
+
+```python
+TASK = "segment"
+MODEL = None
+DATA = "/absolute/path/to/dataset.yaml"
+```
+
+`MODEL` 也可以填写已有 `.pt` 权重；训练还支持模型 `.yaml`，从模型结构开始训练。
+指定模型后，任务由模型自身识别，`TASK` 仅在 `MODEL = None` 时选择默认模型。
+自定义数据必须匹配模型任务；使用自己的数据时，务必在训练和验证脚本中都填写 `DATA`。
+
+数据格式按任务区分：
+
+- `detect`：数据集 YAML 指向图片；对应 TXT 每行是类别及归一化的中心坐标、宽、高。
+- `segment`：数据集 YAML 指向图片；对应 TXT 每行是类别及归一化多边形顶点。
+- `semantic`：数据集 YAML 指定图片与语义掩码配置；掩码像素值表示类别，格式参考 `cityscapes8.yaml`。
+- `depth`：数据集 YAML 指定 RGB 图片及深度配置；对应深度图为 16 位 PNG，`depth_scale` 指定米制换算比例，格式参考 `depth8.yaml`。
+- `classify`：`DATA` 是数据集目录，按 `train/类别名/图片` 和 `val/类别名/图片` 组织，无需数据集 YAML。
+- `pose`：数据集 YAML 包含 `kpt_shape` 等配置；对应 TXT 包含类别、框及关键点，格式参考 `coco8-pose.yaml`。
+- `obb`：数据集 YAML 指向图片；对应 TXT 每行是类别及旋转框的四个归一化顶点。
+
+可复制 `ultralytics/cfg/datasets/` 内对应任务的示例 YAML，再修改路径与类别。
+自定义 YAML 建议使用绝对 `path`，其中 `train`、`val` 相对此数据集根目录解析；分类直接使用绝对目录路径。
+
+## 常用配置与输出
+
+直接修改脚本顶部的 `ARGS`：
+
+- `epochs`：训练轮数，默认 `100`。
+- `imgsz`：输入尺寸，默认 `640`；分类可按需改为 `224`。
+- `batch`：训练和验证批次大小，默认 `8`；内存不足时调小。
+- `workers`：数据加载进程数，默认 `0`，可按运行环境增加。
+- `device`：默认 `None`，由框架选择；可填写 `"cpu"`、`0`（CUDA）或 `"mps"`（Apple Silicon）。
+- `project`：默认 `None`，沿用框架的输出目录设置；相对项目名自动放在对应任务目录下，绝对路径直接作为项目目录。
+- `name`：本次输出子目录名，三个脚本分别默认为 `train`、`val`、`predict`。
+- `split`：验证数据划分，默认 `"val"`；仅在数据集提供相应划分时改用 `"test"`。
+
+默认输出通常位于 `runs/<任务>/<模式>/`，实际根目录取决于 Ultralytics 的 `runs_dir` 设置。
+已有目录会自动递增，例如 `train2`；以运行日志打印的实际路径为准。
+设置绝对 `project` 时，请在路径中自行区分任务，例如 `/absolute/path/to/runs/segment`。
+
+训练结束会打印输出目录和最佳权重路径。将实际路径填入 `val.py` 和 `predict.py`：
+
+```python
+MODEL = "/absolute/path/to/runs/segment/train2/weights/best.pt"
+```
+
+同时在 `val.py` 中填写训练使用的 `DATA`，再运行验证和预测。路径可以包含空格。
+验证输出 `metrics.results_dict`，由任务决定指标，例如检测 mAP、语义分割 mIoU、深度 delta1、分类准确率。
+
+## 图片、视频与摄像头预测
+
+修改 `predict.py` 中的 `SOURCE`，例如：
+
+```python
+SOURCE = "/absolute/path/to/image.jpg"  # 单张图片
+SOURCE = "/absolute/path/to/images"  # 图片目录
+SOURCE = "/absolute/path/to/video.mp4"  # 视频
+SOURCE = 0  # 摄像头
+```
+
+默认输入为仓库自带示例图片，`save=True` 保存可视化，`show=False` 不弹出窗口。
+需要实时查看时，将 `ARGS` 中的 `show` 改为 `True`；摄像头需要设备访问权限，按 Ctrl+C 停止。
+显示和视频保存使用框架及当前环境支持的后端。
+
+脚本逐个消费 `stream=True` 返回的 `Results`，避免将整段视频的预测结果保存在列表中。
+如需后续处理，可在循环内替换 `pass`，读取当前 `result` 的 `boxes`、`masks`、`semantic_mask`、
+`depth`、`probs`、`keypoints` 或 `obb`；可用字段取决于模型任务。
+默认仅保存框架生成的可视化图片或视频，不额外导出原始数组。

--- a/tools/README.md
+++ b/tools/README.md
@@ -76,13 +76,13 @@ DATA = "/absolute/path/to/dataset.yaml"
 - `split`：验证数据划分，默认 `"val"`；仅在数据集提供相应划分时改用 `"test"`。
 
 默认输出通常位于 `runs/<任务>/<模式>/`，实际根目录取决于 Ultralytics 的 `runs_dir` 设置。
-已有目录会自动递增，例如 `train2`；以运行日志打印的实际路径为准。
+已有目录会自动递增，例如 `train-2`；以运行日志打印的实际路径为准。
 设置绝对 `project` 时，请在路径中自行区分任务，例如 `/absolute/path/to/runs/segment`。
 
 训练结束会打印输出目录和最佳权重路径。将实际路径填入 `val.py` 和 `predict.py`：
 
 ```python
-MODEL = "/absolute/path/to/runs/segment/train2/weights/best.pt"
+MODEL = "/absolute/path/to/runs/segment/train-2/weights/best.pt"
 ```
 
 同时在 `val.py` 中填写训练使用的 `DATA`，再运行验证和预测。路径可以包含空格。

--- a/tools/detect.sh
+++ b/tools/detect.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+exec python "$SCRIPT_DIR/predict.py" --task detect "$@"

--- a/tools/detect.sh
+++ b/tools/detect.sh
@@ -3,4 +3,21 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-exec python "$SCRIPT_DIR/predict.py" --task detect "$@"
+
+# ========== 默认配置（按需修改，命令行同名参数会覆盖这里的值） ==========
+TASK="detect"
+MODEL="" # 可填 .pt 权重路径（如训练产出的 best.pt）；留空 "" 使用 TASK 对应的内置预训练模型
+SOURCE="$SCRIPT_DIR/../ultralytics/assets" # 可改为自己的图片、目录、视频或摄像头 0
+DEVICE="cpu"
+PROJECT="" # 输出项目目录：留空 "" 放在框架默认 runs/<任务>/ 下；相对名追加在任务目录后；绝对路径直接作为项目目录
+NAME="" # 输出子目录名：留空 "" 使用默认 predict；与已有目录重名时自动递增（如 predict-2）
+# ========================================================================
+
+exec python "$SCRIPT_DIR/predict.py" \
+    --task "$TASK" \
+    --model "$MODEL" \
+    --source "$SOURCE" \
+    --device "$DEVICE" \
+    --project "$PROJECT" \
+    --name "$NAME" \
+    "$@"

--- a/tools/detect.sh
+++ b/tools/detect.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 set -euo pipefail
 
@@ -6,18 +7,18 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 # ========== 默认配置（按需修改，命令行同名参数会覆盖这里的值） ==========
 TASK="detect"
-MODEL="" # 可填 .pt 权重路径（如训练产出的 best.pt）；留空 "" 使用 TASK 对应的内置预训练模型
+MODEL=""                                   # 可填 .pt 权重路径（如训练产出的 best.pt）；留空 "" 使用 TASK 对应的内置预训练模型
 SOURCE="$SCRIPT_DIR/../ultralytics/assets" # 可改为自己的图片、目录、视频或摄像头 0
 DEVICE="cpu"
 PROJECT="" # 输出项目目录：留空 "" 放在框架默认 runs/<任务>/ 下；相对名追加在任务目录后；绝对路径直接作为项目目录
-NAME="" # 输出子目录名：留空 "" 使用默认 predict；与已有目录重名时自动递增（如 predict-2）
+NAME=""    # 输出子目录名：留空 "" 使用默认 predict；与已有目录重名时自动递增（如 predict-2）
 # ========================================================================
 
 exec python "$SCRIPT_DIR/predict.py" \
-    --task "$TASK" \
-    --model "$MODEL" \
-    --source "$SOURCE" \
-    --device "$DEVICE" \
-    --project "$PROJECT" \
-    --name "$NAME" \
-    "$@"
+  --task "$TASK" \
+  --model "$MODEL" \
+  --source "$SOURCE" \
+  --device "$DEVICE" \
+  --project "$PROJECT" \
+  --name "$NAME" \
+  "$@"

--- a/tools/predict.py
+++ b/tools/predict.py
@@ -1,16 +1,26 @@
 """Predict images, videos, or camera streams with any supported YOLO task."""
 
+import argparse
+
 from ultralytics import YOLO
-from ultralytics.cfg import TASK2MODEL
+from ultralytics.cfg import TASK2MODEL, TASKS
 from ultralytics.utils import ASSETS
 
-TASK = "detect"
-MODEL = None  # Set to the actual best.pt path to predict with your trained model.
-SOURCE = ASSETS  # Image, directory, video path, stream URL, or 0 for a webcam.
-# device=None: framework default; "cpu", 0 (CUDA), or "mps" (Apple Silicon).
-ARGS = {"imgsz": 640, "device": None, "save": True, "show": False, "project": None, "name": "predict"}
+ARGS = {"imgsz": 640, "device": None, "project": None, "name": "predict"}
 
 if __name__ == "__main__":
-    model = YOLO(MODEL or TASK2MODEL[TASK])
-    for result in model.predict(source=SOURCE, stream=True, **ARGS):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--task", choices=TASKS, default="detect", help="Default model task (default: detect)")
+    parser.add_argument("--model", help="Model checkpoint, e.g. the actual best.pt path; defaults to the task model")
+    parser.add_argument("--source", default=str(ASSETS), help="Image, directory, video, stream URL, or 0 for a webcam")
+    parser.add_argument("--no-save", dest="save", action="store_false", help="Disable saving visualizations")
+    parser.add_argument("--show", action="store_true", help="Display predictions in a window")
+    for key, default in ARGS.items():
+        parser.add_argument(
+            f"--{key}", type=type(default) if default is not None else str, default=default, help="Default: %(default)s"
+        )
+    args = vars(parser.parse_args())
+    task = args.pop("task")
+    model = YOLO(args.pop("model") or TASK2MODEL[task])
+    for result in model.predict(stream=True, **args):
         pass  # Consume every result to run inference and save visualizations.

--- a/tools/predict.py
+++ b/tools/predict.py
@@ -1,0 +1,16 @@
+"""Predict images, videos, or camera streams with any supported YOLO task."""
+
+from ultralytics import YOLO
+from ultralytics.cfg import TASK2MODEL
+from ultralytics.utils import ASSETS
+
+TASK = "detect"
+MODEL = None  # Set to the actual best.pt path to predict with your trained model.
+SOURCE = ASSETS  # Image, directory, video path, stream URL, or 0 for a webcam.
+# device=None: framework default; "cpu", 0 (CUDA), or "mps" (Apple Silicon).
+ARGS = {"imgsz": 640, "device": None, "save": True, "show": False, "project": None, "name": "predict"}
+
+if __name__ == "__main__":
+    model = YOLO(MODEL or TASK2MODEL[TASK])
+    for result in model.predict(source=SOURCE, stream=True, **ARGS):
+        pass  # Consume every result to run inference and save visualizations.

--- a/tools/predict.py
+++ b/tools/predict.py
@@ -1,3 +1,4 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 """Predict images, videos, or camera streams with any supported YOLO task."""
 
 import argparse

--- a/tools/train.py
+++ b/tools/train.py
@@ -1,3 +1,4 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 """Train any supported YOLO task with command-line arguments."""
 
 import argparse

--- a/tools/train.py
+++ b/tools/train.py
@@ -1,0 +1,16 @@
+"""Train any supported YOLO task by editing the configuration below."""
+
+from ultralytics import YOLO
+from ultralytics.cfg import TASK2DATA, TASK2MODEL
+
+TASK = "detect"
+MODEL = None  # None: task default; otherwise a .pt checkpoint or model .yaml path.
+DATA = None  # None: task demo data; otherwise dataset YAML or classification directory.
+# device=None: framework default; "cpu", 0 (CUDA), or "mps" (Apple Silicon).
+ARGS = {"epochs": 100, "imgsz": 640, "batch": 8, "workers": 0, "device": None, "project": None, "name": "train"}
+
+if __name__ == "__main__":
+    model = YOLO(MODEL or TASK2MODEL[TASK])
+    model.train(data=DATA or TASK2DATA[model.task], **ARGS)
+    print(f"Training output: {model.trainer.save_dir}")
+    print(f"Best weights: {model.trainer.best}")

--- a/tools/train.py
+++ b/tools/train.py
@@ -1,16 +1,24 @@
-"""Train any supported YOLO task by editing the configuration below."""
+"""Train any supported YOLO task with command-line arguments."""
+
+import argparse
 
 from ultralytics import YOLO
-from ultralytics.cfg import TASK2DATA, TASK2MODEL
+from ultralytics.cfg import TASK2DATA, TASK2MODEL, TASKS
 
-TASK = "detect"
-MODEL = None  # None: task default; otherwise a .pt checkpoint or model .yaml path.
-DATA = None  # None: task demo data; otherwise dataset YAML or classification directory.
-# device=None: framework default; "cpu", 0 (CUDA), or "mps" (Apple Silicon).
 ARGS = {"epochs": 100, "imgsz": 640, "batch": 8, "workers": 0, "device": None, "project": None, "name": "train"}
 
 if __name__ == "__main__":
-    model = YOLO(MODEL or TASK2MODEL[TASK])
-    model.train(data=DATA or TASK2DATA[model.task], **ARGS)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--task", choices=TASKS, default="detect", help="Default model task (default: detect)")
+    parser.add_argument("--model", help="Model checkpoint (.pt) or architecture (.yaml); defaults to the task model")
+    parser.add_argument("--data", help="Dataset YAML or classification directory (default: model task demo data)")
+    for key, default in ARGS.items():
+        parser.add_argument(
+            f"--{key}", type=type(default) if default is not None else str, default=default, help="Default: %(default)s"
+        )
+    args = vars(parser.parse_args())
+    task = args.pop("task")
+    model = YOLO(args.pop("model") or TASK2MODEL[task])
+    model.train(data=args.pop("data") or TASK2DATA[model.task], **args)
     print(f"Training output: {model.trainer.save_dir}")
     print(f"Best weights: {model.trainer.best}")

--- a/tools/train.py
+++ b/tools/train.py
@@ -3,20 +3,47 @@
 import argparse
 
 from ultralytics import YOLO
-from ultralytics.cfg import TASK2DATA, TASK2MODEL, TASKS
+from ultralytics.cfg import DEFAULT_CFG_DICT, TASK2DATA, TASK2MODEL, TASKS, check_cfg, smart_value
 
-ARGS = {"epochs": 100, "imgsz": 640, "batch": 8, "workers": 0, "device": None, "project": None, "name": "train"}
+ARGS = {"epochs": 100, "imgsz": 640, "workers": 0, "device": None, "project": None, "name": "train"}
+HYPERPARAMETERS = {
+    "Optimizer and learning rate": (
+        "optimizer lr0 lrf momentum weight_decay warmup_epochs warmup_momentum warmup_bias_lr cos_lr nbs"
+    ),
+    "Training controls": "patience time seed deterministic amp cache freeze resume pretrained",
+    "Data and performance": "fraction rect single_cls classes multi_scale compile channels_last cls_remap",
+    "Augmentation": (
+        "hsv_h hsv_s hsv_v degrees translate scale shear perspective flipud fliplr bgr mosaic mixup cutmix "
+        "copy_paste copy_paste_mode close_mosaic"
+    ),
+    "Segmentation and classification": "auto_augment erasing dropout overlap_mask mask_ratio",
+    "Loss weights and distillation": "box cls cls_pw dfl pose kobj rle angle dlog dgrad dlam distill_model dis",
+    "Saving and logging": "verbose save save_period plots val exist_ok",
+}
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--task", choices=TASKS, default="detect", help="Default model task (default: detect)")
     parser.add_argument("--model", help="Model checkpoint (.pt) or architecture (.yaml); defaults to the task model")
     parser.add_argument("--data", help="Dataset YAML or classification directory (default: model task demo data)")
+    parser.add_argument(
+        "--batch", type=smart_value, default=8, help="Batch size, -1, or AutoBatch fraction (default: 8)"
+    )
     for key, default in ARGS.items():
         parser.add_argument(
             f"--{key}", type=type(default) if default is not None else str, default=default, help="Default: %(default)s"
         )
+    for title, keys in HYPERPARAMETERS.items():
+        group = parser.add_argument_group(title)
+        for key in keys.split():
+            group.add_argument(
+                f"--{key}",
+                type=smart_value,
+                default=argparse.SUPPRESS,
+                help=f"Framework default: {DEFAULT_CFG_DICT[key]!r}; accepts Python literals, True/False, or strings",
+            )
     args = vars(parser.parse_args())
+    check_cfg(args)
     task = args.pop("task")
     model = YOLO(args.pop("model") or TASK2MODEL[task])
     model.train(data=args.pop("data") or TASK2DATA[model.task], **args)

--- a/tools/train.sh
+++ b/tools/train.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 set -euo pipefail
 
@@ -10,13 +11,13 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 # 基础
 TASK="detect"
-MODEL="" # 预训练权重或架构：.pt 检查点（如自己训出的 best.pt）或 .yaml；留空 "" 使用 TASK 对应的内置预训练模型
+MODEL=""          # 预训练权重或架构：.pt 检查点（如自己训出的 best.pt）或 .yaml；留空 "" 使用 TASK 对应的内置预训练模型
 DATA="coco8.yaml" # 需与 TASK 匹配，可改为自己的数据集 YAML 绝对路径
 EPOCHS=100
 BATCH=8
 DEVICE="cpu"
 PROJECT="fire-smoke" # 输出项目目录：留空 "" 放在框架默认 runs/<任务>/ 下；相对名追加在任务目录后；绝对路径直接作为项目目录
-NAME="test" # 输出子目录名：留空 "" 使用默认 train；与已有目录重名时自动递增（如 train-2）
+NAME="test"          # 输出子目录名：留空 "" 使用默认 train；与已有目录重名时自动递增（如 train-2）
 
 # 优化器与学习率
 OPTIMIZER="auto"
@@ -106,80 +107,80 @@ EXIST_OK=False
 # ==========================================================================================
 
 exec python "$SCRIPT_DIR/train.py" \
-    --task "$TASK" \
-    --model "$MODEL" \
-    --data "$DATA" \
-    --epochs "$EPOCHS" \
-    --batch "$BATCH" \
-    --device "$DEVICE" \
-    --project "$PROJECT" \
-    --name "$NAME" \
-    --optimizer "$OPTIMIZER" \
-    --lr0 "$LR0" \
-    --lrf "$LRF" \
-    --momentum "$MOMENTUM" \
-    --weight_decay "$WEIGHT_DECAY" \
-    --cos_lr "$COS_LR" \
-    --nbs "$NBS" \
-    --warmup_epochs "$WARMUP_EPOCHS" \
-    --warmup_momentum "$WARMUP_MOMENTUM" \
-    --warmup_bias_lr "$WARMUP_BIAS_LR" \
-    --patience "$PATIENCE" \
-    --time "$TIME" \
-    --seed "$SEED" \
-    --deterministic "$DETERMINISTIC" \
-    --amp "$AMP" \
-    --cache "$CACHE" \
-    --freeze "$FREEZE" \
-    --resume "$RESUME" \
-    --pretrained "$PRETRAINED" \
-    --fraction "$FRACTION" \
-    --rect "$RECT" \
-    --single_cls "$SINGLE_CLS" \
-    --classes "$CLASSES" \
-    --multi_scale "$MULTI_SCALE" \
-    --compile "$COMPILE" \
-    --channels_last "$CHANNELS_LAST" \
-    --cls_remap "$CLS_REMAP" \
-    --hsv_h "$HSV_H" \
-    --hsv_s "$HSV_S" \
-    --hsv_v "$HSV_V" \
-    --degrees "$DEGREES" \
-    --translate "$TRANSLATE" \
-    --scale "$SCALE" \
-    --shear "$SHEAR" \
-    --perspective "$PERSPECTIVE" \
-    --flipud "$FLIPUD" \
-    --fliplr "$FLIPLR" \
-    --bgr "$BGR" \
-    --mosaic "$MOSAIC" \
-    --mixup "$MIXUP" \
-    --cutmix "$CUTMIX" \
-    --copy_paste "$COPY_PASTE" \
-    --copy_paste_mode "$COPY_PASTE_MODE" \
-    --close_mosaic "$CLOSE_MOSAIC" \
-    --auto_augment "$AUTO_AUGMENT" \
-    --erasing "$ERASING" \
-    --dropout "$DROPOUT" \
-    --overlap_mask "$OVERLAP_MASK" \
-    --mask_ratio "$MASK_RATIO" \
-    --box "$BOX" \
-    --cls "$CLS" \
-    --cls_pw "$CLS_PW" \
-    --dfl "$DFL" \
-    --pose "$POSE" \
-    --kobj "$KOBJ" \
-    --rle "$RLE" \
-    --angle "$ANGLE" \
-    --dlog "$DLOG" \
-    --dgrad "$DGRAD" \
-    --dlam "$DLAM" \
-    --distill_model "$DISTILL_MODEL" \
-    --dis "$DIS" \
-    --verbose "$VERBOSE" \
-    --save "$SAVE" \
-    --save_period "$SAVE_PERIOD" \
-    --plots "$PLOTS" \
-    --val "$VAL" \
-    --exist_ok "$EXIST_OK" \
-    "$@"
+  --task "$TASK" \
+  --model "$MODEL" \
+  --data "$DATA" \
+  --epochs "$EPOCHS" \
+  --batch "$BATCH" \
+  --device "$DEVICE" \
+  --project "$PROJECT" \
+  --name "$NAME" \
+  --optimizer "$OPTIMIZER" \
+  --lr0 "$LR0" \
+  --lrf "$LRF" \
+  --momentum "$MOMENTUM" \
+  --weight_decay "$WEIGHT_DECAY" \
+  --cos_lr "$COS_LR" \
+  --nbs "$NBS" \
+  --warmup_epochs "$WARMUP_EPOCHS" \
+  --warmup_momentum "$WARMUP_MOMENTUM" \
+  --warmup_bias_lr "$WARMUP_BIAS_LR" \
+  --patience "$PATIENCE" \
+  --time "$TIME" \
+  --seed "$SEED" \
+  --deterministic "$DETERMINISTIC" \
+  --amp "$AMP" \
+  --cache "$CACHE" \
+  --freeze "$FREEZE" \
+  --resume "$RESUME" \
+  --pretrained "$PRETRAINED" \
+  --fraction "$FRACTION" \
+  --rect "$RECT" \
+  --single_cls "$SINGLE_CLS" \
+  --classes "$CLASSES" \
+  --multi_scale "$MULTI_SCALE" \
+  --compile "$COMPILE" \
+  --channels_last "$CHANNELS_LAST" \
+  --cls_remap "$CLS_REMAP" \
+  --hsv_h "$HSV_H" \
+  --hsv_s "$HSV_S" \
+  --hsv_v "$HSV_V" \
+  --degrees "$DEGREES" \
+  --translate "$TRANSLATE" \
+  --scale "$SCALE" \
+  --shear "$SHEAR" \
+  --perspective "$PERSPECTIVE" \
+  --flipud "$FLIPUD" \
+  --fliplr "$FLIPLR" \
+  --bgr "$BGR" \
+  --mosaic "$MOSAIC" \
+  --mixup "$MIXUP" \
+  --cutmix "$CUTMIX" \
+  --copy_paste "$COPY_PASTE" \
+  --copy_paste_mode "$COPY_PASTE_MODE" \
+  --close_mosaic "$CLOSE_MOSAIC" \
+  --auto_augment "$AUTO_AUGMENT" \
+  --erasing "$ERASING" \
+  --dropout "$DROPOUT" \
+  --overlap_mask "$OVERLAP_MASK" \
+  --mask_ratio "$MASK_RATIO" \
+  --box "$BOX" \
+  --cls "$CLS" \
+  --cls_pw "$CLS_PW" \
+  --dfl "$DFL" \
+  --pose "$POSE" \
+  --kobj "$KOBJ" \
+  --rle "$RLE" \
+  --angle "$ANGLE" \
+  --dlog "$DLOG" \
+  --dgrad "$DGRAD" \
+  --dlam "$DLAM" \
+  --distill_model "$DISTILL_MODEL" \
+  --dis "$DIS" \
+  --verbose "$VERBOSE" \
+  --save "$SAVE" \
+  --save_period "$SAVE_PERIOD" \
+  --plots "$PLOTS" \
+  --val "$VAL" \
+  --exist_ok "$EXIST_OK" \
+  "$@"

--- a/tools/train.sh
+++ b/tools/train.sh
@@ -3,4 +3,183 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-exec python "$SCRIPT_DIR/train.py" "$@"
+
+# ==================== 默认配置（按需修改，命令行同名参数会覆盖这里的值） ====================
+# None 表示沿用框架的可选默认（不强制设置），如 TIME、FREEZE、CLASSES、DISTILL_MODEL。
+# 各项取值与 ultralytics/cfg/default.yaml 保持一致；修改后会作为命令行覆盖项传入。
+
+# 基础
+TASK="detect"
+MODEL="" # 预训练权重或架构：.pt 检查点（如自己训出的 best.pt）或 .yaml；留空 "" 使用 TASK 对应的内置预训练模型
+DATA="coco8.yaml" # 需与 TASK 匹配，可改为自己的数据集 YAML 绝对路径
+EPOCHS=100
+BATCH=8
+DEVICE="cpu"
+PROJECT="fire-smoke" # 输出项目目录：留空 "" 放在框架默认 runs/<任务>/ 下；相对名追加在任务目录后；绝对路径直接作为项目目录
+NAME="test" # 输出子目录名：留空 "" 使用默认 train；与已有目录重名时自动递增（如 train-2）
+
+# 优化器与学习率
+OPTIMIZER="auto"
+LR0=0.01
+LRF=0.01
+MOMENTUM=0.937
+WEIGHT_DECAY=0.0005
+COS_LR=False
+NBS=64
+
+# 预热
+WARMUP_EPOCHS=3.0
+WARMUP_MOMENTUM=0.8
+WARMUP_BIAS_LR=0.1
+
+# 训练控制
+PATIENCE=100
+TIME=None
+SEED=0
+DETERMINISTIC=True
+AMP=True
+CACHE=False
+FREEZE=None
+RESUME=False
+PRETRAINED=True
+
+# 数据与性能
+FRACTION=1.0
+RECT=False
+SINGLE_CLS=False
+CLASSES=None
+MULTI_SCALE=0.0
+COMPILE=False
+CHANNELS_LAST=None
+CLS_REMAP=True
+
+# 色彩与几何增强
+HSV_H=0.015
+HSV_S=0.7
+HSV_V=0.4
+DEGREES=0.0
+TRANSLATE=0.1
+SCALE=0.5
+SHEAR=0.0
+PERSPECTIVE=0.0
+FLIPUD=0.0
+FLIPLR=0.5
+BGR=0.0
+
+# 样本混合增强
+MOSAIC=1.0
+MIXUP=0.0
+CUTMIX=0.0
+COPY_PASTE=0.0
+COPY_PASTE_MODE="flip"
+CLOSE_MOSAIC=10
+
+# 分割与分类
+AUTO_AUGMENT="randaugment"
+ERASING=0.4
+DROPOUT=0.0
+OVERLAP_MASK=True
+MASK_RATIO=4
+
+# 损失权重与蒸馏
+BOX=7.5
+CLS=0.5
+CLS_PW=0.0
+DFL=1.5
+POSE=12.0
+KOBJ=1.0
+RLE=1.0
+ANGLE=1.0
+DLOG=1.0
+DGRAD=0.5
+DLAM=1.0
+DISTILL_MODEL=None
+DIS=6.0
+
+# 保存与日志
+VERBOSE=True
+SAVE=True
+SAVE_PERIOD=-1
+PLOTS=True
+VAL=True
+EXIST_OK=False
+# ==========================================================================================
+
+exec python "$SCRIPT_DIR/train.py" \
+    --task "$TASK" \
+    --model "$MODEL" \
+    --data "$DATA" \
+    --epochs "$EPOCHS" \
+    --batch "$BATCH" \
+    --device "$DEVICE" \
+    --project "$PROJECT" \
+    --name "$NAME" \
+    --optimizer "$OPTIMIZER" \
+    --lr0 "$LR0" \
+    --lrf "$LRF" \
+    --momentum "$MOMENTUM" \
+    --weight_decay "$WEIGHT_DECAY" \
+    --cos_lr "$COS_LR" \
+    --nbs "$NBS" \
+    --warmup_epochs "$WARMUP_EPOCHS" \
+    --warmup_momentum "$WARMUP_MOMENTUM" \
+    --warmup_bias_lr "$WARMUP_BIAS_LR" \
+    --patience "$PATIENCE" \
+    --time "$TIME" \
+    --seed "$SEED" \
+    --deterministic "$DETERMINISTIC" \
+    --amp "$AMP" \
+    --cache "$CACHE" \
+    --freeze "$FREEZE" \
+    --resume "$RESUME" \
+    --pretrained "$PRETRAINED" \
+    --fraction "$FRACTION" \
+    --rect "$RECT" \
+    --single_cls "$SINGLE_CLS" \
+    --classes "$CLASSES" \
+    --multi_scale "$MULTI_SCALE" \
+    --compile "$COMPILE" \
+    --channels_last "$CHANNELS_LAST" \
+    --cls_remap "$CLS_REMAP" \
+    --hsv_h "$HSV_H" \
+    --hsv_s "$HSV_S" \
+    --hsv_v "$HSV_V" \
+    --degrees "$DEGREES" \
+    --translate "$TRANSLATE" \
+    --scale "$SCALE" \
+    --shear "$SHEAR" \
+    --perspective "$PERSPECTIVE" \
+    --flipud "$FLIPUD" \
+    --fliplr "$FLIPLR" \
+    --bgr "$BGR" \
+    --mosaic "$MOSAIC" \
+    --mixup "$MIXUP" \
+    --cutmix "$CUTMIX" \
+    --copy_paste "$COPY_PASTE" \
+    --copy_paste_mode "$COPY_PASTE_MODE" \
+    --close_mosaic "$CLOSE_MOSAIC" \
+    --auto_augment "$AUTO_AUGMENT" \
+    --erasing "$ERASING" \
+    --dropout "$DROPOUT" \
+    --overlap_mask "$OVERLAP_MASK" \
+    --mask_ratio "$MASK_RATIO" \
+    --box "$BOX" \
+    --cls "$CLS" \
+    --cls_pw "$CLS_PW" \
+    --dfl "$DFL" \
+    --pose "$POSE" \
+    --kobj "$KOBJ" \
+    --rle "$RLE" \
+    --angle "$ANGLE" \
+    --dlog "$DLOG" \
+    --dgrad "$DGRAD" \
+    --dlam "$DLAM" \
+    --distill_model "$DISTILL_MODEL" \
+    --dis "$DIS" \
+    --verbose "$VERBOSE" \
+    --save "$SAVE" \
+    --save_period "$SAVE_PERIOD" \
+    --plots "$PLOTS" \
+    --val "$VAL" \
+    --exist_ok "$EXIST_OK" \
+    "$@"

--- a/tools/train.sh
+++ b/tools/train.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+exec python "$SCRIPT_DIR/train.py" "$@"

--- a/tools/val.py
+++ b/tools/val.py
@@ -1,0 +1,15 @@
+"""Validate any supported YOLO task by editing the configuration below."""
+
+from ultralytics import YOLO
+from ultralytics.cfg import TASK2DATA, TASK2MODEL
+
+TASK = "detect"
+MODEL = None  # Set to the actual best.pt path to validate your trained model.
+DATA = None  # Set to your training dataset YAML or classification directory.
+# device=None: framework default; "cpu", 0 (CUDA), or "mps" (Apple Silicon).
+ARGS = {"split": "val", "imgsz": 640, "batch": 8, "workers": 0, "device": None, "project": None, "name": "val"}
+
+if __name__ == "__main__":
+    model = YOLO(MODEL or TASK2MODEL[TASK])
+    metrics = model.val(data=DATA or TASK2DATA[model.task], **ARGS)
+    print(metrics.results_dict)

--- a/tools/val.py
+++ b/tools/val.py
@@ -1,15 +1,24 @@
-"""Validate any supported YOLO task by editing the configuration below."""
+"""Validate any supported YOLO task with command-line arguments."""
+
+import argparse
 
 from ultralytics import YOLO
-from ultralytics.cfg import TASK2DATA, TASK2MODEL
+from ultralytics.cfg import TASK2DATA, TASK2MODEL, TASKS
 
-TASK = "detect"
-MODEL = None  # Set to the actual best.pt path to validate your trained model.
-DATA = None  # Set to your training dataset YAML or classification directory.
-# device=None: framework default; "cpu", 0 (CUDA), or "mps" (Apple Silicon).
-ARGS = {"split": "val", "imgsz": 640, "batch": 8, "workers": 0, "device": None, "project": None, "name": "val"}
+ARGS = {"imgsz": 640, "batch": 8, "workers": 0, "device": None, "project": None, "name": "val"}
 
 if __name__ == "__main__":
-    model = YOLO(MODEL or TASK2MODEL[TASK])
-    metrics = model.val(data=DATA or TASK2DATA[model.task], **ARGS)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--task", choices=TASKS, default="detect", help="Default model task (default: detect)")
+    parser.add_argument("--model", help="Model checkpoint, e.g. the actual best.pt path; defaults to the task model")
+    parser.add_argument("--data", help="Dataset YAML or classification directory (default: model task demo data)")
+    parser.add_argument("--split", choices=("train", "val", "test"), default="val", help="Dataset split (default: val)")
+    for key, default in ARGS.items():
+        parser.add_argument(
+            f"--{key}", type=type(default) if default is not None else str, default=default, help="Default: %(default)s"
+        )
+    args = vars(parser.parse_args())
+    task = args.pop("task")
+    model = YOLO(args.pop("model") or TASK2MODEL[task])
+    metrics = model.val(data=args.pop("data") or TASK2DATA[model.task], **args)
     print(metrics.results_dict)

--- a/tools/val.py
+++ b/tools/val.py
@@ -1,3 +1,4 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 """Validate any supported YOLO task with command-line arguments."""
 
 import argparse

--- a/tools/val.sh
+++ b/tools/val.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 set -euo pipefail
 
@@ -6,18 +7,18 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 # ========== 默认配置（按需修改，命令行同名参数会覆盖这里的值） ==========
 TASK="detect"
-MODEL="" # 可填 .pt 权重路径（如训练产出的 best.pt）；留空 "" 使用 TASK 对应的内置预训练模型
+MODEL=""          # 可填 .pt 权重路径（如训练产出的 best.pt）；留空 "" 使用 TASK 对应的内置预训练模型
 DATA="coco8.yaml" # 需与 TASK 匹配，可改为自己的数据集 YAML 绝对路径
 DEVICE="cpu"
 PROJECT="" # 输出项目目录：留空 "" 放在框架默认 runs/<任务>/ 下；相对名追加在任务目录后；绝对路径直接作为项目目录
-NAME="" # 输出子目录名：留空 "" 使用默认 val；与已有目录重名时自动递增（如 val-2）
+NAME=""    # 输出子目录名：留空 "" 使用默认 val；与已有目录重名时自动递增（如 val-2）
 # ========================================================================
 
 exec python "$SCRIPT_DIR/val.py" \
-    --task "$TASK" \
-    --model "$MODEL" \
-    --data "$DATA" \
-    --device "$DEVICE" \
-    --project "$PROJECT" \
-    --name "$NAME" \
-    "$@"
+  --task "$TASK" \
+  --model "$MODEL" \
+  --data "$DATA" \
+  --device "$DEVICE" \
+  --project "$PROJECT" \
+  --name "$NAME" \
+  "$@"

--- a/tools/val.sh
+++ b/tools/val.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+exec python "$SCRIPT_DIR/val.py" "$@"

--- a/tools/val.sh
+++ b/tools/val.sh
@@ -3,4 +3,21 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-exec python "$SCRIPT_DIR/val.py" "$@"
+
+# ========== 默认配置（按需修改，命令行同名参数会覆盖这里的值） ==========
+TASK="detect"
+MODEL="" # 可填 .pt 权重路径（如训练产出的 best.pt）；留空 "" 使用 TASK 对应的内置预训练模型
+DATA="coco8.yaml" # 需与 TASK 匹配，可改为自己的数据集 YAML 绝对路径
+DEVICE="cpu"
+PROJECT="" # 输出项目目录：留空 "" 放在框架默认 runs/<任务>/ 下；相对名追加在任务目录后；绝对路径直接作为项目目录
+NAME="" # 输出子目录名：留空 "" 使用默认 val；与已有目录重名时自动递增（如 val-2）
+# ========================================================================
+
+exec python "$SCRIPT_DIR/val.py" \
+    --task "$TASK" \
+    --model "$MODEL" \
+    --data "$DATA" \
+    --device "$DEVICE" \
+    --project "$PROJECT" \
+    --name "$NAME" \
+    "$@"


### PR DESCRIPTION
Add configurable defaults to tools shell launchers

train.sh / val.sh / detect.sh 顶部新增逐行配置区（TASK、MODEL、DATA/SOURCE、EPOCHS、BATCH、DEVICE、PROJECT、NAME），合并透传给 Python 脚本；命令行同名参数覆盖配置值
train.sh 按 README「训练超参数」表补齐全部 68 个超参数，取值同 ultralytics/cfg/default.yaml，可选参数以 None 表示沿用框架默认
README 同步更新 shell 脚本用法说明

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds configurable shell launchers for training, validation, and prediction, with documented defaults and command-line overrides for common workflows.

### 📊 Key Changes
- Added `tools/train.sh`, `tools/val.sh`, and `tools/detect.sh` with editable configuration sections for task, model, data or source, runtime settings, output paths, and command-specific options.
- Added Python CLI tools for training, validation, and prediction, including task-based model and dataset selection and framework-backed argument validation.
- Added comprehensive training hyperparameter forwarding in `train.sh`, including optional `None` values and command-line precedence.
- Added `tools/README.md` covering installation, supported tasks, data formats, configuration, outputs, training options, resume workflows, and image/video/camera prediction.

### 🎯 Purpose & Impact
Users can run the tool scripts with repository-defined defaults, customize persistent settings at the top of each shell script, or temporarily override them with command-line arguments; the new README documents these workflows and supported options.