### PR TITLE
Speed up RT-DETR matching on dense datasets

### DIFF
--- a/ultralytics/models/utils/ops.py
+++ b/ultralytics/models/utils/ops.py
@@ -106,18 +106,20 @@ class HungarianMatcher(nn.Module):
                 the tensor of indices of the corresponding selected ground truth targets (in order).
             For each batch element, it holds: len(index_i) = len(index_j) = min(num_queries, num_target_boxes).
         """
-        bs, nq, nc = pred_scores.shape
+        bs, nq, _ = pred_scores.shape
 
         if sum(gt_groups) == 0:
             return [(torch.tensor([], dtype=torch.long), torch.tensor([], dtype=torch.long)) for _ in range(bs)]
 
-        # Flatten to compute cost matrices in batch format
-        pred_scores = pred_scores.detach().view(-1, nc)
+        # Pad targets to compute costs within each image.
+        gt_bboxes = torch.nn.utils.rnn.pad_sequence(gt_bboxes.split(gt_groups), batch_first=True)
+        gt_cls = torch.nn.utils.rnn.pad_sequence(gt_cls.split(gt_groups), batch_first=True)
+        pred_scores = pred_scores.detach()
         pred_scores = F.sigmoid(pred_scores) if self.use_fl else F.softmax(pred_scores, dim=-1)
-        pred_bboxes = pred_bboxes.detach().view(-1, 4)
+        pred_bboxes = pred_bboxes.detach()
 
         # Compute classification cost
-        pred_scores = pred_scores[:, gt_cls]
+        pred_scores = pred_scores.gather(2, gt_cls[:, None].expand(-1, nq, -1))
         if self.use_fl:
             neg_cost_class = (1 - self.alpha) * (pred_scores**self.gamma) * (-(1 - pred_scores + 1e-8).log())
             pos_cost_class = self.alpha * ((1 - pred_scores) ** self.gamma) * (-(pred_scores + 1e-8).log())
@@ -126,10 +128,10 @@ class HungarianMatcher(nn.Module):
             cost_class = -pred_scores
 
         # Compute L1 cost between boxes
-        cost_bbox = (pred_bboxes.unsqueeze(1) - gt_bboxes.unsqueeze(0)).abs().sum(-1)  # (bs*num_queries, num_gt)
+        cost_bbox = (pred_bboxes.unsqueeze(2) - gt_bboxes.unsqueeze(1)).abs().sum(-1)
 
-        # Compute GIoU cost between boxes, (bs*num_queries, num_gt)
-        cost_giou = 1.0 - bbox_iou(pred_bboxes.unsqueeze(1), gt_bboxes.unsqueeze(0), xywh=True, GIoU=True).squeeze(-1)
+        # Compute GIoU cost between boxes within each image
+        cost_giou = 1.0 - bbox_iou(pred_bboxes.unsqueeze(2), gt_bboxes.unsqueeze(1), xywh=True, GIoU=True).squeeze(-1)
 
         # Combine costs into final cost matrix
         C = (
@@ -140,13 +142,16 @@ class HungarianMatcher(nn.Module):
 
         # Add mask costs if available
         if self.with_mask:
-            C += self._cost_mask(bs, gt_groups, masks, gt_mask)
+            mask_cost = self._cost_mask(bs, gt_groups, masks, gt_mask).view(bs, nq, -1)
+            C += torch.nn.utils.rnn.pad_sequence(
+                [c[i].T for i, c in enumerate(mask_cost.split(gt_groups, -1))], batch_first=True
+            ).transpose(1, 2)
 
         # Set invalid values (NaNs and infinities) to 0
         C[C.isnan() | C.isinf()] = 0.0
 
-        C = C.view(bs, nq, -1).cpu()
-        indices = [linear_sum_assignment(c[i]) for i, c in enumerate(C.split(gt_groups, -1))]
+        C = C.cpu()
+        indices = [linear_sum_assignment(c[:, :n]) for c, n in zip(C, gt_groups)]
         gt_groups = torch.as_tensor([0, *gt_groups[:-1]]).cumsum_(0)  # (idx for queries, idx for gt)
         return [
             (torch.tensor(i, dtype=torch.long), torch.tensor(j, dtype=torch.long) + gt_groups[k])


### PR DESCRIPTION
Avoid computing and copying Hungarian matching costs between predictions and targets from different images, which are discarded before assignment.

Cost storage changes from `B × Q × sum(targets)` to `B × Q × max(targets)`, with padding removed before each assignment. This benefits dense, high-object-count batches such as SKU-110K; COCO showed essentially unchanged training speed. Assignment solver, losses, precision, and training settings are unchanged.

Benchmarked public RT-DETR-L/X pretrained weights against `main` at `3cb9d0adbf195c22553c77ca07b0dd1df846c4fa`. Each dataset used fixed subsets of 1,024 training and 512 validation images, sampled with seed 1729. The main comparison comprises **24 training runs / 1,560 epochs**: baseline and patch, two models, and seeds 0/1/2, for 100 epochs on SKU-110K and 30 epochs on COCO 2017.

| Dataset | Model | Epochs per run | Training seconds/epoch, before → after | Training speedup | Validation-with-loss speedup |
| --- | --- | ---: | ---: | ---: | ---: |
| SKU-110K subset | RT-DETR-L | 100 | 23.75 → 16.64 | **1.43×** | **1.81×** |
| SKU-110K subset | RT-DETR-X | 100 | 24.29 → 20.22 | **1.20×** | **1.60×** |
| COCO 2017 subset | RT-DETR-L | 30 | 12.04 → 12.01 | 1.003× | 1.005× |
| COCO 2017 subset | RT-DETR-X | 30 | 16.75 → 16.71 | 1.003× | 1.004× |

Mean independently evaluated checkpoint mAP50–95, in percent; deltas are percentage points:

| Dataset / model | Best, before → after | Best Δ | Final, before → after | Final Δ |
| --- | ---: | ---: | ---: | ---: |
| SKU-110K / L | 49.566 → 49.711 | +0.145 | 49.528 → 49.649 | +0.121 |
| SKU-110K / X | 51.811 → 51.798 | −0.013 | 51.654 → 51.694 | +0.041 |
| COCO / L | 51.498 → 51.555 | +0.057 | 46.817 → 46.699 | −0.118 |
| COCO / X | 54.734 → 54.744 | +0.010 | 48.528 → 48.595 | +0.068 |

No NaNs or divergent losses were observed. Accuracy remained close across three seeds, with the small negative deltas reported above rather than claiming exactly identical mAP. These subset runs do not establish full-dataset accuracy equivalence. Training is nondeterministic; fixed-input checks produced identical assignments, losses, and gradients.

NVIDIA RTX PRO 6000 Blackwell Server Edition, PyTorch 2.9.1+cu130, SciPy assignment in both arms, `imgsz=640`, `batch=16`, `nbs=64`, AdamW, `lr0=0.0001`, `lrf=0.01`, `weight_decay=0.0001`, three warmup epochs, four workers, no cache, no compilation, and AMP disabled in both arms. Timing excludes the first three epochs; reported speedups are means of paired ratios. Best and final checkpoints used the same independent validation settings.

- Passed 35 assignment-parity cases, including empty, uneven, dense, and rectangular batches.
- Matched auxiliary/denoising losses and gradients, plus a real seven-layer prediction batch.
- Completed exact-patch L/X 30-epoch runs and PyTorch 2.13/2.14 compatibility pairs.

Standalone `model.val()` and inference do not invoke this matcher, so no standalone validation or inference speedup is claimed. The change is one implementation file, **16 additions / 11 removals (net +5)**: the extra lines pad variable target counts and preserve the existing mask-cost interface. No test files or dependencies are changed.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated RT-DETR Hungarian matching to compute prediction-to-target costs within each image, reducing unnecessary cost storage and computation for dense batches.

### 📊 Key Changes

- Changed target handling in `ultralytics/models/utils/ops.py` to pad targets to the largest per-image target count instead of combining all batch targets.
- Updated classification, L1 box, GIoU, and mask-cost calculations to use per-image target groups.
- Removed padding before assignment by slicing each cost matrix to its actual target count before calling `linear_sum_assignment`.
- Preserved the existing assignment solver, loss calculations, and mask-cost interface while retaining support for empty and uneven target groups.

### 🎯 Purpose & Impact

- Reduces matching memory use from a batch-wide target dimension to the maximum target count in a single image, improving RT-DETR training and validation-with-loss speed on dense datasets such as SKU-110K.
- Reported SKU-110K training speedups were 1.43× for RT-DETR-L and 1.20× for RT-DETR-X; COCO 2017 speed was essentially unchanged.
- Assignment-parity checks found matching losses and gradients consistent with the previous implementation, with no NaNs or divergent losses observed.
- Standalone `model.val()` and inference do not use this matcher, so no standalone validation or inference speedup is claimed.