### PR TITLE
Fix resume, ONNX CUDA fallback, Ray Tune and W&B training crashes

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.148"
+__version__ = "8.4.149"
 
 import importlib
 import os

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -660,7 +660,8 @@ def check_dict_alignment(
             matches = [f"{k}={base[k]}" if base.get(k) is not None else k for k in matches]
             match_str = f"Similar arguments are i.e. {matches}." if matches else ""
             string += f"'{colorstr('red', 'bold', x)}' is not a valid YOLO argument. {match_str}\n"
-        raise SyntaxError(string + CLI_HELP_MSG) from e
+        LOGGER.info(CLI_HELP_MSG)
+        raise SyntaxError(string) from e
 
 
 def merge_equals_args(args: list[str]) -> list[str]:

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -858,7 +858,7 @@ class Model(torch.nn.Module):
             return self.metrics
         if args.get("resume") is True:  # resume=True (boolean) uses current model as checkpoint
             if self.ckpt and self.ckpt.get("epoch", -1) >= 0 and self.ckpt.get("optimizer") is not None:
-                args["resume"] = self.ckpt_path
+                args["resume"], args["data"] = self.ckpt_path, kwargs.get("data") or overrides.get("data")
             else:
                 LOGGER.warning(
                     f"model '{self.ckpt_path}' is not a resumable training checkpoint "

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1035,7 +1035,7 @@ class BaseTrainer:
         """Load optimizer, scaler, EMA, and best_fitness from checkpoint."""
         if ckpt.get("optimizer") is not None:
             self.optimizer.load_state_dict(ckpt["optimizer"])
-        if ckpt.get("scaler") is not None:
+        if ckpt.get("scaler"):
             self.scaler.load_state_dict(ckpt["scaler"])
         if self.ema and ckpt.get("ema"):
             self.ema = ModelEMA(self.model)  # validation with EMA creates inference tensors that can't be updated

--- a/ultralytics/nn/backends/onnx.py
+++ b/ultralytics/nn/backends/onnx.py
@@ -84,10 +84,6 @@ class ONNXBackend(BaseBackend):
                 providers = ["CoreMLExecutionProvider", "CPUExecutionProvider"]
             else:
                 providers = ["CPUExecutionProvider"]
-                if cuda:
-                    LOGGER.warning("CUDA requested but CUDAExecutionProvider not available. Using CPU...")
-                    self.device = torch.device("cpu")
-                    cuda = False
 
             LOGGER.info(
                 f"Using ONNX Runtime {onnxruntime.__version__} with "
@@ -105,6 +101,10 @@ class ONNXBackend(BaseBackend):
                     f"({type(e).__name__}: {e}).\nRecommend fixes are to re-export it with "
                     f"'yolo export model=yolo26n.pt format=onnx', or to re-download the file."
                 ) from e
+            if cuda and "CUDAExecutionProvider" not in self.session.get_providers():
+                LOGGER.warning("CUDA requested but CUDAExecutionProvider not available. Using CPU...")
+                self.device = torch.device("cpu")
+                cuda = False
             self.output_names = [x.name for x in self.session.get_outputs()]
 
             # Check if dynamic shapes

--- a/ultralytics/utils/callbacks/raytune.py
+++ b/ultralytics/utils/callbacks/raytune.py
@@ -6,6 +6,7 @@ try:
     assert SETTINGS["raytune"] is True  # verify integration is enabled
     from ray import tune
 
+    assert hasattr(tune, "get_context")  # verify Ray>=2.41 Tune API, also required by tuner.run_ray_tune
 except (ImportError, AssertionError):
     tune = None
 
@@ -26,10 +27,8 @@ def on_fit_epoch_end(trainer):
     References:
         Ray Tune docs: https://docs.ray.io/en/latest/tune/index.html
     """
-    trial_id = tune.get_context().get_trial_id() if hasattr(tune, "get_context") else tune.get_trial_id()
-    if trial_id:  # check if Ray Tune session is active
-        metrics = trainer.metrics
-        tune.report({**metrics, "epoch": trainer.epoch + 1})
+    if tune.get_context().get_trial_id():  # check if Ray Tune session is active
+        tune.report({**trainer.metrics, "epoch": trainer.epoch + 1})
 
 
 callbacks = (

--- a/ultralytics/utils/callbacks/wb.py
+++ b/ultralytics/utils/callbacks/wb.py
@@ -140,7 +140,7 @@ def on_pretrain_routine_start(trainer):
             config=vars(trainer.args),
             id=latest_run.resolve().name.split("-", 2)[2]
             if resuming
-            else f"{name}_{datetime.now().astimezone().strftime('%Y%m%d_%H%M%S')}",
+            else f"{name[:64]}_{datetime.now().astimezone().strftime('%Y%m%d_%H%M%S')}",
             resume="allow" if resuming else None,
             dir=str(trainer.save_dir),
         )


### PR DESCRIPTION
## Summary

Fixes five crashes seen in package telemetry and makes the invalid-argument error survive tail-truncated logs. Bumps
the version to `8.4.149`. Every change replaces an existing line; net lines are 0.

- **Resume switched to COCO8 when the dataset had moved** (`engine/model.py`). `YOLO("last.pt").train(resume=True)`
  and `yolo train resume model=last.pt` injected the task's default dataset (`coco8.yaml`) over the checkpoint's own
  `data`. When the original dataset path no longer existed, `check_resume` adopted that default and rebuilt the head
  with 80 classes. The run then crashed in `optimizer.load_state_dict` ("loaded state dict has a different number of
  parameter groups"), hit a state_dict shape error, or silently resumed on COCO8. The resumable-checkpoint branch now
  keeps the checkpoint's `data`, and an explicit `data=` still wins. A missing dataset now fails with the existing
  dataset-not-found error.
- **Resume after an AMP-disabled run** (`engine/trainer.py`). A disabled `GradScaler` saves `{}`, and an enabled
  scaler refuses to load it ("The source state dict is empty..."). Runs started on CPU or MPS, or after a failed AMP
  check, could therefore never resume on a GPU. Empty scaler state is now skipped, matching the EMA check beside it.
- **ONNX Runtime CUDA fallback** (`nn/backends/onnx.py`). If `CUDAExecutionProvider` is installed but fails to
  initialise, ONNX Runtime silently builds a CPU-only session. A CUDA 13 `onnxruntime-gpu` wheel next to CUDA 12
  torch is a common cause. The backend still bound CUDA I/O, so every predict, val and benchmark crashed with "There's
  no data transfer registered for copying tensors...". The existing CPU fallback block now runs after the session is
  created and checks the providers the session actually registered.
- **Ray Tune callback crash on Ray 2.7–2.40** (`utils/callbacks/raytune.py`). The fallback added in #25972 called
  `tune.get_trial_id()`, which raises on those versions. That ended plain `yolo train` at the end of epoch 1 whenever
  such a Ray was importable. The callback now registers only when Ray provides the Tune context API. That is Ray
  ≥ 2.41, which `run_ray_tune` already requires.
- **W&B artifact names over 128 characters** (`utils/callbacks/wb.py`). The run id embedded the full run name, so long run
  names crashed curve logging at train end; the shortest name observed failing was 69 characters. The name inside the id is now bounded to 64
  characters; the display name is unchanged.
- **Invalid-argument error hidden behind the CLI help** (`cfg/__init__.py`). `check_dict_alignment` appended the ~1.8k
  character CLI help after the "'x' is not a valid YOLO argument" line. Tools that keep only the end of stderr
  therefore lost the cause. The help is now logged, and the exception carries only the mismatch and its suggestions.

## Verification

- Each failure was reproduced on `main`, then confirmed fixed:
  - resume with the original dataset moved away;
  - a disabled GradScaler's state loaded into an enabled one;
  - a CPU-only session with CUDA requested (simulated on a CPU host);
  - the Ray callback on Ray 2.9.0, 2.40.0 and 2.41.0;
  - W&B artifact names checked with wandb 0.30.0 in offline mode;
  - the tail of CLI stderr for an invalid key.
- `pytest tests/test_engine.py`: 28 passed, 1 failed. The failing depth `test_task` fails identically on clean `main`
  in this environment.
- `ruff format --check` passes on all changed files.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Version 8.4.149 fixes crashes in checkpoint resuming, ONNX CUDA fallback, Ray Tune, W&B logging, and invalid-argument reporting.

### 📊 Key Changes

- Resume now preserves the checkpoint’s dataset unless an explicit `data=` override is supplied, and skips loading an empty GradScaler state.
- ONNX now checks the execution providers registered by the created session and switches to CPU when CUDA initialization fails.
- Ray Tune callbacks now require the `get_context` API, and W&B run IDs truncate run names to 64 characters while leaving display names unchanged.
- Invalid YOLO arguments now raise an error containing the mismatch and suggestions while logging the CLI help separately.
- Bumped the package version from `8.4.148` to `8.4.149`.

### 🎯 Purpose & Impact

- Resuming a checkpoint with a moved dataset no longer replaces its dataset with the default `coco8.yaml`; missing datasets still use the existing dataset-not-found handling.
- Runs saved without AMP can resume with AMP enabled without attempting to load an empty scaler state.
- ONNX prediction, validation, and benchmarking can fall back to CPU when CUDA is requested but is not active in the ONNX Runtime session.
- Plain training no longer registers the Ray Tune callback with Ray versions that lack the required context API, and long W&B run names no longer exceed the artifact ID limit.
- Invalid-argument causes remain visible when tools retain only the end of CLI stderr.