### PR TITLE
Support legacy NumPy metadata and CLIP in restricted loading

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -260,8 +260,10 @@ def test_restricted_load_criterion(tmp_path):
     model = DetectionModel(CFG, verbose=False)
     model.args = DEFAULT_CFG
     model.criterion = model.init_criterion()
-    torch.save({"model": model}, tmp_path / "legacy.pt")
-    assert torch_safe_load(tmp_path / "legacy.pt", safe_only=True)[0]["model"].criterion is not None
+    torch.save({"model": model, "best_fitness": np.float64(0.5)}, tmp_path / "legacy.pt")
+    checkpoint = torch_safe_load(tmp_path / "legacy.pt", safe_only=True)[0]
+    assert checkpoint["model"].criterion is not None
+    assert checkpoint["best_fitness"] == 0.5
 
 
 @pytest.mark.parametrize("cfg", [CFG, "yolov8n.yaml", "yolov10n.yaml", "yolo11n.yaml", "yolo26n-p6.yaml"])

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1674,7 +1674,9 @@ class _SafeLoad:
                 for obj in (tvt.Compose, tvt.Normalize, tvt.Resize, tvt.CenterCrop, tvt.ToTensor, InterpolationMode):
                     cls._registry[f"{obj.__module__}.{obj.__qualname__}"] = obj
             if "ultralytics.nn.text_model.CLIP" in needed:
-                from ultralytics.nn.text_model import CLIP, clip
+                import clip
+
+                from ultralytics.nn.text_model import CLIP
 
                 for obj in (
                     CLIP,

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -9,6 +9,7 @@ import threading
 from copy import deepcopy
 from pathlib import Path
 
+import numpy as np
 import torch
 from torch import nn
 
@@ -1672,7 +1673,23 @@ class _SafeLoad:
 
                 for obj in (tvt.Compose, tvt.Normalize, tvt.Resize, tvt.CenterCrop, tvt.ToTensor, InterpolationMode):
                     cls._registry[f"{obj.__module__}.{obj.__qualname__}"] = obj
+            if "ultralytics.nn.text_model.CLIP" in needed:
+                from ultralytics.nn.text_model import CLIP, clip
+
+                for obj in (
+                    CLIP,
+                    clip.model.CLIP,
+                    clip.model.LayerNorm,
+                    clip.model.QuickGELU,
+                    clip.model.ResidualAttentionBlock,
+                    clip.model.Transformer,
+                    clip.model.VisionTransformer,
+                    clip.clip._convert_image_to_rgb,
+                ):
+                    cls._registry[f"{obj.__module__}.{obj.__qualname__}"] = obj
             entries = [cls._registry[name] for name in needed if name in cls._registry]
+            if "numpy.dtype" in needed:
+                entries.append(type(np.dtype(np.float64)))  # Built dynamically, absent from the checkpoint global scan.
             if entries:
                 torch.serialization.add_safe_globals(entries)
         cls._local.active = True
@@ -1762,6 +1779,8 @@ class _SafeLoad:
             ]
 
         # Non-nn.Module data globals in official checkpoints, incl. the pre-8.0.44 `ultralytics.yolo.utils` path.
+        scalar = np.float64(0).__reduce__()[0]
+        allow += [np.dtype, (scalar, "numpy.core.multiarray.scalar"), (scalar, "numpy._core.multiarray.scalar")]
         allow.append(IterableSimpleNamespace)
         allow.append((IterableSimpleNamespace, "ultralytics.yolo.utils.IterableSimpleNamespace"))
 


### PR DESCRIPTION
Restricted loading rejects valid legacy checkpoints containing NumPy float64 fitness metadata or an embedded Ultralytics CLIP text encoder. A read-only inventory of all 1,660 unique legacy Platform deployment checkpoints found seven files with NumPy scalar/dtype globals and one with CLIP globals. These gaps block moving safe loading into the predict image (ultralytics/portal#4069).

Extend the existing allow-list owner: register the NumPy scalar aliases used by NumPy 1/2 and the dynamically constructed float64 dtype, and register the known CLIP model/transform objects only when the checkpoint contains the Ultralytics CLIP wrapper. Unknown globals remain rejected. Extend the existing legacy-checkpoint test with real NumPy fitness metadata; no mocks or new test file.

Validation: the failure reproduces on 8.4.149; the updated loader passes the real legacy criterion/float64 path and still rejects an eval payload. All seven affected NumPy production checkpoints passed restricted loading and CPU inference in validation. The embedded CLIP production checkpoint also passed restricted loading and CPU inference. In a real environment without CLIP, the loader fails directly with auto-install enabled and does not attempt installation. CLIP is imported directly before its Ultralytics wrapper to prevent that wrapper from installing a checkpoint-requested dependency. Ruff passes with the repository CI's BLE001 exclusion (the pre-existing catch in the registry scanner triggers it otherwise). No version bump.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Restricted checkpoint loading now accepts supported legacy NumPy metadata and embedded Ultralytics CLIP objects while continuing to reject unregistered globals.

### 📊 Key Changes

- Added NumPy 1.x and 2.x scalar aliases, `np.dtype`, and the dynamically constructed `float64` dtype to the restricted-loading allow-list.
- Added conditional registration for the Ultralytics CLIP wrapper and its required `clip` model, layer, transformer, and image-conversion objects.
- Updated `test_restricted_load_criterion` to save and verify real `np.float64` fitness metadata alongside the legacy model.
- Kept CLIP registration conditional on the checkpoint’s required globals, with direct `clip` import before the Ultralytics wrapper import.

### 🎯 Purpose & Impact

- Legacy checkpoints containing NumPy `float64` fitness values or the supported embedded CLIP encoder can now pass restricted loading and proceed through the existing loading workflow.
- Unknown checkpoint globals remain unregistered and rejected.
- No version bump or unrelated user-facing behavior change.