### PR TITLE
Move Platform AutoTrain docs into training

### DIFF
--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -252,7 +252,7 @@ Once deployed, call your endpoint from any language. `conf`, `iou`, and `imgsz` 
 Get started with these resources:
 
 - [**Quickstart**](quickstart.md): Create your first project and train a model in minutes
-- [**Autotraining**](autotraining.md): Use Ask AI to manage datasets, run experiments, compare models, and deploy
+- [**AutoTrain**](train/autotrain.md): Use Ask AI to manage datasets, run experiments, compare models, and deploy
 - [**Explore**](explore.md): Browse and clone public datasets and projects
 - [**Data**](data/index.md): Dataset preparation overview
 - [**Datasets**](data/datasets.md): Upload and manage your training data

--- a/docs/en/platform/quickstart.md
+++ b/docs/en/platform/quickstart.md
@@ -150,7 +150,7 @@ Press `Cmd+K` (Mac) or `Ctrl+K` (Windows/Linux) to open the search bar. Search a
 
 ### AI Chat Assistant
 
-Click **Ask AI** to work with an AI agent that automates tasks across Ultralytics Platform. It works directly with your datasets and models to annotate images, run training experiments, compare results, and export or deploy models. See [Autotraining with Ask AI](autotraining.md) for example prompts and setup for your own coding agent.
+Click **Ask AI** to work with an AI agent that automates tasks across Ultralytics Platform. It works directly with your datasets and models to annotate images, run training experiments, compare results, and export or deploy models. See [AutoTrain with Ask AI](train/autotrain.md) for example prompts and setup for your own coding agent.
 
 ### Onboarding Tours
 

--- a/docs/en/platform/train/autotrain.md
+++ b/docs/en/platform/train/autotrain.md
@@ -2,16 +2,16 @@
 plans: [free, pro, enterprise]
 comments: true
 description: Use Ask AI to manage datasets, train and compare models, annotate images, export, and deploy on Ultralytics Platform.
-keywords: Ultralytics Platform, autotraining, Ask AI, Platform CLI, ul cloud, agent skills, Claude Code, Codex
+keywords: Ultralytics Platform, AutoTrain, Ask AI, Platform CLI, ul cloud, agent skills, Claude Code, Codex
 ---
 
-# Autotraining with Ask AI
+# AutoTrain with Ask AI
 
 **Ask AI turns your requests into actions across Ultralytics Platform.** Find datasets, train and compare models, annotate images, export, and deploy through a conversation.
 
 Sign in to [Ultralytics Platform](https://platform.ultralytics.com) and click **Ask AI**. The AI agent works directly with your datasets and models, automating tasks such as annotation, training, export, and deployment.
 
-To use Platform actions, first create an [Ultralytics API key](account/api-keys.md) in your personal workspace's **Settings > API Keys**. Ask AI uses your existing personal key automatically; you do not need to paste it into the conversation. Include the project or dataset link when working with a team workspace.
+To use Platform actions, first create an [Ultralytics API key](../account/api-keys.md) in your personal workspace's **Settings > API Keys**. Ask AI uses your existing personal key automatically; you do not need to paste it into the conversation. Include the project or dataset link when working with a team workspace.
 
 ![Ultralytics Platform PPE detection dataset with Ask AI reviewing classes, annotations, and training readiness](https://cdn.ul.run/i/94b13a80c2fb15e32ca6044d0ebe1d37.avif)
 
@@ -47,7 +47,7 @@ The `ul` CLI comes with the Ultralytics package on **Python 3.11+**. Install or 
 pip install -U ultralytics
 ```
 
-Create a [Platform API key](account/api-keys.md) and set it in the terminal used by your agent. Check the connection with:
+Create a [Platform API key](../account/api-keys.md) and set it in the terminal used by your agent. Check the connection with:
 
 ```bash
 export ULTRALYTICS_API_KEY="YOUR_API_KEY"
@@ -56,7 +56,7 @@ ul cloud account summary
 
 ### Add the Skill
 
-Follow the [Agent Skills installation guide](../integrations/agent-skills.md#installation) for Claude Code and Codex plugins. For agents supported by the skills CLI, install the Platform skill with:
+Follow the [Agent Skills installation guide](../../integrations/agent-skills.md#installation) for Claude Code and Codex plugins. For agents supported by the skills CLI, install the Platform skill with:
 
 ```bash
 npx skills add ultralytics/skills --skill platform-cli
@@ -75,4 +75,4 @@ ul cloud models training project=license-plate model=baseline
 ul cloud training start --help
 ```
 
-Use `ul cloud --help` to discover commands and `ul cloud <resource> <operation> --help` for their arguments. See the [Platform API reference](api/index.md) for more details.
+Use `ul cloud --help` to discover commands and `ul cloud <resource> <operation> --help` for their arguments. See the [Platform API reference](../api/index.md) for more details.

--- a/docs/en/platform/train/index.md
+++ b/docs/en/platform/train/index.md
@@ -152,6 +152,7 @@ Get started with cloud training in under a minute:
 - [**Projects**](projects.md): Organize your models and experiments
 - [**Models**](models.md): Manage trained checkpoints
 - [**Cloud Training**](cloud-training.md): Train on cloud GPUs
+- [**AutoTrain**](autotrain.md): Use Ask AI to run experiments and compare models
 
 ## FAQ
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -603,7 +603,6 @@ nav:
       - Platform: platform/index.md
       - Quickstart: platform/quickstart.md
       - Agents: platform/agents.md
-      - Autotraining: platform/autotraining.md
       - Data:
           - platform/data/index.md
           - Datasets: platform/data/datasets.md
@@ -613,6 +612,7 @@ nav:
           - Projects: platform/train/projects.md
           - Models: platform/train/models.md
           - Cloud Training: platform/train/cloud-training.md
+          - AutoTrain: platform/train/autotrain.md
       - Deploy:
           - platform/deploy/index.md
           - Inference: platform/deploy/inference.md


### PR DESCRIPTION
Move the Ask AI guide to platform/train/autotrain.md and use AutoTrain in its heading, metadata, navigation, and incoming links. Repair relative links after the move and add it to the training overview. The existing docs.yml source-change trigger already rebuilds Vercel on merge. Validated all relative links in the moved page and git diff --check. Companion redirects: ultralytics/portal#4058.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Moved the Platform Ask AI guide to `platform/train/autotrain.md` and updated its naming, navigation, and links to place it within the training documentation.

### 📊 Key Changes

- Renamed the guide heading and metadata from “Autotraining” to “AutoTrain”.
- Repaired relative links to API keys, Agent Skills, and the Platform API reference after moving the page.
- Added AutoTrain to the Platform training overview and MkDocs navigation.
- Updated Platform overview and Quickstart links to reference the new page location and title.

### 🎯 Purpose & Impact

- Users now find the AutoTrain guide under Platform training, with working links from the Platform overview, Quickstart, and training navigation.
- The previous `platform/autotraining.md` documentation path is replaced by `platform/train/autotrain.md`; companion redirects are handled separately in `ultralytics/portal#4058`.