### PR TITLE
Prevent Sentry credential capture and remove obsolete Ray fallback

### DIFF
--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -1231,6 +1231,7 @@ def set_sentry():
     # If sentry_sdk package is not installed then return and do not use Sentry
     try:
         import sentry_sdk
+        from sentry_sdk.integrations.argv import ArgvIntegration
     except ImportError:
         return
 
@@ -1261,6 +1262,8 @@ def set_sentry():
         dsn="https://888e5a0778212e1d0314c37d4b9aae5d@o4504521589325824.ingest.us.sentry.io/4504521592406016",
         debug=False,
         auto_enabling_integrations=False,
+        disabled_integrations=[ArgvIntegration()],
+        include_local_variables=False,
         traces_sample_rate=1.0,
         release=__version__,
         environment="runpod" if is_runpod() else "production",

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -1231,7 +1231,6 @@ def set_sentry():
     # If sentry_sdk package is not installed then return and do not use Sentry
     try:
         import sentry_sdk
-        from sentry_sdk.integrations.argv import ArgvIntegration
     except ImportError:
         return
 
@@ -1250,6 +1249,7 @@ def set_sentry():
             if exc_type in {KeyboardInterrupt, FileNotFoundError} or "out of memory" in str(exc_value):
                 return None  # do not send event
 
+        event.get("extra", {}).pop("sys.argv", None)
         event["tags"] = {
             "sys_argv": ARGV[0],
             "sys_argv_name": Path(ARGV[0]).name,
@@ -1262,7 +1262,6 @@ def set_sentry():
         dsn="https://888e5a0778212e1d0314c37d4b9aae5d@o4504521589325824.ingest.us.sentry.io/4504521592406016",
         debug=False,
         auto_enabling_integrations=False,
-        disabled_integrations=[ArgvIntegration()],
         include_local_variables=False,
         traces_sample_rate=1.0,
         release=__version__,

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -380,7 +380,7 @@ def run_ray_tune(
     """
     LOGGER.info("💡 Learn about RayTune at https://docs.ultralytics.com/integrations/ray-tune")
     try:
-        checks.check_requirements("ray[tune]>=2.41.0", constrain=["pydantic>=2.0,<2.12"])
+        checks.check_requirements(["ray>=2.41.0", "ray[tune]"], constrain=["pydantic>=2.0,<2.12"])
 
         import ray
         from ray import tune

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -380,7 +380,7 @@ def run_ray_tune(
     """
     LOGGER.info("💡 Learn about RayTune at https://docs.ultralytics.com/integrations/ray-tune")
     try:
-        checks.check_requirements("ray[tune]", constrain=["pydantic>=2.0,<2.12"])
+        checks.check_requirements("ray[tune]>=2.41.0", constrain=["pydantic>=2.0,<2.12"])
 
         import ray
         from ray import tune
@@ -389,7 +389,6 @@ def run_ray_tune(
     except ImportError:
         raise ModuleNotFoundError('Ray Tune required but not found. To install run: pip install "ray[tune]"')
 
-    checks.check_version(ray.__version__, ">=2.0.0", "ray")
     default_space = {
         # 'optimizer': tune.choice(['SGD', 'Adam', 'AdamW', 'NAdam', 'RAdam', 'RMSProp']),
         "lr0": tune.uniform(1e-5, 1e-2),  # initial learning rate (i.e. SGD=1E-2, Adam=1E-3)
@@ -435,10 +434,7 @@ def run_ray_tune(
 
         # Set trial-specific name for W&B logging
         try:
-            if hasattr(tune, "get_context"):
-                trial_id = tune.get_context().get_trial_id()  # Ray ≥2.7, get current trial ID (e.g., "tune_c1c1ce99")
-            else:
-                trial_id = tune.get_trial_id()  # Ray <2.7
+            trial_id = tune.get_context().get_trial_id()
             trial_suffix = trial_id.split("_")[-1] if "_" in trial_id else trial_id
             config["name"] = f"{base_name}_{trial_suffix}"
         except Exception:


### PR DESCRIPTION
Credentials passed to `yolo login` were captured in Sentry's command-line arguments and frame locals. Remove `extra["sys.argv"]` in the existing `before_send` callback and disable local-variable capture, preserving exception reporting and compatibility with Sentry 1.x and 2.x.

Remove the obsolete Ray <2.7 trial-ID fallback and check `ray>=2.41.0` separately from the Tune extra so the existing requirement parser enforces the minimum before importing `RunConfig`.

Validation: real Sentry 1.45.0 and 2.69.1 transports retained a synthetic exception while excluding its argv and frame-local credentials. Python syntax and diff checks pass. No version bump. Tracks ultralytics/portal#4061.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated Sentry handling to prevent command-line and local-variable credential capture, and raised Ray Tune’s enforced minimum version to 2.41.0 while removing the obsolete pre-2.7 trial-ID fallback.

### 📊 Key Changes
- Removed `sys.argv` from Sentry event extras before sending events.
- Disabled Sentry local-variable capture with `include_local_variables=False`, while retaining the existing exception filtering and reporting setup.
- Changed Ray Tune dependency checks to enforce `ray>=2.41.0` separately from the `ray[tune]` extra.
- Removed the Ray versions below 2.7 fallback and now always obtain trial IDs through `tune.get_context().get_trial_id()`.

### 🎯 Purpose & Impact
- Sentry exception events no longer include captured command-line arguments or frame-local variables, reducing the risk of exposing credentials passed to `yolo login`.
- Ray Tune runs now require Ray 2.41.0 or newer and use the current trial-context API; older Ray versions are no longer supported by this workflow.