### PR TITLE
Move AutoTrain documentation under Platform Train

### DIFF
--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -252,7 +252,6 @@ Once deployed, call your endpoint from any language. `conf`, `iou`, and `imgsz` 
 Get started with these resources:
 
 - [**Quickstart**](quickstart.md): Create your first project and train a model in minutes
-- [**Autotraining**](autotraining.md): Use Ask AI to manage datasets, run experiments, compare models, and deploy
 - [**Explore**](explore.md): Browse and clone public datasets and projects
 - [**Data**](data/index.md): Dataset preparation overview
 - [**Datasets**](data/datasets.md): Upload and manage your training data

--- a/docs/en/platform/quickstart.md
+++ b/docs/en/platform/quickstart.md
@@ -150,7 +150,7 @@ Press `Cmd+K` (Mac) or `Ctrl+K` (Windows/Linux) to open the search bar. Search a
 
 ### AI Chat Assistant
 
-Click **Ask AI** to work with an AI agent that automates tasks across Ultralytics Platform. It works directly with your datasets and models to annotate images, run training experiments, compare results, and export or deploy models. See [Autotraining with Ask AI](autotraining.md) for example prompts and setup for your own coding agent.
+Click **Ask AI** to work with an AI agent that automates tasks across Ultralytics Platform. It works directly with your datasets and models to annotate images, run training experiments, compare results, and export or deploy models. See [AutoTrain with Ask AI](train/autotrain.md) for example prompts and setup for your own coding agent.
 
 ### Onboarding Tours
 

--- a/docs/en/platform/train/autotrain.md
+++ b/docs/en/platform/train/autotrain.md
@@ -1,21 +1,23 @@
 ---
 plans: [free, pro, enterprise]
 comments: true
-description: Use Ask AI to manage datasets, train and compare models, annotate images, export, and deploy on Ultralytics Platform.
+description: Use AutoTrain with Ask AI to run training experiments, compare results, and refine YOLO models on Ultralytics Platform.
 keywords: Ultralytics Platform, AutoTrain, Ask AI, Platform CLI, ul cloud, agent skills, Claude Code, Codex
 ---
 
 # AutoTrain with Ask AI
 
-**Ask AI turns your requests into actions across Ultralytics Platform.** Find datasets, train and compare models, annotate images, export, and deploy through a conversation.
+**AutoTrain uses Ask AI to help you train, compare, and improve models through a conversation.** Start with a baseline, review its results, and ask for the next experiment. Ask AI can also find datasets, annotate images, export models, and deploy them.
 
-Sign in to [Ultralytics Platform](https://platform.ultralytics.com) and click **Ask AI**. The AI agent works directly with your datasets and models, automating tasks such as annotation, training, export, and deployment.
+Sign in to [Ultralytics Platform](https://platform.ultralytics.com), open your dataset or project, and click **Ask AI**.
 
 To use Platform actions, first create an [Ultralytics API key](../account/api-keys.md) in your personal workspace's **Settings > API Keys**. Ask AI uses your existing personal key automatically; you do not need to paste it into the conversation. Include the project or dataset link when working with a team workspace.
 
 ![Ultralytics Platform PPE detection dataset with Ask AI reviewing classes, annotations, and training readiness](https://cdn.ul.run/i/94b13a80c2fb15e32ca6044d0ebe1d37.avif)
 
 ## Prompts to Try
+
+Include your target metric, model, epoch limit, and number of experiments in the request. For comparable results, keep the dataset, splits, and random seed fixed while changing one setting at a time. Cloud runs use your [training credits](cloud-training.md#billing).
 
 Open the relevant dataset or project and ask:
 
@@ -25,7 +27,7 @@ Open the relevant dataset or project and ask:
 | Compare resolutions   | Train three models on this dataset at image sizes 640, 800, and 960. Keep all other settings and dataset splits fixed.             |
 | Explore a dataset     | Find container ships, shipping containers, and cranes in xView. Is it a good starting point for port logistics?                    |
 | Create a baseline     | Train YOLO26n on this dataset and name the run "xview-baseline".                                                                   |
-| Compare models        | Compare the completed models. Which performed best, and why?                                                                       |
+| Compare models        | Compare the completed models by validation mAP50-95. Explain the differences and propose the next experiment.                      |
 | Deploy a model        | Deploy the completed model with the best validation mAP in this project. Give me its endpoint URL and status.                      |
 | Auto-annotate         | Use my best compatible model to annotate unlabeled images in this dataset. Preserve existing annotations.                          |
 | Review classification | Which model has the best classification accuracy? Which breeds remain confusing, and what should we try next?                      |
@@ -66,7 +68,7 @@ Then use prompts like the examples above, including the project or dataset link 
 
 ### Run Commands Directly
 
-Use your project and model URL slugs in commands:
+Use your project and model URL slugs in commands. These examples target your personal workspace; add `owner=TEAM` to target a team workspace you belong to:
 
 ```bash
 ul cloud datasets list

--- a/docs/en/platform/train/autotrain.md
+++ b/docs/en/platform/train/autotrain.md
@@ -2,16 +2,16 @@
 plans: [free, pro, enterprise]
 comments: true
 description: Use Ask AI to manage datasets, train and compare models, annotate images, export, and deploy on Ultralytics Platform.
-keywords: Ultralytics Platform, autotraining, Ask AI, Platform CLI, ul cloud, agent skills, Claude Code, Codex
+keywords: Ultralytics Platform, AutoTrain, Ask AI, Platform CLI, ul cloud, agent skills, Claude Code, Codex
 ---
 
-# Autotraining with Ask AI
+# AutoTrain with Ask AI
 
 **Ask AI turns your requests into actions across Ultralytics Platform.** Find datasets, train and compare models, annotate images, export, and deploy through a conversation.
 
 Sign in to [Ultralytics Platform](https://platform.ultralytics.com) and click **Ask AI**. The AI agent works directly with your datasets and models, automating tasks such as annotation, training, export, and deployment.
 
-To use Platform actions, first create an [Ultralytics API key](account/api-keys.md) in your personal workspace's **Settings > API Keys**. Ask AI uses your existing personal key automatically; you do not need to paste it into the conversation. Include the project or dataset link when working with a team workspace.
+To use Platform actions, first create an [Ultralytics API key](../account/api-keys.md) in your personal workspace's **Settings > API Keys**. Ask AI uses your existing personal key automatically; you do not need to paste it into the conversation. Include the project or dataset link when working with a team workspace.
 
 ![Ultralytics Platform PPE detection dataset with Ask AI reviewing classes, annotations, and training readiness](https://cdn.ul.run/i/94b13a80c2fb15e32ca6044d0ebe1d37.avif)
 
@@ -47,7 +47,7 @@ The `ul` CLI comes with the Ultralytics package on **Python 3.11+**. Install or 
 pip install -U ultralytics
 ```
 
-Create a [Platform API key](account/api-keys.md) and set it in the terminal used by your agent. Check the connection with:
+Create a [Platform API key](../account/api-keys.md) and set it in the terminal used by your agent. Check the connection with:
 
 ```bash
 export ULTRALYTICS_API_KEY="YOUR_API_KEY"
@@ -56,7 +56,7 @@ ul cloud account summary
 
 ### Add the Skill
 
-Follow the [Agent Skills installation guide](../integrations/agent-skills.md#installation) for Claude Code and Codex plugins. For agents supported by the skills CLI, install the Platform skill with:
+Follow the [Agent Skills installation guide](../../integrations/agent-skills.md#installation) for Claude Code and Codex plugins. For agents supported by the skills CLI, install the Platform skill with:
 
 ```bash
 npx skills add ultralytics/skills --skill platform-cli
@@ -75,4 +75,4 @@ ul cloud models training project=license-plate model=baseline
 ul cloud training start --help
 ```
 
-Use `ul cloud --help` to discover commands and `ul cloud <resource> <operation> --help` for their arguments. See the [Platform API reference](api/index.md) for more details.
+Use `ul cloud --help` to discover commands and `ul cloud <resource> <operation> --help` for their arguments. See the [Platform API reference](../api/index.md) for more details.

--- a/docs/en/platform/train/index.md
+++ b/docs/en/platform/train/index.md
@@ -152,6 +152,7 @@ Get started with cloud training in under a minute:
 - [**Projects**](projects.md): Organize your models and experiments
 - [**Models**](models.md): Manage trained checkpoints
 - [**Cloud Training**](cloud-training.md): Train on cloud GPUs
+- [**AutoTrain**](autotrain.md): Use Ask AI to run experiments and compare models
 
 ## FAQ
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -603,7 +603,6 @@ nav:
       - Platform: platform/index.md
       - Quickstart: platform/quickstart.md
       - Agents: platform/agents.md
-      - Autotraining: platform/autotraining.md
       - Data:
           - platform/data/index.md
           - Datasets: platform/data/datasets.md
@@ -613,6 +612,7 @@ nav:
           - Projects: platform/train/projects.md
           - Models: platform/train/models.md
           - Cloud Training: platform/train/cloud-training.md
+          - AutoTrain: platform/train/autotrain.md
       - Deploy:
           - platform/deploy/index.md
           - Inference: platform/deploy/inference.md


### PR DESCRIPTION
Move the Platform Autotraining page into **Train → AutoTrain** and rename its heading and metadata to AutoTrain. Update relative links and the quickstart reference, add it to the Train overview’s Quick Links, and remove its link from the Platform overview’s Quick Links.

Clarify the baseline → review → next experiment workflow, request fixed comparison settings and bounded runs, link cloud training billing, and explain team workspace CLI arguments. Existing commands and images are preserved.

Validation: pinned Prettier 3.8.5 formatting, `git diff --check`, and focused checks for navigation placement, relative link targets, and remaining old-name references passed. The original head passed the full docs build in CI; checks rerun for the content improvements.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Moved the Ask AI autotraining documentation to **Platform → Train → AutoTrain**, updating its naming, navigation, links, and training workflow guidance.

### 📊 Key Changes
- Renamed `autotraining.md` to `train/autotrain.md`, including its page title, description, keywords, and references.
- Added **AutoTrain** to the Train overview and moved the MkDocs navigation entry under **Platform → Train**.
- Updated links from the Platform quickstart and corrected relative links for API keys, agent skills, and the API reference.
- Added guidance to keep datasets, splits, seeds, and other settings fixed for comparisons, limit experiments, and review results before the next run.
- Documented training-credit billing and the `owner=TEAM` argument for team workspace CLI commands.

### 🎯 Purpose & Impact
- Users now find AutoTrain within the Train section, with prompts and CLI guidance focused on repeatable baseline-to-next-experiment workflows.
- The Platform overview no longer lists AutoTrain in its Quick Links.