### PR TITLE
Speed up restricted loading and restore fused checkpoints

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -252,18 +252,27 @@ def test_restricted_load_threaded():
     assert pathlib.WindowsPath is windows_path
 
 
-def test_restricted_load_criterion(tmp_path):
-    """Checkpoints saved before 8.4.95 pickle `ema.criterion`; restricted loading must still accept them."""
+@pytest.mark.parametrize("fused", [False, True])
+def test_restricted_load_criterion(tmp_path, fused):
+    """Legacy criterion metadata and fused forward bindings survive restricted checkpoint round trips."""
     from ultralytics.nn.tasks import DetectionModel, torch_safe_load
     from ultralytics.utils import DEFAULT_CFG
 
     model = DetectionModel(CFG, verbose=False)
     model.args = DEFAULT_CFG
     model.criterion = model.init_criterion()
+    model.eval()
+    if fused:
+        model.fuse(verbose=False)
+    image = torch.zeros(1, 3, 64, 64)
+    with torch.no_grad():
+        expected = model(image)[0]
     torch.save({"model": model, "best_fitness": np.float64(0.5)}, tmp_path / "legacy.pt")
     checkpoint = torch_safe_load(tmp_path / "legacy.pt", safe_only=True)[0]
     assert checkpoint["model"].criterion is not None
     assert checkpoint["best_fitness"] == 0.5
+    with torch.no_grad():
+        assert torch.equal(checkpoint["model"](image)[0], expected)
 
 
 @pytest.mark.parametrize("cfg", [CFG, "yolov8n.yaml", "yolov10n.yaml", "yolo11n.yaml", "yolo26n-p6.yaml"])

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.149"
+__version__ = "8.4.150"
 
 import importlib
 import os

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1790,7 +1790,11 @@ class _SafeLoad:
         def _getattr(obj, name):  # ckpts pickle `Detect.forward` and `InterpolationMode.BILINEAR` via getattr
             if isinstance(obj, type) and not name.startswith("__") and issubclass(obj, (nn.Module, enum.Enum)):
                 return getattr(obj, name)
-            raise pickle.UnpicklingError(f"unsafe getattr({obj!r}, {name!r}) blocked during restricted model load")
+            if isinstance(obj, nn.Module) and name in {"forward", "forward_fuse"}:
+                return getattr(type(obj), name).__get__(obj)
+            raise pickle.UnpicklingError(
+                f"unsafe getattr({type(obj).__name__}, {name!r}) blocked during restricted model load"
+            )
 
         allow += [
             (nn.Identity, "ultralytics.nn.modules.block.Silence"),  # YOLOv9e

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import importlib
 import pickle
 import re
 import threading
@@ -1666,6 +1667,20 @@ class _SafeLoad:
         with cls._lock:
             if cls._registry is None:
                 cls._registry = cls._build()
+            for name in needed:
+                module, _, attr = name.rpartition(".")
+                if name not in cls._registry and (
+                    module in {"torch.nn.modules", "ultralytics.nn.modules", "ultralytics.nn.tasks"}
+                    or module.rpartition(".")[0] in {"torch.nn.modules", "ultralytics.nn.modules"}
+                    or module in {"ultralytics.utils.loss", "ultralytics.utils.tal"}
+                ):
+                    obj = getattr(importlib.import_module(module), attr, None)
+                    if isinstance(obj, type) and (
+                        obj.__module__ == module
+                        if module in {"ultralytics.utils.loss", "ultralytics.utils.tal"}
+                        else issubclass(obj, nn.Module)
+                    ):
+                        cls._registry[name] = obj
             if any(name.startswith("torchvision.transforms.") for name in needed):
                 # Classification preprocessing transforms; imported only for checkpoints that serialize them.
                 import torchvision.transforms.transforms as tvt
@@ -1689,7 +1704,7 @@ class _SafeLoad:
                     clip.clip._convert_image_to_rgb,
                 ):
                     cls._registry[f"{obj.__module__}.{obj.__qualname__}"] = obj
-            entries = [cls._registry[name] for name in needed if name in cls._registry]
+            entries = [(cls._registry[name], name) for name in needed if name in cls._registry]
             if "numpy.dtype" in needed:
                 entries.append(type(np.dtype(np.float64)))  # Built dynamically, absent from the checkpoint global scan.
             if entries:
@@ -1732,53 +1747,13 @@ class _SafeLoad:
 
     @classmethod
     def _build(cls):
-        """Auto-discover `nn.Module` subclasses across `torch.nn` and the ultralytics model families, registered under
-        every namespace path they are reachable from (covering re-exports such as `block.RealNVP` as
-        `head.RealNVP`), plus legacy aliases.
-
-        Returns:
-            (dict): `torch.serialization.add_safe_globals` entries — classes and `(obj, "module.Name")` aliases — keyed
-                by the pickled "module.Name" path each one serves.
-        """
+        """Build the known data globals and legacy aliases; model classes are resolved only when referenced."""
         import enum
-        import importlib
-        import inspect
         import pathlib
-        import pkgutil
 
-        import torch.nn.modules as torch_nn
-
-        import ultralytics.nn.modules as ul_nn
         import ultralytics.utils.loss as ul_loss
-        import ultralytics.utils.tal as ul_tal
-        from ultralytics.nn import tasks as ul_tasks  # noqa: PLW0406
 
         allow = []
-
-        def _scan(pkg):
-            mods = [pkg]
-            if hasattr(pkg, "__path__"):  # package: include all submodules
-                for info in pkgutil.iter_modules(pkg.__path__, f"{pkg.__name__}."):
-                    try:
-                        mods.append(importlib.import_module(info.name))
-                    except Exception:  # noqa: S112  # optional/oddball submodule — skip
-                        continue
-            for mod in mods:
-                for name, klass in inspect.getmembers(mod, inspect.isclass):
-                    if issubclass(klass, nn.Module):
-                        # Register under the path the class is reachable from — matches how a checkpoint pickled it.
-                        allow.append((klass, f"{mod.__name__}.{name}"))
-
-        _scan(torch_nn)  # PyTorch nn modules
-        _scan(ul_nn)  # ultralytics block/conv/head/transformer
-        _scan(ul_tasks)  # ultralytics task models
-
-        # Criteria pickled inside pre-8.4.95 checkpoints (`ema.criterion` is stripped at save since then): the plain
-        # loss classes plus the nn.Module box losses and assigners they hold.
-        for mod in (ul_loss, ul_tal):
-            allow += [
-                klass for _, klass in inspect.getmembers(mod, inspect.isclass) if klass.__module__ == mod.__name__
-            ]
 
         # Non-nn.Module data globals in official checkpoints, incl. the pre-8.0.44 `ultralytics.yolo.utils` path.
         scalar = np.float64(0).__reduce__()[0]
@@ -1816,7 +1791,12 @@ class _SafeLoad:
                 (pathlib.PosixPath, "pathlib.WindowsPath"),
                 (pathlib.PosixPath, f"{pathlib.WindowsPath.__module__}.{pathlib.WindowsPath.__qualname__}"),
             ]
-        return {(e[1] if isinstance(e, tuple) else f"{e.__module__}.{e.__qualname__}"): e for e in allow}
+        return {
+            (e[1] if isinstance(e, tuple) else f"{e.__module__}.{e.__qualname__}"): (
+                e[0] if isinstance(e, tuple) else e
+            )
+            for e in allow
+        }
 
 
 def torch_safe_load(weight, safe_only=None):


### PR DESCRIPTION
## Problem

Restricted loading rejects the bound `Conv.forward_fuse` methods serialized by fused YOLOE checkpoints. Two previously working Platform endpoints failed model warmup after enabling restricted loading. Formatting that rejection also invokes `repr()` on a partially reconstructed module, masking the cause with an `_modules` AttributeError. Cold loading additionally scans and imports every supported model module to build a registry, even when the checkpoint references only a small subset.

## Change

- Resolve only the referenced classes within the existing trusted namespaces, preserving the existing class restrictions, aliases, registration lock, and process-wide allow-list lifetime. Remove exhaustive package discovery and class scanning.
- Restore only the known `forward` and `forward_fuse` instance bindings from the module class. Other instance attributes remain blocked. Report the rejected object's type without invoking its representation.
- Extend the existing checkpoint round-trip test to fused models and verify identical inference outputs.
- Bump **8.4.149 → 8.4.150**.

Restricted loading still uses PyTorch `weights_only=True`. There is no change to the model's forward pass, endpoint resources, checkpoint format, or default loading policy.

## Validation

- Both exact failing production checkpoints reproduce the failure before the fix and load and run inference with it, including the deployed container on 1 vCPU / 2 GiB.
- A generated checkpoint containing all **687** previously registered global names loads with identical bindings through the new registry owner.
- Fused and unfused legacy-criterion round trips preserve predictions; `eval` and an unrelated bound module method remain rejected.
- Six alternating fresh-process pairs per checkpoint on GH200 CPU show cold model loading improving **148.4 → 133.9 ms** (YOLO26n), **234.2 → 221.4 ms** (YOLO26l), **211.8 → 199.7 ms**, and **259.6 → 246.7 ms** (the two affected checkpoints). First inference was included to check for deferred loading work. The matching production-container comparison is complete (table below).
- In the deployed Linux/amd64 image on **1 vCPU / 2 GiB**, four alternating fresh-process pairs per model measured:

| Model | Current restricted load | Optimized restricted load | Reduction |
|---|---:|---:|---:|
| YOLO26n | 276.5 ms | 246.6 ms | 10.8% |
| YOLO26l | 484.6 ms | 457.6 ms | 5.6% |
| YOLO11s-seg | 250.6 ms | 218.7 ms | 12.7% |

Both variants retain `weights_only=True`. These are checkpoint-loading improvements, not equivalent percentage improvements in total endpoint cold starts. Import-to-first-inference medians remained approximately 11 seconds. Cloud Run execution: `safe-load-fast-4061-zjkqg`; source SHA-256 was checked against this PR.

- 24 concurrent restricted loads across three model families pass.
- Ruff and diff checks pass. Full CI is required on the final head.

Related: ultralytics/portal#4061.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Restricted checkpoint loading now resolves only referenced classes and restores approved fused model bindings, fixing fused checkpoint loading while reducing cold-load work.

### 📊 Key Changes
- Replaced exhaustive scanning of PyTorch and Ultralytics modules with on-demand resolution of referenced classes in trusted namespaces, while retaining existing restrictions, aliases, and registry locking.
- Allowed restricted loading to restore only `forward` and `forward_fuse` bindings from module classes; other instance attribute access remains blocked.
- Changed rejected-attribute errors to report the object's type without calling `repr()` on partially reconstructed modules.
- Extended legacy checkpoint round-trip coverage to fused models and verified matching inference outputs; bumped the package version from 8.4.149 to 8.4.150.

### 🎯 Purpose & Impact
- Fused YOLOE checkpoints that serialize bound `Conv.forward_fuse` methods can load and run inference under restricted loading.
- Cold restricted loading avoids importing and scanning every supported model module, reducing checkpoint-loading time while continuing to use PyTorch `weights_only=True`.
- Model forward behavior, checkpoint format, endpoint resources, and default loading policy are unchanged.