### PR TITLE
Docs: Deploy configuration and lightweight monitoring

### DIFF
--- a/docs/en/platform/deploy/endpoints.md
+++ b/docs/en/platform/deploy/endpoints.md
@@ -9,7 +9,7 @@ keywords: Ultralytics Platform, deployment, endpoints, YOLO, production, scaling
 
 [Ultralytics Platform](https://platform.ultralytics.com) enables deployment of YOLO models to dedicated endpoints in 42 global regions. Each endpoint is a single-tenant service with a unique endpoint URL and independent monitoring. The default resource size scales to zero when idle; custom sizes keep a warm instance and are billed for uptime.
 
-![Ultralytics Platform Model Deploy Tab With Region Map And Table](https://cdn.ul.run/i/176e99f44ab36318aec89d8a5309376f.avif)<!-- screenshot -->
+![Ultralytics Platform Model Deploy Tab With Region Map And Table](https://cdn.ul.run/i/6685f2d9d5c34b9d72f61263dcb6ad81.avif)<!-- screenshot -->
 
 ## Create Endpoint
 
@@ -35,7 +35,7 @@ Create a deployment from the global `Deploy` page in the sidebar:
 4. Choose CPU and memory, review the pricing, and edit the suggested deployment name if needed
 5. Click **Create Deployment**
 
-![Ultralytics Platform New Deployment Dialog With Model Selector And Region Map](https://cdn.ul.run/i/2ef1fde3be1dd5d048bb0d21bdb5b7f8.avif)<!-- screenshot -->
+![Ultralytics Platform New Deployment Dialog With Model Selector And Region Map](https://cdn.ul.run/i/822cadbbd00c655ec7ca476fcdedaddd.avif)<!-- screenshot -->
 
 ### Deployment Lifecycle
 
@@ -76,7 +76,7 @@ Choose from 42 regions worldwide. The interactive region map and table show:
 - **Deploying regions**: Animated pulse indicator on the pin and the table row
 - **Bidirectional highlighting**: Hover on the map highlights the table row, and vice versa
 
-![Ultralytics Platform Deploy Tab Region Latency Table Sorted By Latency](https://cdn.ul.run/i/b763bfb3b965aac1e274bfed782a82e8.avif)<!-- screenshot -->
+![Ultralytics Platform Deploy Tab Region Latency Table Sorted By Latency](https://cdn.ul.run/i/d7ec7f213efe99c8ea46653de6d3619b.avif)<!-- screenshot -->
 
 The region table on the model `Deploy` tab includes:
 
@@ -175,11 +175,11 @@ The `New Deployment` dialog lets you select a model, region, resources, and depl
 | **CPU and Memory**  | Select the resource size and review its displayed pricing         |
 | **Deployment Name** | Auto-generated once model and region are set, and editable        |
 
-![Ultralytics Platform New Deployment Dialog Fixed Resource Defaults](https://cdn.ul.run/i/2ef1fde3be1dd5d048bb0d21bdb5b7f8.avif)<!-- screenshot -->
+![Ultralytics Platform New Deployment Dialog Fixed Resource Defaults](https://cdn.ul.run/i/6afe9718ada356b06cb87d2b4898c88e.avif)<!-- screenshot -->
 
 Choose the CPU and memory size in the resources controls and review the displayed pricing before creating the deployment. The default size can use an available free deployment allowance; custom sizes use metered pricing. The default size scales to zero when idle. Custom sizes keep one warm instance and are charged from readiness until you stop the endpoint, including idle time. [Agents](../agents.md#choose-where-to-run) reuses this dialog when you select **New deployment…**.
 
-![Ultralytics Platform New Deployment dialog with custom CPU and memory controls, hourly uptime pricing, and deployment name](https://cdn.ul.run/i/62bd92169169dfd3eaea14e3240ca237.avif)
+![Ultralytics Platform New Deployment Dialog Custom CPU Memory Pricing](https://cdn.ul.run/i/cb49ea5bbc304cf9f37a31b163781fc0.avif)<!-- screenshot -->
 
 !!! note "Auto-Generated Names"
 
@@ -195,23 +195,23 @@ Deploying from the model's `Deploy` tab opens the same dialog with the model and
 
 The deployments list supports three view modes:
 
-| Mode        | Description                                               |
-| ----------- | --------------------------------------------------------- |
-| **Cards**   | Full detail cards with logs, code examples, predict panel |
-| **Compact** | Grid of smaller cards with key metrics                    |
-| **Table**   | DataTable with sortable columns and search                |
+| Mode        | Description                                                              |
+| ----------- | ------------------------------------------------------------------------ |
+| **Cards**   | Full detail cards with logs, code, predict, and eligible monitoring tabs |
+| **Compact** | Grid of smaller cards with key metrics                                   |
+| **Table**   | DataTable with sortable columns and search                               |
 
-![Ultralytics Platform Deploy Tab Active Deployments Cards View](https://cdn.ul.run/i/9e21cbf292ff0ff31f787bec8ce9f678.avif)<!-- screenshot -->
+![Ultralytics Platform Deploy Tab Active Deployments Cards View](https://cdn.ul.run/i/df8afcdd198830c0324344e0a0769526.avif)<!-- screenshot -->
 
 ### Deployment Card (Cards View)
 
 Each deployment card in the cards view shows:
 
-- **Header**: Name, region flag, status badge, and the action buttons available for the current status — replace and stop when **Ready**, start when **Stopped**, delete at any time
+- **Header**: Name, region flag, status badge, and the action buttons available for the current status — update configuration, replace, and stop when **Ready**, start when **Stopped**, delete at any time
 - **Endpoint URL**: Copyable URL with a link to the endpoint's own API reference
 - **Metrics**: Request count (24h), P95 latency, error rate, or "No traffic yet"
 - **Health check**: Live health indicator with latency and manual refresh
-- **Tabs**: `Logs`, `Code`, and `Predict`
+- **Tabs**: `Logs`, `Code`, and `Predict`; paid endpoints also show `Monitoring`
 - **Footer**: The API key prefix bound to the deployment and the date it became ready
 - **Status message**: The failure reason, when a deployment failed
 
@@ -223,6 +223,21 @@ directly on the deployment.
 !!! note "Compact and Table Views"
 
     Compact cards show the flag, name, city, status, and the three metrics. The table view is sortable on Name, Region, Status, Requests, P95, and Errors, with search across name, region, and status. Both views keep the delete action; start, stop, and replace are available in the cards view.
+
+### Update CPU and Memory
+
+1. Open a **Ready** endpoint in **Cards** view.
+2. Click **Update deployment configuration**.
+3. Choose **CPU** and **Memory**, and review the displayed hourly cost.
+4. Click **Update Configuration**. The current configuration keeps serving until the new one is ready.
+
+![Ultralytics Platform Deployment Update CPU Memory Configuration](https://cdn.ul.run/i/7143e64cbefe46f24cd5f61c8100f1e1.avif)<!-- screenshot -->
+
+Custom resources use uptime billing and keep an instance warm. Returning to default resources restores scale-to-zero behavior and removes the paid Monitoring tab.
+
+!!! warning "Temporary Monitoring Data"
+
+    Monitoring charts and example images are lightweight, in-memory data. Stopping, restarting, redeploying, resizing, or replacing a model can clear them. Starting the endpoint again does not restore the history. Save useful examples to a dataset and wait for ingestion to finish before changing the endpoint. [Operational metrics and logs](monitoring.md) have separate history windows.
 
 ### Replace a Model
 
@@ -265,7 +280,7 @@ Each endpoint has a unique URL, for example:
 https://predict-<deployment-id>-<hash>-<region>.a.run.app
 ```
 
-![Ultralytics Platform Deployment Card Endpoint Url With Copy Button](https://cdn.ul.run/i/4f02beb3dd4915d65c72051e0235b1ea.avif)<!-- screenshot -->
+![Ultralytics Platform Deployment Card Endpoint Url With Copy Button](https://cdn.ul.run/i/7d4ededac16d1c112f1a594fac5db495.avif)<!-- screenshot -->
 
 Click the copy button to copy the URL. Click the docs icon to open the endpoint's own API reference. The endpoint
 serves these paths:
@@ -308,7 +323,9 @@ Stop an endpoint when you do not want it to accept requests:
 
 Stopped endpoints:
 
-- Don't accept requests, and report no metrics or health status
+- Don't accept requests, and report no live metrics or health status
+- Stop accruing uptime charges
+- Lose temporary monitoring statistics and example images when the serving instance shuts down
 - Keep their URL, region, and bound API key, and can be restarted anytime
 - Still count against your plan's deployment quota — delete an endpoint to free its slot
 

--- a/docs/en/platform/deploy/index.md
+++ b/docs/en/platform/deploy/index.md
@@ -27,10 +27,10 @@ The Deployment section helps you:
 
 - **Test** models directly in the browser with the `Predict` tab
 - **Deploy** to dedicated endpoints in 42 global regions
-- **Monitor** request metrics, logs, and health checks
-- **Scale to zero** when idle (deployments currently run a single active instance)
+- **Monitor** request metrics, logs, health checks, and temporary predictions on paid endpoints
+- **Choose resources**: default endpoints scale to zero; custom sizes keep a warm instance with uptime billing
 
-![Ultralytics Platform Deploy Page World Map With Overview Cards](https://cdn.ul.run/i/e922afb2e2f7573c320821ec4fa62537.avif)<!-- screenshot -->
+![Ultralytics Platform Deploy Page World Map With Overview Cards](https://cdn.ul.run/i/a2b4289abc2df5bc00a704a7b9575515.avif)<!-- screenshot -->
 
 ## Deployment Options
 
@@ -56,12 +56,12 @@ graph LR
     classDef out fill:#9C27B0,color:#fff
 ```
 
-| Stage         | Description                                                               |
-| ------------- | ------------------------------------------------------------------------- |
-| **Test**      | Validate model with the [`Predict` tab](inference.md)                     |
-| **Configure** | Select a region; the deployment name is generated from the model and city |
-| **Deploy**    | Create a dedicated endpoint from the [`Deploy` tab](endpoints.md)         |
-| **Monitor**   | Track requests, latency, errors, and logs in [Monitoring](monitoring.md)  |
+| Stage         | Description                                                                       |
+| ------------- | --------------------------------------------------------------------------------- |
+| **Test**      | Validate model with the [`Predict` tab](inference.md)                             |
+| **Configure** | Select a model, region, CPU, and memory; review pricing and the deployment name   |
+| **Deploy**    | Create a dedicated endpoint from the [`Deploy` tab](endpoints.md)                 |
+| **Monitor**   | Inspect endpoint metrics and temporary predictions in [Monitoring](monitoring.md) |
 
 ## Architecture
 
@@ -97,8 +97,8 @@ Deploy to 42 regions worldwide on Ultralytics Cloud:
 
 Each endpoint is a single-tenant service with:
 
-- Platform-managed sizing (not configurable today)
-- Scale-to-zero when idle
+- Configurable CPU and memory with pricing shown before deployment
+- Scale-to-zero for default resources; a warm, uptime-billed instance for custom resources
 - Unique endpoint URL with its own interactive API reference at `/docs`
 - Its own API key binding, so only that key can call the endpoint
 - Independent monitoring, logs, and health checks
@@ -108,16 +108,20 @@ Each endpoint is a single-tenant service with:
 Access the global deployments page from the sidebar under `Deploy`. This page shows:
 
 - **World map** with deployed region pins; click a region to open the `New Deployment` dialog
-- **Overview cards**: Total Requests (24h), Active Deployments, Error Rate (24h), P95 Latency (24h)
+- **Overview cards**: HTTP Requests (24h), Active Deployments, HTTP Error Rate (24h), HTTP P95 Latency (24h)
 - **Deployments list** with three view modes: cards, compact, and table
 - **New Deployment** button to create endpoints from any completed model
 - **Refresh** button and an `Updated` timestamp in the page header
 
-![Ultralytics Platform Deploy Page Overview Cards And Deployments List](https://cdn.ul.run/i/eb51c1bb9c4884b4b1bc89e4caf94eee.avif)<!-- screenshot -->
+![Ultralytics Platform Deploy Page Overview Cards And Deployments List](https://cdn.ul.run/i/3367ece0827e0f9d43b9acf8d233a49a.avif)<!-- screenshot -->
 
 !!! info "Automatic Polling"
 
     The page refreshes automatically, polling faster while deployments are in a transitional state (`creating`, `deploying`, or `stopping`). See [Monitoring](monitoring.md) for details.
+
+!!! warning "Lightweight, Temporary Monitoring"
+
+    Paid endpoints provide charts and example images held only in the serving instance's memory. Stopping, restarting, redeploying, resizing, or replacing the model can clear this data. Save examples to a dataset and wait for ingestion to finish to keep them. See [Monitoring](monitoring.md#monitoring-tab).
 
 ## Key Features
 
@@ -133,10 +137,11 @@ Deploy close to your users with 42 regions covering:
 
 Endpoints currently behave as follows:
 
-- **Scale to zero**: idle endpoints scale down to zero and cold-start on the next request
+- **Default resources**: idle endpoints scale down to zero and cold-start on the next request
+- **Custom resources**: one instance stays warm and accrues uptime charges until stopped
 - **Single active instance**: each endpoint currently serves from one instance on all plans
 - **Load shedding**: requests receive `429` responses when the endpoint is temporarily at capacity — see [Direct Endpoint Requests](endpoints.md#direct-endpoint-requests)
-- **Request timeout**: each request may run for up to 1 hour, which is enough for video inference
+- **Request timeout**: direct endpoint requests have a maximum duration of 1 hour; see [Inference](inference.md) for supported inputs
 
 ### Regional Deployment
 
@@ -158,16 +163,17 @@ Create a deployment:
 
 1. Train or upload a model to a project
 2. Go to the model's **Deploy** tab
-3. Select a region from the latency table
-4. Click **Deploy** and wait for the deployment status to become **Ready**
+3. Click **Deploy** for a region in the latency table
+4. Review CPU, memory, pricing, and name in the deployment dialog
+5. Click **Create Deployment** and wait for the deployment status to become **Ready**
 
 !!! example "Quick Deploy"
 
     ```text
-    Model → Deploy tab → Select region → Click Deploy → Endpoint URL ready
+    Model → Deploy tab → Deploy in a region → Review configuration → Create Deployment
     ```
 
-    The deployment name is generated from the model name and the region city, so no naming step is required. Once deployed, use the endpoint URL with your API key to send inference requests from any application.
+    The deployment name is generated from the model name and region city and can be edited before deployment. Once deployed, use the endpoint URL with your API key to send inference requests from any application.
 
 ## Quick Links
 
@@ -179,15 +185,15 @@ Create a deployment:
 
 ### What's the difference between shared and dedicated inference?
 
-| Feature         | Shared                       | Dedicated                                |
-| --------------- | ---------------------------- | ---------------------------------------- |
-| **Service**     | Shared across Platform users | Dedicated to one deployment              |
-| **Scale**       | Managed by Platform          | Scale-to-zero, one instance              |
-| **Regions**     | 3 data regions               | Choose from 42 deployment regions        |
-| **URL**         | Platform model API           | Generated deployment endpoint URL        |
-| **Testing**     | Model `Predict` tab          | Deployment-card `Predict` tab or API     |
-| **Rate limits** | 20 requests/minute           | No Platform rate limit on direct calls   |
-| **Auth**        | Any workspace API key        | Only the API key bound to the deployment |
+| Feature         | Shared                       | Dedicated                                   |
+| --------------- | ---------------------------- | ------------------------------------------- |
+| **Service**     | Shared across Platform users | Dedicated to one deployment                 |
+| **Scale**       | Managed by Platform          | Default: scales to zero; custom: stays warm |
+| **Regions**     | 3 data regions               | Choose from 42 deployment regions           |
+| **URL**         | Platform model API           | Generated deployment endpoint URL           |
+| **Testing**     | Model `Predict` tab          | Deployment-card `Predict` tab or API        |
+| **Rate limits** | 20 requests/minute           | No Platform rate limit on direct calls      |
+| **Auth**        | Any workspace API key        | Only the API key bound to the deployment    |
 
 ### How long does deployment take?
 
@@ -202,7 +208,7 @@ one model at a time — use [model replacement](endpoints.md#replace-a-model) to
 
 ### What happens when an endpoint is idle?
 
-With scale-to-zero enabled:
+Default-resource endpoints scale to zero when idle:
 
 - Endpoint scales down after inactivity
 - First request triggers cold start
@@ -210,3 +216,5 @@ With scale-to-zero enabled:
 
 First requests after an idle period trigger a cold start. Opening the deployment card runs a health check that warms
 the endpoint, so a test prediction right after it responds quickly.
+
+Custom-resource endpoints stay warm and are charged for uptime, including idle time. Stop an endpoint to stop its uptime charge.

--- a/docs/en/platform/deploy/inference.md
+++ b/docs/en/platform/deploy/inference.md
@@ -11,7 +11,7 @@ keywords: Ultralytics Platform, inference, API, YOLO, object detection, predicti
 [Ultralytics Platform](https://platform.ultralytics.com) provides browser-based inference for testing trained models
 and dedicated endpoints for programmatic access.
 
-![Ultralytics Platform Model Predict Tab With Detections Overlay](https://cdn.ul.run/i/3cb26693dd15bd98be3742b7c8b09cc5.avif)<!-- screenshot -->
+![Ultralytics Platform Model Predict Tab With Detections Overlay](https://cdn.ul.run/i/0c19d802fbe4e81b32f34b9826ba2ee4.avif)<!-- screenshot -->
 
 ## Predict Tab
 
@@ -24,7 +24,7 @@ Every model with weights includes a `Predict` tab for browser-based inference:
 
 Models without weights show an empty state instead — train the model or upload weights first.
 
-![Ultralytics Platform Predict Tab Image Upload Dropzone](https://cdn.ul.run/i/d2dafa4b28ec36687eaf850ccb1fea3c.avif)<!-- screenshot -->
+![Ultralytics Platform Predict Tab Image Upload Dropzone](https://cdn.ul.run/i/116d77e49c6fd00d9eb49a26217e3cc5.avif)<!-- screenshot -->
 
 ### Input Methods
 
@@ -95,7 +95,7 @@ Inference results display the output appropriate to the model task: boxes, masks
 classification scores, semantic coverage, or a depth map. Object results use the dataset class colors when available.
 The panel also shows preprocess, inference, postprocess, and network timing.
 
-![Ultralytics Platform Predict Tab Results With Detections And Speed Stats](https://cdn.ul.run/i/b12413a329d89294abbe75ed8b488356.avif)<!-- screenshot -->
+![Ultralytics Platform Predict Tab Results With Detections And Speed Stats](https://cdn.ul.run/i/d220b0d1e04768b6417ae09cf07bfefa.avif)<!-- screenshot -->
 
 The results panel shows:
 
@@ -113,7 +113,7 @@ download button to save an annotated JPEG of the current result.
 
 Adjust inference behavior with the three sliders below the image:
 
-![Ultralytics Platform Predict Tab Parameters Sliders](https://cdn.ul.run/i/9cfec37c66590d4e323567478693c800.avif)<!-- screenshot -->
+![Ultralytics Platform Predict Tab Parameters Sliders](https://cdn.ul.run/i/1ca455d168dce72b251904b1f5ffff69.avif)<!-- screenshot -->
 
 | Parameter      | Range                     | Default | Description                  |
 | -------------- | ------------------------- | ------- | ---------------------------- |
@@ -144,6 +144,8 @@ Control Non-Maximum Suppression:
 ## Deployment Predict
 
 Each running [dedicated endpoint](endpoints.md) includes a `Predict` tab directly on its deployment card. This uses the deployment's own inference service rather than the shared predict service, letting you test your deployed endpoint from the browser.
+
+On a paid endpoint with monitoring enabled, processed images also contribute to the [Monitoring tab](monitoring.md#monitoring-tab). Its sampled examples and aggregate charts are lightweight, temporary data held in memory; stopping, restarting, redeploying, resizing, or replacing the model can clear them. Save examples to a dataset to keep them.
 
 ## Dedicated Endpoint API
 
@@ -240,7 +242,7 @@ with open("image.jpg", "rb") as f:
     console.log(result);
     ```
 
-![Ultralytics Platform Predict Tab Code Examples Python Tab](https://cdn.ul.run/i/b3913018ed5745d7abdb03fefa67a21a.avif)<!-- screenshot -->
+![Ultralytics Platform Predict Tab Code Examples Python Tab](https://cdn.ul.run/i/42273bfce7b498f3ed996ef73a219140.avif)<!-- screenshot -->
 
 ### Request Parameters
 
@@ -289,7 +291,7 @@ with open("image.jpg", "rb") as f:
 }
 ```
 
-![Ultralytics Platform Predict Tab Json Response View](https://cdn.ul.run/i/2103262abc6d1ea0832eff6e280f4661.avif)<!-- screenshot -->
+![Ultralytics Platform Predict Tab Json Response View](https://cdn.ul.run/i/51b46ea38818156171938e1dae77f32e.avif)<!-- screenshot -->
 
 ### Response Fields
 

--- a/docs/en/platform/deploy/monitoring.md
+++ b/docs/en/platform/deploy/monitoring.md
@@ -10,7 +10,7 @@ keywords: Ultralytics Platform, monitoring, metrics, logs, deployment, performan
 
 [Ultralytics Platform](https://platform.ultralytics.com) provides [monitoring for deployed endpoints](../../guides/model-monitoring-and-maintenance.md). Track endpoint requests, latency, errors, and logs. Paid dedicated endpoints also provide live prediction statistics and temporary examples that you can inspect and save to datasets.
 
-![Ultralytics Platform Deploy Page Overview Cards And World Map](https://cdn.ul.run/i/39e125429eb799c95eb006398e8ab6a4.avif)<!-- screenshot -->
+![Ultralytics Platform Deploy Page Overview Cards And World Map](https://cdn.ul.run/i/f13ad8c9a1b981b5b3863a9ba602b345.avif)<!-- screenshot -->
 
 ## Deployments Dashboard
 
@@ -46,14 +46,14 @@ graph TB
 
 Four summary cards at the top of the page show:
 
-![Ultralytics Platform Deploy Page Four Overview Cards](https://cdn.ul.run/i/4ee4595697397d7ffc102fed995168c1.avif)<!-- screenshot -->
+![Ultralytics Platform Deploy Page Four Overview Cards](https://cdn.ul.run/i/b315ed2fb56e0d934b78014fb46030e1.avif)<!-- screenshot -->
 
-| Metric                   | Description                                                             |
-| ------------------------ | ----------------------------------------------------------------------- |
-| **Total Requests (24h)** | Requests across all endpoints                                           |
-| **Active Deployments**   | Endpoints currently in the **Ready** state                              |
-| **Error Rate (24h)**     | Share of responses with a 4xx or 5xx status, weighted by request volume |
-| **P95 Latency (24h)**    | Average of the hourly 95th-percentile latencies, weighted by volume     |
+| Metric                     | Description                                                                           |
+| -------------------------- | ------------------------------------------------------------------------------------- |
+| **HTTP Requests (24h)**    | HTTP requests across endpoints, including prediction, monitoring, and health requests |
+| **Active Deployments**     | Endpoints currently in the **Ready** state                                            |
+| **HTTP Error Rate (24h)**  | Share of responses with a 4xx or 5xx status, weighted by request volume               |
+| **HTTP P95 Latency (24h)** | Average of the hourly 95th-percentile latencies, weighted by volume                   |
 
 P95 rather than median latency is reported because health checks return in a couple of milliseconds and would otherwise
 dominate the picture of real inference latency.
@@ -73,7 +73,7 @@ The interactive world map shows:
 
 Click any region to open the `New Deployment` dialog. The map is hidden on small screens.
 
-![Ultralytics Platform Deploy Page World Map With Deployed Regions](https://cdn.ul.run/i/af47d4f67a807072155765ce3861a9c4.avif)<!-- screenshot -->
+![Ultralytics Platform Deploy Page World Map With Deployed Regions](https://cdn.ul.run/i/a52b2daa4483953d8aa9877af53ee6a8.avif)<!-- screenshot -->
 
 ### Deployments List
 
@@ -119,7 +119,7 @@ Health checks auto-retry while unhealthy and stop once the endpoint responds. Cl
 refresh icon to manually trigger a health check, which doubles as a way to warm a scaled-to-zero endpoint before
 sending traffic.
 
-![Ultralytics Platform Deployment Card Health Check Healthy With Latency](https://cdn.ul.run/i/c1c2da5731737f6afbd70b12eb144f9f.avif)<!-- screenshot -->
+![Ultralytics Platform Deployment Card Health Check Healthy With Latency](https://cdn.ul.run/i/20d4da9bf7a27469cdf9d93a85530034.avif)<!-- screenshot -->
 
 !!! info "Cold Start Tolerance"
 
@@ -133,11 +133,11 @@ Open **Deploy**, switch to **Cards** view, and select **Monitoring** on a **Read
 
     Monitoring requires a paid, uptime-billed endpoint running a monitoring-capable runtime. An included endpoint does not gain this tab from a paid workspace plan alone. See [Dedicated Endpoints](endpoints.md) for resource configuration. Existing endpoints are not automatically updated with every runtime release, so an older endpoint may show **Monitoring unavailable** until its runtime is updated.
 
-<!-- Screenshot placeholder: Ready paid endpoint with Monitoring selected, Temporary Examples, and Prediction Statistics. -->
+![Ultralytics Platform Deployment Monitoring Temporary Examples And Statistics](https://cdn.ul.run/i/a3d9495d8a8fdc14eacafe2dc631b3ba.avif)<!-- screenshot -->
 
 !!! warning "Temporary Data"
 
-    Examples and prediction statistics are held in the serving instance's memory. They reset when the instance restarts or is replaced, including during redeployment. This is temporary inspection history; save useful examples to a dataset to keep them.
+    Monitoring is lightweight and temporary: charts, prediction statistics, and example images live only in the serving instance's memory. They can be lost when the endpoint shuts down, stops, restarts, redeploys, changes resources, or replaces its model. History is not restored when the endpoint starts again. Save useful examples to a dataset and wait for ingestion to finish before changing the endpoint.
 
 ### Temporary Examples
 
@@ -148,7 +148,7 @@ The gallery contains a rolling sample of processed images with prediction overla
 - **Replacement:** Older examples are replaced when either limit is reached. An example may become unavailable while you are viewing it.
 - **Storage:** Temporary examples remain in endpoint memory. Saving them to a dataset uses normal workspace storage and processing limits.
 
-<!-- Screenshot placeholder: Temporary Examples gallery and an example open in the prediction viewer. -->
+![Ultralytics Platform Deployment Monitoring Prediction Viewer](https://cdn.ul.run/i/b701a3d589f966da4f00b3693c6ea030.avif)<!-- screenshot -->
 
 ### Save Examples to a Dataset
 
@@ -161,7 +161,7 @@ Workspace members with content editing permission can save examples to a dataset
 
 Selected images and predictions are copied through the standard dataset upload and ingestion workflow. Normal quota, class mapping, and duplicate handling apply. Saving leaves the temporary examples in the gallery; successfully ingested dataset images survive endpoint restarts and deletion. Review predicted labels before using them for training.
 
-<!-- Screenshot placeholder: Selected temporary examples and the Save examples to dataset dialog with a compatible dataset. -->
+![Ultralytics Platform Deployment Monitoring Save Examples To Dataset](https://cdn.ul.run/i/18c1c9cd8decb4e3c115d6e02fdf49fe.avif)<!-- screenshot -->
 
 To remove temporary examples, use an image's hover trash control or select examples and click the bulk trash button, then confirm **Delete**. Deleting examples leaves aggregate prediction statistics and images already saved to datasets unchanged.
 
@@ -186,7 +186,9 @@ Available charts depend on the task and collected predictions:
 | **Prediction Dimensions** | Prediction width and height relative to the input image, when box dimensions are available                      |
 | **Prediction Locations**  | Spatial heatmap of predictions, when location data is available                                                 |
 
-<!-- Screenshot placeholder: Prediction Statistics with the date picker, time series, confidence distribution, and spatial charts. -->
+![Ultralytics Platform Deployment Monitoring Prediction Statistics](https://cdn.ul.run/i/cb3decac9b9a31e4f7d3d1cb6377e7f3.avif)<!-- screenshot -->
+
+![Ultralytics Platform Deployment Monitoring Confidence And Spatial Statistics](https://cdn.ul.run/i/f9cb24a8692f568f96617c6026c90b8e.avif)<!-- screenshot -->
 
 !!! tip "Interpreting Statistics"
 
@@ -198,7 +200,7 @@ Monitoring refreshes about every **2 seconds** while its panel is open and visib
 
 Each deployment card includes a `Logs` tab for viewing recent log entries:
 
-![Ultralytics Platform Deployment Card Logs Tab With Severity Filter](https://cdn.ul.run/i/f7b9acee12aab29e7b05f1f77d44d65e.avif)<!-- screenshot -->
+![Ultralytics Platform Deployment Card Logs Tab With Severity Filter](https://cdn.ul.run/i/87447dfe15d51c112e12956a72f5fd06.avif)<!-- screenshot -->
 
 ### Log Entries
 
@@ -417,7 +419,7 @@ Use monitoring data to optimize your deployments:
 
 ### How long is data retained?
 
-**Prediction statistics and temporary examples** last only for the serving instance's lifetime, within the bucket and gallery limits described above. Restarting or redeploying clears them. Only examples successfully saved to a dataset persist independently of the endpoint.
+**Prediction statistics and temporary examples** last only for the serving instance's lifetime, within the bucket and gallery limits described above. Stopping, restarting, redeploying, resizing, or replacing the model can clear them. Only examples successfully saved to a dataset persist independently of the endpoint.
 
 **Operational metrics and logs** have separate history windows. The metrics API supports selectable windows from 1 hour through 30 days, sampled more coarsely as the window grows —
 1-minute buckets over 1 hour up to 4-hour buckets over 30 days. The deployment card shows the 20 most recent log

--- a/docs/en/platform/deploy/monitoring.md
+++ b/docs/en/platform/deploy/monitoring.md
@@ -2,13 +2,13 @@
 plans: [free, pro, enterprise]
 title: Deployment Monitoring
 comments: true
-description: Monitor deployed YOLO models with live RTSP previews, captured predictions, performance charts, runtime metrics, and logs on Ultralytics Platform.
+description: Monitor deployed YOLO models with live prediction statistics, temporary examples, dataset saving, endpoint metrics, and logs on Ultralytics Platform.
 keywords: Ultralytics Platform, monitoring, metrics, logs, deployment, performance, YOLO, observability
 ---
 
 # Monitoring
 
-[Ultralytics Platform](https://platform.ultralytics.com) provides [monitoring for deployed endpoints](../../guides/model-monitoring-and-maintenance.md). Review captured predictions, connect an RTSP camera for live inference, and track prediction quality and endpoint performance alongside logs and health checks.
+[Ultralytics Platform](https://platform.ultralytics.com) provides [monitoring for deployed endpoints](../../guides/model-monitoring-and-maintenance.md). Track endpoint requests, latency, errors, and logs. Paid dedicated endpoints also provide live prediction statistics and temporary examples that you can inspect and save to datasets.
 
 ![Ultralytics Platform Deploy Page Overview Cards And World Map](https://cdn.ul.run/i/39e125429eb799c95eb006398e8ab6a4.avif)<!-- screenshot -->
 
@@ -23,7 +23,7 @@ graph TB
         Cards --- List[Deployments List]:::decide
     end
     subgraph "Per Ready Deployment"
-        Monitoring[Monitoring Tab]:::out
+        Monitoring[Monitoring Tab: Paid Endpoints]:::out
         Metrics[Metrics Row]:::out
         Health[Health Check]:::out
         Logs[Logs Tab]:::out
@@ -79,11 +79,11 @@ Click any region to open the `New Deployment` dialog. The map is hidden on small
 
 Below the overview cards, the deployments list shows all endpoints across your projects. Use the view mode toggle to switch between:
 
-| View        | Description                                                                  |
-| ----------- | ---------------------------------------------------------------------------- |
-| **Cards**   | Full detail cards with monitoring, logs, code, and predict tabs              |
-| **Compact** | Grid of smaller cards (1-4 columns) with key metrics                         |
-| **Table**   | DataTable with sortable columns: Name, Region, Status, Requests, P95, Errors |
+| View        | Description                                                                       |
+| ----------- | --------------------------------------------------------------------------------- |
+| **Cards**   | Full detail cards with metrics, logs, code, predict, and eligible monitoring tabs |
+| **Compact** | Grid of smaller cards (1-4 columns) with key metrics                              |
+| **Table**   | DataTable with sortable columns: Name, Region, Status, Requests, P95, Errors      |
 
 !!! tip "Real-Time Updates"
 
@@ -127,116 +127,72 @@ sending traffic.
 
 ## Monitoring Tab
 
-For paid endpoints, **Monitoring** is the first tab on a **Ready** deployment. It contains the camera preview, **Last Predictions**, and prediction and runtime charts, in that order. Free endpoints do not show this tab.
+Open **Deploy**, switch to **Cards** view, and select **Monitoring** on a **Ready**, paid dedicated endpoint. Send an image through its **Predict** tab or endpoint API to populate **Temporary Examples** and **Prediction Statistics**. Before the first processed image, the tab shows **No images processed**.
 
-Send an image through the endpoint's `Predict` tab or API to start collecting prediction data. You can also connect an RTSP camera to run continuous inference.
+!!! note "Endpoint Eligibility"
 
-!!! note "Paid Instances Required"
+    Monitoring requires a paid, uptime-billed endpoint running a monitoring-capable runtime. An included endpoint does not gain this tab from a paid workspace plan alone. See [Dedicated Endpoints](endpoints.md) for resource configuration. Existing endpoints are not automatically updated with every runtime release, so an older endpoint may show **Monitoring unavailable** until its runtime is updated.
 
-    The Monitoring tab, including camera previews, captured predictions, and charts, is available only on paid instances. A free instance does not show Monitoring, even if your workspace has a paid plan.
+<!-- Screenshot placeholder: Ready paid endpoint with Monitoring selected, Temporary Examples, and Prediction Statistics. -->
 
-### CPU and Memory Configuration
+!!! warning "Temporary Data"
 
-Choose **CPU** and **Memory** when creating an endpoint to provision a more powerful instance for larger models or higher inference throughput. Available options range from **1 to 8 vCPU** and **2 to 32 GiB** of memory; the dialog validates supported combinations and shows the estimated endpoint cost.
+    Examples and prediction statistics are held in the serving instance's memory. They reset when the instance restarts or is replaced, including during redeployment. This is temporary inspection history; save useful examples to a dataset to keep them.
 
-To resize an existing endpoint:
+### Temporary Examples
 
-1. Find the **Ready** deployment in cards view.
-2. Click its **Update configuration** icon.
-3. Select the CPU and memory allocation and review the cost estimate.
-4. Click **Update Configuration**. The endpoint keeps serving its current configuration until the new one is ready.
+The gallery contains a rolling sample of processed images with prediction overlays. Open an image to inspect its predictions in the full-screen viewer and use the visibility controls to adjust the overlays. The gallery initially shows up to 12 examples; **Show all** expands it.
 
-Use **CPU & RAM Usage**, **Prediction Latency**, and the camera's **Frame Rate** chart to assess the change. More CPU can improve inference throughput, while more memory provides room for larger workloads; a larger instance does not guarantee that inference FPS will match source FPS.
+- **Sampling:** Up to two examples initially, then up to one additional image per minute. Capture is best effort; inference does not wait for example encoding.
+- **Capacity:** At most 100 images within a shared 100 MiB memory budget for compressed images, prediction metadata, and associated assets. The interface labels this budget as **100 MB**.
+- **Replacement:** Older examples are replaced when either limit is reached. An example may become unavailable while you are viewing it.
+- **Storage:** Temporary examples remain in endpoint memory. Saving them to a dataset uses normal workspace storage and processing limits.
 
-### Live Camera Preview
+<!-- Screenshot placeholder: Temporary Examples gallery and an example open in the prediction viewer. -->
 
-Connect a camera from the top of the `Monitoring` tab:
+### Save Examples to a Dataset
 
-1. Click **Connect** to open the **Connect Camera** dialog.
-2. Enter the camera's **RTSP URL**, for example `rtsp://camera.example.com/stream`.
-3. Click **Connect**. The dialog closes after the request is accepted; the preview shows the connection status while the camera starts.
-4. Once frames arrive, use the **Annotations** toggle to switch between the original image and model predictions.
+Workspace members with content editing permission can save examples to a dataset in the endpoint's workspace:
 
-Hover over the preview to reveal the **Disconnect camera** stop button in the top-right corner. To change the camera URL, disconnect first, then click **Connect** again.
+1. Select individual examples using their checkboxes, or click **Select all**.
+2. Click **Save to dataset**.
+3. Choose an existing dataset with the same task as the deployed model. Connected-source datasets are excluded; create a compatible dataset first if none is available.
+4. Click the **Save** button, which shows the selected image count, then open the dataset to follow processing.
 
-!!! note "Camera Connectivity"
+Selected images and predictions are copied through the standard dataset upload and ingestion workflow. Normal quota, class mapping, and duplicate handling apply. Saving leaves the temporary examples in the gallery; successfully ingested dataset images survive endpoint restarts and deletion. Review predicted labels before using them for training.
 
-    The camera must be reachable from the deployed endpoint, not just from your browser or local network. Include credentials in the RTSP URL if the camera requires authentication. A connecting state means the request was accepted, not that frames are already arriving.
+<!-- Screenshot placeholder: Selected temporary examples and the Save examples to dataset dialog with a compatible dataset. -->
 
-The preview displays the latest camera frames on the left and session statistics on the right. Statistics appear only after camera data arrives:
+To remove temporary examples, use an image's hover trash control or select examples and click the bulk trash button, then confirm **Delete**. Deleting examples leaves aggregate prediction statistics and images already saved to datasets unchanged.
 
-| Metric                | Description                                                                                  |
-| --------------------- | -------------------------------------------------------------------------------------------- |
-| **Session coverage**  | Percentage of received source frames processed by the model during this session              |
-| **Uptime / downtime** | Time the camera session has spent receiving frames versus waiting for frames                 |
-| **Last frame**        | Time of the most recently received frame                                                     |
-| **Frame Rate**        | Source and inference FPS, shown as rolling 5-second averages over the recent session history |
+### Prediction Statistics
 
-Source FPS measures incoming frames; inference FPS measures frames processed by the model. Inference FPS can be lower when the model cannot process every source frame. Compare them when choosing a model, image size, or endpoint resources.
+Statistics aggregate processed images independently of gallery sampling. Deleting or replacing an example does not subtract its contribution. The summary shows images, predictions, and images without predictions for the selected period; depth models show image counts.
 
-### Last Predictions
+The date picker defaults to the last **30 days** and accepts ranges up to **365 days**. Selected dates use **UTC** boundaries; chart timestamps display in local time. Recent ranges of up to three days use hourly history when the full range falls within the last 72 hours; other ranges use daily history. The date range filters statistics, while the gallery continues to show the current temporary examples.
 
-**Last Predictions** shows up to the latest **100 captured images**, retained for up to **30 days**. Use the view toggle to switch between cards, compact, and table views. Cards and compact views initially show three rows; click **Show all** to expand the gallery. Click an image to inspect its predictions in the full-screen viewer, and use the visibility controls to show or hide annotations and labels.
+History is bounded to **72 hourly buckets** and **365 daily buckets**, and is available only since the current instance started. A selected period with no processed images shows **No images processed in this period**.
 
-!!! info "Sampled Predictions"
+Available charts depend on the task and collected predictions:
 
-    Captures are best-effort samples, not a recording of every prediction or camera frame. Images count toward workspace storage. Inference continues when capture is busy or storage is full, so gallery counts can differ from request counts and live inference activity.
+| Chart                     | What it shows                                                                                                   |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| **Predictions over Time** | Processed image and prediction totals; depth models show **Images over Time**                                   |
+| **Inference Time**        | Mean model inference time in milliseconds, excluding network and request overhead                               |
+| **Top Classes**           | Prediction counts by class                                                                                      |
+| **Predictions per Image** | Distribution including images with no predictions and a final **100+** bin; hidden for classification and depth |
+| **Prediction Confidence** | Confidence distribution and mean, when confidence scores are available                                          |
+| **Confidence over Time**  | Mean prediction confidence for each time bucket                                                                 |
+| **Prediction Dimensions** | Prediction width and height relative to the input image, when box dimensions are available                      |
+| **Prediction Locations**  | Spatial heatmap of predictions, when location data is available                                                 |
 
-To reuse predictions for training:
+<!-- Screenshot placeholder: Prediction Statistics with the date picker, time series, confidence distribution, and spatial charts. -->
 
-1. Select images in **Last Predictions**.
-2. Click **Add to dataset**.
-3. Choose a dataset and split, then confirm.
+!!! tip "Interpreting Statistics"
 
-Selected images move into the dataset with their predictions as labels. Duplicate images remain in **Last Predictions**. Review the predicted labels before using them for training.
+    Confidence measures the model's certainty, not correctness. Inspect examples and compare against reviewed labels when assessing accuracy. **Inference Time** measures model execution; the deployment's **P95 Latency** includes request handling and can also reflect non-inference traffic such as health checks.
 
-### Chart Controls
-
-The grouping, interval, and date controls appear **below Last Predictions** and apply to the charts and metrics that follow. They do not filter the image gallery or camera preview.
-
-| Control        | Options                                              |
-| -------------- | ---------------------------------------------------- |
-| **Group by**   | **No grouping** or **Class**, for tasks with classes |
-| **Interval**   | **Hourly**, **Daily**, or **Monthly**                |
-| **Date range** | Defaults to today; select a range of up to 366 days  |
-
-Hourly intervals support up to 31 days. Selecting a longer range switches the interval to daily. Class grouping shows the top 20 classes in applicable charts.
-
-### Prediction Charts
-
-Prediction charts describe captured samples. Available charts depend on the model task and collected data:
-
-| Chart                                             | What it shows                                                                     |
-| ------------------------------------------------- | --------------------------------------------------------------------------------- |
-| **Prediction Volume**                             | Captured images and predictions over time, or counts by class                     |
-| **Images by Predicted Class**                     | Percentage of images containing each class; one image can contain several classes |
-| **Predictions per Image**                         | Number of predictions per captured image                                          |
-| **Confidence over Time**                          | Mean prediction confidence over the selected period                               |
-| **Confidence Distribution / Confidence by Class** | Confidence in 5% bands and mean confidence for each top class                     |
-| **Prediction locations**                          | Heatmap of where predictions occur within images                                  |
-| **Image and bounding box dimensions**             | Width, height, aspect ratio, and bounding box area distributions                  |
-| **Prediction Latency**                            | Prediction call duration before capture, with approximate percentiles             |
-| **Latency Distribution**                          | Distribution of prediction call durations in milliseconds                         |
-
-!!! tip "Confidence Is Not Accuracy"
-
-    Confidence describes the model's predictions, not their correctness. Use changes in confidence or class distribution to identify samples worth reviewing, then validate accuracy against labeled data.
-
-### Runtime Metrics
-
-Runtime charts describe endpoint activity, including requests other than inference:
-
-| Chart                     | What it shows                                                                         |
-| ------------------------- | ------------------------------------------------------------------------------------- |
-| **Requests and Errors**   | All endpoint requests, responses with 4xx or 5xx status, and server errors separately |
-| **Observed Availability** | Percentage of requests without server errors; periods without requests are unobserved |
-| **CPU & RAM Usage**       | Mean resource utilization across serving instances                                    |
-
-Observed availability is request-based, while the camera's uptime and downtime describe its current stream session. Prediction latency measures prediction calls; runtime request metrics also include traffic such as health checks.
-
-!!! info "Automatic Updates"
-
-    Last Predictions and camera connection details refresh every 5 seconds. The live preview streams frames as they arrive. Prediction charts and runtime metrics refresh every 60 seconds while displayed; new data can take additional time to appear after collection.
+Monitoring refreshes about every **2 seconds** while its panel is open and visible. Polling pauses when the panel is offscreen or the browser tab is hidden. Successful inference through the deployment's **Predict** tab also triggers a statistics refresh.
 
 ## Logs
 
@@ -373,31 +329,13 @@ Returns the full metrics payload for a deployment: a `summary` block with total 
 average, P50, P95, and P99 latency, plus `timeSeries` arrays for requests, errors, P50 and P95 latency, CPU and memory
 utilization, and instance count.
 
-| Parameter    | Type   | Description                                                                 |
-| ------------ | ------ | --------------------------------------------------------------------------- |
-| `range`      | string | Time range: `1h`, `6h`, `24h`, `7d`, or `30d` (default `24h`)               |
-| `sparkline`  | bool   | Return the compact dashboard summary instead of the full payload            |
-| `from`, `to` | string | Optional ISO 8601 start and end timestamps; supply both to override `range` |
-| `interval`   | string | Bucket size for explicit dates: `hour`, `day`, or `month` (default `day`)   |
+| Parameter   | Type   | Description                                                      |
+| ----------- | ------ | ---------------------------------------------------------------- |
+| `range`     | string | Time range: `1h`, `6h`, `24h`, `7d`, or `30d` (default `24h`)    |
+| `sparkline` | bool   | Return the compact dashboard summary instead of the full payload |
 
 With `sparkline=true`, the response is the compact form the deployment cards use — 24 hourly request counts plus total
 requests, error rate, and average latency. This is the call that refreshes every 60 seconds.
-
-### Prediction Statistics
-
-```http
-GET /api/deployments/{owner}/{deployment}/statistics?from=2026-09-01T00:00:00Z&to=2026-09-02T00:00:00Z&interval=hour
-```
-
-Returns aggregated statistics for captured predictions, including volume, classes, confidence, dimensions, locations, and prediction latency. Supply `from` and `to` as ISO 8601 timestamps and an `interval` of `hour`, `day`, or `month`. Hourly queries support up to 31 days; daily and monthly queries support up to 366 days. The same limits apply to explicit date ranges on the metrics route.
-
-### Captured Images
-
-```http
-GET /api/deployments/{owner}/{deployment}/images
-```
-
-Returns the latest captured images and their prediction metadata, newest first. Add `?imageId=IMAGE_ID` to retrieve an individual capture with its labels for detailed inspection.
 
 ### Deployment Logs
 
@@ -479,11 +417,14 @@ Use monitoring data to optimize your deployments:
 
 ### How long is data retained?
 
-Captured images are retained for up to **30 days**, with the latest **100** available in Last Predictions. Move images you want to keep into a dataset before they expire.
+**Prediction statistics and temporary examples** last only for the serving instance's lifetime, within the bucket and gallery limits described above. Restarting or redeploying clears them. Only examples successfully saved to a dataset persist independently of the endpoint.
 
-The chart date picker supports queries of up to 366 days, depending on the selected interval and available history. The metrics API also supports preset windows from 1 hour through 30 days. A selectable range does not guarantee data exists for the whole period.
+**Operational metrics and logs** have separate history windows. The metrics API supports selectable windows from 1 hour through 30 days, sampled more coarsely as the window grows —
+1-minute buckets over 1 hour up to 4-hour buckets over 30 days. The deployment card shows the 20 most recent log
+entries; the logs API can return up to 200 entries per request and supports pagination.
 
-The deployment card shows the 20 most recent log entries; the logs API supports up to 200 entries per request and pagination. Deleting a deployment ends access to its monitoring history through the deployment routes.
+Metrics and logs are retained only while the deployment exists, so deleting a deployment also ends access to its history.
+Export anything you need to keep before deleting an endpoint.
 
 ### Can I monitor multiple endpoints together?
 

--- a/docs/en/platform/deploy/monitoring.md
+++ b/docs/en/platform/deploy/monitoring.md
@@ -2,13 +2,13 @@
 plans: [free, pro, enterprise]
 title: Deployment Monitoring
 comments: true
-description: Monitor deployed YOLO models on Ultralytics Platform with real-time metrics, request logs, and performance dashboards.
+description: Monitor deployed YOLO models with live RTSP previews, captured predictions, performance charts, runtime metrics, and logs on Ultralytics Platform.
 keywords: Ultralytics Platform, monitoring, metrics, logs, deployment, performance, YOLO, observability
 ---
 
 # Monitoring
 
-[Ultralytics Platform](https://platform.ultralytics.com) provides [monitoring for deployed endpoints](../../guides/model-monitoring-and-maintenance.md). Track request metrics, view logs, and check health status with automatic polling.
+[Ultralytics Platform](https://platform.ultralytics.com) provides [monitoring for deployed endpoints](../../guides/model-monitoring-and-maintenance.md). Review captured predictions, connect an RTSP camera for live inference, and track prediction quality and endpoint performance alongside logs and health checks.
 
 ![Ultralytics Platform Deploy Page Overview Cards And World Map](https://cdn.ul.run/i/39e125429eb799c95eb006398e8ab6a4.avif)<!-- screenshot -->
 
@@ -23,12 +23,14 @@ graph TB
         Cards --- List[Deployments List]:::decide
     end
     subgraph "Per Ready Deployment"
+        Monitoring[Monitoring Tab]:::out
         Metrics[Metrics Row]:::out
         Health[Health Check]:::out
         Logs[Logs Tab]:::out
         Code[Code Tab]:::out
         Predict[Predict Tab]:::out
     end
+    List --> Monitoring
     List --> Metrics
     List --> Health
     List --> Logs
@@ -79,7 +81,7 @@ Below the overview cards, the deployments list shows all endpoints across your p
 
 | View        | Description                                                                  |
 | ----------- | ---------------------------------------------------------------------------- |
-| **Cards**   | Full detail cards with metrics, logs, code, and predict tabs                 |
+| **Cards**   | Full detail cards with monitoring, logs, code, and predict tabs              |
 | **Compact** | Grid of smaller cards (1-4 columns) with key metrics                         |
 | **Table**   | DataTable with sortable columns: Name, Region, Status, Requests, P95, Errors |
 
@@ -122,6 +124,119 @@ sending traffic.
 !!! info "Cold Start Tolerance"
 
     Platform gives the health check extra time and retries transient connection failures, so a scale-to-zero endpoint has time to start. If the card reports "Service starting up...", refresh it to pick up an instance that finished booting in the meantime.
+
+## Monitoring Tab
+
+For paid endpoints, **Monitoring** is the first tab on a **Ready** deployment. It contains the camera preview, **Last Predictions**, and prediction and runtime charts, in that order. Free endpoints do not show this tab.
+
+Send an image through the endpoint's `Predict` tab or API to start collecting prediction data. You can also connect an RTSP camera to run continuous inference.
+
+!!! note "Paid Instances Required"
+
+    The Monitoring tab, including camera previews, captured predictions, and charts, is available only on paid instances. A free instance does not show Monitoring, even if your workspace has a paid plan.
+
+### CPU and Memory Configuration
+
+Choose **CPU** and **Memory** when creating an endpoint to provision a more powerful instance for larger models or higher inference throughput. Available options range from **1 to 8 vCPU** and **2 to 32 GiB** of memory; the dialog validates supported combinations and shows the estimated endpoint cost.
+
+To resize an existing endpoint:
+
+1. Find the **Ready** deployment in cards view.
+2. Click its **Update configuration** icon.
+3. Select the CPU and memory allocation and review the cost estimate.
+4. Click **Update Configuration**. The endpoint keeps serving its current configuration until the new one is ready.
+
+Use **CPU & RAM Usage**, **Prediction Latency**, and the camera's **Frame Rate** chart to assess the change. More CPU can improve inference throughput, while more memory provides room for larger workloads; a larger instance does not guarantee that inference FPS will match source FPS.
+
+### Live Camera Preview
+
+Connect a camera from the top of the `Monitoring` tab:
+
+1. Click **Connect** to open the **Connect Camera** dialog.
+2. Enter the camera's **RTSP URL**, for example `rtsp://camera.example.com/stream`.
+3. Click **Connect**. The dialog closes after the request is accepted; the preview shows the connection status while the camera starts.
+4. Once frames arrive, use the **Annotations** toggle to switch between the original image and model predictions.
+
+Hover over the preview to reveal the **Disconnect camera** stop button in the top-right corner. To change the camera URL, disconnect first, then click **Connect** again.
+
+!!! note "Camera Connectivity"
+
+    The camera must be reachable from the deployed endpoint, not just from your browser or local network. Include credentials in the RTSP URL if the camera requires authentication. A connecting state means the request was accepted, not that frames are already arriving.
+
+The preview displays the latest camera frames on the left and session statistics on the right. Statistics appear only after camera data arrives:
+
+| Metric                | Description                                                                                  |
+| --------------------- | -------------------------------------------------------------------------------------------- |
+| **Session coverage**  | Percentage of received source frames processed by the model during this session              |
+| **Uptime / downtime** | Time the camera session has spent receiving frames versus waiting for frames                 |
+| **Last frame**        | Time of the most recently received frame                                                     |
+| **Frame Rate**        | Source and inference FPS, shown as rolling 5-second averages over the recent session history |
+
+Source FPS measures incoming frames; inference FPS measures frames processed by the model. Inference FPS can be lower when the model cannot process every source frame. Compare them when choosing a model, image size, or endpoint resources.
+
+### Last Predictions
+
+**Last Predictions** shows up to the latest **100 captured images**, retained for up to **30 days**. Use the view toggle to switch between cards, compact, and table views. Cards and compact views initially show three rows; click **Show all** to expand the gallery. Click an image to inspect its predictions in the full-screen viewer, and use the visibility controls to show or hide annotations and labels.
+
+!!! info "Sampled Predictions"
+
+    Captures are best-effort samples, not a recording of every prediction or camera frame. Images count toward workspace storage. Inference continues when capture is busy or storage is full, so gallery counts can differ from request counts and live inference activity.
+
+To reuse predictions for training:
+
+1. Select images in **Last Predictions**.
+2. Click **Add to dataset**.
+3. Choose a dataset and split, then confirm.
+
+Selected images move into the dataset with their predictions as labels. Duplicate images remain in **Last Predictions**. Review the predicted labels before using them for training.
+
+### Chart Controls
+
+The grouping, interval, and date controls appear **below Last Predictions** and apply to the charts and metrics that follow. They do not filter the image gallery or camera preview.
+
+| Control        | Options                                              |
+| -------------- | ---------------------------------------------------- |
+| **Group by**   | **No grouping** or **Class**, for tasks with classes |
+| **Interval**   | **Hourly**, **Daily**, or **Monthly**                |
+| **Date range** | Defaults to today; select a range of up to 366 days  |
+
+Hourly intervals support up to 31 days. Selecting a longer range switches the interval to daily. Class grouping shows the top 20 classes in applicable charts.
+
+### Prediction Charts
+
+Prediction charts describe captured samples. Available charts depend on the model task and collected data:
+
+| Chart                                             | What it shows                                                                     |
+| ------------------------------------------------- | --------------------------------------------------------------------------------- |
+| **Prediction Volume**                             | Captured images and predictions over time, or counts by class                     |
+| **Images by Predicted Class**                     | Percentage of images containing each class; one image can contain several classes |
+| **Predictions per Image**                         | Number of predictions per captured image                                          |
+| **Confidence over Time**                          | Mean prediction confidence over the selected period                               |
+| **Confidence Distribution / Confidence by Class** | Confidence in 5% bands and mean confidence for each top class                     |
+| **Prediction locations**                          | Heatmap of where predictions occur within images                                  |
+| **Image and bounding box dimensions**             | Width, height, aspect ratio, and bounding box area distributions                  |
+| **Prediction Latency**                            | Prediction call duration before capture, with approximate percentiles             |
+| **Latency Distribution**                          | Distribution of prediction call durations in milliseconds                         |
+
+!!! tip "Confidence Is Not Accuracy"
+
+    Confidence describes the model's predictions, not their correctness. Use changes in confidence or class distribution to identify samples worth reviewing, then validate accuracy against labeled data.
+
+### Runtime Metrics
+
+Runtime charts describe endpoint activity, including requests other than inference:
+
+| Chart                     | What it shows                                                                         |
+| ------------------------- | ------------------------------------------------------------------------------------- |
+| **Requests and Errors**   | All endpoint requests, responses with 4xx or 5xx status, and server errors separately |
+| **Observed Availability** | Percentage of requests without server errors; periods without requests are unobserved |
+| **CPU & RAM Usage**       | Mean resource utilization across serving instances                                    |
+
+Observed availability is request-based, while the camera's uptime and downtime describe its current stream session. Prediction latency measures prediction calls; runtime request metrics also include traffic such as health checks.
+
+!!! info "Automatic Updates"
+
+    Last Predictions and camera connection details refresh every 5 seconds. The live preview streams frames as they arrive. Prediction charts and runtime metrics refresh every 60 seconds while displayed; new data can take additional time to appear after collection.
 
 ## Logs
 
@@ -258,13 +373,31 @@ Returns the full metrics payload for a deployment: a `summary` block with total 
 average, P50, P95, and P99 latency, plus `timeSeries` arrays for requests, errors, P50 and P95 latency, CPU and memory
 utilization, and instance count.
 
-| Parameter   | Type   | Description                                                      |
-| ----------- | ------ | ---------------------------------------------------------------- |
-| `range`     | string | Time range: `1h`, `6h`, `24h`, `7d`, or `30d` (default `24h`)    |
-| `sparkline` | bool   | Return the compact dashboard summary instead of the full payload |
+| Parameter    | Type   | Description                                                                 |
+| ------------ | ------ | --------------------------------------------------------------------------- |
+| `range`      | string | Time range: `1h`, `6h`, `24h`, `7d`, or `30d` (default `24h`)               |
+| `sparkline`  | bool   | Return the compact dashboard summary instead of the full payload            |
+| `from`, `to` | string | Optional ISO 8601 start and end timestamps; supply both to override `range` |
+| `interval`   | string | Bucket size for explicit dates: `hour`, `day`, or `month` (default `day`)   |
 
 With `sparkline=true`, the response is the compact form the deployment cards use — 24 hourly request counts plus total
 requests, error rate, and average latency. This is the call that refreshes every 60 seconds.
+
+### Prediction Statistics
+
+```http
+GET /api/deployments/{owner}/{deployment}/statistics?from=2026-09-01T00:00:00Z&to=2026-09-02T00:00:00Z&interval=hour
+```
+
+Returns aggregated statistics for captured predictions, including volume, classes, confidence, dimensions, locations, and prediction latency. Supply `from` and `to` as ISO 8601 timestamps and an `interval` of `hour`, `day`, or `month`. Hourly queries support up to 31 days; daily and monthly queries support up to 366 days. The same limits apply to explicit date ranges on the metrics route.
+
+### Captured Images
+
+```http
+GET /api/deployments/{owner}/{deployment}/images
+```
+
+Returns the latest captured images and their prediction metadata, newest first. Add `?imageId=IMAGE_ID` to retrieve an individual capture with its labels for detailed inspection.
 
 ### Deployment Logs
 
@@ -346,12 +479,11 @@ Use monitoring data to optimize your deployments:
 
 ### How long is data retained?
 
-The metrics API supports selectable windows from 1 hour through 30 days, sampled more coarsely as the window grows —
-1-minute buckets over 1 hour up to 4-hour buckets over 30 days. The deployment card shows the 20 most recent log
-entries; the logs API can return up to 200 entries per request and supports pagination.
+Captured images are retained for up to **30 days**, with the latest **100** available in Last Predictions. Move images you want to keep into a dataset before they expire.
 
-Metrics and logs are retained only while the deployment exists, so deleting a deployment also ends access to its history.
-Export anything you need to keep before deleting an endpoint.
+The chart date picker supports queries of up to 366 days, depending on the selected interval and available history. The metrics API also supports preset windows from 1 hour through 30 days. A selectable range does not guarantee data exists for the whole period.
+
+The deployment card shows the 20 most recent log entries; the logs API supports up to 200 entries per request and pagination. Deleting a deployment ends access to its monitoring history through the deployment routes.
 
 ### Can I monitor multiple endpoints together?
 


### PR DESCRIPTION
Documents the lightweight monitoring shipped in ultralytics/portal#4059 across the Deploy overview, dedicated endpoints, inference, and monitoring guides. Replaces the earlier proposed behavior with the actual paid-endpoint eligibility, temporary example sampling, task-aware statistics, and saving examples through normal dataset ingestion.

Makes the temporary nature explicit: charts and examples can disappear when an endpoint stops, restarts, redeploys, changes resources, or replaces its model. Updates CPU/memory configuration, uptime billing, scale-to-zero behavior, and current HTTP metric labels.

Includes 26 freshly captured screenshots (20 replacements and 6 additions) captured from the live Platform using its documentation screenshot script and published through Portal assets. Superseded assets are retained. Capture recipe maintenance is in ultralytics/portal#4066.

Validation: compared against the merged implementation; captured and visually checked all 26 screenshots; verified the screenshot inventory, Markdown formatting, and published image responses. The Docs build passed. Merged after final LGTM review with the maintainer-authorized admin override; remaining package CI was not a merge gate. Production Vercel deployment is Ready.
