### PR TITLE
List SAM 3.1 as the default Platform smart annotation model

### DIFF
--- a/docs/en/models/index.md
+++ b/docs/en/models/index.md
@@ -1,7 +1,7 @@
 ---
 comments: true
 description: Discover a variety of models supported by Ultralytics, including YOLO26 back to YOLOv3, NAS, SAM, and RT-DETR for detection, segmentation, semantic segmentation, depth estimation, and more.
-keywords: Ultralytics, supported models, YOLO26, YOLO12, YOLO11, YOLOv10, YOLOv9, YOLOv8, YOLOv7, YOLOv6, YOLOv5, YOLOv4, YOLOv3, SAM3, SAM2, SAM, MobileSAM, FastSAM, YOLO-NAS, RT-DETR, YOLO-World, YOLOE, object detection, image segmentation, semantic segmentation, depth estimation, classification, pose estimation, multi-object tracking
+keywords: Ultralytics, supported models, YOLO26, YOLO12, YOLO11, YOLOv10, YOLOv9, YOLOv8, YOLOv7, YOLOv6, YOLOv5, YOLOv4, YOLOv3, SAM3.1, SAM3, SAM2, SAM, MobileSAM, FastSAM, YOLO-NAS, RT-DETR, YOLO-World, YOLOE, object detection, image segmentation, semantic segmentation, depth estimation, classification, pose estimation, multi-object tracking
 ---
 
 # Models Supported by Ultralytics

--- a/docs/en/models/sam-3.md
+++ b/docs/en/models/sam-3.md
@@ -617,7 +617,11 @@ SAM 3 was released by Meta on **November 19, 2025** and is fully integrated into
 
 ### Is SAM 3 Integrated Into Ultralytics?
 
-Yes! SAM 3 is fully integrated into the Ultralytics Python package, including concept segmentation, SAM 2–style visual prompts, and multi-object video tracking. SAM 3 also powers the [smart annotation](../platform/data/annotation.md) feature on [Ultralytics Platform](https://platform.ultralytics.com), where you can annotate images with just a few clicks.
+Yes! SAM 3 is fully integrated into the Ultralytics Python package, including concept segmentation, SAM 2–style visual prompts, and multi-object video tracking. SAM 3 and SAM 3.1 also power the [smart annotation](../platform/data/annotation.md) feature on [Ultralytics Platform](https://platform.ultralytics.com), where SAM 3.1 is the default model and you can annotate images with just a few clicks.
+
+### Does Ultralytics support SAM 3.1?
+
+Yes, for image prediction. Load `sam3.1_multiplex.pt` wherever the image examples on this page use `sam3.pt`: `SAM("sam3.1_multiplex.pt")` for point and box prompts, and `SAM3SemanticPredictor` for text and exemplar prompts. Object Multiplex video tracking is not supported yet, so keep using `sam3.pt` with the video predictors. See [SAM 3.1](#sam-31) for Meta's benchmarks.
 
 ### What Is Promptable Concept Segmentation (PCS)?
 

--- a/docs/en/platform/account/billing.md
+++ b/docs/en/platform/account/billing.md
@@ -32,7 +32,7 @@ Get started at no cost:
 - 3 cloud deployments
 - 100 GB storage · 10 GB dataset upload limit
 - Model export to all 20 formats
-- Manual, SAM3, and YOLO Smart annotation
+- Manual, SAM 3.1, and YOLO Smart annotation
 - 24 cloud GPU types including 5090, H100 & H200 ($0.24–$4.39/hr)
 - Community support
 

--- a/docs/en/platform/data/annotation.md
+++ b/docs/en/platform/data/annotation.md
@@ -310,7 +310,7 @@ Auto-apply mode speeds up Smart annotation by automatically saving the SAM mask 
 
 #### SAM Model Selection
 
-When Smart mode is active, a model picker appears in the toolbar. Five SAM models are available — choose based on the speed vs. accuracy trade-off that suits your dataset:
+When Smart mode is active, a model picker appears in the toolbar. Six SAM models are available — choose based on the speed vs. accuracy trade-off that suits your dataset:
 
 | Model             | Size    | Speed    | Notes                      |
 | ----------------- | ------- | -------- | -------------------------- |
@@ -318,7 +318,8 @@ When Smart mode is active, a model picker appears in the toolbar. Five SAM model
 | **SAM 2.1 Small** | 88 MB   | Fast     |                            |
 | **SAM 2.1 Base**  | 154 MB  | Moderate |                            |
 | **SAM 2.1 Large** | 428 MB  | Slower   | Most accurate of SAM 2.1   |
-| **SAM 3**         | 3.45 GB | Slowest  | Default, latest generation |
+| **SAM 3**         | 3.45 GB | Slowest  |                            |
+| **SAM 3.1**       | 3.50 GB | Slowest  | Default, latest generation |
 
 ![Ultralytics Platform Annotate Sam Model Selector](https://cdn.ul.run/i/88703961af233af7fe5ddf35ff8a5f96.avif)<!-- screenshot -->
 
@@ -567,7 +568,7 @@ Yes, but for best results:
 
 ### Which SAM model should I use?
 
-**SAM 3** is the default and the latest generation model — start there for the highest quality masks. Switch to **SAM 2.1 Small** for a faster interactive workflow on common objects, or **SAM 2.1 Large** when you need higher mask precision on complex shapes. Use **SAM 2.1 Tiny** for maximum speed on simple, high-contrast objects.
+**SAM 3.1** is the default and the latest generation model — start there for the highest quality masks, with **SAM 3** still available. Switch to **SAM 2.1 Small** for a faster interactive workflow on common objects, or **SAM 2.1 Large** when you need higher mask precision on complex shapes. Use **SAM 2.1 Tiny** for maximum speed on simple, high-contrast objects.
 
 ### Which tasks support SAM smart annotation?
 

--- a/docs/en/platform/data/index.md
+++ b/docs/en/platform/data/index.md
@@ -28,7 +28,7 @@ The Data section of Ultralytics Platform helps you:
 - **Import from a URL** by pasting a direct link to an archive or NDJSON export, or from [Roboflow](../integrations/roboflow.md)
 - **Connect** [Google Cloud Storage](../integrations/google-cloud-storage.md), [Amazon S3](../integrations/amazon-s3.md), or [Azure Blob Storage](../integrations/azure-blob-storage.md) and use your data in place without uploading a copy
 - **Keep pixels on premise** with Enterprise [On Premise](../integrations/on-premise.md) CPU/GPU workers
-- **Annotate** with manual drawing tools and SAM-powered smart labeling — choose from [SAM 2.1](../../models/sam-2.md) or the new [SAM 3](../../models/sam-3.md)
+- **Annotate** with manual drawing tools and SAM-powered smart labeling — choose from [SAM 2.1](../../models/sam-2.md), [SAM 3](../../models/sam-3.md), or the default [SAM 3.1](../../models/sam-3.md#sam-31)
 - **Manage classes** by renaming, recoloring, merging, and deleting them across the whole dataset
 - **Analyze** your data with statistics, visualizations, and embedding-based clustering
 - **Export** in [NDJSON format](../../datasets/detect/index.md#ultralytics-ndjson-format) for local training

--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -81,7 +81,7 @@ Dedicated endpoints are deployed separately to a region you choose from the glob
 - **Dataset Management**: Create datasets from local files, a URL, connected [cloud storage](integrations/index.md), or an [on-premise host](integrations/on-premise.md), with automatic processing
 - **[Annotation Editor](https://www.ultralytics.com/annotate)**: Manual annotation tools for 6 YOLO task types (detect, segment, semantic, classify, pose, OBB; see [supported task types](data/annotation.md#supported-task-types))
 - **Skeleton Templates**: Built-in (Person, Hand, Dog, Face, Box) and custom skeleton templates for one-click pose annotation
-- **Smart Annotation**: Use [SAM 2.1](../models/sam-2.md) (Tiny, Small, Base, Large), [SAM 3](../models/sam-3.md), pretrained Ultralytics YOLO models, or your own fine-tuned YOLO models from the annotation toolbar for detect, segment, semantic, and OBB tasks
+- **Smart Annotation**: Use [SAM 2.1](../models/sam-2.md) (Tiny, Small, Base, Large), [SAM 3](../models/sam-3.md), [SAM 3.1](../models/sam-3.md#sam-31) (default), pretrained Ultralytics YOLO models, or your own fine-tuned YOLO models from the annotation toolbar for detect, segment, semantic, and OBB tasks
 - **Dataset Versioning**: Create numbered NDJSON snapshots with descriptions, then download or restore any version for reproducible training
 - **Statistics**: Class distribution, split distribution, location heatmaps, and bounding box dimension analysis
 
@@ -436,7 +436,7 @@ The Platform includes a full-featured annotation editor supporting:
 
 - **Manual Tools**: Bounding boxes, polygons, keypoints with skeleton templates, oriented boxes, classification
 - **Skeleton Templates**: Place all keypoints at once using built-in (Person, Hand, Dog, Face, Box) or custom templates
-- **Smart Annotation**: Use [SAM 2.1](../models/sam-2.md) or [SAM 3](../models/sam-3.md) for click-based annotation, or run pretrained Ultralytics YOLO models and your own fine-tuned YOLO models from the toolbar for detect, segment, semantic, and OBB
+- **Smart Annotation**: Use [SAM 2.1](../models/sam-2.md), [SAM 3](../models/sam-3.md), or [SAM 3.1](../models/sam-3.md#sam-31) (default) for click-based annotation, or run pretrained Ultralytics YOLO models and your own fine-tuned YOLO models from the toolbar for detect, segment, semantic, and OBB
 - **Keyboard Shortcuts**: Efficient workflows with hotkeys, listed in the editor's shortcuts popover
 
 | Shortcut               | Action                            |

--- a/docs/en/usage/simple-utilities.md
+++ b/docs/en/usage/simple-utilities.md
@@ -732,7 +732,7 @@ auto_annotate(
 )
 ```
 
-For more details, check the [auto_annotate reference section](../reference/data/annotator.md#ultralytics.data.annotator.auto_annotate), or use [Ultralytics Platform](https://platform.ultralytics.com) as a hosted, no-code alternative with click-based masking via [SAM 2.1](../models/sam-2.md) or [SAM 3](../models/sam-3.md), or predictions from pretrained and fine-tuned YOLO models for detect, segment, and OBB tasks.
+For more details, check the [auto_annotate reference section](../reference/data/annotator.md#ultralytics.data.annotator.auto_annotate), or use [Ultralytics Platform](https://platform.ultralytics.com) as a hosted, no-code alternative with click-based masking via [SAM 2.1](../models/sam-2.md), [SAM 3](../models/sam-3.md), or [SAM 3.1](../models/sam-3.md#sam-31), or predictions from pretrained and fine-tuned YOLO models for detect, segment, and OBB tasks.
 
 ### How do I convert COCO dataset annotations to YOLO format in Ultralytics?
 


### PR DESCRIPTION
Ultralytics Platform smart annotation now offers SAM 3.1 and uses it as the default, with SAM 3 and SAM 2.1 still available, and `ultralytics 8.4.148` (#26144) loads SAM 3.1 for image prediction. This brings every docs page that lists these models up to date:

- `platform/data/annotation.md`: the SAM model table lists six models with SAM 3.1 as the default, and the "Which SAM model should I use?" FAQ points to SAM 3.1 first
- `platform/index.md`, `platform/data/index.md`: the Smart Annotation model lists include SAM 3.1 (default)
- `platform/account/billing.md`: the plan feature list names SAM 3.1 smart annotation
- `usage/simple-utilities.md`: the Platform alternative to `auto_annotate` lists SAM 3.1
- `models/sam-3.md`: the Platform FAQ answer names SAM 3.1 as the default, and a new "Does Ultralytics support SAM 3.1?" FAQ covers image support and the unsupported Object Multiplex video tracking
- `models/index.md`: a `SAM3.1` keyword

The default is backed by the COCO click benchmark in https://github.com/ultralytics/ultralytics/pull/26144#issuecomment-5637912746: SAM 3.1 beats SAM 3 at every click count (mIoU@1 0.728 vs 0.698) at the same speed.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated Ultralytics documentation to list SAM 3.1 as the default Platform smart annotation model while retaining SAM 3 and SAM 2.1 options.

### 📊 Key Changes

- Added SAM 3.1 to the Platform smart annotation model lists and SAM model selection table, marking it as the default.
- Updated the smart annotation FAQ, billing feature list, and `auto_annotate` Platform alternative to reference SAM 3.1.
- Added SAM 3.1 to the supported-model keywords and documented image prediction usage with `sam3.1_multiplex.pt`.
- Documented that Object Multiplex video tracking is not supported with SAM 3.1 and that `sam3.pt` remains used for video predictors.

### 🎯 Purpose & Impact

- Platform and model documentation now directs users to SAM 3.1 first for image-based smart annotation and prediction, while clearly describing the available alternatives and current video limitation.